### PR TITLE
PCRE2 migration (drop PCRE1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             build-essential \
             libc-ares-dev \
             libldap-dev \
-            libpcre3-dev \
+            libpcre2-dev \
             librrd-dev \
             libssl-dev \
             libtirpc-dev

--- a/build/Makefile.test-pcre
+++ b/build/Makefile.test-pcre
@@ -4,7 +4,7 @@ test-compile:
 	@$(CC) $(CFLAGS) $(PCREINC) -o test-pcre.o -c test-pcre.c
 
 test-link:
-	@$(CC) $(CFLAGS) $(PCRELIB) -o test-pcre test-pcre.o -lpcre
+	@$(CC) $(CFLAGS) $(PCRELIB) -o test-pcre test-pcre.o -lpcre2-8
 
 clean:
 	@rm -f test-pcre.o test-pcre

--- a/build/pcre.sh
+++ b/build/pcre.sh
@@ -4,28 +4,28 @@
 	PCRELIB=""
 	for DIR in /opt/pcre* /usr/local/pcre* /usr/local /usr/pkg /opt/csw /opt/sfw
 	do
-		if test -f $DIR/include/pcre.h
+		if test -f $DIR/include/pcre2.h
 		then
 			PCREINC=$DIR/include
 		fi
-		if test -f $DIR/include/pcre/pcre.h
+		if test -f $DIR/include/pcre/pcre2.h
 		then
 			PCREINC=$DIR/include/pcre
 		fi
 
-		if test -f $DIR/lib/libpcre.so
+		if test -f $DIR/lib/libpcre2-8.so
 		then
 			PCRELIB=$DIR/lib
 		fi
-		if test -f $DIR/lib/libpcre.a
+		if test -f $DIR/lib/libpcre2-8.a
 		then
 			PCRELIB=$DIR/lib
 		fi
-		if test -f $DIR/lib64/libpcre.so
+		if test -f $DIR/lib64/libpcre2-8.so
 		then
 			PCRELIB=$DIR/lib64
 		fi
-		if test -f $DIR/lib64/libpcre.a
+		if test -f $DIR/lib64/libpcre2-8.a
 		then
 			PCRELIB=$DIR/lib64
 		fi

--- a/build/test-pcre.c
+++ b/build/test-pcre.c
@@ -1,11 +1,12 @@
-#include <pcre.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 
 int main(int argc, char *argv[])
 {
-	pcre *result;
-	const char *errmsg;
-	int errofs;
-	result = pcre_compile("xymon.*", PCRE_CASELESS, &errmsg, &errofs, NULL);
+	pcre2_code *result;
+	int err;
+	PCRE2_SIZE errofs;
+	result = pcre2_compile("xymon.*", PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
 
 	return 0;
 }

--- a/configure.client
+++ b/configure.client
@@ -237,10 +237,10 @@ then
 		echo "PCREINCDIR = -I$PCREINC"   >>Makefile
     	fi
     	if test "$PCRELIB" != ""; then
-		echo "PCRELIBS = -L$PCRELIB -lpcre" >>Makefile
+		echo "PCRELIBS = -L$PCRELIB -lpcre2-8" >>Makefile
 		echo "RPATHVAL += ${PCRELIB}"       >>Makefile
 	else
-		echo "PCRELIBS = -lpcre"         >>Makefile
+		echo "PCRELIBS = -lpcre2-8"         >>Makefile
     	fi
 fi
 echo "#"                                 >>Makefile

--- a/configure.server
+++ b/configure.server
@@ -470,10 +470,10 @@ then
 	echo "PCREINCDIR = -I$PCREINC"   >>Makefile
     fi
     if test "$PCRELIB" != ""; then
-	echo "PCRELIBS = -L$PCRELIB -lpcre" >>Makefile
+	echo "PCRELIBS = -L$PCRELIB -lpcre2-8" >>Makefile
 	echo "RPATHVAL += ${PCRELIB}"       >>Makefile
     else
-	echo "PCRELIBS = -lpcre"         >>Makefile
+	echo "PCRELIBS = -lpcre2-8"      >>Makefile
     fi
 fi
 echo ""                                  >>Makefile

--- a/lib/acknowledgementslog.c
+++ b/lib/acknowledgementslog.c
@@ -26,7 +26,8 @@ static char rcsid[] = "$Id: acknowledgementslog.c 7085 2012-07-16 11:08:37Z stor
 #include <errno.h>
 #include <time.h>
 
-#include <pcre.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 
 #include "libxymon.h"
 
@@ -103,16 +104,17 @@ void do_acknowledgementslog(FILE *output,
 	char title[200];
 
 	/* For the PCRE matching */
-	const char *errmsg = NULL;
-	int errofs = 0;
-	pcre *pageregexp = NULL;
-	pcre *expageregexp = NULL;
-	pcre *hostregexp = NULL;
-	pcre *exhostregexp = NULL;
-	pcre *testregexp = NULL;
-	pcre *extestregexp = NULL;
-	pcre *rcptregexp = NULL;
-	pcre *exrcptregexp = NULL;
+	int err;
+	PCRE2_SIZE errofs;
+	pcre2_code *pageregexp = NULL;
+	pcre2_code *expageregexp = NULL;
+	pcre2_code *hostregexp = NULL;
+	pcre2_code *exhostregexp = NULL;
+	pcre2_code *testregexp = NULL;
+	pcre2_code *extestregexp = NULL;
+	pcre2_code *rcptregexp = NULL;
+	pcre2_code *exrcptregexp = NULL;
+	pcre2_match_data *ovector;
 
 	if (maxminutes && (fromtime || totime)) {
 		fprintf(output, "<B>Only one time interval type is allowed!</B>");
@@ -147,14 +149,14 @@ void do_acknowledgementslog(FILE *output,
 
 	if (!maxcount) maxcount = 100;
 
-	if (pageregex && *pageregex) pageregexp = pcre_compile(pageregex, PCRE_CASELESS, &errmsg, &errofs, NULL);
-	if (expageregex && *expageregex) expageregexp = pcre_compile(expageregex, PCRE_CASELESS, &errmsg, &errofs, NULL);
-	if (hostregex && *hostregex) hostregexp = pcre_compile(hostregex, PCRE_CASELESS, &errmsg, &errofs, NULL);
-	if (exhostregex && *exhostregex) exhostregexp = pcre_compile(exhostregex, PCRE_CASELESS, &errmsg, &errofs, NULL);
-	if (testregex && *testregex) testregexp = pcre_compile(testregex, PCRE_CASELESS, &errmsg, &errofs, NULL);
-	if (extestregex && *extestregex) extestregexp = pcre_compile(extestregex, PCRE_CASELESS, &errmsg, &errofs, NULL);
-	if (rcptregex && *rcptregex) rcptregexp = pcre_compile(rcptregex, PCRE_CASELESS, &errmsg, &errofs, NULL);
-	if (exrcptregex && *exrcptregex) exrcptregexp = pcre_compile(exrcptregex, PCRE_CASELESS, &errmsg, &errofs, NULL);
+	if (pageregex && *pageregex) pageregexp = pcre2_compile(pageregex, strlen(pageregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (expageregex && *expageregex) expageregexp = pcre2_compile(expageregex, strlen(expageregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (hostregex && *hostregex) hostregexp = pcre2_compile(hostregex, strlen(hostregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (exhostregex && *exhostregex) exhostregexp = pcre2_compile(exhostregex, strlen(exhostregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (testregex && *testregex) testregexp = pcre2_compile(testregex, strlen(testregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (extestregex && *extestregex) extestregexp = pcre2_compile(extestregex, strlen(extestregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (rcptregex && *rcptregex) rcptregexp = pcre2_compile(rcptregex, strlen(rcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (exrcptregex && *exrcptregex) exrcptregexp = pcre2_compile(exrcptregex, strlen(exrcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
 
 	snprintf(acknowledgementslogfilename, sizeof(acknowledgementslogfilename), "%s/acknowledge.log", xgetenv("XYMONSERVERLOGS"));
 	acknowledgementslog = fopen(acknowledgementslogfilename, "r");
@@ -194,6 +196,7 @@ void do_acknowledgementslog(FILE *output,
 	}
 	
 	head = NULL;
+	ovector = pcre2_match_data_create(30, NULL);
 
 	while (acknowledgementslog && (fgets(l, sizeof(l), acknowledgementslog))) {
 
@@ -211,7 +214,6 @@ void do_acknowledgementslog(FILE *output,
 		acknowledgements_t *newrec;
 		void *eventhost;
 		struct htnames_t *eventcolumn;
-		int ovector[30];
 
                 /* 2015-03-07 18:17:03 myserver disk andy 1 1425724570 1425752223 1425838623 testing message */
 		itemsfound = sscanf(l, "%*u-%*u-%*u %*u:%*u:%*u %s %s %s %*u %*u %u %u %[^\t\n]", host, svc, recipient, &etim, &valid, message);
@@ -254,8 +256,8 @@ void do_acknowledgementslog(FILE *output,
 			pagename = xmh_item_multi(eventhost, XMH_PAGEPATH);
 			pagematch = 0;
 			while (!pagematch && pagename) {
-			pagematch = (pcre_exec(pageregexp, NULL, pagename, strlen(pagename), 0, 0, 
-					ovector, (sizeof(ovector)/sizeof(int))) >= 0);
+			pagematch = (pcre2_match(pageregexp, pagename, strlen(pagename), 0, 0,
+					ovector, NULL) >= 0);
 				pagename = xmh_item_multi(NULL, XMH_PAGEPATH);
 			}
 		}
@@ -269,8 +271,8 @@ void do_acknowledgementslog(FILE *output,
 			pagename = xmh_item_multi(eventhost, XMH_PAGEPATH);
 			pagematch = 0;
 			while (!pagematch && pagename) {
-			pagematch = (pcre_exec(expageregexp, NULL, pagename, strlen(pagename), 0, 0, 
-					ovector, (sizeof(ovector)/sizeof(int))) >= 0);
+			pagematch = (pcre2_match(expageregexp, pagename, strlen(pagename), 0, 0,
+					ovector, NULL) >= 0);
 				pagename = xmh_item_multi(NULL, XMH_PAGEPATH);
 			}
 		}
@@ -279,43 +281,43 @@ void do_acknowledgementslog(FILE *output,
 		if (pagematch) continue;
 
 		if (hostregexp)
-			hostmatch = (pcre_exec(hostregexp, NULL, hostname, strlen(hostname), 0, 0, 
-					ovector, (sizeof(ovector)/sizeof(int))) >= 0);
+			hostmatch = (pcre2_match(hostregexp, hostname, strlen(hostname), 0, 0,
+					ovector, NULL) >= 0);
 		else
 			hostmatch = 1;
 		if (!hostmatch) continue;
 
 		if (exhostregexp)
-			hostmatch = (pcre_exec(exhostregexp, NULL, hostname, strlen(hostname), 0, 0, 
-					ovector, (sizeof(ovector)/sizeof(int))) >= 0);
+			hostmatch = (pcre2_match(exhostregexp, hostname, strlen(hostname), 0, 0,
+					ovector, NULL) >= 0);
 		else
 			hostmatch = 0;
 		if (hostmatch) continue;
 
 		if (testregexp)
-			testmatch = (pcre_exec(testregexp, NULL, svcname, strlen(svcname), 0, 0, 
-					ovector, (sizeof(ovector)/sizeof(int))) >= 0);
+			testmatch = (pcre2_match(testregexp, svcname, strlen(svcname), 0, 0,
+					ovector, NULL) >= 0);
 		else
 			testmatch = 1;
 		if (!testmatch) continue;
 
 		if (extestregexp)
-			testmatch = (pcre_exec(extestregexp, NULL, svcname, strlen(svcname), 0, 0, 
-					ovector, (sizeof(ovector)/sizeof(int))) >= 0);
+			testmatch = (pcre2_match(extestregexp, svcname, strlen(svcname), 0, 0,
+					ovector, NULL) >= 0);
 		else
 			testmatch = 0;
 		if (testmatch) continue;
 
 		if (rcptregexp)
-			rcptmatch = (pcre_exec(rcptregexp, NULL, recipient, strlen(recipient), 0, 0, 
-					ovector, (sizeof(ovector)/sizeof(int))) >= 0);
+			rcptmatch = (pcre2_match(rcptregexp, recipient, strlen(recipient), 0, 0,
+					ovector, NULL) >= 0);
 		else
 			rcptmatch = 1;
 		if (!rcptmatch) continue;
 
 		if (exrcptregexp)
-			rcptmatch = (pcre_exec(exrcptregexp, NULL, recipient, strlen(recipient), 0, 0, 
-					ovector, (sizeof(ovector)/sizeof(int))) >= 0);
+			rcptmatch = (pcre2_match(exrcptregexp, recipient, strlen(recipient), 0, 0,
+					ovector, NULL) >= 0);
 		else
 			rcptmatch = 0;
 		if (rcptmatch) continue;
@@ -405,13 +407,14 @@ void do_acknowledgementslog(FILE *output,
 
 	if (acknowledgementslog) fclose(acknowledgementslog);
 
-	if (pageregexp)   pcre_free(pageregexp);
-	if (expageregexp) pcre_free(expageregexp);
-	if (hostregexp)   pcre_free(hostregexp);
-	if (exhostregexp) pcre_free(exhostregexp);
-	if (testregexp)   pcre_free(testregexp);
-	if (extestregexp) pcre_free(extestregexp);
-	if (rcptregexp)   pcre_free(rcptregexp);
-	if (exrcptregexp) pcre_free(exrcptregexp);
+	if (pageregexp)   pcre2_code_free(pageregexp);
+	if (expageregexp) pcre2_code_free(expageregexp);
+	if (hostregexp)   pcre2_code_free(hostregexp);
+	if (exhostregexp) pcre2_code_free(exhostregexp);
+	if (testregexp)   pcre2_code_free(testregexp);
+	if (extestregexp) pcre2_code_free(extestregexp);
+	if (rcptregexp)   pcre2_code_free(rcptregexp);
+	if (exrcptregexp) pcre2_code_free(exrcptregexp);
+	pcre2_match_data_free(ovector);
 }
 

--- a/lib/clientlocal.c
+++ b/lib/clientlocal.c
@@ -16,11 +16,13 @@ static char rcsid[] = "$Id$";
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 
 #include "libxymon.h"
 
 typedef struct clientconfig_t {
-	pcre *hostptn, *classptn, *osptn;
+	pcre2_code *hostptn, *classptn, *osptn;
 	strbuffer_t *config;
 	struct clientconfig_t *next;
 } clientconfig_t;
@@ -117,7 +119,7 @@ void load_clientconfig(void)
 
 		if (!insection) {
 			if (*STRBUF(buf) == '[') {
-				pcre *hostptn = NULL, *classptn = NULL, *osptn = NULL;
+				pcre2_code *hostptn = NULL, *classptn = NULL, *osptn = NULL;
 				clientconfig_t *newrec;
 
 				p = STRBUF(buf) + strcspn(STRBUF(buf), "\r\n");

--- a/lib/loadalerts.c
+++ b/lib/loadalerts.c
@@ -25,7 +25,8 @@ static char rcsid[] = "$Id$";
 #include <limits.h>
 #include <errno.h>
 
-#include <pcre.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 
 #include "libxymon.h"
 
@@ -164,29 +165,29 @@ static void free_criteria(criteria_t *crit)
 {
 	if (crit->cfline)        xfree(crit->cfline);
 	if (crit->pagespec)      xfree(crit->pagespec);
-	if (crit->pagespecre)    pcre_free(crit->pagespecre);
+	if (crit->pagespecre)    pcre2_code_free(crit->pagespecre);
 	if (crit->expagespec)    xfree(crit->expagespec);
-	if (crit->expagespecre)  pcre_free(crit->expagespecre);
+	if (crit->expagespecre)  pcre2_code_free(crit->expagespecre);
 	if (crit->dgspec)        xfree(crit->dgspec);
-	if (crit->dgspecre)      pcre_free(crit->dgspecre);
+	if (crit->dgspecre)      pcre2_code_free(crit->dgspecre);
 	if (crit->exdgspec)      xfree(crit->exdgspec);
-	if (crit->exdgspecre)    pcre_free(crit->exdgspecre);
+	if (crit->exdgspecre)    pcre2_code_free(crit->exdgspecre);
 	if (crit->hostspec)      xfree(crit->hostspec);
-	if (crit->hostspecre)    pcre_free(crit->hostspecre);
+	if (crit->hostspecre)    pcre2_code_free(crit->hostspecre);
 	if (crit->exhostspec)    xfree(crit->exhostspec);
-	if (crit->exhostspecre)  pcre_free(crit->exhostspecre);
+	if (crit->exhostspecre)  pcre2_code_free(crit->exhostspecre);
 	if (crit->svcspec)       xfree(crit->svcspec);
-	if (crit->svcspecre)     pcre_free(crit->svcspecre);
+	if (crit->svcspecre)     pcre2_code_free(crit->svcspecre);
 	if (crit->exsvcspec)     xfree(crit->exsvcspec);
-	if (crit->exsvcspecre)   pcre_free(crit->exsvcspecre);
+	if (crit->exsvcspecre)   pcre2_code_free(crit->exsvcspecre);
 	if (crit->classspec)     xfree(crit->classspec);
-	if (crit->classspecre)   pcre_free(crit->classspecre);
+	if (crit->classspecre)   pcre2_code_free(crit->classspecre);
 	if (crit->exclassspec)   xfree(crit->exclassspec);
-	if (crit->exclassspecre) pcre_free(crit->exclassspecre);
+	if (crit->exclassspecre) pcre2_code_free(crit->exclassspecre);
 	if (crit->groupspec)     xfree(crit->groupspec);
-	if (crit->groupspecre)   pcre_free(crit->groupspecre);
+	if (crit->groupspecre)   pcre2_code_free(crit->groupspecre);
 	if (crit->exgroupspec)   xfree(crit->exgroupspec);
-	if (crit->exgroupspecre) pcre_free(crit->exgroupspecre);
+	if (crit->exgroupspecre) pcre2_code_free(crit->exgroupspecre);
 	if (crit->timespec)      xfree(crit->timespec);
 	if (crit->extimespec)    xfree(crit->extimespec);
 }

--- a/lib/loadalerts.h
+++ b/lib/loadalerts.h
@@ -16,7 +16,8 @@
 
 /* The clients probably don't have the pcre headers */
 #if defined(LOCALCLIENT) || !defined(CLIENTONLY)
-#include <pcre.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 
 typedef enum { A_PAGING, A_NORECIP, A_ACKED, A_RECOVERED, A_DISABLED, A_NOTIFY, A_DEAD } astate_t;
 
@@ -50,29 +51,29 @@ typedef struct criteria_t {
 	int cfid;
 	char *cfline;
 	char *pagespec;		/* Pages to include */
-	pcre *pagespecre;
+	pcre2_code *pagespecre;
 	char *expagespec;	/* Pages to exclude */
-	pcre *expagespecre;
+	pcre2_code *expagespecre;
 	char *dgspec;		/* Display groups to include */
-	pcre *dgspecre;
+	pcre2_code *dgspecre;
 	char *exdgspec;		/* Display groups to exclude */
-	pcre *exdgspecre;
+	pcre2_code *exdgspecre;
 	char *hostspec;		/* Hosts to include */
-	pcre *hostspecre;
+	pcre2_code *hostspecre;
 	char *exhostspec;	/* Hosts to exclude */
-	pcre *exhostspecre;
+	pcre2_code *exhostspecre;
 	char *svcspec;		/* Services to include */
-	pcre *svcspecre;
+	pcre2_code *svcspecre;
 	char *exsvcspec;	/* Services to exclude */
-	pcre *exsvcspecre;
+	pcre2_code *exsvcspecre;
 	char *classspec;
-	pcre *classspecre;
+	pcre2_code *classspecre;
 	char *exclassspec;
-	pcre *exclassspecre;
+	pcre2_code *exclassspecre;
 	char *groupspec;
-	pcre *groupspecre;
+	pcre2_code *groupspecre;
 	char *exgroupspec;
-	pcre *exgroupspecre;
+	pcre2_code *exgroupspecre;
 	int colors;
 	char *timespec;
 	char *extimespec;

--- a/lib/matching.h
+++ b/lib/matching.h
@@ -13,11 +13,12 @@
 
 /* The clients probably don't have the pcre headers */
 #if defined(LOCALCLIENT) || !defined(CLIENTONLY)
-#include <pcre.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 #include <stdarg.h>
 
-extern pcre *compileregex(const char *pattern);
-extern pcre *compileregex_opts(const char *pattern, int flags);
+extern pcre2_code *compileregex(const char *pattern);
+extern pcre2_code *compileregex_opts(const char *pattern, uint32_t flags);
 #ifdef PCRE_FIRSTLINE
 #define firstlineregex(P) compileregex_opts(P, PCRE_FIRSTLINE);
 #define firstlineregexnocase(P) compileregex_opts(P, PCRE_CASELESS|PCRE_FIRSTLINE);
@@ -25,13 +26,13 @@ extern pcre *compileregex_opts(const char *pattern, int flags);
 #define firstlineregex(P) compileregex_opts(P, 0);
 #define firstlineregexnocase(P) compileregex_opts(P, PCRE_CASELESS);
 #endif
-extern pcre *multilineregex(const char *pattern);
-extern int matchregex(const char *needle, pcre *pcrecode);
-extern void freeregex(pcre *pcrecode);
-extern int namematch(const char *needle, char *haystack, pcre *pcrecode);
-extern int patternmatch(char *datatosearch, char *pattern, pcre *pcrecode);
-extern pcre **compile_exprs(char *id, const char **patterns, int count);
-extern int pickdata(char *buf, pcre *expr, int dupok, ...);
+extern pcre2_code *multilineregex(const char *pattern);
+extern int matchregex(const char *needle, pcre2_code *pcrecode);
+extern void freeregex(pcre2_code *pcrecode);
+extern int namematch(const char *needle, char *haystack, pcre2_code *pcrecode);
+extern int patternmatch(char *datatosearch, char *pattern, pcre2_code *pcrecode);
+extern pcre2_code **compile_exprs(char *id, const char **patterns, int count);
+extern int pickdata(char *buf, pcre2_code *expr, int dupok, ...);
 extern int timematch(char *holidaykey, char *tspec);
 #endif
 

--- a/web/acknowledge.c
+++ b/web/acknowledge.c
@@ -264,7 +264,7 @@ int main(int argc, char *argv[])
 
 			if (obeycookies && !gotfilter && ((hostname = get_cookie("host")) != NULL)) {
 				if (*hostname) {
-					pcre *dummy;
+					pcre2_code *dummy;
 					SBUF_DEFINE(re);
 
 					SBUF_MALLOC(re, 3+strlen(hostname));
@@ -286,7 +286,7 @@ int main(int argc, char *argv[])
 
 			if (obeycookies && !gotfilter && ((pagename = get_cookie("pagepath")) != NULL)) {
 				if (*pagename) {
-					pcre *dummy;
+					pcre2_code *dummy;
 					SBUF_DEFINE(re);
 
 					SBUF_MALLOC(re, 8 + strlen(pagename)*2);

--- a/web/confreport.c
+++ b/web/confreport.c
@@ -693,7 +693,7 @@ int main(int argc, char *argv[])
 
 	/* Fetch the list of host+test statuses we currently know about */
 	if (pagepattern) {
-		pcre *dummy;
+		pcre2_code *dummy;
 		SBUF_DEFINE(re);
 
 		SBUF_MALLOC(re, 8 + 2*strlen(pagepattern));
@@ -716,7 +716,7 @@ int main(int argc, char *argv[])
 		xfree(re);
 	}
 	else if (hostpattern) {
-		pcre *dummy;
+		pcre2_code *dummy;
 		SBUF_DEFINE(re);
 
 		SBUF_MALLOC(re,3 + strlen(hostpattern));

--- a/web/hostlist.c
+++ b/web/hostlist.c
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
 	int argi, res;
 	sendreturn_t *sres;
 	char *cookie;
-	pcre *dummy;
+	pcre2_code *dummy;
 
 	init_timestamp();
 	for (argi=1; (argi < argc); argi++) {

--- a/web/perfdata.c
+++ b/web/perfdata.c
@@ -21,7 +21,8 @@ static char rcsid[] = "$Id$";
 #include <dirent.h>
 
 #include <rrd.h>
-#include <pcre.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 
 #include "libxymon.h"
 
@@ -319,7 +320,7 @@ void format_rrdtime(char *t, char **tday, char **thm)
 
 int main(int argc, char **argv)
 {
-	pcre *hostptn, *exhostptn, *pageptn, *expageptn;
+	pcre2_code *hostptn, *exhostptn, *pageptn, *expageptn;
 	void *hwalk;
 	char *hostname, *pagename;
 

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -1027,7 +1027,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 
 			/* We have a matching file! */
 			rrddbs[rrddbcount].rrdfn = strdup(d->d_name);
-			if (pcre2_substring_copy_bynumber(ovector, 1, param, &l) > 0) {
+			if (pcre2_substring_copy_bynumber(ovector, 1, param, &l) == 0) {
 				/*
 				 * This is ugly, but I cannot find a pretty way of un-mangling
 				 * the disk- and http-data that has been molested by the back-end.

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -27,7 +27,8 @@ static char rcsid[] = "$Id$";
 #include <sys/un.h>
 #include <fcntl.h>
 
-#include <pcre.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 #include <rrd.h>
 
 #include "libxymon.h"
@@ -950,10 +951,11 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	}
 	else {
 		struct dirent *d;
-		pcre *pat, *expat = NULL;
-		const char *errmsg;
-		int errofs, result;
-		int ovector[30];
+		pcre2_code *pat, *expat = NULL;
+		char errmsg[120];
+		int err, result;
+		PCRE2_SIZE errofs;
+		pcre2_match_data *ovector;
 		struct stat st;
 		time_t now = getcurrenttime(NULL);
 
@@ -961,21 +963,23 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		dir = opendir("."); if (dir == NULL) errormsg("Unexpected error while accessing RRD directory");
 
 		/* Setup the pattern to match filenames against */
-		pat = pcre_compile(gdef->fnpat, PCRE_CASELESS, &errmsg, &errofs, NULL);
+		pat = pcre2_compile(gdef->fnpat, strlen(gdef->fnpat), PCRE2_CASELESS, &err, &errofs, NULL);
 		if (!pat) {
 			char msg[8192];
 
-			snprintf(msg, sizeof(msg), "graphs.cfg error, PCRE pattern %s invalid: %s, offset %d\n",
+			pcre2_get_error_message(err, errmsg, sizeof(errmsg));
+			snprintf(msg, sizeof(msg), "graphs.cfg error, PCRE pattern %s invalid: %s, offset %zu\n",
 				 htmlquoted(gdef->fnpat), errmsg, errofs);
 			errormsg(msg);
 		}
 		if (gdef->exfnpat) {
-			expat = pcre_compile(gdef->exfnpat, PCRE_CASELESS, &errmsg, &errofs, NULL);
+			expat = pcre2_compile(gdef->exfnpat, strlen(gdef->exfnpat), PCRE2_CASELESS, &err, &errofs, NULL);
 			if (!expat) {
 				char msg[8192];
 
+				pcre2_get_error_message(err, errmsg, sizeof(errmsg));
 				snprintf(msg, sizeof(msg), 
-					 "graphs.cfg error, PCRE pattern %s invalid: %s, offset %d\n",
+					 "graphs.cfg error, PCRE pattern %s invalid: %s, offset %zu\n",
 					 htmlquoted(gdef->exfnpat), errmsg, errofs);
 				errormsg(msg);
 			}
@@ -985,9 +989,11 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		rrddbsize = 5;
 		rrddbs = (rrddb_t *) malloc((rrddbsize+1) * sizeof(rrddb_t));
 
+		ovector = pcre2_match_data_create(30, NULL);
 		while ((d = readdir(dir)) != NULL) {
 			char *ext;
 			char param[PATH_MAX];
+			PCRE2_SIZE l = sizeof(param);
 
 			/* Ignore dot-files and files with names shorter than ".rrd" */
 			if (*(d->d_name) == '.') continue;
@@ -996,14 +1002,14 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 
 			/* First check the exclude pattern. */
 			if (expat) {
-				result = pcre_exec(expat, NULL, d->d_name, strlen(d->d_name), 0, 0, 
-						   ovector, (sizeof(ovector)/sizeof(int)));
+				result = pcre2_match(expat, d->d_name, strlen(d->d_name), 0, 0,
+						     ovector, NULL);
 				if (result >= 0) continue;
 			}
 
 			/* Then see if the include pattern matches. */
-			result = pcre_exec(pat, NULL, d->d_name, strlen(d->d_name), 0, 0, 
-					   ovector, (sizeof(ovector)/sizeof(int)));
+			result = pcre2_match(pat, d->d_name, strlen(d->d_name), 0, 0,
+					     ovector, NULL);
 			if (result < 0) continue;
 
 			if (wantsingle) {
@@ -1021,7 +1027,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 
 			/* We have a matching file! */
 			rrddbs[rrddbcount].rrdfn = strdup(d->d_name);
-			if (pcre_copy_substring(d->d_name, ovector, result, 1, param, sizeof(param)) > 0) {
+			if (pcre2_substring_copy_bynumber(ovector, 1, param, &l) > 0) {
 				/*
 				 * This is ugly, but I cannot find a pretty way of un-mangling
 				 * the disk- and http-data that has been molested by the back-end.
@@ -1059,8 +1065,9 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 				rrddbs = (rrddb_t *)realloc(rrddbs, (rrddbsize+1) * sizeof(rrddb_t));
 			}
 		}
-		pcre_free(pat);
-		if (expat) pcre_free(expat);
+		pcre2_code_free(pat);
+		if (expat) pcre2_code_free(expat);
+		pcre2_match_data_free(ovector);
 		closedir(dir);
 	}
 	rrddbs[rrddbcount].key = rrddbs[rrddbcount].rrdfn = rrddbs[rrddbcount].rrdparam = NULL;

--- a/web/statusreport.c
+++ b/web/statusreport.c
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
       		/* Setup the filter we use for the report */
 		cookie = get_cookie("pagepath");
 		if (cookie && *cookie) {
-			pcre *dummy;
+			pcre2_code *dummy;
 			SBUF_DEFINE(re);
 
 			SBUF_MALLOC(re, 8 + 2*strlen(cookie));

--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -359,7 +359,7 @@ int do_request(void)
 
 		/* We need not check that hostname is valid, has already been done with loadhostdata() */
 		if (!complist) {
-			pcre *dummy = NULL;
+			pcre2_code *dummy = NULL;
 
 			/* Check service as a pcre pattern. And no spaces in servicenames */
 			if (strchr(service, ' ') == NULL) dummy = compileregex(service);
@@ -373,7 +373,7 @@ int do_request(void)
 			snprintf(xymondreq, xymondreq_buflen, "xymondlog host=%s test=%s fields=hostname,testname,color,flags,lastchange,logtime,validtime,acktime,disabletime,sender,cookie,ackmsg,dismsg,client,acklist,XMH_IP,XMH_DISPLAYNAME,clntstamp,flapinfo,modifiers", hostname, service);
 		}
 		else {
-			pcre *dummy = NULL;
+			pcre2_code *dummy = NULL;
 			SBUF_DEFINE(re);
 
 			SBUF_MALLOC(re, 5 + strlen(complist));

--- a/xymond/client_config.c
+++ b/xymond/client_config.c
@@ -28,14 +28,15 @@ static char rcsid[] = "$Id$";
 #include <limits.h>
 #include <errno.h>
 
-#include <pcre.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 
 #include "libxymon.h"
 #include "client_config.h"
 
 typedef struct exprlist_t {
 	char *pattern;
-	pcre *exp;
+	pcre2_code *exp;
 	struct exprlist_t *next;
 } exprlist_t;
 
@@ -591,7 +592,7 @@ int load_client_config(char *configfn)
 		exprlist_t *tmp = exprhead;
 		exprhead = exprhead->next;
 		if (tmp->pattern) xfree(tmp->pattern);
-		if (tmp->exp) pcre_free(tmp->exp);
+		if (tmp->exp) pcre2_code_free(tmp->exp);
 		xfree(tmp);
 	}
 	exprhead = NULL;

--- a/xymond/do_alert.c
+++ b/xymond/do_alert.c
@@ -27,8 +27,6 @@ static char rcsid[] = "$Id$";
 #include <errno.h>
 #include <sys/wait.h>
 
-#include <pcre.h>
-
 #include "libxymon.h"
 
 /*

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -23,7 +23,8 @@ static char rcsid[] = "$Id$";
 #include <utime.h>
 
 #include <rrd.h>
-#include <pcre.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 
 #include "libxymon.h"
 

--- a/xymond/rrd/do_devmon.c
+++ b/xymond/rrd/do_devmon.c
@@ -18,8 +18,8 @@ int do_devmon_rrd(char *hostname, char *testname, char *classname, char *pagepat
 
 	char *eoln, *curline;
 	static int ptnsetup = 0;
-	static pcre *inclpattern = NULL;
-	static pcre *exclpattern = NULL;
+	static pcre2_code *inclpattern = NULL;
+	static pcre2_code *exclpattern = NULL;
 	int in_devmon = 1;
 	int numds = 0;
 	char *rrdbasename;

--- a/xymond/rrd/do_ifstat.c
+++ b/xymond/rrd/do_ifstat.c
@@ -120,17 +120,17 @@ static const char *ifstat_bbwin_exprs[] = {
 int do_ifstat_rrd(char *hostname, char *testname, char *classname, char *pagepaths, char *msg, time_t tstamp)
 {
 	static int pcres_compiled = 0;
-	static pcre **ifstat_linux_pcres = NULL;
-	static pcre **ifstat_freebsd_pcres = NULL;
-	static pcre **ifstat_freebsdV8_pcres = NULL;
-	static pcre **ifstat_openbsd_pcres = NULL;
-	static pcre **ifstat_netbsd_pcres = NULL;
-	static pcre **ifstat_darwin_pcres = NULL;
-	static pcre **ifstat_solaris_pcres = NULL;
-	static pcre **ifstat_aix_pcres = NULL;
-	static pcre **ifstat_hpux_pcres = NULL;
-	static pcre **ifstat_sco_sv_pcres = NULL;
-	static pcre **ifstat_bbwin_pcres = NULL;
+	static pcre2_code **ifstat_linux_pcres = NULL;
+	static pcre2_code **ifstat_freebsd_pcres = NULL;
+	static pcre2_code **ifstat_freebsdV8_pcres = NULL;
+	static pcre2_code **ifstat_openbsd_pcres = NULL;
+	static pcre2_code **ifstat_netbsd_pcres = NULL;
+	static pcre2_code **ifstat_darwin_pcres = NULL;
+	static pcre2_code **ifstat_solaris_pcres = NULL;
+	static pcre2_code **ifstat_aix_pcres = NULL;
+	static pcre2_code **ifstat_hpux_pcres = NULL;
+	static pcre2_code **ifstat_sco_sv_pcres = NULL;
+	static pcre2_code **ifstat_bbwin_pcres = NULL;
 
 	enum ostype_t ostype;
 	char *datapart = msg;
@@ -138,7 +138,7 @@ int do_ifstat_rrd(char *hostname, char *testname, char *classname, char *pagepat
 	int dmatch;
 
 	void *xmh;
-	pcre *ifname_filter_pcre = NULL;
+	pcre2_code *ifname_filter_pcre = NULL;
 
 	xmh = hostinfo(hostname);
 	if (xmh) {

--- a/xymond/rrd/do_netstat.c
+++ b/xymond/rrd/do_netstat.c
@@ -65,7 +65,7 @@ static void prepare_update(char *outp)
 	outp += sprintf(outp, ":%s", (tcpretranspackets ? tcpretranspackets : "U")); if (tcpretranspackets) xfree(tcpretranspackets);
 }
 
-static int handle_pcre_netstat(char *msg, pcre **pcreset, char *outp)
+static int handle_pcre_netstat(char *msg, pcre2_code **pcreset, char *outp)
 {
 	enum { AT_NONE, AT_TCP, AT_UDP } sect = AT_NONE;
 	int havedata = 0;
@@ -432,12 +432,12 @@ static int do_valbeforemarker(char *layout[], char *msg, char *outp)
 int do_netstat_rrd(char *hostname, char *testname, char *classname, char *pagepaths, char *msg, time_t tstamp)
 {
 	static int pcres_compiled = 0;
-	static pcre **netstat_osf_pcres = NULL;
-	static pcre **netstat_aix_pcres = NULL;
-	static pcre **netstat_irix_pcres = NULL;
-	static pcre **netstat_hpux_pcres = NULL;
-	static pcre **netstat_bsd_pcres = NULL;
-	static pcre **netstat_sco_sv_pcres = NULL;
+	static pcre2_code **netstat_osf_pcres = NULL;
+	static pcre2_code **netstat_aix_pcres = NULL;
+	static pcre2_code **netstat_irix_pcres = NULL;
+	static pcre2_code **netstat_hpux_pcres = NULL;
+	static pcre2_code **netstat_bsd_pcres = NULL;
+	static pcre2_code **netstat_sco_sv_pcres = NULL;
 
 	enum ostype_t ostype;
 	char *datapart = msg;

--- a/xymond/xymon-mailack.c
+++ b/xymond/xymon-mailack.c
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
 	if (result >= 0) {
 		char delaytxt[4096];
 		l = sizeof(delaytxt);
-		if (pcre2_substring_copy_bynumber(ovector, 1, delaytxt, &l) > 0) {
+		if (pcre2_substring_copy_bynumber(ovector, 1, delaytxt, &l) == 0) {
 			duration = durationvalue(delaytxt);
 		}
 	}
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
 	if (result >= 0) {
 		char msgtxt[4096];
 		l = sizeof(msgtxt);
-		if (pcre2_substring_copy_bynumber(ovector, 1, msgtxt, &l) > 0) {
+		if (pcre2_substring_copy_bynumber(ovector, 1, msgtxt, &l) == 0) {
 			firsttxtline = strdup(msgtxt);
 		}
 	}

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -361,7 +361,7 @@ enum filtertype_t { FILTER_XMH, FILTER_PAGEPATH, FILTER_TEST, FILTER_FIELD, FILT
 
 typedef struct hostfilter_rec_t {
 	enum filtertype_t filtertype;
-	pcre *wantedptn; int wantedvalue;
+	pcre2_code *wantedptn; int wantedvalue;
 	struct hostfilter_rec_t *next;
 	enum xmh_item_t field;	/* Only for filtertype == FILTER_XMH */
 	enum boardfield_t boardfield;	/* Only for filtertype == FILTER_FIELD(TIME) */
@@ -2870,7 +2870,7 @@ hostfilter_rec_t *setup_filter(char *buf, char **fields, int *acklevel, int *hav
 {
 	char *tok;
 	hostfilter_rec_t *filterhead = NULL, *filtertail = NULL;
-	static pcre *xmhptn = NULL;
+	static pcre2_code *xmhptn = NULL;
 
 	dbgprintf("-> setup_filter: %s\n", buf);
 

--- a/xymond/xymond_channel.c
+++ b/xymond/xymond_channel.c
@@ -426,8 +426,8 @@ int main(int argc, char *argv[])
 	char *pidfile = NULL;
 	char *envarea = NULL;
 	int cnid = -1;
-	pcre *msgfilter = NULL;
-	pcre *stdfilter = NULL;
+	pcre2_code *msgfilter = NULL;
+	pcre2_code *stdfilter = NULL;
 
 	int argi;
 	struct sigaction sa;

--- a/xymonnet/beastat.c
+++ b/xymonnet/beastat.c
@@ -22,8 +22,6 @@ static char rcsid[] = "$Id$";
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#include <pcre.h>
-
 #include "libxymon.h"
 #include "version.h"
 

--- a/xymonnet/httpresult.c
+++ b/xymonnet/httpresult.c
@@ -80,7 +80,7 @@ static int statuscolor_by_set(testedhost_t *h, int status, char *okcodes, char *
 {
 	int result = -1;
 	char codestr[15];
-	pcre *ptn;
+	pcre2_code *ptn;
 
 	/* Use code 999 to indicate we could not fetch the URL */
 	snprintf(codestr, sizeof(codestr), "%d", (status ? status : 999));


### PR DESCRIPTION
This adds support for pcre2 as a replacement for older pcre3 library, written by Yavor Doganov <yavor@gnu.org> with a little fixup for pcre2_substring_copy_bynumber() by me.

See https://bugs.debian.org/999921for more information about this changes.  They are used in Debian since 4.3.30-2, which was released Mon, 12 Feb 2024 18:05:54 +0100.  This is also part of the Debian 13 (trixie) release, which was released as stable on 2025-08-09.

I already applied a change for the build pipleline (https://github.com/xymon-monitoring/xymon/pull/4) to use libpcre2-dev instead of the older libpcre3-dev.