### PR TITLE
Add ALPN support for xymonnet tests

### DIFF
--- a/docs/manpages/man5/protocols.cfg.5.html
+++ b/docs/manpages/man5/protocols.cfg.5.html
@@ -56,6 +56,21 @@ to the service. It will then expect a response beginning with &quot;220&quot;.
 Any data returned by the service (a so-called &quot;banner&quot;) will be recorded 
 and included in the status message.
 <P>
+For services that require ALPN protocol negotiation (such as IMAPS multiplexed 
+by Nginx on the same port as HTTPS), you can define:
+<BR>
+
+<P>
+<BR>&nbsp;&nbsp;&nbsp;[imaps443]
+<BR>
+
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;options&nbsp;ssl,alpn=imap
+<BR>
+
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port&nbsp;443
+<BR>
+
+<P>
 The full set of commands available for the protocols.cfg file are:
 <P>
 <DL COMPACT>
@@ -100,6 +115,9 @@ Defines test options. The possible options are
 <BR>
 
 <BR>&nbsp;&nbsp;&nbsp;telnet&nbsp;-&nbsp;service&nbsp;is&nbsp;telnet,&nbsp;so&nbsp;exchange&nbsp;telnet&nbsp;options
+<BR>
+
+<BR>&nbsp;&nbsp;&nbsp;alpn=protocol1,protocol2&nbsp;-&nbsp;specify&nbsp;ALPN&nbsp;protocols&nbsp;to&nbsp;negotiate&nbsp;during&nbsp;SSL&nbsp;handshake
 <P>
 <P>
 </DL>

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -151,6 +151,7 @@ char *init_tcp_services(void)
 				if (svcinfo[i].svcname) xfree(svcinfo[i].svcname);
 				if (svcinfo[i].sendtxt) xfree(svcinfo[i].sendtxt);
 				if (svcinfo[i].exptext) xfree(svcinfo[i].exptext);
+				if (svcinfo[i].alpns) xfree(svcinfo[i].alpns);
 			}
 			xfree(svcinfo);
 			svcinfo = default_svcinfo;
@@ -243,6 +244,9 @@ char *init_tcp_services(void)
 					if      (strcmp(opt, "ssl") == 0)    first->rec->flags |= TCP_SSL;
 					else if (strcmp(opt, "banner") == 0) first->rec->flags |= TCP_GET_BANNER;
 					else if (strcmp(opt, "telnet") == 0) first->rec->flags |= TCP_TELNET;
+					else if (strncmp(opt, "alpn=", 5) == 0) {
+						first->rec->alpns = strdup(opt+5);
+					}
 					else errprintf("Unknown option: %s\n", opt);
 
 					opt = strtok(NULL, ",");
@@ -276,6 +280,7 @@ char *init_tcp_services(void)
 		svcinfo[i].expofs  = walk->rec->expofs;
 		svcinfo[i].flags   = walk->rec->flags;
 		svcinfo[i].port    = walk->rec->port;
+		svcinfo[i].alpns   = walk->rec->alpns;
 	}
 	memset(&svcinfo[svccount], 0, sizeof(svcinfo_t));
 

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -18,6 +18,7 @@
 #define TCP_TELNET     0x0002
 #define TCP_SSL        0x0004
 #define TCP_HTTP       0x0008
+#define TCP_ALPN       0x0010
 
 typedef struct svcinfo_t {
 	char *svcname;
@@ -27,6 +28,7 @@ typedef struct svcinfo_t {
 	int  expofs, explen;
 	unsigned int flags;
 	int port;
+	char *alpns;
 } svcinfo_t;
 
 extern char *init_tcp_services(void);

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -68,6 +68,7 @@ typedef struct {
 	char *cipherlist;
 	int  sslversion;
 	char *clientcert;
+	char *alpns;		/* ALPN protocols (comma-separated) */
 } ssloptions_t;
 
 typedef int (*f_callback_data)(unsigned char *buffer, unsigned int size, void *privdata);

--- a/xymonnet/protocols.cfg.5
+++ b/xymonnet/protocols.cfg.5
@@ -35,6 +35,17 @@ to the service. It will then expect a response beginning with "220".
 Any data returned by the service (a so-called "banner") will be recorded 
 and included in the status message.
 .sp
+For services that require ALPN protocol negotiation (such as IMAPS multiplexed 
+by Nginx on the same port as HTTPS), you can define:
+.br
+.sp
+   [imaps443]
+.br
+      options ssl,alpn=imap
+.br
+      port 443
+.br
+.sp
 The full set of commands available for the protocols.cfg file are:
 
 .IP "[NAME]"
@@ -73,6 +84,8 @@ Defines test options. The possible options are
    ssl - service uses SSL so perform an SSL handshake
 .br
    telnet - service is telnet, so exchange telnet options
+.br
+   alpn=protocol1,protocol2 - specify ALPN protocols to negotiate during SSL handshake
 
 
 .SH FILES


### PR DESCRIPTION
This makes it possible to add a custom protocol like this:

[imaps443]
    options ssl,alpn=imap
    port 443

And now it will be able to monitor IMAP being reverse proxied on port 443 multiplexed with other protocols.