### PR TITLE
Fix a large number of GCC build warnings and issues (Tom Schmidt, with Ralph Mitchell)

### DIFF
--- a/client/logfetch.c
+++ b/client/logfetch.c
@@ -326,8 +326,16 @@ char *logdata(char *filename, logdef_t *logdef)
 
 			dbgprintf(" - Last position was %u, found curpos location at %u in current buffer.\n", logdef->lastpos[1], bytesin);
 			t = strdup(fillpos);	/* need shuffle about to insert before this line */
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+			#pragma GCC diagnostic push
+			#pragma GCC diagnostic ignored "-Wstringop-truncation"
+			#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif  // __GNUC__
 			strncpy(fillpos, curpostxt, strlen(curpostxt));		/* add in the CURRENT + \n */
 			strncpy(fillpos+strlen(curpostxt), t, strlen(t));	/* add in whatever this line originally was */
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+			#pragma GCC diagnostic pop
+#endif  // __GNUC__
 			*(fillpos+strlen(curpostxt)+strlen(t)) = '\0';		/* and terminate it */
 			xfree(t);						/* free temp */
 			curpos = fillpos;					/* leave curpos to the beginning of the CURRENT flag */
@@ -496,11 +504,19 @@ char *logdata(char *filename, logdef_t *logdef)
 		       for (i = 0, pos = replacement; i < triggerptrs_count; i++) {
 		               dbgprintf("Copying buffer content for trigger %i.\n", (i + 1));
 
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+				#pragma GCC diagnostic push
+				#pragma GCC diagnostic ignored "-Wstringop-truncation"
+				#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif  // __GNUC__
 		               strncpy(pos, skiptxt, strlen(skiptxt));
 		               pos += strlen(skiptxt);
 
 		               size = strlen(triggerptrs[i][0]) - strlen(triggerptrs[i][1]);
 		               strncpy(pos, triggerptrs[i][0], size);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+				#pragma GCC diagnostic pop
+#endif  // __GNUC__
 		               pos += size;
 		       }
 
@@ -533,7 +549,15 @@ char *logdata(char *filename, logdef_t *logdef)
 
 				if (finalstartptr > lasttriggerptr) {
 					/* Add the final skip for completeness */
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+					#pragma GCC diagnostic push
+					#pragma GCC diagnostic ignored "-Wstringop-truncation"
+					#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif  // __GNUC__
 					strncpy(pos, skiptxt, strlen(skiptxt));
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+					#pragma GCC diagnostic pop
+#endif  // __GNUC__
 					pos += strlen(skiptxt);
 				}
 

--- a/common/xymonlaunch.c
+++ b/common/xymonlaunch.c
@@ -187,7 +187,14 @@ void load_config(char *conffn)
 					char *newcmd = xcalloc(1, l1+l2+1);
 
 					strncpy(newcmd,curtask->cmd,l1);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+					#pragma GCC diagnostic push
+					#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif  // __GNUC__
 					strncpy(newcmd+l1,p,l2);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+					#pragma GCC diagnostic pop
+#endif  // __GNUC__
 					newcmd[l1]=' '; /* this also overwrites the + */
 
 					/* free and assign new */

