### PR TITLE
RRDtool: compatibility for < 1.9 and >= 1.9

### DIFF
--- a/build/Makefile.test-rrd
+++ b/build/Makefile.test-rrd
@@ -1,11 +1,10 @@
 include Makefile.$(OS)
 
 test-compile:
-	@$(CC) $(CFLAGS) $(RRDDEF) $(RRDINC) -o test-rrd.o -c test-rrd.c
+	@$(CC) $(CFLAGS) $(RRDDEF) $(RRDINC) -I../include -o test-rrd.o -c test-rrd.c
 
 test-link:
 	@$(CC) $(CFLAGS) $(RRDDEF) $(RRDLIB) -o test-rrd test-rrd.o -lrrd $(PNGLIB)
 
 clean:
 	@rm -f test-rrd.o test-rrd xymongen.png
-

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -71,73 +71,156 @@
 		RRDLIB="$USERRRDLIB"
 	fi
 
-	# See if it builds
+	# Probe + compile/link validation
 	RRDOK="YES"
+	OS=`uname -s | sed -e's@/@_@g'`
 	if test "$RRDINC" != ""; then INCOPT="-I$RRDINC"; fi
 	if test "$RRDLIB" != ""; then LIBOPT="-L$RRDLIB"; fi
-	if pkg-config --atleast-version=1.9.0 librrd > /dev/null 2>&1; then
-		echo "Found RRDtool >= 1.9.0 via pkg-config"
-		RRDDEF="-DRRDTOOL19"
-	else
-		echo "Found RRDtool < 1.9.0 via pkg-config"
-	fi
-	cd build
-	OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
-	OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile 2>/dev/null
-	if test $? -ne 0; then
-		# See if it's the new RRDtool 1.2.x
-		echo "Not RRDtool 1.0.x, checking for 1.2.x"
-		RRDDEF="$RRDDEF -DRRDTOOL12"
-		OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
-		OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile
-	fi
-	if test $? -eq 0; then
-		echo "Compiling with RRDtool works OK"
-	else
-		echo "ERROR: Cannot compile with RRDtool."
-		RRDOK="NO"
-	fi
 
-	OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-	if test $? -ne 0; then
+	# --- Helpers ---
+	mktemp_xymon() {
+		prefix="$1"
+		f=
+		n=0
+		if command -v mktemp >/dev/null 2>&1; then
+			f=`mktemp "${TMPDIR:-/tmp}/${prefix}.XXXXXX" 2>/dev/null` && { echo "$f"; return 0; }
+		fi
+		while test $n -lt 50; do
+			f="${TMPDIR:-/tmp}/${prefix}.$$.$n"
+			(umask 077; : > "$f") 2>/dev/null && { echo "$f"; return 0; }
+			n=`expr $n + 1`
+		done
+		return 1
+	}
+
+	# Probe whether rrd_update() expects const char ** (newer) or char ** (legacy).
+	detect_rrd_const_args() {
+		CONSTTESTSRC=`mktemp_xymon "xymon-rrd-const"` || return 2
+		CONSTTESTOBJ=`mktemp_xymon "xymon-rrd-const-obj"` || { rm -f "$CONSTTESTSRC"; return 2; }
+		STRICT_CFLAGS=""
+		FLAGTESTOBJ=`mktemp_xymon "xymon-rrd-flag-obj"` || { rm -f "$CONSTTESTSRC" "$CONSTTESTOBJ"; return 2; }
+		if ${CC:-cc} -Werror=incompatible-pointer-types -x c -c -o "$FLAGTESTOBJ" - >/dev/null 2>&1 <<EOF
+int main(void) { return 0; }
+EOF
+		then
+			STRICT_CFLAGS="-Werror=incompatible-pointer-types"
+		fi
+		rm -f "$FLAGTESTOBJ"
+
+		cat > "$CONSTTESTSRC" <<EOF
+#include <stddef.h>
+#include <rrd.h>
+int main(void)
+{
+	const char *args[] = { "rrdupdate", "dummy.rrd", NULL };
+	return rrd_update(2, args);
+}
+EOF
+		if ${CC:-cc} ${INCOPT} ${STRICT_CFLAGS} -x c -c "$CONSTTESTSRC" -o "$CONSTTESTOBJ" >/dev/null 2>&1; then
+			rm -f "$CONSTTESTSRC" "$CONSTTESTOBJ"
+			echo "const"
+			return 0
+		fi
+
+		rm -f "$CONSTTESTSRC" "$CONSTTESTOBJ"
+		echo "mutable"
+		return 0
+	}
+
+	try_rrd_compile() {
+		OS=$OS RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile
+	}
+
+	try_rrd_link() {
+		OS=$OS RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
+	}
+
+	try_rrd_compile_with_legacy_fallback() {
+		FIRSTCOMPILELOG=`mktemp_xymon "xymon-rrd-first-compile.log"` || FIRSTCOMPILELOG="/tmp/xymon-rrd-first-compile.log.$$"
+
+		# test-rrd.c exercises update/create/fetch/graph signatures through rrd_compat.h.
+		if try_rrd_compile >/dev/null 2>"$FIRSTCOMPILELOG"; then
+			rm -f "$FIRSTCOMPILELOG"
+			return 0
+		fi
+
+		echo "RRD: initial compile probe failed; first diagnostics:"
+		head -n 20 "$FIRSTCOMPILELOG"
+		echo "RRD: full diagnostics saved at: $FIRSTCOMPILELOG"
+		# Initial compile failed; retry with the legacy RRD graph ABI macro.
+		echo "RRD: retrying compile probe with RRDTOOL12 compatibility"
+		RRDDEF="$RRDDEF -DRRDTOOL12"
+		OS=$OS $MAKE -f Makefile.test-rrd clean
+		try_rrd_compile
+	}
+
+	try_rrd_link_with_fallbacks() {
+		try_rrd_link && return 0
+
 		# Could be that we need -lz for RRD
 		PNGLIB="$PNGLIB $ZLIB"
-	fi
-	OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-	if test $? -ne 0; then
+		try_rrd_link && return 0
+
 		# Could be that we need -lm for RRD
 		PNGLIB="$PNGLIB -lm"
-	fi
-	OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-	if test $? -ne 0; then
+		try_rrd_link && return 0
+
 		# Could be that we need -L/usr/X11R6/lib (OpenBSD)
 		LIBOPT="$LIBOPT -L/usr/X11R6/lib"
 		RRDLIB="$RRDLIB -L/usr/X11R6/lib"
+		try_rrd_link
+	}
+
+	# --- Phase 1: ABI detection ---
+	# Detect whether RRDtool APIs use const argv pointers.
+	# Newer headers expect const char **, older expect char **.
+	RRD_CONST_ARGS_DETECTED=`detect_rrd_const_args`
+	RRD_CONST_PROBE_STATUS=$?
+	if test "$RRD_CONST_PROBE_STATUS" -ne 0; then
+		echo "RRD: detect ABI -> error (status=$RRD_CONST_PROBE_STATUS)"
+		RRDOK="NO"
+		RRD_CONST_ARGS_DETECTED=mutable
 	fi
