### PR TITLE
Fix buffer overflow in md5hash()

### DIFF
--- a/lib/digest.c
+++ b/lib/digest.c
@@ -41,7 +41,7 @@ char *md5hash(char *input)
 	myMD5_Final(md_value, ctx->mdctx);
 
 	for(i = 0, p = md_string; (i < sizeof(md_value)); i++) 
-		p += snprintf(p, (sizeof(md_string) - (md_string - p)), "%02x", md_value[i]);
+		p += snprintf(p, (sizeof(md_string) - (p - md_string)), "%02x", md_value[i]);
 	*p = '\0';
 
 	return md_string;


### PR DESCRIPTION
There is an issue in xymon 4.3.30 when build in Ubuntu 24.04, which is
triggered by -D_FORTIFY_SOURCE=3, which is enabled on this Ubuntu
version by default.

This results in a segfault in xymond_client, xymond_rrd and
xymond_alert always on the same function:

> #9  md5hash (
>     input=input@entry=0x5594c83023e0 "#\n# Master configuration file for Xymon\n#\n# This file defines several things:\n#\n# 1) By adding hosts to this file, you define hosts that are monitored by Xymon\n# 2) By adding \"page\", \"subpage\", \"group"...) at ./lib/digest.c:44
>         ctx = 0x5594c83023a0
>         md_value = "\301tJ\342^\312T\032bGjɨ\f\267I"
>         md_string = "c1", '\000' <repeats 30 times>
>         i = 1
>         p = 0x5594c6dd7c02 <md_string+2> ""

Seems that there's a bug in the calculation of the buffer size.

Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/xymon/+bug/2078638
Forwarded: https://sourceforge.net/p/xymon/mailman/message/58824967/