### PR TITLE
Use cc (instead of gcc) in OpenBSD

### DIFF
--- a/build/Makefile.OpenBSD
+++ b/build/Makefile.OpenBSD
@@ -6,8 +6,8 @@ OSDEF = -DBSD
 NETLIBS =
 
 # Compile flags for normal build
-CC = gcc
-GCCVER := $(shell gcc -dumpversion|cut -d. -f1)
+CC = cc
+GCCVER := $(shell cc -dumpversion|cut -d. -f1)
 ifeq ($(GCCVER),4)
 	CFLAGS = -g -O2 -Wall -Wno-unused -Wno-pointer-sign -D_REENTRANT -I/usr/local/include -L/usr/local/lib $(LFSDEF) $(OSDEF)
 else


### PR DESCRIPTION
clang is the default compiler in OpenBSD, not gcc.

Since the compiler is hard coded in build/Makefile.OpenBSD, this should be changed to their standard compiler.