### PR TITLE
FreeBSD XymonClient: Filter out autofs for df and inode

### DIFF
--- a/client/xymonclient-freebsd.sh
+++ b/client/xymonclient-freebsd.sh
@@ -28,7 +28,7 @@ s/[ 	]*\n[ 	]*/ /
 }'
 echo "[inode]"
 # The sed stuff is to make sure lines are not split into two.
-df -i -tnonfs,nullfs,cd9660,procfs,devfs,linprocfs,fdescfs,autofs | sed -e '/^[^ 	][^ 	]*$/{
+df -i -tnonfs,nullfs,cd9660,procfs,devfs,linprocfs,fdescfs,autofs,zfs | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
 }' | awk '

--- a/client/xymonclient-freebsd.sh
+++ b/client/xymonclient-freebsd.sh
@@ -22,13 +22,13 @@ echo "[who]"
 who
 echo "[df]"
 # The sed stuff is to make sure lines are not split into two.
-df -H -tnonfs,nullfs,cd9660,procfs,devfs,linprocfs,fdescfs | sed -e '/^[^ 	][^ 	]*$/{
+df -H -tnonfs,nullfs,cd9660,procfs,devfs,linprocfs,fdescfs,autofs | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
 }'
 echo "[inode]"
 # The sed stuff is to make sure lines are not split into two.
-df -i -tnonfs,nullfs,cd9660,procfs,devfs,linprocfs,fdescfs | sed -e '/^[^ 	][^ 	]*$/{
+df -i -tnonfs,nullfs,cd9660,procfs,devfs,linprocfs,fdescfs,autofs | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
 }' | awk '


### PR DESCRIPTION
autofs shows up in df output, but it's not a real filesystem and also cannot be parsed the same way as it includes an extra column in the output.

Example of df output (trimmed for clarity):

Filesystem                    Size    Used   Avail Capacity  Mounted on
zflash/ROOT/default           156G    9.5G    146G     6%    /
map auto_plex                   0B      0B      0B   100%