--- a/lib/acknowledgementslog.c
+++ b/lib/acknowledgementslog.c
@@ -222,12 +222,14 @@ void do_acknowledgementslog(FILE *output,
 		    p = strrchr(host, '.');
 		    if (p) {
                         *p = '\0';
-			strncpy(svc,p+1,  sizeof(svc));
+			strncpy(svc, p+1, sizeof(svc));
+			svc[sizeof(svc)-1] = '\0'; /* Make sure it is null terminated */
                     }
 		    /* Xymon uses \n in the ack message, for the "acked by" data. Cut it off. */
 		    p = strstr(message, "\\nAcked by:");
 		    if (p) {
-			strncpy(recipient,p+12, sizeof(recipient));
+			strncpy(recipient, p+12, sizeof(recipient));
+			recipient[sizeof(recipient)-1] = '\0'; /* Make sure it is null terminated */
                         *(p-1) = '\0';
 		    }
 		    else {

--- a/lib/acknowledgementslog.c
+++ b/lib/acknowledgementslog.c
@@ -224,12 +224,14 @@ void do_acknowledgementslog(FILE *output,
 		    p = strrchr(host, '.');
 		    if (p) {
                         *p = '\0';
-			strncpy(svc,p+1,  sizeof(svc));
+			strncpy(svc, p+1, sizeof(svc));
+			svc[sizeof(svc)-1] = '\0'; /* Make sure it is null terminated */
                     }
 		    /* Xymon uses \n in the ack message, for the "acked by" data. Cut it off. */
 		    p = strstr(message, "\\nAcked by:");
 		    if (p) {
-			strncpy(recipient,p+12, sizeof(recipient));
+			strncpy(recipient, p+12, sizeof(recipient));
+			recipient[sizeof(recipient)-1] = '\0'; /* Make sure it is null terminated */
                         *(p-1) = '\0';
 		    }
 		    else {

--- a/lib/links.c
+++ b/lib/links.c
@@ -144,9 +144,13 @@ void load_all_links(void)
 		load_links(dirname, notesskin);
 	}
 
-	/* Change xxx/xxx/xxx/notes into xxx/xxx/xxx/help */
-	strncpy(dirname, xgetenv("XYMONNOTESDIR"), sizeof(dirname));
-	p = strrchr(dirname, '/'); *p = '\0'; strncat(dirname, "/help", (sizeof(dirname) - strlen(dirname)));
+	/* If no XYMONHELPDIR, change xxx/xxx/xxx/notes into xxx/xxx/xxx/help */
+	if (xgetenv("XYMONHELPDIR")) strcpy(dirname, xgetenv("XYMONHELPDIR"));
+	else {
+		strncpy(dirname, xgetenv("XYMONNOTESDIR"), sizeof(dirname));
+		dirname[sizeof(dirname)-1] = '\0'; /* Make sure it is null terminated */
+		p = strrchr(dirname, '/'); *p = '\0'; strncat(dirname, "/help", (sizeof(dirname) - strlen(dirname)));
+	}
 	load_links(dirname, helpskin);
 
 	linksloaded = 1;

--- a/lib/loadalerts.c
+++ b/lib/loadalerts.c
@@ -202,9 +202,12 @@ int load_alertconfig(char *configfn, int defcolors, int defaultinterval)
 	rule_t *currule = NULL;
 	recip_t *currcp = NULL, *rcptail = NULL;
 
-	MEMDEFINE(fn);
-
-	if (configfn) strncpy(fn, configfn, sizeof(fn)); else snprintf(fn, sizeof(fn), "%s/etc/alerts.cfg", xgetenv("XYMONHOME"));
+	if (configfn) {
+		strncpy(fn, configfn, sizeof(fn));
+		fn[sizeof(fn)-1] = '\0'; /* Make sure it is null terminated */
+	}
+	else
+		snprintf(fn, sizeof(fn), "%s/etc/alerts.cfg", xgetenv("XYMONHOME"));
 
 	/* First check if there were no modifications at all */
 	if (configfiles) {
@@ -865,7 +868,15 @@ static int criteriamatch(activealerts_t *alert, criteria_t *crit, criteria_t *ru
 
 		if ((alert->groups && (*(alert->groups)))) {
 			SBUF_MALLOC(grouplist, strlen(alert->groups));
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+			#pragma GCC diagnostic push
+			#pragma GCC diagnostic ignored "-Wstringop-truncation"
+			#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif  // __GNUC__
 			strncpy(grouplist, alert->groups, grouplist_buflen);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+			#pragma GCC diagnostic pop
+#endif  // __GNUC__
 		}
 
 		if (crit->groupspec) {
@@ -1217,11 +1228,18 @@ void print_alert_recipients(activealerts_t *alert, strbuffer_t *buf)
 		if (recip->method == M_IGNORE) {
 			recip->recipient = "-- ignored --";
 		}
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif  // __GNUC__
 		if (recip->noalerts) { if (*codes) strncat(codes, ",A", codes_bytesleft); else strncat(codes, "-A", codes_bytesleft); codes_bytesleft -= 2; }
 		if (recovered && !recip->noalerts) { if (*codes) strncat(codes, ",R", codes_bytesleft); else strncat(codes, "R", codes_bytesleft); codes_bytesleft -= 2; }
 		if (notice) { if (*codes) strncat(codes, ",N", codes_bytesleft); else strncat(codes, "N", codes_bytesleft); codes_bytesleft -= 2; }
 		if (recip->stoprule) { if (*codes) strncat(codes, ",S", codes_bytesleft); else strncat(codes, "S", codes_bytesleft); codes_bytesleft -= 2; }
 		if (recip->unmatchedonly) { if (*codes) strncat(codes, ",U", codes_bytesleft); else strncat(codes, "U", codes_bytesleft); codes_bytesleft -= 2; }
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		#pragma GCC diagnostic pop
+#endif  // __GNUC__
 
 		if (strlen(codes) == 0)
 			snprintf(l, sizeof(l), "<td><font %s>%s</font></td>", fontspec, recip->recipient);

--- a/lib/loadalerts.c
+++ b/lib/loadalerts.c
@@ -203,9 +203,12 @@ int load_alertconfig(char *configfn, int defcolors, int defaultinterval)
 	rule_t *currule = NULL;
 	recip_t *currcp = NULL, *rcptail = NULL;
 
-	MEMDEFINE(fn);
-
-	if (configfn) strncpy(fn, configfn, sizeof(fn)); else snprintf(fn, sizeof(fn), "%s/etc/alerts.cfg", xgetenv("XYMONHOME"));
+	if (configfn) {
+		strncpy(fn, configfn, sizeof(fn));
+		fn[sizeof(fn)-1] = '\0'; /* Make sure it is null terminated */
+	}
+	else
+		snprintf(fn, sizeof(fn), "%s/etc/alerts.cfg", xgetenv("XYMONHOME"));
 
 	/* First check if there were no modifications at all */
 	if (configfiles) {
@@ -866,7 +869,15 @@ static int criteriamatch(activealerts_t *alert, criteria_t *crit, criteria_t *ru
 
 		if ((alert->groups && (*(alert->groups)))) {
 			SBUF_MALLOC(grouplist, strlen(alert->groups));
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+			#pragma GCC diagnostic push
+			#pragma GCC diagnostic ignored "-Wstringop-truncation"
+			#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif  // __GNUC__
 			strncpy(grouplist, alert->groups, grouplist_buflen);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+			#pragma GCC diagnostic pop
+#endif  // __GNUC__
 		}
 
 		if (crit->groupspec) {
@@ -1218,11 +1229,18 @@ void print_alert_recipients(activealerts_t *alert, strbuffer_t *buf)
 		if (recip->method == M_IGNORE) {
 			recip->recipient = "-- ignored --";
 		}
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif  // __GNUC__
 		if (recip->noalerts) { if (*codes) strncat(codes, ",A", codes_bytesleft); else strncat(codes, "-A", codes_bytesleft); codes_bytesleft -= 2; }
 		if (recovered && !recip->noalerts) { if (*codes) strncat(codes, ",R", codes_bytesleft); else strncat(codes, "R", codes_bytesleft); codes_bytesleft -= 2; }
 		if (notice) { if (*codes) strncat(codes, ",N", codes_bytesleft); else strncat(codes, "N", codes_bytesleft); codes_bytesleft -= 2; }
 		if (recip->stoprule) { if (*codes) strncat(codes, ",S", codes_bytesleft); else strncat(codes, "S", codes_bytesleft); codes_bytesleft -= 2; }
 		if (recip->unmatchedonly) { if (*codes) strncat(codes, ",U", codes_bytesleft); else strncat(codes, "U", codes_bytesleft); codes_bytesleft -= 2; }
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		#pragma GCC diagnostic pop
+#endif  // __GNUC__
 
 		if (strlen(codes) == 0)
 			snprintf(l, sizeof(l), "<td><font %s>%s</font></td>", fontspec, recip->recipient);

--- a/lib/loadhosts_file.c
+++ b/lib/loadhosts_file.c
@@ -111,6 +111,7 @@ static int prepare_fromnet(void)
 	if (contentbuffer) freestrbuffer(contentbuffer);
 	contentbuffer = convertstrbuffer(fdata, 0);
 	strncpy(contentmd5, fhash, sizeof(contentmd5));
+	contentmd5[sizeof(contentmd5)-1] = '\0'; /* Make sure it is null terminated */
 
 	return 0;
 }

--- a/lib/locator.c
+++ b/lib/locator.c
@@ -207,6 +207,7 @@ char *locator_cmd(char *cmd)
 	int res;
 
 	strncpy(pingbuf, cmd, sizeof(pingbuf));
+	pingbuf[sizeof(pingbuf)-1] = '\0'; /* Make sure it is null terminated */
 	res = call_locator(pingbuf, sizeof(pingbuf));
 
 	return (res == 0) ? pingbuf : NULL;

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -162,6 +162,10 @@ char *commafy(char *hostname)
 	STATIC_SBUF_DEFINE(s);
 	char *p;
 
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif  // __GNUC__
 	if (s == NULL) {
 		SBUF_MALLOC(s, strlen(hostname)+1);
 		strncpy(s, hostname, s_buflen);
@@ -174,6 +178,9 @@ char *commafy(char *hostname)
 	else {
 		strncpy(s, hostname, s_buflen);
 	}
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic pop
+#endif  // __GNUC__
 
 	for (p = strchr(s, '.'); (p); p = strchr(s, '.')) *p = ',';
 	return s;

--- a/lib/sig.c
+++ b/lib/sig.c
@@ -98,11 +98,14 @@ void setup_signalhandler(char *programname)
 	 * Used inside signal-handler. Must be setup in
 	 * advance.
 	 */
-	strncpy(signal_xymoncmd, xgetenv("XYMON"), sizeof(signal_xymoncmd));
-	strncpy(signal_xymondserver, xgetenv("XYMSRV"), sizeof(signal_xymondserver));
-	strncpy(signal_tmpdir, xgetenv("XYMONTMP"), sizeof(signal_tmpdir));
-	snprintf(signal_msg, sizeof(signal_msg), "status %s.%s red - Program crashed\n\nFatal signal caught!\n", 
-		(xgetenv("MACHINE") ? xgetenv("MACHINE") : "XYMSERVERS"), programname);
+	strncpy(signal_xymoncmd, (getenv("XYMON") ? getenv("XYMON") : "xymon"), sizeof(signal_xymoncmd));
+	signal_xymoncmd[sizeof(signal_xymoncmd)-1] = '\0'; /* Make sure it is null terminated */
+	strncpy(signal_xymondserver, (getenv("XYMSRV") ? getenv("XYMSRV") : "0.0.0.0"), sizeof(signal_xymondserver));
+	signal_xymondserver[sizeof(signal_xymondserver)-1] = '\0'; /* Make sure it is null terminated */
+	strncpy(signal_tmpdir, (getenv("XYMONTMP") ? getenv("XYMONTMP") : "/tmp"), sizeof(signal_tmpdir));
+	signal_tmpdir[sizeof(signal_tmpdir)-1] = '\0'; /* Make sure it is null terminated */
+	snprintf(signal_msg, sizeof(signal_msg), "status+1d/group:signal %s.xymond red %s program crashed\n\nFatal signal caught!\n",
+		(getenv("MACHINE") ? getenv("MACHINE") : (getenv("HOSTNAME") ? getenv("HOSTNAME") : "localhost") ), programname);
 
 	sigaction(SIGSEGV, &sa, NULL);
 	sigaction(SIGILL, &sa, NULL);

--- a/lib/stackio.c
+++ b/lib/stackio.c
@@ -205,10 +205,13 @@ FILE *stackfopen(char *filename, char *mode, void **v_listhead)
 		stackfd_mode = strdup(mode);
 
 		strncpy(stackfd_filename, filename, sizeof(stackfd_filename));
+		stackfd_filename[sizeof(stackfd_filename)-1] = '\0'; /* Make sure it is null terminated */
 	}
 	else {
-		if (*filename == '/')
+		if (*filename == '/') {
 			strncpy(stackfd_filename, filename, sizeof(stackfd_filename));
+			stackfd_filename[sizeof(stackfd_filename)-1] = '\0'; /* Make sure it is null terminated */
+		}
 		else
 			snprintf(stackfd_filename, sizeof(stackfd_filename), "%s/%s", stackfd_base, filename);
 	}
@@ -335,7 +338,12 @@ static void addtofnlist(char *dirname, int is_optional, void **v_listhead)
 	int fnsz = 0;
 	int i;
 
-	if (*dirname == '/') strncpy(dirfn, dirname, sizeof(dirfn)); else snprintf(dirfn, sizeof(dirfn), "%s/%s", stackfd_base, dirname);
+	if (*dirname == '/') {
+		strncpy(dirfn, dirname, sizeof(dirfn));
+		dirfn[sizeof(dirfn)-1] = '\0'; /* Make sure it is null terminated */
+	}
+	else
+		snprintf(dirfn, sizeof(dirfn), "%s/%s", stackfd_base, dirname);
 
 	if ((dirfd = opendir(dirfn)) == NULL) {
 		if (!is_optional) errprintf("WARNING: Cannot open directory %s\n", dirfn);

--- a/lib/xymonrrd.c
+++ b/lib/xymonrrd.c
@@ -82,7 +82,14 @@ static void rrd_setup(void)
 	/* Get the tcp services, and count how many there are */
 	services = strdup(init_tcp_services());
 	SBUF_MALLOC(tcptests, strlen(services)+1);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif  // __GNUC__
 	strncpy(tcptests, services, tcptests_buflen);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic pop
+#endif  // __GNUC__
 	count = 0; p = strtok(tcptests, " "); while (p) { count++; p = strtok(NULL, " "); }
 	strncpy(tcptests, services, tcptests_buflen);
 
@@ -242,6 +249,7 @@ static char *xymon_graph_text(char *hostname, char *dispname, char *service, int
 	}
 	else {
 		strncpy(rrdservicename, graphdef->xymonrrdname, sizeof(rrdservicename));
+		rrdservicename[sizeof(rrdservicename)-1] = '\0'; /* Make sure it is null terminated */
 	}
 
 	SBUF_MALLOC(svcurl, 

--- a/web/confreport.c
+++ b/web/confreport.c
@@ -124,6 +124,7 @@ static void print_disklist(char *hostname)
 	while ((de = readdir(d)) != NULL) {
 		if (strncmp(de->d_name, "disk,", 5) == 0) {
 			strncpy(fn, de->d_name + 4, sizeof(fn));
+			fn[sizeof(fn)-1] = '\0'; /* Make sure it is null terminated */
 			p = strstr(fn, ".rrd"); if (!p) continue;
 			*p = '\0';
 			p = fn; while ((p = strchr(p, ',')) != NULL) *p = '/';

--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -152,7 +152,14 @@ static int parse_query(void)
 
 		req = getenv("SCRIPT_NAME");
 		SBUF_MALLOC(clienturi, strlen(req) + 10 + strlen(hostquoted));
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif  // __GNUC__
 		strncpy(clienturi, req, clienturi_buflen);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		#pragma GCC diagnostic pop
+#endif  // __GNUC__
 		p = strchr(clienturi, '?'); if (p) *p = '\0'; else p = clienturi + strlen(clienturi);
 		snprintf(p, (clienturi_buflen - (clienturi - p)), "?CLIENT=%s", hostquoted);
 	}

--- a/xymond/client/darwin.c
+++ b/xymond/client/darwin.c
@@ -79,13 +79,17 @@ void handle_darwin_client(char *hostname, char *clienttype, enum ostype_t os,
 
 		if (pgsize != -1) {
 			p = strstr(meminfostr, "\nPages free:");
-			if (p) p = strchr(p, ':'); if (p) pagesfree = atol(p+1);
+			if (p) p = strchr(p, ':');
+			if (p) pagesfree = atol(p+1);
 			p = strstr(meminfostr, "\nPages active:");
-			if (p) p = strchr(p, ':'); if (p) pagesactive = atol(p+1);
+			if (p) p = strchr(p, ':');
+			if (p) pagesactive = atol(p+1);
 			p = strstr(meminfostr, "\nPages inactive:");
-			if (p) p = strchr(p, ':'); if (p) pagesinactive = atol(p+1);
+			if (p) p = strchr(p, ':');
+			if (p) pagesinactive = atol(p+1);
 			p = strstr(meminfostr, "\nPages wired down:");
-			if (p) p = strchr(p, ':'); if (p) pageswireddown = atol(p+1);
+			if (p) p = strchr(p, ':');
+			if (p) pageswireddown = atol(p+1);
 
 			if ((pagesfree >= 0) && (pagesactive >= 0) && (pagesinactive >= 0) && (pageswireddown >= 0)) {
 				unsigned long memphystotal, memphysused;

--- a/xymond/client/zvse.c
+++ b/xymond/client/zvse.c
@@ -532,6 +532,7 @@ static void zvse_getvis_report(char *hostname, char *clientclass, enum ostype_t 
                 q = strchr(jinfo, '-');              /* Check if jobname passed  */
                 if (q) {
                         strncpy(pid, jinfo, 2);          /*  Copy partition ID  */
+			pid[sizeof(pid)-1] = '\0';       /*  Make sure it is null terminated */
                         q++;                             /*  Increment pointer  */
 			strcpy(jobname,q);		 /*  Copy jobname       */
                         }

--- a/xymond/combostatus.c
+++ b/xymond/combostatus.c
@@ -351,7 +351,14 @@ static long evaluate(char *symbolicexpr, char **resultexpr, value_t **valuelist,
 	result = compute(expr, &error);
 
 	if (error) {
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif  // __GNUC__
 		sprintf(errtext, "compute(%s) returned error %d\n", expr, error);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		#pragma GCC diagnostic pop
+#endif  // __GNUC__
 		if (*errbuf == NULL) {
 			*errbuf = strdup(errtext);
 		}

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -299,7 +299,14 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		}
 	}
 	/* Watch out here - "rrdfn" may be very large. */
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif  // __GNUC__
 	snprintf(filedir, sizeof(filedir)-1, "%s/%s/%s", rrddir, hostname, rrdfn);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic pop
+#endif  // __GNUC__
 	filedir[sizeof(filedir)-1] = '\0'; /* Make sure it is null terminated */
 
 	/* 
@@ -607,7 +614,14 @@ static int rrddatasets(char *hostname, char ***dsnames)
 	unsigned long steptime, dscount;
 	rrd_value_t *rrddata;
 
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif  // __GNUC__
 	snprintf(filedir, sizeof(filedir)-1, "%s/%s/%s", rrddir, hostname, rrdfn);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic pop
+#endif  // __GNUC__
 	filedir[sizeof(filedir)-1] = '\0';
 	if (stat(filedir, &st) == -1) return 0;
 

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -300,7 +300,14 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		}
 	}
 	/* Watch out here - "rrdfn" may be very large. */
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif  // __GNUC__
 	snprintf(filedir, sizeof(filedir)-1, "%s/%s/%s", rrddir, hostname, rrdfn);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic pop
+#endif  // __GNUC__
 	filedir[sizeof(filedir)-1] = '\0'; /* Make sure it is null terminated */
 
 	/* 
@@ -608,7 +615,14 @@ static int rrddatasets(char *hostname, char ***dsnames)
 	unsigned long steptime, dscount;
 	rrd_value_t *rrddata;
 
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif  // __GNUC__
 	snprintf(filedir, sizeof(filedir)-1, "%s/%s/%s", rrddir, hostname, rrdfn);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic pop
+#endif  // __GNUC__
 	filedir[sizeof(filedir)-1] = '\0';
 	if (stat(filedir, &st) == -1) return 0;
 

--- a/xymond/rrd/do_netstat.c
+++ b/xymond/rrd/do_netstat.c
@@ -415,7 +415,8 @@ static int do_valbeforemarker(char *layout[], char *msg, char *outp)
 			while (ln && (ln > msg) && (*ln != '\n')) ln--;
 			if (ln) {
 				int numlen;
-				if (*ln == '\n') ln++; ln += strspn(ln, " \t");
+				if (*ln == '\n') ln++;
+				ln += strspn(ln, " \t");
 				numlen = strspn(ln, "0123456789");
 				*outp = ':'; outp++; memcpy(outp, ln, numlen); outp += numlen; *outp = '\0';
 				gotany = gotval = 1;

--- a/xymond/trimhistory.c
+++ b/xymond/trimhistory.c
@@ -333,7 +333,14 @@ void trim_logs(time_t cutoff)
 
 					ltime = logtime(lent->d_name);
 					if ((ltime > 0) && (ltime < cutoff)) {
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+						#pragma GCC diagnostic push
+						#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif  // __GNUC__
 						sprintf(fn2, "%s/%s", fn1, lent->d_name);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+						#pragma GCC diagnostic pop
+#endif  // __GNUC__
 						if (unlink(fn2) == -1) {
 							errprintf("Failed to unlink %s: %s\n", fn2, strerror(errno));
 						}

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -4523,7 +4523,8 @@ void do_message(conn_t *msg, char *origin)
 		line1 = strdup(msg->buf); if (p) *p = savech;
 
 		p = strtok(line1, " \t"); /* Skip the client keyword */
-		if (p) collectorid = strchr(p, '/'); if (collectorid) collectorid++;
+		if (p) collectorid = strchr(p, '/');
+		if (collectorid) collectorid++;
 		if (p) hostname = strtok(NULL, " \t"); /* Actually, HOSTNAME.CLIENTOS */
 		if (hostname) {
 			clientos = strrchr(hostname, '.'); 

--- a/xymond/xymond_client.c
+++ b/xymond/xymond_client.c
@@ -1876,7 +1876,8 @@ void testmode(char *configfn)
 		oldhinfo = hinfo;
 
 		printf("Test (cpu, mem, disk, proc, log, port): "); fflush(stdout); 
-		if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+		if (!fgets(s, sizeof(s), stdin)) return;
+		clean_instr(s);
 		if (strcmp(s, "cpu") == 0) {
 			float loadyellow, loadred;
 			int recentlimit, ancientlimit, uptimecolor;
@@ -1904,7 +1905,8 @@ void testmode(char *configfn)
 			char *groups;
 
 			printf("Filesystem: "); fflush(stdout);
-			if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+			if (!fgets(s, sizeof(s), stdin)) return;
+			clean_instr(s);
 			get_disk_thresholds(hinfo, clientclass, s, &warnlevel, &paniclevel, 
 						   &abswarn, &abspanic, &ignored, &groups);
 			if (ignored) 
@@ -1929,7 +1931,8 @@ void testmode(char *configfn)
 			printf("To read 'ps' data from a file, enter '@FILENAME' at the prompt\n");
 			do {
 				printf("ps command string: "); fflush(stdout);
-				if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+				if (!fgets(s, sizeof(s), stdin)) return;
+				clean_instr(s);
 				if (*s == '@') {
 					fd = fopen(s+1, "r");
 					while (fd && fgets(s, sizeof(s), fd)) {
@@ -1955,7 +1958,8 @@ void testmode(char *configfn)
 			int logcolor;
 
 			printf("log filename: "); fflush(stdout);
-			if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+			if (!fgets(s, sizeof(s), stdin)) return;
+			clean_instr(s);
 			sectname = (char *)malloc(strlen(s) + 20);
 			sprintf(sectname, "msgs:%s", s);
 
@@ -1965,7 +1969,8 @@ void testmode(char *configfn)
 			printf("To read log data from a file, enter '@FILENAME' at the prompt\n");
 			do {
 				printf("log line: "); fflush(stdout);
-				if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+				if (!fgets(s, sizeof(s), stdin)) return;
+				clean_instr(s);
 				if (*s == '@') {
 					fd = fopen(s+1, "r");
 					while (fd && fgets(s, sizeof(s), fd)) {
@@ -1999,13 +2004,15 @@ void testmode(char *configfn)
 
 			printf("Need to know netstat columns for 'Local address', 'Remote address' and 'State'\n");
 			printf("Enter columns [%d %d %d]: ", localcol, remotecol, statecol); fflush(stdout);
-			if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+			if (!fgets(s, sizeof(s), stdin)) return;
+			clean_instr(s);
 			if (*s) sscanf(s, "%d %d %d", &localcol, &remotecol, &statecol);
 
 			printf("To read 'netstat' data from a file, enter '@FILENAME' at the prompt\n");
 			do {
 				printf("netstat line: "); fflush(stdout);
-				if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+				if (!fgets(s, sizeof(s), stdin)) return;
+				clean_instr(s);
 				if (*s == '@') {
 					FILE *fd;
 

--- a/xymond/xymond_hostdata.c
+++ b/xymond/xymond_hostdata.c
@@ -210,7 +210,14 @@ int main(int argc, char *argv[])
 
 				sprintf(hostdir, "%s/%s", clientlogdir, metadata[3]);
 				mkdir(hostdir, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+				#pragma GCC diagnostic push
+				#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif  // __GNUC__
 				sprintf(fn, "%s/%s", hostdir, metadata[4]);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+				#pragma GCC diagnostic pop
+#endif  // __GNUC__
 				fd = fopen(fn, "w");
 				if (fd == NULL) {
 					errprintf("Cannot create file %s: %s\n", fn, strerror(errno));

--- a/xymongen/pagegen.c
+++ b/xymongen/pagegen.c
@@ -641,8 +641,15 @@ void do_hosts(host_t *head, int sorthosts, char *onlycols, char *exceptcols, FIL
 								pagepath, h->hostname, e->column->name, htmlextension);
 							sprintf(textrepfn, "%savail-%s-%s.txt",
 								pagepath, h->hostname, e->column->name);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+							#pragma GCC diagnostic push
+							#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif  // __GNUC__
 							sprintf(textrepurl, "%s/%s", 
 								xgetenv("XYMONWEB"), textrepfn);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+							#pragma GCC diagnostic pop
+#endif  // __GNUC__
 
 							htmlrep = fopen(htmlrepfn, "w");
 							if (!htmlrep) {
@@ -918,6 +925,10 @@ void do_one_page(xymongen_page_t *page, dispsummary_t *sums, int embedded)
 		output = stdout;
 	}
 	else {
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif  // __GNUC__
 		if (page->parent == NULL) {
 			char	indexfilename[PATH_MAX];
 
@@ -946,6 +957,9 @@ void do_one_page(xymongen_page_t *page, dispsummary_t *sums, int embedded)
 		}
 		sprintf(tmpfilename, "%s.tmp", filename);
 		sprintf(tmprssfilename, "%s.tmp", rssfilename);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		#pragma GCC diagnostic pop
+#endif  // __GNUC__
 
 
 		/* Try creating the output file. If it fails, we may need to create the directories */
@@ -1248,7 +1262,14 @@ int do_nongreen_page(char *nssidebarfilename, int summarytype, char *filenamebas
 		break;
 	}
 
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif  // __GNUC__
 	sprintf(tmpfilename, "%s.tmp", filename);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic pop
+#endif  // __GNUC__
 	output = fopen(tmpfilename, "w");
 	if (output == NULL) {
 		errprintf("Cannot create file %s: %s\n", tmpfilename, strerror(errno));
@@ -1256,7 +1277,14 @@ int do_nongreen_page(char *nssidebarfilename, int summarytype, char *filenamebas
 	}
 
 	if (wantrss) {
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif  // __GNUC__
 		sprintf(tmprssfilename, "%s.tmp", rssfilename);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		#pragma GCC diagnostic pop
+#endif  // __GNUC__
 		rssoutput = fopen(tmprssfilename, "w");
 		if (rssoutput == NULL) {
 			errprintf("Cannot create RSS file %s: %s\n", tmpfilename, strerror(errno));

--- a/xymongen/process.c
+++ b/xymongen/process.c
@@ -107,7 +107,7 @@ void calc_pagecolors(xymongen_page_t *phead)
 						     (e->color > color) &&
 						     wantedcolumn(e->column->name, g->onlycols) )
 							color = e->color;
-							oldage &= e->oldage;
+						oldage &= e->oldage;
 					}
 
 					/* Blue and clear is not propagated upwards */
@@ -127,7 +127,7 @@ void calc_pagecolors(xymongen_page_t *phead)
 						     (e->color > color) &&
 						     !wantedcolumn(e->column->name, g->exceptcols) )
 							color = e->color;
-							oldage &= e->oldage;
+						oldage &= e->oldage;
 					}
 
 					/* Blue and clear is not propagated upwards */

--- a/xymongen/util.c
+++ b/xymongen/util.c
@@ -43,7 +43,14 @@ char *hostpage_link(host_t *host)
 		sprintf(pagelink, "%s%s", ((xymongen_page_t *)host->parent)->name, htmlextension);
 		for (pgwalk = host->parent; (pgwalk); pgwalk = pgwalk->parent) {
 			if (strlen(pgwalk->name)) {
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+				#pragma GCC diagnostic push
+				#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif  // __GNUC__
 				sprintf(tmppath, "%s/%s", pgwalk->name, pagelink);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+				#pragma GCC diagnostic pop
+#endif  // __GNUC__
 				strcpy(pagelink, tmppath);
 			}
 		}

--- a/xymongen/wmlgen.c
+++ b/xymongen/wmlgen.c
@@ -119,7 +119,14 @@ static void generate_wml_statuscard(host_t *host, entry_t *entry)
 	nextline = msg;
 	l[MAX_LINE_LEN - 1] = '\0';
 
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif  // __GNUC__
 	sprintf(fn, "%s/%s.%s.wml", wmldir, host->hostname, entry->column->name);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic pop
+#endif  // __GNUC__
 	fd = fopen(fn, "w");
 	if (fd == NULL) {
 		errprintf("Cannot create file %s\n", fn);
@@ -312,7 +319,14 @@ void do_wml_cards(char *webdir)
 	}
 
 	/* Start the non-green WML card */
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif  // __GNUC__
 	sprintf(nongreenfn, "%s/nongreen.wml.tmp", wmldir);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+	#pragma GCC diagnostic pop
+#endif  // __GNUC__
 	nongreenfd = fopen(nongreenfn, "w");
 	if (nongreenfd == NULL) {
 		errprintf("Cannot open non-green WML file %s\n", nongreenfn);
@@ -336,7 +350,14 @@ void do_wml_cards(char *webdir)
 		if (h->hostentry->anywaps) {
 
 			/* Create the host WAP card, with links to individual test results */
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+			#pragma GCC diagnostic push
+			#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif  // __GNUC__
 			sprintf(hostfn, "%s/%s.wml", wmldir, h->hostentry->hostname);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+			#pragma GCC diagnostic pop
+#endif  // __GNUC__
 			hostfd = fopen(hostfn, "w");
 			if (hostfd == NULL) {
 				errprintf("Cannot create file %s\n", hostfn);
@@ -386,7 +407,14 @@ void do_wml_cards(char *webdir)
 				fclose(nongreenfd);
 
 				/* Start a new Nongreen WML card */
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+				#pragma GCC diagnostic push
+				#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif  // __GNUC__
 				sprintf(nongreenfn, "%s/nongreen-%d.wml", wmldir, nongreenpart);
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+				#pragma GCC diagnostic pop
+#endif  // __GNUC__
 				nongreenfd = fopen(nongreenfn, "w");
 				if (nongreenfd == NULL) {
 					errprintf("Cannot open Nongreen WML file %s\n", nongreenfd);

--- a/xymonnet/beastat.c
+++ b/xymonnet/beastat.c
@@ -110,6 +110,7 @@ char *getstring(char *databuf, char *beaindex, char *key)
 		eol = strchr(p, '\n');
 		if (eol) *eol = '\0';
 		strncpy(result, p, sizeof(result));
+		result[sizeof(result)-1] = '\0'; /* Make sure it is null terminated */
 		if (eol) *eol = '\n';
 	}
 

--- a/xymonnet/beastat.c
+++ b/xymonnet/beastat.c
@@ -108,6 +108,7 @@ char *getstring(char *databuf, char *beaindex, char *key)
 		eol = strchr(p, '\n');
 		if (eol) *eol = '\0';
 		strncpy(result, p, sizeof(result));
+		result[sizeof(result)-1] = '\0'; /* Make sure it is null terminated */
 		if (eol) *eol = '\n';
 	}
 

--- a/xymonproxy/xymonproxy.c
+++ b/xymonproxy/xymonproxy.c
@@ -456,7 +456,7 @@ int main(int argc, char *argv[])
 			int ccount = 0;
 			unsigned long bufspace = 0;
 			unsigned long avgtime;	/* In millisecs */
-			char runtime_s[30];
+			char runtime_s[31];	/* Include room for null termination */
 			unsigned long runt = (unsigned long) (now-startuptime);
 			char *p;
 			unsigned long msgs_sent = msgs_total - msgs_total_last;


### PR DESCRIPTION
I tried to merge/backport https://github.com/xymon-monitoring/xymon/commit/3686fbeef5ad7e1668878fab4eaf6c1e498699f7 from 4.4-alpha2 to 4.3.30.

The original Changes entry be jccleaver was:
* A large number of build warnings and possible buffer issues have been resolved
  (Thanks, Tom Schmidt, with Ralph Mitchell)

This reduced the number of warnings in the server build log from 84 to 24.

This was requested in https://github.com/xymon-monitoring/xymon/issues/43