### PR TITLE
Fix handling of $CARESLIB in configure.server.

### DIFF
--- a/configure.server
+++ b/configure.server
@@ -453,8 +453,8 @@ then
 	echo "CARESINCDIR = -I$CARESINC" >>Makefile
     fi
     if test "$CARESLIB" != ""; then
-	echo "CARESLIBS = -L$LIB -lcares" >>Makefile
-	echo "RPATHVAL += ${LIB}"        >>Makefile
+	echo "CARESLIBS = -L$CARESLIB -lcares" >>Makefile
+	echo "RPATHVAL += ${CARESLIB}"        >>Makefile
     else
 	echo "CARESLIBS = -lcares"       >>Makefile
     fi


### PR DESCRIPTION
If $CARESLIB is set, it should be used and not $LIB (which is not defined). 

This fixes https://github.com/xymon-monitoring/xymon/issues/68.