### PR TITLE
Fix compatibility errors with rrdtool 1.9.0

### DIFF
--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -75,13 +75,19 @@
 	RRDOK="YES"
 	if test "$RRDINC" != ""; then INCOPT="-I$RRDINC"; fi
 	if test "$RRDLIB" != ""; then LIBOPT="-L$RRDLIB"; fi
+	if pkg-config --atleast-version=1.9.0 librrd > /dev/null 2>&1; then
+		echo "Found RRDtool >= 1.9.0 via pkg-config"
+		RRDDEF="-DRRDTOOL19"
+	else
+		echo "Found RRDtool < 1.9.0 via pkg-config"
+	fi
 	cd build
 	OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
 	OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile 2>/dev/null
 	if test $? -ne 0; then
 		# See if it's the new RRDtool 1.2.x
 		echo "Not RRDtool 1.0.x, checking for 1.2.x"
-		RRDDEF="-DRRDTOOL12"
+		RRDDEF="$RRDDEF -DRRDTOOL12"
 		OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
 		OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile
 	fi

--- a/build/test-rrd.c
+++ b/build/test-rrd.c
@@ -4,7 +4,11 @@
 
 int main(int argc, char *argv[])
 {
+#ifdef RRDTOOL19
+	const char *rrdargs[] = {
+#else
 	char *rrdargs[] = {
+#endif
 		"rrdgraph",
 		"xymongen.png",
 		"-s", "e - 48d",

--- a/web/perfdata.c
+++ b/web/perfdata.c
@@ -111,8 +111,13 @@ int oneset(char *hostname, char *rrdname, char *starttime, char *endtime, char *
 	rrdargs[9] = NULL;
 
 	optind = opterr = 0; rrd_clear_error();
+#ifdef RRDTOOL19
+	result = rrd_fetch(9, (const char **)rrdargs,
+			   &start, &end, &step, &dscount, &dsnames, &data);
+#else
 	result = rrd_fetch(9, rrdargs,
 			   &start, &end, &step, &dscount, &dsnames, &data);
+#endif
 
 	if (result != 0) {
 		errprintf("RRD error: %s\n", rrd_get_error());

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -1215,7 +1215,11 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	rrd_clear_error();
 
 #ifdef RRDTOOL12
+    #ifdef RRDTOOL19
+	result = rrd_graph(rrdargcount, (const char **)rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
+    #else
 	result = rrd_graph(rrdargcount, rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
+    #endif
 
 	/*
 	 * If we have neither the upper- nor lower-limits of the graph, AND we allow vertical 

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -216,7 +216,11 @@ static void setupinterval(int intvl)
 static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 {
 	/* Flush any updates we've cached */
+#ifdef RRDTOOL19
+	const char *updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
+#else
 	char *updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
+#endif
 	int i, pcount, result;
 
 	dbgprintf("Flushing '%s' with %d updates pending, template '%s'\n", 
@@ -378,7 +382,11 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		 * we MUST reset this before every call.
 		 */
 		optind = opterr = 0; rrd_clear_error();
+#ifdef RRDTOOL19
+		result = rrd_create(4+pcount, (const char **)rrdcreate_params);
+#else
 		result = rrd_create(4+pcount, rrdcreate_params);
+#endif
 		xfree(rrdcreate_params);
 		if (rrakey) xfree(rrakey);
 
@@ -590,7 +598,11 @@ static int rrddatasets(char *hostname, char ***dsnames)
 	struct stat st;
 
 	int result;
+#ifdef RRDTOOL19
+	const char *fetch_params[] = { "rrdfetch", filedir, "AVERAGE", "-s", "-30m", NULL };
+#else
 	char *fetch_params[] = { "rrdfetch", filedir, "AVERAGE", "-s", "-30m", NULL };
+#endif
 	time_t starttime, endtime;
 	unsigned long steptime, dscount;
 	rrd_value_t *rrddata;


### PR DESCRIPTION
Including a switch to work with older rrdtool versions. 
This is based on pkg-config detection of librrd version.

This fixes https://github.com/xymon-monitoring/xymon/issues/54