### PR TITLE
Fix vmstat rrd graphing for FreeBSD

### DIFF
--- a/xymond/rrd/do_vmstat.c
+++ b/xymond/rrd/do_vmstat.c
@@ -116,31 +116,6 @@ static vmstat_layout_t vmstat_irix_layout[] = {
 	{ -1, NULL }
 };
 
-/* This one matches FreeBSD 4.10 */
-/* LARRD 0.43c compatible */
-static vmstat_layout_t vmstat_freebsd4_layout[] = {
-	{ 0, "cpu_r" },
-	{ 1, "cpu_b" },
-	{ 2, "cpu_w" },
-	{ 3, "mem_avm" },
-	{ 4, "mem_free" },
-	{ 5, "mem_flt" },
-	{ 6, "mem_re" },
-	{ 7, "mem_pi" },
-	{ 8, "mem_po" },
-	{ 9, "mem_fr" },
-	{ 10, "sr" },
-	{ 11, "dsk_da0" },
-	{ 12, "dsk_fd0" },
-	{ 13, "cpu_int" },
-	{ 15, "cpu_csw" },
-	{ 16, "cpu_sys" },
-	{ 17, "cpu_usr" },
-	{ 18, "cpu_idl" },
-	{ -1, NULL }
-};
-
-/* FreeBSD v6 and later, possibly v5 also */
 static vmstat_layout_t vmstat_freebsd_layout[] = {
 	{ 0, "cpu_r" },
 	{ 1, "cpu_b" },
@@ -418,25 +393,7 @@ int do_vmstat_rrd(char *hostname, char *testname, char *classname, char *pagepat
 	  case OS_HPUX: 
 		layout = vmstat_hpux_layout; break;
 	  case OS_FREEBSD:
-		/* 
-		 * Special, because there are two layouts for FreeBSD
-		 * FreeBSD v4.x has 19 fields, later versions of FreeBSD
-		 * are the same as OpenBSD, with 18 fields.
-		 */
-		{
-			char **dsnames = NULL;
-			int dscount, i;
-
-			dscount = rrddatasets(hostname, &dsnames);
-			layout = ((dscount == 19) ? vmstat_freebsd4_layout : vmstat_freebsd_layout);
-
-			if ((dscount > 0) && dsnames) {
-				/* Free the dsnames list */
-				for (i=0; (i<dscount); i++) xfree(dsnames[i]);
-				xfree(dsnames);
-			}
-		}
-		break;
+		layout = vmstat_freebsd_layout; break;
 	  case OS_NETBSD:
 		layout = vmstat_netbsd_layout; break;
 	  case OS_OPENBSD:


### PR DESCRIPTION
The parsing of vmstat code was broken. The original code attempted to detect FreeBSD 4.10's vmstat output vs FreeBSD 6, but probably never worked correctly anyway.

FreeBSD 4.12's vmstat output (verified in a VM):

```
 procs memory page disks faults cpu
 r b w avm fre flt re pi po fr sr ad0 md0 in sy cs us sy id
 0 0 0 10908 991180 68 1 1 0 55 0 0 0 241 201 12 0 1 99
```

FreeBSD 14.3 vmstat output:

```
 procs    memory    page                      disks       faults       cpu
 r  b  w  avm  fre  flt  re  pi  po   fr   sr nda0 nda1   in   sy   cs us sy id
 1  2  0 7627545837568 4208828416 21155  13  15   1 14995 3542    0    0 1964 61975 39820  3  2 93
```

The code had this comment explaining the parsing which was wrong:

```
/*
 * Special, because there are two layouts for FreeBSD
 * FreeBSD v4.x has 19 fields, later versions of FreeBSD
 * are the same as OpenBSD, with 18 fields. 
 */
```

Both have 19 fields which are in the same order, so the vmstat data was always being parsed into the struct for FreeBSD 4.11 which notably skipped index 14 (sy) "cpu_syc" so it never had data for this and mapped index 16 (us) to "cpu_sys" and index 17 (sy) to "cpu_usr" which are obviously swapped.

With this patch I deleted the vmstat rrd files for FreeBSD hosts and the data started to populate and graph correctly.