-	OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-	if test $? -eq 0; then
-		echo "Linking with RRDtool works OK"
-		if test "$PNGLIB" != ""; then
-			echo "Linking RRD needs extra library: $PNGLIB"
-		fi
+	if test "$RRD_CONST_ARGS_DETECTED" = "const"; then
+		echo "RRD: detect ABI -> const argv pointers"
+		RRDDEF="$RRDDEF -DRRD_CONST_ARGS=1"
 	else
-		echo "ERROR: Linking with RRDtool fails"
+		echo "RRD: detect ABI -> mutable argv pointers"
+		RRDDEF="$RRDDEF -DRRD_CONST_ARGS=0"
+	fi
+
+	# --- Phase 2: compile/link probes ---
+	cd build
+	OS=$OS $MAKE -f Makefile.test-rrd clean
+	if try_rrd_compile_with_legacy_fallback; then
+		echo "RRD: compile probe -> ok"
+	else
+		echo "RRD: compile probe -> failed"
 		RRDOK="NO"
 	fi
-	OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
+	echo "RRD: selected compatibility flags -> $RRDDEF"
+
+	if try_rrd_link_with_fallbacks; then
+		echo "RRD: link probe -> ok"
+		if test "$PNGLIB" != ""; then
+			echo "RRD: link probe required extra libraries: $PNGLIB"
+		fi
+	else
+		echo "RRD: link probe -> failed"
+		RRDOK="NO"
+	fi
+	OS=$OS $MAKE -f Makefile.test-rrd clean
 	cd ..
 
 	if test "$RRDOK" = "NO"; then
-		echo "RRDtool include- or library-files not found."
-		echo "These are REQUIRED for trend-graph support in Xymon, but Xymon can"
-		echo "be built without them (e.g. for a network-probe only installation."
+		echo "RRDtool include files or libraries were not found."
+		echo "These are required for trend graph support in Xymon, but Xymon can"
+		echo "be built without them (for example, for a network-probe-only installation)."
 		echo ""
 		echo "RRDtool can be found at http://oss.oetiker.ch/rrdtool/"
 		echo "If you have RRDtool installed, use the \"--rrdinclude DIR\" and \"--rrdlib DIR\""
 		echo "options to configure to specify where they are."
 		echo ""
-		echo "Continuing with all trend-graph support DISABLED"
+		echo "Continuing with trend graph support disabled."
 		sleep 3
 	fi
-
-

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -147,7 +147,8 @@ EOF
 		echo "RRD: initial compile probe failed; first diagnostics:"
 		head -n 20 "$FIRSTCOMPILELOG"
 		echo "RRD: full diagnostics saved at: $FIRSTCOMPILELOG"
