### PR TITLE
Make the date header of html man pages reproducible

### DIFF
--- a/build/makehtml.sh
+++ b/build/makehtml.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export LANG=C
-DATE=`date +"%e %b %Y"`
+DATE=`date +"%e %b %Y" --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}"`
 VERSION="$1"
 if [ "$VERSION" = "" ]
 then
@@ -23,7 +23,7 @@ do
 				NAME=`head -n 1 $FILE | awk '{print $2}'`;
 				SECTION=`head -n 1 $FILE | awk '{print $3}'`;
 				(echo ".TH $NAME $SECTION \"Version $VERSION: $DATE\" \"Xymon\""; tail -n +2 $FILE) | \
-				man2html -r - | tail -n +2 >docs/manpages/man$SECT/`basename $FILE`.html
+				man2html -H localhost -r - | tail -n +2 >docs/manpages/man$SECT/`basename $FILE`.html
 			fi
 		done
 	done


### PR DESCRIPTION
While re-generating the HTML man pages I noticed the following issues:

a) Generating the man pages places the current day in the header, so
   the files cannot be generated reproducible (see
   https://en.wikipedia.org/wiki/Reproducible_builds).  Using
   SOURCE_DATE_EPOCH (if it is set) solves this problem.

b) Without "-H localhost" as parameter of man2html the generated HTML
   files differ from what is packaged in the tarball.  So I added this
   option.

https://lists.xymon.com/archive/2024-February/048293.html https://salsa.debian.org/debian/xymon/-/blob/master/debian/patches/97_makehtml.patch