### PR TITLE
xymonclient-linux.sh: Send (reformatted) dpkg -l output with client message

### DIFF
--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -78,6 +78,8 @@ echo "[ifstat]"
 if test -r /proc/mdstat; then echo "[mdstat]"; cat /proc/mdstat; fi
 echo "[ps]"
 ps -Aww f -o pid,ppid,user,start,state,pri,pcpu,time:12,pmem,rsz:10,vsz:10,cmd
+echo "[dpkg]"
+COLUMNS=200 dpkg -l | awk '/^..  / { print $1 " " $2 " " $3 }'
 
 # $TOP must be set, the install utility should do that for us if it exists.
 if test "$TOP" != ""

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -78,8 +78,10 @@ echo "[ifstat]"
 if test -r /proc/mdstat; then echo "[mdstat]"; cat /proc/mdstat; fi
 echo "[ps]"
 ps -Aww f -o pid,ppid,user,start,state,pri,pcpu,time:12,pmem,rsz:10,vsz:10,cmd
-echo "[dpkg]"
-COLUMNS=200 dpkg -l | awk '/^..  / { print $1 " " $2 " " $3 }'
+if command -v dpkg >/dev/null 2>&1; then
+	echo "[dpkg]"
+	COLUMNS=200 dpkg -l | awk '/^..  / { print $1 " " $2 " " $3 }'
+fi
 
 # $TOP must be set, the install utility should do that for us if it exists.
 if test "$TOP" != ""


### PR DESCRIPTION
From Debian patch: https://salsa.debian.org/debian/xymon/-/blob/master/debian/patches/09_hobbitclient-debian.patch

Description: Send (reformatted) dpkg -l output with client message
Author: Christoph Berg <myon@debian.org>

With an additional wrapper, that only runs this when dpkg is existing on the system (since xymonclient-linux.sh runs on all Linux systems, not only Debian based).