-		# Initial compile failed; retry with the legacy RRD graph ABI macro.
+		# Hard-fail here so the caller reports compile probe failure accurately.
+		return 1
 	}
 
 	try_rrd_link_with_fallbacks() {

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -148,10 +148,6 @@ EOF
 		head -n 20 "$FIRSTCOMPILELOG"
 		echo "RRD: full diagnostics saved at: $FIRSTCOMPILELOG"
 		# Initial compile failed; retry with the legacy RRD graph ABI macro.
-		echo "RRD: retrying compile probe with RRDTOOL12 compatibility"
-		RRDDEF="$RRDDEF -DRRDTOOL12"
-		OS=$OS $MAKE -f Makefile.test-rrd clean
-		try_rrd_compile
 	}
 
 	try_rrd_link_with_fallbacks() {

--- a/build/test-rrd.c
+++ b/build/test-rrd.c
@@ -22,9 +22,10 @@ int main(void)
 	xymon_rrd_argv_item_t fetchargs[]  = { "rrdfetch", "dummy.rrd", NULL };
 	char **calcpr=NULL;
 
-	int pcount, result, xsize, ysize;
+	int pcount, xsize, ysize;
 	double ymin, ymax;
-	unsigned long start = 0, end = 0, step = 0, dscount = 0;
+	time_t start = 0, end = 0;
+	unsigned long step = 0, dscount = 0;
 	char **dsnames = NULL;
 	rrd_value_t *data = NULL;
 
@@ -35,7 +36,7 @@ int main(void)
 	(void)xymon_rrd_create(3, createargs);
 	(void)xymon_rrd_fetch(3, fetchargs, &start, &end, &step, &dscount, &dsnames, &data);
 	/* Keep one graph invocation to validate the graph ABI shape as well. */
-	result = xymon_rrd_graph(pcount, graphargs, &calcpr, &xsize, &ysize, &ymin, &ymax);
+	(void)xymon_rrd_graph(pcount, graphargs, &calcpr, &xsize, &ysize, &ymin, &ymax);
 
 	return 0;
 }

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -25,6 +25,8 @@ Linking RRD with PNG library: -L/usr/lib -lpng
 Manual-build note:
 If you compile without running configure, define RRD_CONST_ARGS to match your
 RRDtool headers (0 for mutable char ** argv, 1 for const char ** argv).
+Compatibility macros: RRDTOOL19 is the preferred gate for modern RRDtool;
+RRDTOOL12 is obsolete and intentionally ignored.
 
 
 Checking for PCRE ...

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -22,6 +22,10 @@ Found RRDtool include files in /usr/include
 Found RRDtool libraries in /usr/lib
 Linking RRD with PNG library: -L/usr/lib -lpng
 
+Manual-build note:
+If you compile without running configure, define RRD_CONST_ARGS to match your
+RRDtool headers (0 for mutable char ** argv, 1 for const char ** argv).
+
 
 Checking for PCRE ...
 Found PCRE include files in /usr/include

