### PR TITLE
Fix reading service banners from TLS-1.3-enabled hosts

### DIFF
--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -1347,13 +1347,12 @@ restartselect:
 							}
 						}
 
-						if ((item->svcinfo->flags & TCP_HTTP) && 
-						    ((res > 0) || item->sslagain)     &&
-						    (!datadone) ) {
+						if (((item->svcinfo->flags & TCP_HTTP) && res > 0) || item->sslagain) {
 							/*
-							 * HTTP : Grab the entire response.
+							 * Grab the entire HTTP response or wait for
+							 * TLS handshake to complete.
 							 */
-							wantmoredata = 1;
+							wantmoredata = !datadone;
 						}
 
 						if (!wantmoredata) {


### PR DESCRIPTION
Andreas Oberritter analyzed and fixed the well known and often discussed issue with pop3s/imaps flapping in combination with TLS 1.3.
See https://bugs.debian.org/930532 and https://salsa.debian.org/debian/xymon/-/merge_requests/1

I use this patch for many months now without any issues, so I'd like to see it applied in the official code.

Bug-Debian: https://bugs.debian.org/930532
Forwarded: https://lists.xymon.com/archive/2024-February/048290.html

Related discussion:
https://lists.xymon.com/archive/2019-July/046585.html https://lists.xymon.com/archive/2019-November/046893.html https://lists.xymon.com/archive/2020-February/046986.html https://lists.xymon.com/archive/2020-March/046987.html https://sourceforge.net/p/xymon/discussion/435278/thread/c0359f08e7/