### PR TITLE
Ignore duplicate submissions for the "/" partition

### DIFF
--- a/xymond/rrd/do_disk.c
+++ b/xymond/rrd/do_disk.c
@@ -20,6 +20,7 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 	static int ptnsetup = 0;
 	static pcre *inclpattern = NULL;
 	static pcre *exclpattern = NULL;
+	int seen_root_fs = 0;
 
 	if (strstr(msg, "netapp.pl")) return do_netapp_disk_rrd(hostname, testname, classname, pagepaths, msg, tstamp);
 	if (strstr(msg, "dbcheck.pl")) return do_dbcheck_tablespace_rrd(hostname, testname, classname, pagepaths, msg, tstamp);
@@ -163,6 +164,19 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 
 		/* Check include/exclude patterns */
 		wanteddisk = 1;
+		/*
+		 * On some systems, including the Debian Wheezy default setup,
+		 * df shows two entries for / (one for "rootfs", one for the
+		 * real device). Skip the second one or else the rrd files
+		 * produced contain ugly gaps. (A complete fix would do this
+		 * for all filesystems, but this case should be rare.)
+		 */
+		if (!strcmp(diskname, "/")) {
+			if (seen_root_fs)
+				wanteddisk = 0;
+			else
+				seen_root_fs = 1;
+		}
 		if (exclpattern) {
 			int ovector[30];
 			int result;

--- a/xymond/rrd/do_disk.c
+++ b/xymond/rrd/do_disk.c
@@ -21,6 +21,7 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 	static pcre2_code *inclpattern = NULL;
 	static pcre2_code *exclpattern = NULL;
 	pcre2_match_data *ovector;
+	int seen_root_fs = 0;
 
 	if (strstr(msg, "netapp.pl")) return do_netapp_disk_rrd(hostname, testname, classname, pagepaths, msg, tstamp);
 	if (strstr(msg, "dbcheck.pl")) return do_dbcheck_tablespace_rrd(hostname, testname, classname, pagepaths, msg, tstamp);
@@ -172,6 +173,19 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 
 		/* Check include/exclude patterns */
 		wanteddisk = 1;
+		/*
+		 * On some systems, including the Debian Wheezy default setup,
+		 * df shows two entries for / (one for "rootfs", one for the
+		 * real device). Skip the second one or else the rrd files
+		 * produced contain ugly gaps. (A complete fix would do this
+		 * for all filesystems, but this case should be rare.)
+		 */
+		if (!strcmp(diskname, "/")) {
+			if (seen_root_fs)
+				wanteddisk = 0;
+			else
+				seen_root_fs = 1;
+		}
 		if (exclpattern) {
 			int result;
 


### PR DESCRIPTION
https://salsa.debian.org/debian/xymon/-/blob/master/debian/patches/69_disk-no-duplicate-root.patch

Author: Christoph Berg <myon@debian.org>
Forwarded: https://lists.xymon.com/archive/2015-September/042223.html
Last-Update: 2015-09-10
Reviewed-By: Axel Beckert <abe@debian.org>

On some systems, including the Debian Wheezy default setup, df shows two entries for / (one for "rootfs", one for the real device). Skip the second one or else the rrd files produced contain ugly gaps. (A complete fix would do this for all filesystems, but this case should be rare.)