### PR TITLE
Fix Snapshort and Availability Report on Firefox

### DIFF
--- a/web/report.c
+++ b/web/report.c
@@ -204,7 +204,7 @@ int main(int argc, char *argv[])
 	int argi, newargi;
 	char *envarea = NULL;
 	char *useragent = NULL;
-	int usemultipart = 1;
+	int usemultipart = 0;
 
 	SBUF_MALLOC(outdir, PATH_MAX+1024);
 	SBUF_MALLOC(xymonwebenv, PATH_MAX+1024);

--- a/web/snapshot.c
+++ b/web/snapshot.c
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
 	int argi, newargi;
 	char *envarea = NULL;
 	char *useragent;
-	int usemultipart = 1;
+	int usemultipart = 0;
 
 	SBUF_MALLOC(xymongencmd, 2048+PATH_MAX);
 	SBUF_MALLOC(xymonwebenv, 4096);


### PR DESCRIPTION
I noticed, that in Xymon 4.3.30 opening the "Snapshot Report" (snapshot.sh) as well as the "Availability Report" (report.sh) in the "Reports" menu do not work as expected, but try to download a file snapshot.sh or report.sh.

Digging deeper into this, I noticed, that this seems a Firefox only problem, while chromium works without problems.

In the code web/snapshot.c and web/report.c I found a variable usemultipart, which is 1 by default and is reset to 0 if
HTTP_USER_AGENT contains "KHTML", which (according to a comment) cannot handle multipart documents.

It seems, that current Firefox also can not handle this correct, while Chromium uses the User-Agent "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36"
so it already disables multipart.

From my point of view, it may be a good idea to disable usemultipart by default, if Safari, Konqueror and Chrom(ium) disable it via the KHTML in the User-Agent and Firefox doesn't work with usemultipart=0.

Bug-Debian: https://bugs.debian.org/990989
Forwarded: https://lists.xymon.com/archive/2024-February/048287.html