### PR TITLE
Allow specifying TLSv1.3 for xymonnet tests

### DIFF
--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -1018,6 +1018,8 @@ one or more "dialect names" to the URL scheme, i.e. the
 .br
 * "c",  e.g. httpsc://www.sample.com/ : use only TLSv1.2
 .br
+* "d",  e.g. httpsd://www.sample.com/ : use only TLSv1.3
+.br
 * "m",  e.g. httpsm://www.sample.com/ : use only 128-bit ciphers
 .br
 * "h",  e.g. httpsh://www.sample.com/ : use only >128-bit ciphers

--- a/docs/manpages/man5/hosts.cfg.5.html
+++ b/docs/manpages/man5/hosts.cfg.5.html
@@ -1142,6 +1142,9 @@ one or more &quot;dialect names&quot; to the URL scheme, i.e. the
 * &quot;c&quot;,  e.g. <A HREF="httpsc://www.sample.com/">httpsc://www.sample.com/</A> : use only TLSv1.2
 <BR>
 
+* &quot;d&quot;,  e.g. <A HREF="httpsd://www.sample.com/">httpsc://www.sample.com/</A> : use only TLSv1.3
+<BR>
+
 * &quot;m&quot;,  e.g. <A HREF="httpsm://www.sample.com/">httpsm://www.sample.com/</A> : use only 128-bit ciphers
 <BR>
 

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -484,6 +484,12 @@ static void setup_ssl(tcptest_t *item)
 #endif
 
 		switch (item->ssloptions->sslversion) {
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+		  case SSLVERSION_TLS13:
+			SSL_CTX_set_min_proto_version(item->sslctx, TLS1_3_VERSION);
+			SSL_CTX_set_max_proto_version(item->sslctx, TLS1_3_VERSION);
+			break;
+#endif
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 		  case SSLVERSION_TLS12:
 			SSL_CTX_set_min_proto_version(item->sslctx, TLS1_2_VERSION);

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -63,6 +63,7 @@ extern int snienabled;
 #define SSLVERSION_TLS10   3
 #define SSLVERSION_TLS11   4
 #define SSLVERSION_TLS12   5
+#define SSLVERSION_TLS13   6
 
 typedef struct {
 	char *cipherlist;

--- a/xymonnet/httptest.c
+++ b/xymonnet/httptest.c
@@ -492,6 +492,7 @@ void add_http_test(testitem_t *t)
 		else if (strstr(httptest->weburl.desturl->schemeopts, "a"))      sslopt_version = SSLVERSION_TLS10;
 		else if (strstr(httptest->weburl.desturl->schemeopts, "b"))      sslopt_version = SSLVERSION_TLS11;
 		else if (strstr(httptest->weburl.desturl->schemeopts, "c"))      sslopt_version = SSLVERSION_TLS12;
+		else if (strstr(httptest->weburl.desturl->schemeopts, "d"))      sslopt_version = SSLVERSION_TLS13;
 
 		if      (strstr(httptest->weburl.desturl->schemeopts, "h"))      sslopt_ciphers = ciphershigh;
 		else if (strstr(httptest->weburl.desturl->schemeopts, "m"))      sslopt_ciphers = ciphersmedium;


### PR DESCRIPTION
Fixes #17 

This is pretty straightforward but I would like more eyes on it.

e.g., `httpsd://www.sample.com/` should now work -- the "d" after https will tell it to use the protocol "d" which is TLSv1.3

- [ ] do we have the docs updated everywhere
- [ ] is the changelog message clear enough?
- [ ] do we have any formatting or style guidelines we need to be enforcing for commits