--- a/include/rrd_compat.h
+++ b/include/rrd_compat.h
@@ -45,25 +45,30 @@ static inline char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
 
 static inline int xymon_rrd_update(int argc, xymon_rrd_argv_item_t *argv)
 {
-	return rrd_update(argc, xymon_rrd_api_argv(argv));
+	/*
+	 * Some build paths may define RRDTOOL12 without defining RRD_CONST_ARGS.
+	 * Cast through void* so either rrd_update(int,char**) or
+	 * rrd_update(int,const char**) is accepted by the compiler.
+	 */
+	return rrd_update(argc, (void *)xymon_rrd_api_argv(argv));
 }
 
 static inline int xymon_rrd_create(int argc, xymon_rrd_argv_item_t *argv)
 {
-	return rrd_create(argc, xymon_rrd_api_argv(argv));
+	return rrd_create(argc, (void *)xymon_rrd_api_argv(argv));
 }
 
 static inline int xymon_rrd_fetch(int argc, xymon_rrd_argv_item_t *argv,
 				  time_t *start, time_t *end, unsigned long *step, unsigned long *dscount,
 				  char ***dsnames, rrd_value_t **data)
 {
-	return rrd_fetch(argc, xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
+	return rrd_fetch(argc, (void *)xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
 }
 
 static inline int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv, 
 				  char ***calcpr, int *xsize, int *ysize, double *ymin, double *ymax)
 { 
-	return rrd_graph(argc, xymon_rrd_api_argv(argv), calcpr, xsize, ysize, NULL, ymin, ymax); 
+	return rrd_graph(argc, (void *)xymon_rrd_api_argv(argv), calcpr, xsize, ysize, NULL, ymin, ymax); 
 }
 
 #endif /* XYMON_RRD_COMPAT_H */

--- a/include/rrd_compat.h
+++ b/include/rrd_compat.h
@@ -1,0 +1,73 @@
+#ifndef XYMON_RRD_COMPAT_H
+#define XYMON_RRD_COMPAT_H
+
+#include <stddef.h>
+#include <time.h>
+#include <rrd.h>
+
+/*
+ * RRDtool API compatibility:
+ * - Some releases declare argv parameters as char **.
+ * - Newer releases declare argv parameters as const char **.
+ *
+ * Usage:
+ * - Declare argv vectors as xymon_rrd_argv_item_t[].
+ * - Call the xymon_rrd_update/create/fetch/graph wrappers only.
+ *
+ * RRD_CONST_ARGS is detected by build/rrd.sh and propagated via RRDDEF.
+ */
+#ifndef RRD_CONST_ARGS
+/*
+ * Ad-hoc/manual builds that skip configure must opt in explicitly.
+ */
+#if defined(XYMON_ASSUME_RRD_MUTABLE_ARGS)
+#define RRD_CONST_ARGS 0
+#else
+#error "RRD_CONST_ARGS is not defined. Run configure or define XYMON_ASSUME_RRD_MUTABLE_ARGS=1."
+#endif
+#endif
+
+#if RRD_CONST_ARGS
+typedef const char *xymon_rrd_argv_item_t;
+static inline const char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
+{
+	return (const char **)argv;
+}
+#else
+typedef char *xymon_rrd_argv_item_t;
+static inline char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
+{
+	return (char **)argv;
+}
+#endif
+
+static inline int xymon_rrd_update(int argc, xymon_rrd_argv_item_t *argv)
+{
+	return rrd_update(argc, xymon_rrd_api_argv(argv));
+}
+
+static inline int xymon_rrd_create(int argc, xymon_rrd_argv_item_t *argv)
+{
+	return rrd_create(argc, xymon_rrd_api_argv(argv));
+}
+
+static inline int xymon_rrd_fetch(int argc, xymon_rrd_argv_item_t *argv,
+				  time_t *start, time_t *end, unsigned long *step, unsigned long *dscount,
+				  char ***dsnames, rrd_value_t **data)
+{
+	return rrd_fetch(argc, xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
+}
+
+static inline int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv,
+				  char ***calcpr, int *xsize, int *ysize, double *ymin, double *ymax)
+{
+#if defined(RRDTOOL12)
+	return rrd_graph(argc, xymon_rrd_api_argv(argv), calcpr, xsize, ysize, NULL, ymin, ymax);
+#else
+	(void)ymin;
+	(void)ymax;
+	return rrd_graph(argc, xymon_rrd_api_argv(argv), calcpr, xsize, ysize);
+#endif
+}
+
+#endif /* XYMON_RRD_COMPAT_H */

--- a/include/rrd_compat.h
+++ b/include/rrd_compat.h
@@ -31,44 +31,31 @@
 
 #if RRD_CONST_ARGS
 typedef const char *xymon_rrd_argv_item_t;
-static inline const char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
-{
-	return (const char **)argv;
-}
 #else
 typedef char *xymon_rrd_argv_item_t;
-static inline char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
-{
-	return (char **)argv;
-}
 #endif
 
 static inline int xymon_rrd_update(int argc, xymon_rrd_argv_item_t *argv)
 {
-	/*
-	 * Some build paths may define RRDTOOL12 without defining RRD_CONST_ARGS.
-	 * Cast through void* so either rrd_update(int,char**) or
-	 * rrd_update(int,const char**) is accepted by the compiler.
-	 */
-	return rrd_update(argc, (void *)xymon_rrd_api_argv(argv));
+	return rrd_update(argc, argv);
 }
 
 static inline int xymon_rrd_create(int argc, xymon_rrd_argv_item_t *argv)
 {
-	return rrd_create(argc, (void *)xymon_rrd_api_argv(argv));
+	return rrd_create(argc, argv);
 }
 
 static inline int xymon_rrd_fetch(int argc, xymon_rrd_argv_item_t *argv,
 				  time_t *start, time_t *end, unsigned long *step, unsigned long *dscount,
 				  char ***dsnames, rrd_value_t **data)
 {
-	return rrd_fetch(argc, (void *)xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
+	return rrd_fetch(argc, argv, start, end, step, dscount, dsnames, data);
 }
 
 static inline int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv, 
 				  char ***calcpr, int *xsize, int *ysize, double *ymin, double *ymax)
 { 
-	return rrd_graph(argc, (void *)xymon_rrd_api_argv(argv), calcpr, xsize, ysize, NULL, ymin, ymax); 
+	return rrd_graph(argc, argv, calcpr, xsize, ysize, NULL, ymin, ymax);
 }
 
 #endif /* XYMON_RRD_COMPAT_H */

--- a/include/rrd_compat.h
+++ b/include/rrd_compat.h
@@ -20,42 +20,53 @@
 /*
  * Ad-hoc/manual builds that skip configure must opt in explicitly.
  */
-#if defined(RRDTOOL12)
-#define RRD_CONST_ARGS 0
+#if defined(RRDTOOL19)
+#define RRD_CONST_ARGS 1
 #elif defined(XYMON_ASSUME_RRD_MUTABLE_ARGS)
 #define RRD_CONST_ARGS 0
-#else
-#error "RRD_CONST_ARGS is not defined. Run configure or define XYMON_ASSUME_RRD_MUTABLE_ARGS=1."
+#elif defined(RRDTOOL12)
+/* RRDTOOL12 is obsolete and intentionally ignored. */
+#endif
+#ifndef RRD_CONST_ARGS
+#error "RRD_CONST_ARGS is not defined. Run configure or define RRDTOOL19 (or RRD_CONST_ARGS directly)."
 #endif
 #endif
 
 #if RRD_CONST_ARGS
 typedef const char *xymon_rrd_argv_item_t;
+static inline const char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
+{
+	return (const char **)argv;
+}
 #else
 typedef char *xymon_rrd_argv_item_t;
+static inline char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
+{
+	return (char **)argv;
+}
 #endif
 
 static inline int xymon_rrd_update(int argc, xymon_rrd_argv_item_t *argv)
 {
-	return rrd_update(argc, argv);
+	return rrd_update(argc, (void *)xymon_rrd_api_argv(argv));
 }
 
 static inline int xymon_rrd_create(int argc, xymon_rrd_argv_item_t *argv)
 {
-	return rrd_create(argc, argv);
+	return rrd_create(argc, (void *)xymon_rrd_api_argv(argv));
 }
 
 static inline int xymon_rrd_fetch(int argc, xymon_rrd_argv_item_t *argv,
 				  time_t *start, time_t *end, unsigned long *step, unsigned long *dscount,
 				  char ***dsnames, rrd_value_t **data)
 {
-	return rrd_fetch(argc, argv, start, end, step, dscount, dsnames, data);
+	return rrd_fetch(argc, (void *)xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
 }
 
 static inline int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv, 
 				  char ***calcpr, int *xsize, int *ysize, double *ymin, double *ymax)
 { 
-	return rrd_graph(argc, argv, calcpr, xsize, ysize, NULL, ymin, ymax);
+	return rrd_graph(argc, (void *)xymon_rrd_api_argv(argv), calcpr, xsize, ysize, NULL, ymin, ymax);
 }
 
 #endif /* XYMON_RRD_COMPAT_H */

--- a/include/rrd_compat.h
+++ b/include/rrd_compat.h
@@ -20,7 +20,9 @@
 /*
  * Ad-hoc/manual builds that skip configure must opt in explicitly.
  */
-#if defined(XYMON_ASSUME_RRD_MUTABLE_ARGS)
+#if defined(RRDTOOL12)
+#define RRD_CONST_ARGS 0
+#elif defined(XYMON_ASSUME_RRD_MUTABLE_ARGS)
 #define RRD_CONST_ARGS 0
 #else
 #error "RRD_CONST_ARGS is not defined. Run configure or define XYMON_ASSUME_RRD_MUTABLE_ARGS=1."

--- a/include/rrd_compat.h
+++ b/include/rrd_compat.h
@@ -58,16 +58,10 @@ static inline int xymon_rrd_fetch(int argc, xymon_rrd_argv_item_t *argv,
 	return rrd_fetch(argc, xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
 }
 
-static inline int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv,
+static inline int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv, 
 				  char ***calcpr, int *xsize, int *ysize, double *ymin, double *ymax)
-{
-#if defined(RRDTOOL12)
-	return rrd_graph(argc, xymon_rrd_api_argv(argv), calcpr, xsize, ysize, NULL, ymin, ymax);
-#else
-	(void)ymin;
-	(void)ymax;
-	return rrd_graph(argc, xymon_rrd_api_argv(argv), calcpr, xsize, ysize);
-#endif
+{ 
+	return rrd_graph(argc, xymon_rrd_api_argv(argv), calcpr, xsize, ysize, NULL, ymin, ymax); 
 }
 
 #endif /* XYMON_RRD_COMPAT_H */

--- a/web/perfdata.c
+++ b/web/perfdata.c
@@ -24,6 +24,7 @@ static char rcsid[] = "$Id$";
 #include <pcre.h>
 
 #include "libxymon.h"
+#include "rrd_compat.h"
 
 enum { O_NONE, O_XML, O_CSV } outform = O_NONE;
 char csvdelim = ',';
@@ -100,7 +101,7 @@ int oneset(char *hostname, char *rrdname, char *starttime, char *endtime, char *
 	int dataindex, rowcount, havemin, havemax, missingdata;
 	double sum, min = 0.0, max = 0.0, val;
 
-	char *rrdargs[10];
+	xymon_rrd_argv_item_t rrdargs[10];
 	int result;
 
 	rrdargs[0] = "rrdfetch";
@@ -111,13 +112,7 @@ int oneset(char *hostname, char *rrdname, char *starttime, char *endtime, char *
 	rrdargs[9] = NULL;
 
 	optind = opterr = 0; rrd_clear_error();
-#ifdef RRDTOOL19
-	result = rrd_fetch(9, (const char **)rrdargs,
-			   &start, &end, &step, &dscount, &dsnames, &data);
-#else
-	result = rrd_fetch(9, rrdargs,
-			   &start, &end, &step, &dscount, &dsnames, &data);
-#endif
+	result = xymon_rrd_fetch(9, rrdargs, &start, &end, &step, &dscount, &dsnames, &data);
 
 	if (result != 0) {
 		errprintf("RRD error: %s\n", rrd_get_error());
@@ -430,4 +425,3 @@ int main(int argc, char **argv)
 
 	return 0;
 }
-

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -31,6 +31,7 @@ static char rcsid[] = "$Id$";
 #include <rrd.h>
 
 #include "libxymon.h"
+#include "rrd_compat.h"
 
 #define HOUR_GRAPH  "e-48h"
 #define DAY_GRAPH   "e-12d"
@@ -1214,24 +1215,18 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	/* All set - generate the graph */
 	rrd_clear_error();
 
-#ifdef RRDTOOL12
-    #ifdef RRDTOOL19
-	result = rrd_graph(rrdargcount, (const char **)rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
-    #else
-	result = rrd_graph(rrdargcount, rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
-    #endif
+	result = xymon_rrd_graph(rrdargcount, rrdargs, &calcpr, &xsize, &ysize, &ymin, &ymax);
 
 	/*
 	 * If we have neither the upper- nor lower-limits of the graph, AND we allow vertical 
 	 * zooming of this graph, then save the upper/lower limit values and flag that we have 
 	 * them. The values are then used for the zoom URL we construct later on.
 	 */
+#ifdef RRDTOOL12
 	if (!haveupperlimit && !havelowerlimit) {
 		upperlimit = ymax; haveupperlimit = 1;
 		lowerlimit = ymin; havelowerlimit = 1;
 	}
-#else
-	result = rrd_graph(rrdargcount, rrdargs, &calcpr, &xsize, &ysize);
 #endif
 
 	/* Was it OK ? */
@@ -1363,4 +1358,3 @@ int main(int argc, char *argv[])
 
 	return 0;
 }
-

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -38,9 +38,12 @@ static char rcsid[] = "$Id$";
 #define WEEK_GRAPH  "e-48d"
 #define MONTH_GRAPH "e-576d"
 
-/* RRDtool 1.0.x handles graphs with no DS definitions just fine. 1.2.x does not. */
+/* Keep a blank-image fallback when no graph data is available. */
+#ifndef HIDE_EMPTYGRAPH
+#define HIDE_EMPTYGRAPH 1
+#endif
 
-#ifdef HIDE_EMPTYGRAPH
+#if HIDE_EMPTYGRAPH
 unsigned char blankimg[] = "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\x04\x67\x41\x4d\x41\x00\x00\xb1\x8f\x0b\xfc\x61\x05\x00\x00\x00\x06\x62\x4b\x47\x44\x00\xff\x00\xff\x00\xff\xa0\xbd\xa7\x93\x00\x00\x00\x09\x70\x48\x59\x73\x00\x00\x0b\x12\x00\x00\x0b\x12\x01\xd2\xdd\x7e\xfc\x00\x00\x00\x07\x74\x49\x4d\x45\x07\xd1\x01\x14\x12\x21\x14\x7e\x4a\x3a\xd2\x00\x00\x00\x0d\x49\x44\x41\x54\x78\xda\x63\x60\x60\x60\x60\x00\x00\x00\x05\x00\x01\x7a\xa8\x57\x50\x00\x00\x00\x00\x49\x45\x4e\x44\xae\x42\x60\x82";
 #endif
 
@@ -1190,13 +1193,13 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		printf("%s\n", expirehdr);
 		printf("\n");
 
-#ifdef HIDE_EMPTYGRAPH
-		/* It works, but we still get the "zoom" magnifying glass which looks odd */
-		if (rrddbcount == 0) {
-			/* No graph */
-			fwrite(blankimg, 1, sizeof(blankimg), stdout);
-			return;
-		}
+#if HIDE_EMPTYGRAPH
+			/* It works, but we still get the "zoom" magnifying glass which looks odd */
+			if (rrddbcount == 0) {
+				/* No graph */
+				fwrite(blankimg, 1, sizeof(blankimg), stdout);
+				return;
+			}
 #endif
 	}
 

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -513,6 +513,7 @@ char *expand_tokens(char *tpl)
 {
 	static strbuffer_t *result = NULL;
 	char *inp, *p;
+	char numstr[10];
 
 	if (strchr(tpl, '@') == NULL) return tpl;
 

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -634,8 +634,8 @@ char *expand_tokens(char *tpl)
 
 int rrd_name_compare(const void *v1, const void *v2)
 {
-	rrddb_t *r1 = (rrddb_t *)v1;
-	rrddb_t *r2 = (rrddb_t *)v2;
+	const rrddb_t *r1 = v1;
+	const rrddb_t *r2 = v2;
 	char *endptr;
 	long numkey1, numkey2;
 	int key1isnumber, key2isnumber;

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -516,7 +516,6 @@ char *expand_tokens(char *tpl)
 {
 	static strbuffer_t *result = NULL;
 	char *inp, *p;
-	char numstr[10];
 
 	if (strchr(tpl, '@') == NULL) return tpl;
 

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -619,8 +619,8 @@ char *expand_tokens(char *tpl)
 			char numstr[10];
 
 			if (rrdidx == 0) {
-			}
 				numstr[0] = '\0';
+			}
 			else {
 				snprintf(numstr, sizeof(numstr), "STACK");
 			}

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -598,25 +598,10 @@ char *expand_tokens(char *tpl)
 		else if (strncmp(inp, "@STACKIT@", 9) == 0) {
 			/* Contributed by Gildas Le Nadan <gn1@sanger.ac.uk> */
 
-			/* the STACK behavior changed between rrdtool 1.0.x
-			 * and 1.2.x, hence the ifdef:
-			 * - in 1.0.x, you replace the graph type (AREA|LINE)
-			 *  for the graph you want to stack with the  STACK
-			 *  keyword
-			 * - in 1.2.x, you add the STACK keyword at the end
-			 *  of the definition
-			 *
-			 * Please note that in both cases the first entry
-			 * mustn't contain the keyword STACK at all, so
-			 * we need a different treatment for the first rrdidx
-			 *
-			 * examples of graphs.cfg entries:
-			 *
-			 * - rrdtool 1.0.x
-			 * @STACKIT@:la@RRDIDX@#@COLOR@:@RRDPARAM@
-			 *
-			 * - rrdtool 1.2.x
-			 * AREA::la@RRDIDX@#@COLOR@:@RRDPARAM@:@STACKIT@
+			/*
+			 * Keep the first series unstacked; add "STACK" for subsequent
+			 * series. Graph templates should place @STACKIT@ where RRDtool
+			 * expects the stacking keyword.
 			 */
 			char numstr[10];
 

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -39,11 +39,6 @@ static char rcsid[] = "$Id$";
 #define MONTH_GRAPH "e-576d"
 
 /* RRDtool 1.0.x handles graphs with no DS definitions just fine. 1.2.x does not. */
-#ifdef RRDTOOL12
-#ifndef HIDE_EMPTYGRAPH
-#define HIDE_EMPTYGRAPH 1
-#endif
-#endif
 
 #ifdef HIDE_EMPTYGRAPH
 unsigned char blankimg[] = "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\x04\x67\x41\x4d\x41\x00\x00\xb1\x8f\x0b\xfc\x61\x05\x00\x00\x00\x06\x62\x4b\x47\x44\x00\xff\x00\xff\x00\xff\xa0\xbd\xa7\x93\x00\x00\x00\x09\x70\x48\x59\x73\x00\x00\x0b\x12\x00\x00\x0b\x12\x01\xd2\xdd\x7e\xfc\x00\x00\x00\x07\x74\x49\x4d\x45\x07\xd1\x01\x14\x12\x21\x14\x7e\x4a\x3a\xd2\x00\x00\x00\x0d\x49\x44\x41\x54\x78\xda\x63\x60\x60\x60\x60\x00\x00\x00\x05\x00\x01\x7a\xa8\x57\x50\x00\x00\x00\x00\x49\x45\x4e\x44\xae\x42\x60\x82";
@@ -623,12 +618,8 @@ char *expand_tokens(char *tpl)
 			char numstr[10];
 
 			if (rrdidx == 0) {
-#ifdef RRDTOOL12
-				strncpy(numstr, "", sizeof(numstr));
-#else
-				snprintf(numstr, sizeof(numstr), "AREA");
-#endif
 			}
+				numstr[0] = '\0';
 			else {
 				snprintf(numstr, sizeof(numstr), "STACK");
 			}
@@ -1179,11 +1170,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		}
 	}
 
-#ifdef RRDTOOL12
 	strftime(timestamp, sizeof(timestamp), "COMMENT:Updated\\: %d-%b-%Y %H\\:%M\\:%S", localtime(&now));
-#else
-	strftime(timestamp, sizeof(timestamp), "COMMENT:Updated: %d-%b-%Y %H:%M:%S", localtime(&now));
-#endif
 	rrdargs[argi++] = strdup(timestamp);
 
 
@@ -1222,12 +1209,10 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	 * zooming of this graph, then save the upper/lower limit values and flag that we have 
 	 * them. The values are then used for the zoom URL we construct later on.
 	 */
-#ifdef RRDTOOL12
 	if (!haveupperlimit && !havelowerlimit) {
 		upperlimit = ymax; haveupperlimit = 1;
 		lowerlimit = ymin; havelowerlimit = 1;
 	}
-#endif
 
 	/* Was it OK ? */
 	if (rrd_test_error() || (result != 0)) {
@@ -1276,13 +1261,11 @@ void generate_zoompage(char *selfURI)
 				n = fread(buf, 1, st.st_size, fd);
 				fclose(fd);
 
-#ifdef RRDTOOL12
 				zoomrightoffsetp = strstr(buf, zoomrightoffsetmarker);
 				if (zoomrightoffsetp) {
 					zoomrightoffsetp += strlen(zoomrightoffsetmarker);
 					memcpy(zoomrightoffsetp, "30", 2);
 				}
-#endif
 
 				fwrite(buf, 1, n, stdout);
 			}

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -781,7 +781,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 
 	/* Options for rrd_graph() */
 	int  rrdargcount;
-	char **rrdargs = NULL;	/* The full argv[] table of string pointers to arguments */
+	xymon_rrd_argv_item_t *rrdargs = NULL;	/* The full argv[] table of string pointers to arguments */
 	char heightopt[30];	/* -h HEIGHT */
 	char widthopt[30];	/* -w WIDTH */
 	char upperopt[30];	/* -u MAX */
@@ -1111,7 +1111,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	 * there are multiple RRD-files to handle).
 	 */
 	for (pcount = 0; (gdef->defs[pcount]); pcount++) ;
-	rrdargs = (char **) calloc(16 + pcount*rrddbcount + useroptcount + 1, sizeof(char *));
+	rrdargs = (xymon_rrd_argv_item_t *) calloc(16 + pcount*rrddbcount + useroptcount + 1, sizeof(xymon_rrd_argv_item_t));
 
 
 	argi = 0;

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -1111,7 +1111,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	 * there are multiple RRD-files to handle).
 	 */
 	for (pcount = 0; (gdef->defs[pcount]); pcount++) ;
-	rrdargs = (xymon_rrd_argv_item_t *) calloc(16 + pcount*rrddbcount + useroptcount + 1, sizeof(xymon_rrd_argv_item_t));
+	rrdargs = calloc(16 + pcount*rrddbcount + useroptcount + 1, sizeof(*rrdargs));
 
 
 	argi = 0;

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -26,6 +26,7 @@ static char rcsid[] = "$Id$";
 #include <pcre.h>
 
 #include "libxymon.h"
+#include "rrd_compat.h"
 
 #include "xymond_rrd.h"
 #include "do_rrd.h"
@@ -216,11 +217,7 @@ static void setupinterval(int intvl)
 static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 {
 	/* Flush any updates we've cached */
-#ifdef RRDTOOL19
-	const char *updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
-#else
-	char *updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
-#endif
+	xymon_rrd_argv_item_t updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
 	int i, pcount, result;
 
 	dbgprintf("Flushing '%s' with %d updates pending, template '%s'\n", 
@@ -243,7 +240,7 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 
 	for (pcount = 0; (updparams[pcount]); pcount++);
 	optind = opterr = 0; rrd_clear_error();
-	result = rrd_update(pcount, updparams);
+	result = xymon_rrd_update(pcount, updparams);
 
 #if defined(LINUX) && defined(RRDTOOL12)
 	/*
@@ -281,7 +278,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	pollinterval = rrdinterval;
 	rrdinterval = DEFAULT_RRD_INTERVAL;
 
-	if ((rrdfn == NULL) || (strlen(rrdfn) == 0)) {
+	if (strlen(rrdfn) == 0) {
 		errprintf("RRD update for no file\n");
 		return -1;
 	}
@@ -334,7 +331,8 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 
 	/* If the RRD file doesn't exist, create it immediately */
 	if (stat(filedir, &st) == -1) {
-		char **rrdcreate_params, **rrddefinitions;
+		xymon_rrd_argv_item_t *rrdcreate_params;
+		char **rrddefinitions;
 		int rrddefcount, i;
 		char *rrakey = NULL;
 		char stepsetting[10];
@@ -353,7 +351,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		sprintf(stepsetting, "%d", pollinterval);
 
 		rrddefinitions = get_rrd_definition((rrakey ? rrakey : testname), &rrddefcount);
-		rrdcreate_params = (char **)calloc(4 + pcount + rrddefcount + 1, sizeof(char *));
+		rrdcreate_params = (xymon_rrd_argv_item_t *)calloc(4 + pcount + rrddefcount + 1, sizeof(xymon_rrd_argv_item_t));
 		rrdcreate_params[0] = "rrdcreate";
 		rrdcreate_params[1] = filedir;
 
@@ -382,11 +380,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		 * we MUST reset this before every call.
 		 */
 		optind = opterr = 0; rrd_clear_error();
-#ifdef RRDTOOL19
-		result = rrd_create(4+pcount, (const char **)rrdcreate_params);
-#else
-		result = rrd_create(4+pcount, rrdcreate_params);
-#endif
+		result = xymon_rrd_create(4+pcount, rrdcreate_params);
 		xfree(rrdcreate_params);
 		if (rrakey) xfree(rrakey);
 
@@ -598,11 +592,7 @@ static int rrddatasets(char *hostname, char ***dsnames)
 	struct stat st;
 
 	int result;
-#ifdef RRDTOOL19
-	const char *fetch_params[] = { "rrdfetch", filedir, "AVERAGE", "-s", "-30m", NULL };
-#else
-	char *fetch_params[] = { "rrdfetch", filedir, "AVERAGE", "-s", "-30m", NULL };
-#endif
+	xymon_rrd_argv_item_t fetch_params[] = { "rrdfetch", filedir, "AVERAGE", "-s", "-30m", NULL };
 	time_t starttime, endtime;
 	unsigned long steptime, dscount;
 	rrd_value_t *rrddata;
@@ -612,7 +602,7 @@ static int rrddatasets(char *hostname, char ***dsnames)
 	if (stat(filedir, &st) == -1) return 0;
 
 	optind = opterr = 0; rrd_clear_error();
-	result = rrd_fetch(5, fetch_params, &starttime, &endtime, &steptime, &dscount, dsnames, &rrddata);
+	result = xymon_rrd_fetch(5, fetch_params, &starttime, &endtime, &steptime, &dscount, dsnames, &rrddata);
 	if (result == -1) {
 		errprintf("Error while retrieving RRD dataset names from %s: %s\n",
 			  filedir, rrd_get_error());
@@ -787,4 +777,3 @@ void update_rrd(char *hostname, char *testname, char *msg, time_t tstamp, char *
 
 	MEMUNDEFINE(rrdvalues);
 }
-

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -244,9 +244,8 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 
 #if defined(LINUX)
 	/*
-	 * RRDtool 1.2+ uses mmap'ed I/O, but the Linux kernel does not update timestamps when
-	 * doing file I/O on mmap'ed files. This breaks our check for stale/nostale RRD's.
-	 * So do an explicit timestamp update on the file here.
+	 * RRDtool >= 1.2 uses mmap'ed I/O, but Linux does not update file timestamps for
+	 * mmap writes. This breaks our stale/nostale checks, so force a timestamp update.
 	 */
 	utimes(filedir, NULL);
 #endif

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -242,7 +242,7 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 	optind = opterr = 0; rrd_clear_error();
 	result = xymon_rrd_update(pcount, updparams);
 
-#if defined(LINUX) && defined(RRDTOOL12)
+#if defined(LINUX)
 	/*
 	 * RRDtool 1.2+ uses mmap'ed I/O, but the Linux kernel does not update timestamps when
 	 * doing file I/O on mmap'ed files. This breaks our check for stale/nostale RRD's.

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -351,7 +351,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		sprintf(stepsetting, "%d", pollinterval);
 
 		rrddefinitions = get_rrd_definition((rrakey ? rrakey : testname), &rrddefcount);
-		rrdcreate_params = (xymon_rrd_argv_item_t *)calloc(4 + pcount + rrddefcount + 1, sizeof(xymon_rrd_argv_item_t));
+		rrdcreate_params = calloc(4 + pcount + rrddefcount + 1, sizeof(*rrdcreate_params));
 		rrdcreate_params[0] = "rrdcreate";
 		rrdcreate_params[1] = filedir;
 


### PR DESCRIPTION
# RRDtool: ensure compatibility with < 1.9 and >= 1.9 (const argv ABI)

## Summary

RRDtool 1.9.x changed several APIs from `char **argv` to `const char **argv`.  
This PR replaces version-based checks with an ABI probe at build time and introduces a unified compatibility layer (`rrd_compat.h`).

All RRDtool calls are now routed through `xymon_rrd_*` wrappers, removing scattered `RRDTOOL19` conditionals and centralizing compatibility handling.

## What Changed

- ABI detection added to `build/rrd.sh`
- New `include/rrd_compat.h` with wrapper functions
- Refactored:
  - `xymond/do_rrd.c`
  - `web/perfdata.c`
  - `web/showgraph.c`
  - `build/test-rrd.c`
- Removed redundant `rrdfn == NULL` check

No functional changes intended.

## Checklist

- [x] Build without RRDtool (graphs disabled)
- [x] Build with RRDtool < 1.9
- [x] Build with RRDtool >= 1.9
- [x] No incompatible pointer warnings
- [ ] Basic runtime: create / update / fetch / graph
