### PR TITLE
lib: include stdlib for abort

### DIFF
--- a/lib/suid.c
+++ b/lib/suid.c
@@ -15,6 +15,7 @@ static char rcsid[] = "$Id$";
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #include "libxymon.h"
@@ -71,4 +72,3 @@ void drop_root_and_removesuid(char *fn)
 
 	drop_root();
 }
-


### PR DESCRIPTION
**Description:**

Fixes #58

This pull request fixes a CI build failure observed with clang and CMake-based builds.

`abort()` is used in `lib/suid.c` without including the required standard C header.
With modern C standards (C99 and later) and stricter compilers such as clang, implicit function declarations are not allowed, which causes the build to fail.

**Change:**

* Add the missing standard header:

  ```c
  #include <stdlib.h>
  ```

  in `lib/suid.c`.

**Context:**

* Triggered by CI builds using clang (CMake / packaging preset)
* Improves portability and standards compliance

**Impact:**

* Fixes clang CI failure
* No functional change at runtime
