### PR TITLE
Fix/snmpcollect: switch MD5 to SHA1 when MD5 is unavailable

### DIFF
--- a/xymonnet/xymon-snmpcollect.c
+++ b/xymonnet/xymon-snmpcollect.c
@@ -248,6 +248,7 @@ int print_result (int status, req_t *req, struct snmp_pdu *pdu)
 }
 
 
+
 /*
  * response handler
  */
@@ -426,12 +427,19 @@ void startonehost(struct req_t *req, int ipchange)
 			/* set the authentication method */
 			switch (req->authmethod) {
 			  case SNMP_V3AUTH_MD5:
+#ifndef NETSNMP_DISABLE_MD5
 				s.securityAuthProto = usmHMACMD5AuthProtocol;
 				s.securityAuthProtoLen = sizeof(usmHMACMD5AuthProtocol)/sizeof(oid);
 				s.securityAuthKeyLen = USM_AUTH_KU_LEN;
 				break;
+#else
+				errprintf("SNMPv3 authmethod MD5 requested for host %s, but Net-SNMP was built without MD5 support. Falling back to SHA1.\n",
+					  req->hostname);
+				/* FALLTHROUGH */
+#endif
 
 			  case SNMP_V3AUTH_SHA1:
+			  default:
 				s.securityAuthProto = usmHMACSHA1AuthProtocol;
 				s.securityAuthProtoLen = sizeof(usmHMACSHA1AuthProtocol)/sizeof(oid);
 				s.securityAuthKeyLen = USM_AUTH_KU_LEN;
@@ -686,7 +694,11 @@ void readconfig(char *cfgfn, int verbose)
 
 			reqitem->hostip[0] = reqitem->hostname;
 			reqitem->version = SNMP_VERSION_1;
+#ifdef NETSNMP_DISABLE_MD5
+			reqitem->authmethod = SNMP_V3AUTH_SHA1;
+#else
 			reqitem->authmethod = SNMP_V3AUTH_MD5;
+#endif
 			reqitem->next = reqhead;
 			reqhead = reqitem;
 
@@ -732,8 +744,15 @@ void readconfig(char *cfgfn, int verbose)
 		}
 
 		if (strncmp(bot, "authmethod=", 11) == 0) {
-			if (strcasecmp(bot+11, "md5") == 0)
+			if (strcasecmp(bot+11, "md5") == 0) {
+#ifdef NETSNMP_DISABLE_MD5
+				errprintf("SNMPv3 authmethod MD5 requested for host %s, but Net-SNMP was built without MD5 support. Using SHA1.\n",
+					  reqitem->hostname);
+				reqitem->authmethod = SNMP_V3AUTH_SHA1;
+#else
 				reqitem->authmethod = SNMP_V3AUTH_MD5;
+#endif
+			}
 			else if (strcasecmp(bot+11, "sha1") == 0)
 				reqitem->authmethod = SNMP_V3AUTH_SHA1;
 			else

--- a/xymonnet/xymon-snmpcollect.c
+++ b/xymonnet/xymon-snmpcollect.c
@@ -433,9 +433,10 @@ void startonehost(struct req_t *req, int ipchange)
 				s.securityAuthKeyLen = USM_AUTH_KU_LEN;
 				break;
 #else
-				errprintf("SNMPv3 authmethod MD5 requested for host %s, but Net-SNMP was built without MD5 support. Falling back to SHA1.\n",
+				errprintf("SNMPv3 authmethod MD5 requested for host %s, but Net-SNMP was built without MD5 support.\n",
 					  req->hostname);
-				/* FALLTHROUGH */
+				xfree(s.securityName);
+				return;
 #endif
 
 			  case SNMP_V3AUTH_SHA1:
@@ -746,12 +747,10 @@ void readconfig(char *cfgfn, int verbose)
 		if (strncmp(bot, "authmethod=", 11) == 0) {
 			if (strcasecmp(bot+11, "md5") == 0) {
 #ifdef NETSNMP_DISABLE_MD5
-				errprintf("SNMPv3 authmethod MD5 requested for host %s, but Net-SNMP was built without MD5 support. Using SHA1.\n",
+				errprintf("SNMPv3 authmethod MD5 requested for host %s, but Net-SNMP was built without MD5 support.\n",
 					  reqitem->hostname);
-				reqitem->authmethod = SNMP_V3AUTH_SHA1;
-#else
-				reqitem->authmethod = SNMP_V3AUTH_MD5;
 #endif
+				reqitem->authmethod = SNMP_V3AUTH_MD5;
 			}
 			else if (strcasecmp(bot+11, "sha1") == 0)
 				reqitem->authmethod = SNMP_V3AUTH_SHA1;
@@ -1132,4 +1131,3 @@ int main (int argc, char **argv)
 
 	return 0;
 }
-

--- a/xymonnet/xymon-snmpcollect.c
+++ b/xymonnet/xymon-snmpcollect.c
@@ -426,12 +426,20 @@ void startonehost(struct req_t *req, int ipchange)
 			/* set the authentication method */
 			switch (req->authmethod) {
 			  case SNMP_V3AUTH_MD5:
+#ifndef NETSNMP_DISABLE_MD5
 				s.securityAuthProto = usmHMACMD5AuthProtocol;
 				s.securityAuthProtoLen = sizeof(usmHMACMD5AuthProtocol)/sizeof(oid);
 				s.securityAuthKeyLen = USM_AUTH_KU_LEN;
 				break;
+#else
+				errprintf("SNMPv3 authmethod MD5 requested for host %s, but Net-SNMP was built without MD5 support.\n",
+					  req->hostname);
+				xfree(s.securityName);
+				return;
+#endif
 
 			  case SNMP_V3AUTH_SHA1:
+			  default:
 				s.securityAuthProto = usmHMACSHA1AuthProtocol;
 				s.securityAuthProtoLen = sizeof(usmHMACSHA1AuthProtocol)/sizeof(oid);
 				s.securityAuthKeyLen = USM_AUTH_KU_LEN;
@@ -686,7 +694,11 @@ void readconfig(char *cfgfn, int verbose)
 
 			reqitem->hostip[0] = reqitem->hostname;
 			reqitem->version = SNMP_VERSION_1;
+#ifdef NETSNMP_DISABLE_MD5
+			reqitem->authmethod = SNMP_V3AUTH_SHA1;
+#else
 			reqitem->authmethod = SNMP_V3AUTH_MD5;
+#endif
 			reqitem->next = reqhead;
 			reqhead = reqitem;
 
@@ -732,8 +744,13 @@ void readconfig(char *cfgfn, int verbose)
 		}
 
 		if (strncmp(bot, "authmethod=", 11) == 0) {
-			if (strcasecmp(bot+11, "md5") == 0)
+			if (strcasecmp(bot+11, "md5") == 0) {
+#ifdef NETSNMP_DISABLE_MD5
+				errprintf("SNMPv3 authmethod MD5 requested for host %s, but Net-SNMP was built without MD5 support.\n",
+					  reqitem->hostname);
+#endif
 				reqitem->authmethod = SNMP_V3AUTH_MD5;
+			}
 			else if (strcasecmp(bot+11, "sha1") == 0)
 				reqitem->authmethod = SNMP_V3AUTH_SHA1;
 			else
@@ -1113,4 +1130,3 @@ int main (int argc, char **argv)
 
 	return 0;
 }
-


### PR DESCRIPTION
Fixes #77

When Net-SNMP is built with `NETSNMP_DISABLE_MD5` (e.g. openSUSE
Tumbleweed), `usmHMACMD5AuthProtocol` is unavailable and the build
fails:

    error: 'usmHMACMD5AuthProtocol' undeclared

This PR guards all MD5 references in `xymonnet/xymon-snmpcollect.c`
with `#ifndef NETSNMP_DISABLE_MD5`.

## Behavior on MD5-disabled builds

- Default SNMPv3 auth method becomes SHA1 (instead of MD5).
- Hosts configured with `authmethod=md5` trigger a warning at parse
  time and are dropped at runtime (errprintf + xfree + return in the
  auth-method switch). No silent fallback to SHA1, since an explicit
  MD5 directive signals a policy intent that cannot be safely guessed.

One file changed: `xymonnet/xymon-snmpcollect.c` (+18/-2).