### PR TITLE
RRDtool: compatibility for < 1.9 and >= 1.9

### DIFF
--- a/build/Makefile.test-rrd
+++ b/build/Makefile.test-rrd
@@ -1,11 +1,10 @@
 include Makefile.$(OS)
 
 test-compile:
-	@$(CC) $(CFLAGS) $(RRDDEF) $(RRDINC) -o test-rrd.o -c test-rrd.c
+	@$(CC) $(CFLAGS) $(RRDDEF) $(RRDINC) -I../include -o test-rrd.o -c test-rrd.c
 
 test-link:
 	@$(CC) $(CFLAGS) $(RRDDEF) $(RRDLIB) -o test-rrd test-rrd.o -lrrd $(PNGLIB)
 
 clean:
 	@rm -f test-rrd.o test-rrd xymongen.png
-

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -73,7 +73,7 @@
 
 	# Probe + compile/link validation
 	RRDOK="YES"
-	OS=`uname -s | sed -e's@/@_@g'`
+	OS=$(uname -s | sed -e's@/@_@g')
 	if test "$RRDINC" != ""; then INCOPT="-I$RRDINC"; fi
 	if test "$RRDLIB" != ""; then LIBOPT="-L$RRDLIB"; fi
 
@@ -83,19 +83,19 @@
 		f=
 		n=0
 		if command -v mktemp >/dev/null 2>&1; then
-			f=`mktemp "${TMPDIR:-/tmp}/${prefix}.XXXXXX" 2>/dev/null` && { echo "$f"; return 0; }
+			f=$(mktemp "${TMPDIR:-/tmp}/${prefix}.XXXXXX" 2>/dev/null) && { echo "$f"; return 0; }
 		fi
 		while test $n -lt 50; do
 			f="${TMPDIR:-/tmp}/${prefix}.$$.$n"
 			(umask 077; : > "$f") 2>/dev/null && { echo "$f"; return 0; }
-			n=`expr $n + 1`
+			n=$(expr "$n" + 1)
 		done
 		return 1
 	}
 
 	# Probe whether rrd_update() expects const char ** (newer) or char ** (legacy).
 	detect_rrd_const_args() {
-		TESTOBJ=`mktemp_xymon "xymon-rrd-abi-obj"` || return 2
+		TESTOBJ=$(mktemp_xymon "xymon-rrd-abi-obj") || return 2
 		CONSTOK=0
 		MUTABLEOK=0
 		RRD_PROBE_CFLAGS=""
@@ -205,7 +205,7 @@ EOF
 			echo "RRD: ABI override -> mutable argv pointers (USERRRDCONSTARGS=$USERRRDCONSTARGS)"
 			;;
 		""|auto)
-			RRD_CONST_ARGS_DETECTED=`detect_rrd_const_args`
+			RRD_CONST_ARGS_DETECTED=$(detect_rrd_const_args)
 			RRD_CONST_PROBE_STATUS=$?
 			;;
 		*)

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -1,265 +1,143 @@
-	echo "Checking for RRDtool ..."
+        echo "Checking for RRDtool ..."
 
-	RRDDEF=""
-	RRDINC=""
-	RRDLIB=""
-	PNGLIB=""
-	ZLIB=""
-	for DIR in /opt/rrdtool* /usr/local/rrdtool* /usr/local /usr/pkg /opt/csw /opt/sfw /usr/sfw
-	do
-		if test -f $DIR/include/rrd.h
-		then
-			RRDINC=$DIR/include
-		fi
+        RRDDEF=""
+        RRDINC=""
+        RRDLIB=""
+        PNGLIB=""
+        ZLIB=""
+        for DIR in /opt/rrdtool* /usr/local/rrdtool* /usr/local /usr/pkg /opt/csw /opt/sfw /usr/sfw
+        do
+                if test -f $DIR/include/rrd.h
+                then
+                        RRDINC=$DIR/include
+                fi
 
-		if test -f $DIR/lib/librrd.so
-		then
-			RRDLIB=$DIR/lib
-		fi
-		if test -f $DIR/lib/librrd.a
-		then
-			RRDLIB=$DIR/lib
-		fi
-		if test -f $DIR/lib64/librrd.so
-		then
-			RRDLIB=$DIR/lib64
-		fi
-		if test -f $DIR/lib64/librrd.a
-		then
-			RRDLIB=$DIR/lib64
-		fi
+                if test -f $DIR/lib/librrd.so
+                then
+                        RRDLIB=$DIR/lib
+                fi
+                if test -f $DIR/lib/librrd.a
+                then
+                        RRDLIB=$DIR/lib
+                fi
+                if test -f $DIR/lib64/librrd.so
+                then
+                        RRDLIB=$DIR/lib64
+                fi
+                if test -f $DIR/lib64/librrd.a
+                then
+                        RRDLIB=$DIR/lib64
+                fi
 
-		if test -f $DIR/lib/libpng.so
-		then
-			PNGLIB="-L$DIR/lib -lpng"
-		fi
-		if test -f $DIR/lib/libpng.a
-		then
-			PNGLIB="-L$DIR/lib -lpng"
-		fi
-		if test -f $DIR/lib64/libpng.so
-		then
-			PNGLIB="-L$DIR/lib64 -lpng"
-		fi
-		if test -f $DIR/lib64/libpng.a
-		then
-			PNGLIB="-L$DIR/lib64 -lpng"
-		fi
+                if test -f $DIR/lib/libpng.so
+                then
+                        PNGLIB="-L$DIR/lib -lpng"
+                fi
+                if test -f $DIR/lib/libpng.a
+                then
+                        PNGLIB="-L$DIR/lib -lpng"
+                fi
+                if test -f $DIR/lib64/libpng.so
+                then
+                        PNGLIB="-L$DIR/lib64 -lpng"
+                fi
+                if test -f $DIR/lib64/libpng.a
+                then
+                        PNGLIB="-L$DIR/lib64 -lpng"
+                fi
 
-		if test -f $DIR/lib/libz.so
-		then
-			ZLIB="-L$DIR/lib -lz"
-		fi
-		if test -f $DIR/lib/libz.a
-		then
-			ZLIB="-L$DIR/lib -lz"
-		fi
-		if test -f $DIR/lib64/libz.so
-		then
-			ZLIB="-L$DIR/lib64 -lz"
-		fi
-		if test -f $DIR/lib64/libz.a
-		then
-			ZLIB="-L$DIR/lib64 -lz"
-		fi
-	done
+                if test -f $DIR/lib/libz.so
+                then
+                        ZLIB="-L$DIR/lib -lz"
+                fi
+                if test -f $DIR/lib/libz.a
+                then
+                        ZLIB="-L$DIR/lib -lz"
+                fi
+                if test -f $DIR/lib64/libz.so
+                then
+                        ZLIB="-L$DIR/lib64 -lz"
+                fi
+                if test -f $DIR/lib64/libz.a
+                then
+                        ZLIB="-L$DIR/lib64 -lz"
+                fi
+        done
 
-	if test "$USERRRDINC" != ""; then
-		RRDINC="$USERRRDINC"
-	fi
-	if test "$USERRRDLIB" != ""; then
-		RRDLIB="$USERRRDLIB"
-	fi
+        if test "$USERRRDINC" != ""; then
+                RRDINC="$USERRRDINC"
+        fi
+        if test "$USERRRDLIB" != ""; then
+                RRDLIB="$USERRRDLIB"
+        fi
 
-	# Probe + compile/link validation
-	RRDOK="YES"
-	OS=`uname -s | sed -e's@/@_@g'`
-	if test "$RRDINC" != ""; then INCOPT="-I$RRDINC"; fi
-	if test "$RRDLIB" != ""; then LIBOPT="-L$RRDLIB"; fi
+        # See if it builds
+        RRDOK="YES"
+        if test "$RRDINC" != ""; then INCOPT="-I$RRDINC"; fi
+        if test "$RRDLIB" != ""; then LIBOPT="-L$RRDLIB"; fi
+        if pkg-config --atleast-version=1.9.0 librrd > /dev/null 2>&1; then
+                echo "Found RRDtool >= 1.9.0 via pkg-config"
+                RRDDEF="-DRRDTOOL19"
+        else
+                echo "Found RRDtool < 1.9.0 via pkg-config"
+        fi
+        cd build
+        OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
+        OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile 2>/dev/null
+        if test $? -ne 0; then
+                # See if it's the new RRDtool 1.2.x
+                echo "Not RRDtool 1.0.x, checking for 1.2.x"
+                RRDDEF="$RRDDEF -DRRDTOOL12"
+                OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
+                OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile
+        fi
+        if test $? -eq 0; then
+                echo "Compiling with RRDtool works OK"
+        else
+                echo "ERROR: Cannot compile with RRDtool."
+                RRDOK="NO"
+        fi
 
-	# --- Helpers ---
-	mktemp_xymon() {
-		prefix="$1"
-		f=
-		n=0
-		if command -v mktemp >/dev/null 2>&1; then
-			f=`mktemp "${TMPDIR:-/tmp}/${prefix}.XXXXXX" 2>/dev/null` && { echo "$f"; return 0; }
-		fi
-		while test $n -lt 50; do
-			f="${TMPDIR:-/tmp}/${prefix}.$$.$n"
-			(umask 077; : > "$f") 2>/dev/null && { echo "$f"; return 0; }
-			n=`expr $n + 1`
-		done
-		return 1
-	}
+        OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
+        if test $? -ne 0; then
+                # Could be that we need -lz for RRD
+                PNGLIB="$PNGLIB $ZLIB"
+        fi
+        OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
+        if test $? -ne 0; then
+                # Could be that we need -lm for RRD
+                PNGLIB="$PNGLIB -lm"
+        fi
+        OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
+        if test $? -ne 0; then
+                # Could be that we need -L/usr/X11R6/lib (OpenBSD)
+                LIBOPT="$LIBOPT -L/usr/X11R6/lib"
+                RRDLIB="$RRDLIB -L/usr/X11R6/lib"
+        fi
+        OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
+        if test $? -eq 0; then
+                echo "Linking with RRDtool works OK"
+                if test "$PNGLIB" != ""; then
+                        echo "Linking RRD needs extra library: $PNGLIB"
+                fi
+        else
+                echo "ERROR: Linking with RRDtool fails"
+                RRDOK="NO"
+        fi
+        OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
+        cd ..
 
-	# Probe whether rrd_update() expects const char ** (newer) or char ** (legacy).
-	detect_rrd_const_args() {
-		TESTOBJ=`mktemp_xymon "xymon-rrd-abi-obj"` || return 2
-		CONSTOK=0
-		MUTABLEOK=0
-		RRD_PROBE_CFLAGS=""
+        if test "$RRDOK" = "NO"; then
+                echo "RRDtool include- or library-files not found."
+                echo "These are REQUIRED for trend-graph support in Xymon, but Xymon can"
+                echo "be built without them (e.g. for a network-probe only installation."
+                echo ""
+                echo "RRDtool can be found at http://oss.oetiker.ch/rrdtool/"
+                echo "If you have RRDtool installed, use the \"--rrdinclude DIR\" and \"--rrdlib DIR\""
+                echo "options to configure to specify where they are."
+                echo ""
+                echo "Continuing with all trend-graph support DISABLED"
+                sleep 3
+        fi
 
-		if ${CC:-cc} -Werror=incompatible-pointer-types -x c -c -o "$TESTOBJ" - >/dev/null 2>&1 <<EOF
-int main(void) { return 0; }
-EOF
-		then
-			RRD_PROBE_CFLAGS="-Werror=incompatible-pointer-types"
-		elif ${CC:-cc} -Werror -x c -c -o "$TESTOBJ" - >/dev/null 2>&1 <<EOF
-int main(void) { return 0; }
-EOF
-		then
-			RRD_PROBE_CFLAGS="-Werror"
-		fi
 
-		if ${CC:-cc} ${INCOPT} ${RRD_PROBE_CFLAGS} -x c -c -o "$TESTOBJ" - >/dev/null 2>&1 <<EOF
-#include <stddef.h>
-#include <rrd.h>
-int main(void)
-{
-	const char *args[] = { "rrdupdate", "dummy.rrd", NULL };
-	return rrd_update(2, args);
-}
-EOF
-		then
-			CONSTOK=1
-		fi
-		if ${CC:-cc} ${INCOPT} ${RRD_PROBE_CFLAGS} -x c -c -o "$TESTOBJ" - >/dev/null 2>&1 <<EOF
-#include <stddef.h>
-#include <rrd.h>
-int main(void)
-{
-	char *args[] = { "rrdupdate", "dummy.rrd", NULL };
-	return rrd_update(2, args);
-}
-EOF
-		then
-			MUTABLEOK=1
-		fi
-
-		rm -f "$TESTOBJ"
-		case "$CONSTOK:$MUTABLEOK" in
-			1:0)
-				echo "const"
-				return 0
-				;;
-			0:1)
-				echo "mutable"
-				return 0
-				;;
-			1:1)
-				echo "RRD: detect ABI is ambiguous (both const and mutable probes compiled)." >&2
-				echo "RRD: set USERRRDCONSTARGS=0 or USERRRDCONSTARGS=1 to override." >&2
-				return 3
-				;;
-			*)
-				echo "RRD: detect ABI failed (neither const nor mutable probe compiled)." >&2
-				echo "RRD: set USERRRDCONSTARGS=0 or USERRRDCONSTARGS=1 to override." >&2
-				return 4
-				;;
-		esac
-	}
-
-	try_rrd_compile() {
-		OS=$OS RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile
-	}
-
-	try_rrd_link() {
-		OS=$OS RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-	}
-
-	try_rrd_compile_probe() {
-		# test-rrd.c exercises update/create/fetch/graph signatures through rrd_compat.h.
-		try_rrd_compile >/dev/null 2>&1
-	}
-
-	try_rrd_link_with_fallbacks() {
-		try_rrd_link && return 0
-
-		# Could be that we need -lz for RRD
-		PNGLIB="$PNGLIB $ZLIB"
-		try_rrd_link && return 0
-
-		# Could be that we need -lm for RRD
-		PNGLIB="$PNGLIB -lm"
-		try_rrd_link && return 0
-
-		# Could be that we need -L/usr/X11R6/lib (OpenBSD)
-		LIBOPT="$LIBOPT -L/usr/X11R6/lib"
-		RRDLIB="$RRDLIB -L/usr/X11R6/lib"
-		try_rrd_link
-	}
-
-	# --- Phase 1: ABI detection ---
-	# Detect whether RRDtool APIs use const argv pointers.
-	# Newer headers expect const char **, older expect char **.
-	RRD_CONST_ARGS_DETECTED=""
-	RRD_CONST_PROBE_STATUS=0
-	case "$USERRRDCONSTARGS" in
-		1)
-			RRD_CONST_ARGS_DETECTED="const"
-			echo "RRD: ABI override -> const argv pointers (USERRRDCONSTARGS=$USERRRDCONSTARGS)"
-			;;
-		0)
-			RRD_CONST_ARGS_DETECTED="mutable"
-			echo "RRD: ABI override -> mutable argv pointers (USERRRDCONSTARGS=$USERRRDCONSTARGS)"
-			;;
-		""|auto)
-			RRD_CONST_ARGS_DETECTED=`detect_rrd_const_args`
-			RRD_CONST_PROBE_STATUS=$?
-			;;
-		*)
-			echo "RRD: invalid USERRRDCONSTARGS value '$USERRRDCONSTARGS' (expected 0, 1, or auto)"
-			RRD_CONST_PROBE_STATUS=9
-			;;
-	esac
-	if test "$RRD_CONST_PROBE_STATUS" -ne 0; then
-		echo "RRD: detect ABI -> failed (status=$RRD_CONST_PROBE_STATUS)"
-		RRDOK="NO"
-	fi
-	if test "$RRD_CONST_ARGS_DETECTED" = "const"; then
-		echo "RRD: detect ABI -> const argv pointers"
-		RRDDEF="$RRDDEF -DRRD_CONST_ARGS=1"
-	elif test "$RRD_CONST_ARGS_DETECTED" = "mutable"; then
-		echo "RRD: detect ABI -> mutable argv pointers"
-		RRDDEF="$RRDDEF -DRRD_CONST_ARGS=0"
-	else
-		echo "RRD: detect ABI -> unresolved"
-		RRDOK="NO"
-	fi
-
-	# --- Phase 2: compile/link probes ---
-	cd build
-	OS=$OS $MAKE -f Makefile.test-rrd clean
-	if try_rrd_compile_probe; then
-		echo "Compiling with RRDtool works OK"
-	else
-		echo "ERROR: Cannot compile with RRDtool."
-		RRDOK="NO"
-	fi
-	echo "RRD: selected compatibility flags -> $RRDDEF"
-
-	if try_rrd_link_with_fallbacks; then
-		echo "Linking with RRDtool works OK"
-		if test "$PNGLIB" != ""; then
-			echo "Linking RRD needs extra library: $PNGLIB"
-		fi
-	else
-		echo "ERROR: Linking with RRDtool fails"
-		RRDOK="NO"
-	fi
-	OS=$OS $MAKE -f Makefile.test-rrd clean
-	cd ..
-
-	if test "$RRDOK" = "NO"; then
-		echo "RRDtool include- or library-files not found."
-		echo "These are REQUIRED for trend-graph support in Xymon, but Xymon can"
-		echo "be built without them (e.g. for a network-probe only installation."
-		echo ""
-		echo "RRDtool can be found at http://oss.oetiker.ch/rrdtool/"
-		echo "If you have RRDtool installed, use the \"--rrdinclude DIR\" and \"--rrdlib DIR\""
-		echo "options to configure to specify where they are."
-		echo ""
-		echo "Continuing with all trend-graph support DISABLED"
-		sleep 3
-	fi

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -73,7 +73,7 @@
 
 	# Probe + compile/link validation
 	RRDOK="YES"
-	OS=$(uname -s | sed -e's@/@_@g')
+	OS=`uname -s | sed -e's@/@_@g'`
 	if test "$RRDINC" != ""; then INCOPT="-I$RRDINC"; fi
 	if test "$RRDLIB" != ""; then LIBOPT="-L$RRDLIB"; fi
 
@@ -83,19 +83,19 @@
 		f=
 		n=0
 		if command -v mktemp >/dev/null 2>&1; then
-			f=$(mktemp "${TMPDIR:-/tmp}/${prefix}.XXXXXX" 2>/dev/null) && { echo "$f"; return 0; }
+			f=`mktemp "${TMPDIR:-/tmp}/${prefix}.XXXXXX" 2>/dev/null` && { echo "$f"; return 0; }
 		fi
 		while test $n -lt 50; do
 			f="${TMPDIR:-/tmp}/${prefix}.$$.$n"
 			(umask 077; : > "$f") 2>/dev/null && { echo "$f"; return 0; }
-			n=$(expr "$n" + 1)
+			n=`expr $n + 1`
 		done
 		return 1
 	}
 
 	# Probe whether rrd_update() expects const char ** (newer) or char ** (legacy).
 	detect_rrd_const_args() {
-		TESTOBJ=$(mktemp_xymon "xymon-rrd-abi-obj") || return 2
+		TESTOBJ=`mktemp_xymon "xymon-rrd-abi-obj"` || return 2
 		CONSTOK=0
 		MUTABLEOK=0
 		RRD_PROBE_CFLAGS=""
@@ -205,7 +205,7 @@ EOF
 			echo "RRD: ABI override -> mutable argv pointers (USERRRDCONSTARGS=$USERRRDCONSTARGS)"
 			;;
 		""|auto)
-			RRD_CONST_ARGS_DETECTED=$(detect_rrd_const_args)
+			RRD_CONST_ARGS_DETECTED=`detect_rrd_const_args`
 			RRD_CONST_PROBE_STATUS=$?
 			;;
 		*)

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -77,9 +77,16 @@
 
 	test -n "$RRDINC" && INCOPT="-I$RRDINC"
 	test -n "$RRDLIB" && LIBOPT="-L$RRDLIB"
+	PTRTYPE_WERROR="-Werror=incompatible-pointer-types"
+	if ! ${CC:-cc} ${PTRTYPE_WERROR} -x c -c -o /dev/null - >/dev/null 2>&1 <<'EOF'
+int main(void) { return 0; }
+EOF
+	then
+		PTRTYPE_WERROR=""
+	fi
 
 	detect_rrd_const_args() {
-		${CC:-cc} ${INCOPT} -Werror=incompatible-pointer-types \
+		${CC:-cc} ${INCOPT} ${PTRTYPE_WERROR} \
 			-x c -c -o /dev/null - >/dev/null 2>&1 <<EOF
 #include <rrd.h>
 int main(void) {
@@ -89,7 +96,7 @@ int main(void) {
 EOF
 		test $? -eq 0 && return 1
 
-		${CC:-cc} ${INCOPT} -Werror=incompatible-pointer-types \
+		${CC:-cc} ${INCOPT} ${PTRTYPE_WERROR} \
 			-x c -c -o /dev/null - >/dev/null 2>&1 <<EOF
 #include <rrd.h>
 int main(void) {

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -1,143 +1,167 @@
-       echo "Checking for RRDtool ..."
+	echo "Checking for RRDtool ..."
 
-       RRDDEF=""
-       RRDINC=""
-       RRDLIB=""
-       PNGLIB=""
-       ZLIB=""
-       for DIR in /opt/rrdtool* /usr/local/rrdtool* /usr/local /usr/pkg /opt/csw /opt/sfw /usr/sfw
-       do
-               if test -f $DIR/include/rrd.h
-               then
-                       RRDINC=$DIR/include
-               fi
+	RRDDEF=""
+	RRDINC=""
+	RRDLIB=""
+	PNGLIB=""
+	ZLIB=""
+	for DIR in /opt/rrdtool* /usr/local/rrdtool* /usr/local /usr/pkg /opt/csw /opt/sfw /usr/sfw
+	do
+		if test -f $DIR/include/rrd.h
+		then
+			RRDINC=$DIR/include
+		fi
 
-               if test -f $DIR/lib/librrd.so
-               then
-                       RRDLIB=$DIR/lib
-               fi
-               if test -f $DIR/lib/librrd.a
-               then
-                       RRDLIB=$DIR/lib
-               fi
-               if test -f $DIR/lib64/librrd.so
-               then
-                       RRDLIB=$DIR/lib64
-               fi
-               if test -f $DIR/lib64/librrd.a
-               then
-                       RRDLIB=$DIR/lib64
-               fi
+		if test -f $DIR/lib/librrd.so
+		then
+			RRDLIB=$DIR/lib
+		fi
+		if test -f $DIR/lib/librrd.a
+		then
+			RRDLIB=$DIR/lib
+		fi
+		if test -f $DIR/lib64/librrd.so
+		then
+			RRDLIB=$DIR/lib64
+		fi
+		if test -f $DIR/lib64/librrd.a
+		then
+			RRDLIB=$DIR/lib64
+		fi
 
-               if test -f $DIR/lib/libpng.so
-               then
-                       PNGLIB="-L$DIR/lib -lpng"
-               fi
-               if test -f $DIR/lib/libpng.a
-               then
-                       PNGLIB="-L$DIR/lib -lpng"
-               fi
-               if test -f $DIR/lib64/libpng.so
-               then
-                       PNGLIB="-L$DIR/lib64 -lpng"
-               fi
-               if test -f $DIR/lib64/libpng.a
-               then
-                       PNGLIB="-L$DIR/lib64 -lpng"
-               fi
+		if test -f $DIR/lib/libpng.so
+		then
+			PNGLIB="-L$DIR/lib -lpng"
+		fi
+		if test -f $DIR/lib/libpng.a
+		then
+			PNGLIB="-L$DIR/lib -lpng"
+		fi
+		if test -f $DIR/lib64/libpng.so
+		then
+			PNGLIB="-L$DIR/lib64 -lpng"
+		fi
+		if test -f $DIR/lib64/libpng.a
+		then
+			PNGLIB="-L$DIR/lib64 -lpng"
+		fi
 
-               if test -f $DIR/lib/libz.so
-               then
-                       ZLIB="-L$DIR/lib -lz"
-               fi
-               if test -f $DIR/lib/libz.a
-               then
-                       ZLIB="-L$DIR/lib -lz"
-               fi
-               if test -f $DIR/lib64/libz.so
-               then
-                       ZLIB="-L$DIR/lib64 -lz"
-               fi
-               if test -f $DIR/lib64/libz.a
-               then
-                       ZLIB="-L$DIR/lib64 -lz"
-               fi
-       done
+		if test -f $DIR/lib/libz.so
+		then
+			ZLIB="-L$DIR/lib -lz"
+		fi
+		if test -f $DIR/lib/libz.a
+		then
+			ZLIB="-L$DIR/lib -lz"
+		fi
+		if test -f $DIR/lib64/libz.so
+		then
+			ZLIB="-L$DIR/lib64 -lz"
+		fi
+		if test -f $DIR/lib64/libz.a
+		then
+			ZLIB="-L$DIR/lib64 -lz"
+		fi
+	done
 
-       if test "$USERRRDINC" != ""; then
-               RRDINC="$USERRRDINC"
-       fi
-       if test "$USERRRDLIB" != ""; then
-               RRDLIB="$USERRRDLIB"
-       fi
+	if test "$USERRRDINC" != ""; then
+		RRDINC="$USERRRDINC"
+	fi
+	if test "$USERRRDLIB" != ""; then
+		RRDLIB="$USERRRDLIB"
+	fi
+    
+        # Probe + compile/link validation
+        RRDOK="YES"
+        OS="$(uname -s | sed 's@/@_@g')"
 
-       # See if it builds
-       RRDOK="YES"
-       if test "$RRDINC" != ""; then INCOPT="-I$RRDINC"; fi
-       if test "$RRDLIB" != ""; then LIBOPT="-L$RRDLIB"; fi
-       if pkg-config --atleast-version=1.9.0 librrd > /dev/null 2>&1; then
-               echo "Found RRDtool >= 1.9.0 via pkg-config"
-               RRDDEF="-DRRDTOOL19"
-       else
-               echo "Found RRDtool < 1.9.0 via pkg-config"
-       fi
-       cd build
-       OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
-       OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile 2>/dev/null
-       if test $? -ne 0; then
-               # See if it's the new RRDtool 1.2.x
-               echo "Not RRDtool 1.0.x, checking for 1.2.x"
-               RRDDEF="$RRDDEF -DRRDTOOL12"
-               OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
-               OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile
-       fi
-       if test $? -eq 0; then
-               echo "Compiling with RRDtool works OK"
-       else
-               echo "ERROR: Cannot compile with RRDtool."
-               RRDOK="NO"
-       fi
+        test -n "$RRDINC" && INCOPT="-I$RRDINC"
+        test -n "$RRDLIB" && LIBOPT="-L$RRDLIB"
 
-       OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-       if test $? -ne 0; then
-               # Could be that we need -lz for RRD
-               PNGLIB="$PNGLIB $ZLIB"
-       fi
-       OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-       if test $? -ne 0; then
-               # Could be that we need -lm for RRD
-               PNGLIB="$PNGLIB -lm"
-       fi
-       OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-       if test $? -ne 0; then
-               # Could be that we need -L/usr/X11R6/lib (OpenBSD)
-               LIBOPT="$LIBOPT -L/usr/X11R6/lib"
-               RRDLIB="$RRDLIB -L/usr/X11R6/lib"
-       fi
-       OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-       if test $? -eq 0; then
-               echo "Linking with RRDtool works OK"
-               if test "$PNGLIB" != ""; then
-                       echo "Linking RRD needs extra library: $PNGLIB"
-               fi
-       else
-               echo "ERROR: Linking with RRDtool fails"
-               RRDOK="NO"
-       fi
-       OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
-       cd ..
+        detect_rrd_const_args() {
+                ${CC:-cc} ${INCOPT} -Werror=incompatible-pointer-types \
+                        -x c -c -o /dev/null - >/dev/null 2>&1 <<EOF
+#include <rrd.h>
+int main(void) {
+        const char *args[] = { "rrdupdate", "dummy.rrd", NULL };
+        return rrd_update(2, args);
+}
+EOF
+                test $? -eq 0 && return 1
 
-       if test "$RRDOK" = "NO"; then
-               echo "RRDtool include- or library-files not found."
-               echo "These are REQUIRED for trend-graph support in Xymon, but Xymon can"
-               echo "be built without them (e.g. for a network-probe only installation."
-               echo ""
-               echo "RRDtool can be found at http://oss.oetiker.ch/rrdtool/"
-               echo "If you have RRDtool installed, use the \"--rrdinclude DIR\" and \"--rrdlib DIR\""
-               echo "options to configure to specify where they are."
-               echo ""
-               echo "Continuing with all trend-graph support DISABLED"
-               sleep 3
-       fi
+                ${CC:-cc} ${INCOPT} -Werror=incompatible-pointer-types \
+                        -x c -c -o /dev/null - >/dev/null 2>&1 <<EOF
+#include <rrd.h>
+int main(void) {
+        char *args[] = { "rrdupdate", "dummy.rrd", NULL };
+        return rrd_update(2, args);
+}
+EOF
+                test $? -eq 0 && return 0
 
+        return 2
+        }
 
+        # --- ABI detection ---
+        case "$USERRRDCONSTARGS" in
+                1) RRDDEF="$RRDDEF -DRRD_CONST_ARGS=1" ;;
+                0) RRDDEF="$RRDDEF -DRRD_CONST_ARGS=0" ;;
+                ""|auto)
+                        detect_rrd_const_args || RRDOK="NO"
+                        case $? in
+                        1) RRDDEF="$RRDDEF -DRRD_CONST_ARGS=1" ;;
+                        0) RRDDEF="$RRDDEF -DRRD_CONST_ARGS=0" ;;
+                        *) RRDOK="NO" ;;
+                        esac
+                        ;;
+                *) RRDOK="NO" ;;
+        esac
+
+        # --- Compile / Link ---
+        cd build || exit 1
+        OS=$OS $MAKE -f Makefile.test-rrd clean
+
+        if OS=$OS RRDDEF="$RRDDEF" RRDINC="$INCOPT" \
+                $MAKE -f Makefile.test-rrd test-compile >/dev/null 2>&1
+        then
+                echo "Compiling with RRDtool works OK"
+        else
+                echo "ERROR: Cannot compile with RRDtool."
+                RRDOK="NO"
+        fi
+
+        LINKOK=0
+        for EXTRA in "" "$ZLIB" "-lm" "-L/usr/X11R6/lib"
+        do
+                test -n "$EXTRA" && PNGLIB="$PNGLIB $EXTRA"
+                if OS=$OS RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" \
+                        $MAKE -f Makefile.test-rrd test-link >/dev/null 2>&1
+                then
+                        LINKOK=1
+                        break
+                fi
+        done
+
+        if test "$LINKOK" -eq 1; then
+                echo "Linking with RRDtool works OK"
+                test -n "$PNGLIB" && echo "Linking RRD needs extra library: $PNGLIB"
+        else
+                echo "ERROR: Linking with RRDtool fails"
+                RRDOK="NO"
+        fi
+
+        OS=$OS $MAKE -f Makefile.test-rrd clean
+        cd ..
+
+        if test "$RRDOK" = "NO"; then
+                echo "RRDtool include- or library-files not found."
+                echo "These are REQUIRED for trend-graph support in Xymon, but Xymon can"
+                echo "be built without them (e.g. for a network-probe only installation."
+                echo ""
+                echo "RRDtool can be found at http://oss.oetiker.ch/rrdtool/"
+                echo "If you have RRDtool installed, use the \"--rrdinclude DIR\" and \"--rrdlib DIR\""
+                echo "options to configure to specify where they are."
+                echo ""
+                echo "Continuing with all trend-graph support DISABLED"
+                sleep 1
+        fi

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -115,7 +115,16 @@ EOF
 	case "$RRD_CONST_ARGS_DETECTED" in
 	1) RRDDEF="$RRDDEF -DRRD_CONST_ARGS=1" ;;
 	0) RRDDEF="$RRDDEF -DRRD_CONST_ARGS=0" ;;
-	*) RRDOK="NO" ;;
+	*)
+		if pkg-config --atleast-version=1.9.0 librrd >/dev/null 2>&1; then
+			RRDDEF="$RRDDEF -DRRD_CONST_ARGS=1"
+		elif pkg-config --exists librrd >/dev/null 2>&1; then
+			RRDDEF="$RRDDEF -DRRD_CONST_ARGS=0"
+		else
+			echo "ERROR: Unable to determine RRDtool argv ABI (probe + pkg-config failed)."
+			RRDOK="NO"
+		fi
+		;;
 	esac
 
 	# --- Compile / Link ---

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -1,143 +1,143 @@
-        echo "Checking for RRDtool ..."
+       echo "Checking for RRDtool ..."
 
-        RRDDEF=""
-        RRDINC=""
-        RRDLIB=""
-        PNGLIB=""
-        ZLIB=""
-        for DIR in /opt/rrdtool* /usr/local/rrdtool* /usr/local /usr/pkg /opt/csw /opt/sfw /usr/sfw
-        do
-                if test -f $DIR/include/rrd.h
-                then
-                        RRDINC=$DIR/include
-                fi
+       RRDDEF=""
+       RRDINC=""
+       RRDLIB=""
+       PNGLIB=""
+       ZLIB=""
+       for DIR in /opt/rrdtool* /usr/local/rrdtool* /usr/local /usr/pkg /opt/csw /opt/sfw /usr/sfw
+       do
+               if test -f $DIR/include/rrd.h
+               then
+                       RRDINC=$DIR/include
+               fi
 
-                if test -f $DIR/lib/librrd.so
-                then
-                        RRDLIB=$DIR/lib
-                fi
-                if test -f $DIR/lib/librrd.a
-                then
-                        RRDLIB=$DIR/lib
-                fi
-                if test -f $DIR/lib64/librrd.so
-                then
-                        RRDLIB=$DIR/lib64
-                fi
-                if test -f $DIR/lib64/librrd.a
-                then
-                        RRDLIB=$DIR/lib64
-                fi
+               if test -f $DIR/lib/librrd.so
+               then
+                       RRDLIB=$DIR/lib
+               fi
+               if test -f $DIR/lib/librrd.a
+               then
+                       RRDLIB=$DIR/lib
+               fi
+               if test -f $DIR/lib64/librrd.so
+               then
+                       RRDLIB=$DIR/lib64
+               fi
+               if test -f $DIR/lib64/librrd.a
+               then
+                       RRDLIB=$DIR/lib64
+               fi
 
-                if test -f $DIR/lib/libpng.so
-                then
-                        PNGLIB="-L$DIR/lib -lpng"
-                fi
-                if test -f $DIR/lib/libpng.a
-                then
-                        PNGLIB="-L$DIR/lib -lpng"
-                fi
-                if test -f $DIR/lib64/libpng.so
-                then
-                        PNGLIB="-L$DIR/lib64 -lpng"
-                fi
-                if test -f $DIR/lib64/libpng.a
-                then
-                        PNGLIB="-L$DIR/lib64 -lpng"
-                fi
+               if test -f $DIR/lib/libpng.so
+               then
+                       PNGLIB="-L$DIR/lib -lpng"
+               fi
+               if test -f $DIR/lib/libpng.a
+               then
+                       PNGLIB="-L$DIR/lib -lpng"
+               fi
+               if test -f $DIR/lib64/libpng.so
+               then
+                       PNGLIB="-L$DIR/lib64 -lpng"
+               fi
+               if test -f $DIR/lib64/libpng.a
+               then
+                       PNGLIB="-L$DIR/lib64 -lpng"
+               fi
 
-                if test -f $DIR/lib/libz.so
-                then
-                        ZLIB="-L$DIR/lib -lz"
-                fi
-                if test -f $DIR/lib/libz.a
-                then
-                        ZLIB="-L$DIR/lib -lz"
-                fi
-                if test -f $DIR/lib64/libz.so
-                then
-                        ZLIB="-L$DIR/lib64 -lz"
-                fi
-                if test -f $DIR/lib64/libz.a
-                then
-                        ZLIB="-L$DIR/lib64 -lz"
-                fi
-        done
+               if test -f $DIR/lib/libz.so
+               then
+                       ZLIB="-L$DIR/lib -lz"
+               fi
+               if test -f $DIR/lib/libz.a
+               then
+                       ZLIB="-L$DIR/lib -lz"
+               fi
+               if test -f $DIR/lib64/libz.so
+               then
+                       ZLIB="-L$DIR/lib64 -lz"
+               fi
+               if test -f $DIR/lib64/libz.a
+               then
+                       ZLIB="-L$DIR/lib64 -lz"
+               fi
+       done
 
-        if test "$USERRRDINC" != ""; then
-                RRDINC="$USERRRDINC"
-        fi
-        if test "$USERRRDLIB" != ""; then
-                RRDLIB="$USERRRDLIB"
-        fi
+       if test "$USERRRDINC" != ""; then
+               RRDINC="$USERRRDINC"
+       fi
+       if test "$USERRRDLIB" != ""; then
+               RRDLIB="$USERRRDLIB"
+       fi
 
-        # See if it builds
-        RRDOK="YES"
-        if test "$RRDINC" != ""; then INCOPT="-I$RRDINC"; fi
-        if test "$RRDLIB" != ""; then LIBOPT="-L$RRDLIB"; fi
-        if pkg-config --atleast-version=1.9.0 librrd > /dev/null 2>&1; then
-                echo "Found RRDtool >= 1.9.0 via pkg-config"
-                RRDDEF="-DRRDTOOL19"
-        else
-                echo "Found RRDtool < 1.9.0 via pkg-config"
-        fi
-        cd build
-        OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
-        OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile 2>/dev/null
-        if test $? -ne 0; then
-                # See if it's the new RRDtool 1.2.x
-                echo "Not RRDtool 1.0.x, checking for 1.2.x"
-                RRDDEF="$RRDDEF -DRRDTOOL12"
-                OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
-                OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile
-        fi
-        if test $? -eq 0; then
-                echo "Compiling with RRDtool works OK"
-        else
-                echo "ERROR: Cannot compile with RRDtool."
-                RRDOK="NO"
-        fi
+       # See if it builds
+       RRDOK="YES"
+       if test "$RRDINC" != ""; then INCOPT="-I$RRDINC"; fi
+       if test "$RRDLIB" != ""; then LIBOPT="-L$RRDLIB"; fi
+       if pkg-config --atleast-version=1.9.0 librrd > /dev/null 2>&1; then
+               echo "Found RRDtool >= 1.9.0 via pkg-config"
+               RRDDEF="-DRRDTOOL19"
+       else
+               echo "Found RRDtool < 1.9.0 via pkg-config"
+       fi
+       cd build
+       OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
+       OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile 2>/dev/null
+       if test $? -ne 0; then
+               # See if it's the new RRDtool 1.2.x
+               echo "Not RRDtool 1.0.x, checking for 1.2.x"
+               RRDDEF="$RRDDEF -DRRDTOOL12"
+               OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
+               OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile
+       fi
+       if test $? -eq 0; then
+               echo "Compiling with RRDtool works OK"
+       else
+               echo "ERROR: Cannot compile with RRDtool."
+               RRDOK="NO"
+       fi
 
-        OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-        if test $? -ne 0; then
-                # Could be that we need -lz for RRD
-                PNGLIB="$PNGLIB $ZLIB"
-        fi
-        OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-        if test $? -ne 0; then
-                # Could be that we need -lm for RRD
-                PNGLIB="$PNGLIB -lm"
-        fi
-        OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-        if test $? -ne 0; then
-                # Could be that we need -L/usr/X11R6/lib (OpenBSD)
-                LIBOPT="$LIBOPT -L/usr/X11R6/lib"
-                RRDLIB="$RRDLIB -L/usr/X11R6/lib"
-        fi
-        OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-        if test $? -eq 0; then
-                echo "Linking with RRDtool works OK"
-                if test "$PNGLIB" != ""; then
-                        echo "Linking RRD needs extra library: $PNGLIB"
-                fi
-        else
-                echo "ERROR: Linking with RRDtool fails"
-                RRDOK="NO"
-        fi
-        OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
-        cd ..
+       OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
+       if test $? -ne 0; then
+               # Could be that we need -lz for RRD
+               PNGLIB="$PNGLIB $ZLIB"
+       fi
+       OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
+       if test $? -ne 0; then
+               # Could be that we need -lm for RRD
+               PNGLIB="$PNGLIB -lm"
+       fi
+       OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
+       if test $? -ne 0; then
+               # Could be that we need -L/usr/X11R6/lib (OpenBSD)
+               LIBOPT="$LIBOPT -L/usr/X11R6/lib"
+               RRDLIB="$RRDLIB -L/usr/X11R6/lib"
+       fi
+       OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
+       if test $? -eq 0; then
+               echo "Linking with RRDtool works OK"
+               if test "$PNGLIB" != ""; then
+                       echo "Linking RRD needs extra library: $PNGLIB"
+               fi
+       else
+               echo "ERROR: Linking with RRDtool fails"
+               RRDOK="NO"
+       fi
+       OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
+       cd ..
 
-        if test "$RRDOK" = "NO"; then
-                echo "RRDtool include- or library-files not found."
-                echo "These are REQUIRED for trend-graph support in Xymon, but Xymon can"
-                echo "be built without them (e.g. for a network-probe only installation."
-                echo ""
-                echo "RRDtool can be found at http://oss.oetiker.ch/rrdtool/"
-                echo "If you have RRDtool installed, use the \"--rrdinclude DIR\" and \"--rrdlib DIR\""
-                echo "options to configure to specify where they are."
-                echo ""
-                echo "Continuing with all trend-graph support DISABLED"
-                sleep 3
-        fi
+       if test "$RRDOK" = "NO"; then
+               echo "RRDtool include- or library-files not found."
+               echo "These are REQUIRED for trend-graph support in Xymon, but Xymon can"
+               echo "be built without them (e.g. for a network-probe only installation."
+               echo ""
+               echo "RRDtool can be found at http://oss.oetiker.ch/rrdtool/"
+               echo "If you have RRDtool installed, use the \"--rrdinclude DIR\" and \"--rrdlib DIR\""
+               echo "options to configure to specify where they are."
+               echo ""
+               echo "Continuing with all trend-graph support DISABLED"
+               sleep 3
+       fi
 
 

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -71,51 +71,175 @@
 		RRDLIB="$USERRRDLIB"
 	fi
 
-	# See if it builds
+	# Probe + compile/link validation
 	RRDOK="YES"
+	OS=`uname -s | sed -e's@/@_@g'`
 	if test "$RRDINC" != ""; then INCOPT="-I$RRDINC"; fi
 	if test "$RRDLIB" != ""; then LIBOPT="-L$RRDLIB"; fi
-	if pkg-config --atleast-version=1.9.0 librrd > /dev/null 2>&1; then
-		echo "Found RRDtool >= 1.9.0 via pkg-config"
-		RRDDEF="-DRRDTOOL19"
+
+	# --- Helpers ---
+	mktemp_xymon() {
+		prefix="$1"
+		f=
+		n=0
+		if command -v mktemp >/dev/null 2>&1; then
+			f=`mktemp "${TMPDIR:-/tmp}/${prefix}.XXXXXX" 2>/dev/null` && { echo "$f"; return 0; }
+		fi
+		while test $n -lt 50; do
+			f="${TMPDIR:-/tmp}/${prefix}.$$.$n"
+			(umask 077; : > "$f") 2>/dev/null && { echo "$f"; return 0; }
+			n=`expr $n + 1`
+		done
+		return 1
+	}
+
+	# Probe whether rrd_update() expects const char ** (newer) or char ** (legacy).
+	detect_rrd_const_args() {
+		TESTOBJ=`mktemp_xymon "xymon-rrd-abi-obj"` || return 2
+		CONSTOK=0
+		MUTABLEOK=0
+		RRD_PROBE_CFLAGS=""
+
+		if ${CC:-cc} -Werror=incompatible-pointer-types -x c -c -o "$TESTOBJ" - >/dev/null 2>&1 <<EOF
+int main(void) { return 0; }
+EOF
+		then
+			RRD_PROBE_CFLAGS="-Werror=incompatible-pointer-types"
+		elif ${CC:-cc} -Werror -x c -c -o "$TESTOBJ" - >/dev/null 2>&1 <<EOF
+int main(void) { return 0; }
+EOF
+		then
+			RRD_PROBE_CFLAGS="-Werror"
+		fi
+
+		if ${CC:-cc} ${INCOPT} ${RRD_PROBE_CFLAGS} -x c -c -o "$TESTOBJ" - >/dev/null 2>&1 <<EOF
+#include <stddef.h>
+#include <rrd.h>
+int main(void)
+{
+	const char *args[] = { "rrdupdate", "dummy.rrd", NULL };
+	return rrd_update(2, args);
+}
+EOF
+		then
+			CONSTOK=1
+		fi
+		if ${CC:-cc} ${INCOPT} ${RRD_PROBE_CFLAGS} -x c -c -o "$TESTOBJ" - >/dev/null 2>&1 <<EOF
+#include <stddef.h>
+#include <rrd.h>
+int main(void)
+{
+	char *args[] = { "rrdupdate", "dummy.rrd", NULL };
+	return rrd_update(2, args);
+}
+EOF
+		then
+			MUTABLEOK=1
+		fi
+
+		rm -f "$TESTOBJ"
+		case "$CONSTOK:$MUTABLEOK" in
+			1:0)
+				echo "const"
+				return 0
+				;;
+			0:1)
+				echo "mutable"
+				return 0
+				;;
+			1:1)
+				echo "RRD: detect ABI is ambiguous (both const and mutable probes compiled)." >&2
+				echo "RRD: set USERRRDCONSTARGS=0 or USERRRDCONSTARGS=1 to override." >&2
+				return 3
+				;;
+			*)
+				echo "RRD: detect ABI failed (neither const nor mutable probe compiled)." >&2
+				echo "RRD: set USERRRDCONSTARGS=0 or USERRRDCONSTARGS=1 to override." >&2
+				return 4
+				;;
+		esac
+	}
+
+	try_rrd_compile() {
+		OS=$OS RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile
+	}
+
+	try_rrd_link() {
+		OS=$OS RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
+	}
+
+	try_rrd_compile_probe() {
+		# test-rrd.c exercises update/create/fetch/graph signatures through rrd_compat.h.
+		try_rrd_compile >/dev/null 2>&1
+	}
+
+	try_rrd_link_with_fallbacks() {
+		try_rrd_link && return 0
+
+		# Could be that we need -lz for RRD
+		PNGLIB="$PNGLIB $ZLIB"
+		try_rrd_link && return 0
+
+		# Could be that we need -lm for RRD
+		PNGLIB="$PNGLIB -lm"
+		try_rrd_link && return 0
+
+		# Could be that we need -L/usr/X11R6/lib (OpenBSD)
+		LIBOPT="$LIBOPT -L/usr/X11R6/lib"
+		RRDLIB="$RRDLIB -L/usr/X11R6/lib"
+		try_rrd_link
+	}
+
+	# --- Phase 1: ABI detection ---
+	# Detect whether RRDtool APIs use const argv pointers.
+	# Newer headers expect const char **, older expect char **.
+	RRD_CONST_ARGS_DETECTED=""
+	RRD_CONST_PROBE_STATUS=0
+	case "$USERRRDCONSTARGS" in
+		1)
+			RRD_CONST_ARGS_DETECTED="const"
+			echo "RRD: ABI override -> const argv pointers (USERRRDCONSTARGS=$USERRRDCONSTARGS)"
+			;;
+		0)
+			RRD_CONST_ARGS_DETECTED="mutable"
+			echo "RRD: ABI override -> mutable argv pointers (USERRRDCONSTARGS=$USERRRDCONSTARGS)"
+			;;
+		""|auto)
+			RRD_CONST_ARGS_DETECTED=`detect_rrd_const_args`
+			RRD_CONST_PROBE_STATUS=$?
+			;;
+		*)
+			echo "RRD: invalid USERRRDCONSTARGS value '$USERRRDCONSTARGS' (expected 0, 1, or auto)"
+			RRD_CONST_PROBE_STATUS=9
+			;;
+	esac
+	if test "$RRD_CONST_PROBE_STATUS" -ne 0; then
+		echo "RRD: detect ABI -> failed (status=$RRD_CONST_PROBE_STATUS)"
+		RRDOK="NO"
+	fi
+	if test "$RRD_CONST_ARGS_DETECTED" = "const"; then
+		echo "RRD: detect ABI -> const argv pointers"
+		RRDDEF="$RRDDEF -DRRD_CONST_ARGS=1"
+	elif test "$RRD_CONST_ARGS_DETECTED" = "mutable"; then
+		echo "RRD: detect ABI -> mutable argv pointers"
+		RRDDEF="$RRDDEF -DRRD_CONST_ARGS=0"
 	else
-		echo "Found RRDtool < 1.9.0 via pkg-config"
+		echo "RRD: detect ABI -> unresolved"
+		RRDOK="NO"
 	fi
+
+	# --- Phase 2: compile/link probes ---
 	cd build
-	OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
-	OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile 2>/dev/null
-	if test $? -ne 0; then
-		# See if it's the new RRDtool 1.2.x
-		echo "Not RRDtool 1.0.x, checking for 1.2.x"
-		RRDDEF="$RRDDEF -DRRDTOOL12"
-		OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
-		OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile
-	fi
-	if test $? -eq 0; then
+	OS=$OS $MAKE -f Makefile.test-rrd clean
+	if try_rrd_compile_probe; then
 		echo "Compiling with RRDtool works OK"
 	else
 		echo "ERROR: Cannot compile with RRDtool."
 		RRDOK="NO"
 	fi
+	echo "RRD: selected compatibility flags -> $RRDDEF"
 
-	OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-	if test $? -ne 0; then
-		# Could be that we need -lz for RRD
-		PNGLIB="$PNGLIB $ZLIB"
-	fi
-	OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-	if test $? -ne 0; then
-		# Could be that we need -lm for RRD
-		PNGLIB="$PNGLIB -lm"
-	fi
-	OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-	if test $? -ne 0; then
-		# Could be that we need -L/usr/X11R6/lib (OpenBSD)
-		LIBOPT="$LIBOPT -L/usr/X11R6/lib"
-		RRDLIB="$RRDLIB -L/usr/X11R6/lib"
-	fi
-	OS=`uname -s | sed -e's@/@_@g'` RRDLIB="$LIBOPT" PNGLIB="$PNGLIB" $MAKE -f Makefile.test-rrd test-link 2>/dev/null
-	if test $? -eq 0; then
+	if try_rrd_link_with_fallbacks; then
 		echo "Linking with RRDtool works OK"
 		if test "$PNGLIB" != ""; then
 			echo "Linking RRD needs extra library: $PNGLIB"
@@ -124,7 +248,7 @@
 		echo "ERROR: Linking with RRDtool fails"
 		RRDOK="NO"
 	fi
-	OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
+	OS=$OS $MAKE -f Makefile.test-rrd clean
 	cd ..
 
 	if test "$RRDOK" = "NO"; then
@@ -139,5 +263,3 @@
 		echo "Continuing with all trend-graph support DISABLED"
 		sleep 3
 	fi
-
-

--- a/build/test-rrd.c
+++ b/build/test-rrd.c
@@ -2,7 +2,7 @@
 
 int main(void)
 {
-	/* Compile-time ABI surface checks for all wrapped RRDtool entry points. */
+	/* Compile/link probe target for the compat graph wrapper. */
 	xymon_rrd_argv_item_t graphargs[] = {
 		"rrdgraph",
 		"xymongen.png",
@@ -16,25 +16,13 @@ int main(void)
 		"COMMENT: Timestamp",
 		NULL
 	};
-	xymon_rrd_argv_item_t updateargs[] = { "rrdupdate", "dummy.rrd", NULL };
-	xymon_rrd_argv_item_t createargs[] = { "rrdcreate", "dummy.rrd", NULL };
-	xymon_rrd_argv_item_t fetchargs[]  = { "rrdfetch", "dummy.rrd", NULL };
-	char **calcpr=NULL;
+	char **calcpr = NULL;
 
 	int pcount, xsize, ysize;
 	double ymin, ymax;
-	time_t start = 0, end = 0;
-	unsigned long step = 0, dscount = 0;
-	char **dsnames = NULL;
-	rrd_value_t *data = NULL;
 
 	for (pcount = 0; (graphargs[pcount]); pcount++);
 	rrd_clear_error();
-	/* We only need these calls to type-check against the active RRDtool headers. */
-	(void)xymon_rrd_update(3, updateargs);
-	(void)xymon_rrd_create(3, createargs);
-	(void)xymon_rrd_fetch(3, fetchargs, &start, &end, &step, &dscount, &dsnames, &data);
-	/* Keep one graph invocation to validate the graph ABI shape as well. */
 	(void)xymon_rrd_graph(pcount, graphargs, &calcpr, &xsize, &ysize, &ymin, &ymax);
 
 	return 0;

--- a/build/test-rrd.c
+++ b/build/test-rrd.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include "rrd_compat.h"
 
 int main(void)

--- a/build/test-rrd.c
+++ b/build/test-rrd.c
@@ -1,14 +1,10 @@
 #include <stdio.h>
+#include "rrd_compat.h"
 
-#include <rrd.h>
-
-int main(int argc, char *argv[])
+int main(void)
 {
-#ifdef RRDTOOL19
-	const char *rrdargs[] = {
-#else
-	char *rrdargs[] = {
-#endif
+	/* Compile-time ABI surface checks for all wrapped RRDtool entry points. */
+	xymon_rrd_argv_item_t graphargs[] = {
 		"rrdgraph",
 		"xymongen.png",
 		"-s", "e - 48d",
@@ -21,19 +17,26 @@ int main(int argc, char *argv[])
 		"COMMENT: Timestamp",
 		NULL
 	};
+	xymon_rrd_argv_item_t updateargs[] = { "rrdupdate", "dummy.rrd", NULL };
+	xymon_rrd_argv_item_t createargs[] = { "rrdcreate", "dummy.rrd", NULL };
+	xymon_rrd_argv_item_t fetchargs[]  = { "rrdfetch", "dummy.rrd", NULL };
 	char **calcpr=NULL;
 
-	int pcount, result, xsize, ysize;
+	int pcount, xsize, ysize;
 	double ymin, ymax;
+	time_t start = 0, end = 0;
+	unsigned long step = 0, dscount = 0;
+	char **dsnames = NULL;
+	rrd_value_t *data = NULL;
 
-	for (pcount = 0; (rrdargs[pcount]); pcount++);
+	for (pcount = 0; (graphargs[pcount]); pcount++);
 	rrd_clear_error();
-#ifdef RRDTOOL12
-	result = rrd_graph(pcount, rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
-#else
-	result = rrd_graph(pcount, rrdargs, &calcpr, &xsize, &ysize);
-#endif
+	/* We only need these calls to type-check against the active RRDtool headers. */
+	(void)xymon_rrd_update(3, updateargs);
+	(void)xymon_rrd_create(3, createargs);
+	(void)xymon_rrd_fetch(3, fetchargs, &start, &end, &step, &dscount, &dsnames, &data);
+	/* Keep one graph invocation to validate the graph ABI shape as well. */
+	(void)xymon_rrd_graph(pcount, graphargs, &calcpr, &xsize, &ysize, &ymin, &ymax);
 
 	return 0;
 }
-

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -25,8 +25,7 @@ Linking RRD with PNG library: -L/usr/lib -lpng
 Manual-build note:
 If you compile without running configure, define RRD_CONST_ARGS to match your
 RRDtool headers (0 for mutable char ** argv, 1 for const char ** argv).
-Compatibility macros: RRDTOOL19 is the preferred gate for modern RRDtool;
-RRDTOOL12 is obsolete and intentionally ignored.
+Compatibility macro: RRDTOOL19 is the preferred gate for modern RRDtool.
 
 
 Checking for PCRE ...

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -25,7 +25,6 @@ Linking RRD with PNG library: -L/usr/lib -lpng
 Manual-build note:
 If you compile without running configure, define RRD_CONST_ARGS to match your
 RRDtool headers (0 for mutable char ** argv, 1 for const char ** argv).
-Compatibility macro: RRDTOOL19 is the preferred gate for modern RRDtool.
 
 
 Checking for PCRE ...

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -22,6 +22,12 @@ Found RRDtool include files in /usr/include
 Found RRDtool libraries in /usr/lib
 Linking RRD with PNG library: -L/usr/lib -lpng
 
+Manual-build note:
+If you compile without running configure, define RRD_CONST_ARGS to match your
+RRDtool headers (0 for mutable char ** argv, 1 for const char ** argv).
+Compatibility macros: RRDTOOL19 is the preferred gate for modern RRDtool;
+RRDTOOL12 is obsolete and intentionally ignored.
+
 
 Checking for PCRE ...
 Found PCRE include files in /usr/include

--- a/include/rrd_compat.h
+++ b/include/rrd_compat.h
@@ -24,8 +24,6 @@
 #define RRD_CONST_ARGS 1
 #elif defined(XYMON_ASSUME_RRD_MUTABLE_ARGS)
 #define RRD_CONST_ARGS 0
-#elif defined(RRDTOOL12)
-/* RRDTOOL12 is obsolete and intentionally ignored. */
 #endif
 #ifndef RRD_CONST_ARGS
 #error "RRD_CONST_ARGS is not defined. Run configure or define RRDTOOL19 (or RRD_CONST_ARGS directly)."

--- a/include/rrd_compat.h
+++ b/include/rrd_compat.h
@@ -22,8 +22,6 @@
  */
 #if defined(RRDTOOL19)
 #define RRD_CONST_ARGS 1
-#elif defined(XYMON_ASSUME_RRD_MUTABLE_ARGS)
-#define RRD_CONST_ARGS 0
 #endif
 #ifndef RRD_CONST_ARGS
 #error "RRD_CONST_ARGS is not defined. Run configure or define RRDTOOL19 (or RRD_CONST_ARGS directly)."
@@ -46,25 +44,25 @@ static inline char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
 
 static inline int xymon_rrd_update(int argc, xymon_rrd_argv_item_t *argv)
 {
-	return rrd_update(argc, (void *)xymon_rrd_api_argv(argv));
+	return rrd_update(argc, xymon_rrd_api_argv(argv));
 }
 
 static inline int xymon_rrd_create(int argc, xymon_rrd_argv_item_t *argv)
 {
-	return rrd_create(argc, (void *)xymon_rrd_api_argv(argv));
+	return rrd_create(argc, xymon_rrd_api_argv(argv));
 }
 
 static inline int xymon_rrd_fetch(int argc, xymon_rrd_argv_item_t *argv,
 				  time_t *start, time_t *end, unsigned long *step, unsigned long *dscount,
 				  char ***dsnames, rrd_value_t **data)
 {
-	return rrd_fetch(argc, (void *)xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
+	return rrd_fetch(argc, xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
 }
 
 static inline int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv,
 				  char ***calcpr, int *xsize, int *ysize, double *ymin, double *ymax)
 {
-	return rrd_graph(argc, (void *)xymon_rrd_api_argv(argv), calcpr, xsize, ysize, NULL, ymin, ymax);
+	return rrd_graph(argc, xymon_rrd_api_argv(argv), calcpr, xsize, ysize, NULL, ymin, ymax);
 }
 
 #endif /* XYMON_RRD_COMPAT_H */

--- a/include/rrd_compat.h
+++ b/include/rrd_compat.h
@@ -18,13 +18,14 @@
  */
 #ifndef RRD_CONST_ARGS
 /*
- * Ad-hoc/manual builds that skip configure must opt in explicitly.
+ * Ad-hoc/manual builds that skip configure must define RRD_CONST_ARGS.
+ * Keep RRDTOOL19 as a legacy compatibility fallback.
  */
 #if defined(RRDTOOL19)
 #define RRD_CONST_ARGS 1
 #endif
 #ifndef RRD_CONST_ARGS
-#error "RRD_CONST_ARGS is not defined. Run configure or define RRDTOOL19 (or RRD_CONST_ARGS directly)."
+#error "RRD_CONST_ARGS is not defined. Run configure or define RRD_CONST_ARGS (0 or 1)."
 #endif
 #endif
 

--- a/include/rrd_compat.h
+++ b/include/rrd_compat.h
@@ -1,0 +1,72 @@
+#ifndef XYMON_RRD_COMPAT_H
+#define XYMON_RRD_COMPAT_H
+
+#include <stddef.h>
+#include <time.h>
+#include <rrd.h>
+
+/*
+ * RRDtool API compatibility:
+ * - Some releases declare argv parameters as char **.
+ * - Newer releases declare argv parameters as const char **.
+ *
+ * Usage:
+ * - Declare argv vectors as xymon_rrd_argv_item_t[].
+ * - Call the xymon_rrd_update/create/fetch/graph wrappers only.
+ *
+ * RRD_CONST_ARGS is detected by build/rrd.sh and propagated via RRDDEF.
+ */
+#ifndef RRD_CONST_ARGS
+/*
+ * Ad-hoc/manual builds that skip configure must opt in explicitly.
+ */
+#if defined(RRDTOOL19)
+#define RRD_CONST_ARGS 1
+#elif defined(XYMON_ASSUME_RRD_MUTABLE_ARGS)
+#define RRD_CONST_ARGS 0
+#elif defined(RRDTOOL12)
+/* RRDTOOL12 is obsolete and intentionally ignored. */
+#endif
+#ifndef RRD_CONST_ARGS
+#error "RRD_CONST_ARGS is not defined. Run configure or define RRDTOOL19 (or RRD_CONST_ARGS directly)."
+#endif
+#endif
+
+#if RRD_CONST_ARGS
+typedef const char *xymon_rrd_argv_item_t;
+static inline const char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
+{
+	return (const char **)argv;
+}
+#else
+typedef char *xymon_rrd_argv_item_t;
+static inline char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
+{
+	return (char **)argv;
+}
+#endif
+
+static inline int xymon_rrd_update(int argc, xymon_rrd_argv_item_t *argv)
+{
+	return rrd_update(argc, (void *)xymon_rrd_api_argv(argv));
+}
+
+static inline int xymon_rrd_create(int argc, xymon_rrd_argv_item_t *argv)
+{
+	return rrd_create(argc, (void *)xymon_rrd_api_argv(argv));
+}
+
+static inline int xymon_rrd_fetch(int argc, xymon_rrd_argv_item_t *argv,
+				  time_t *start, time_t *end, unsigned long *step, unsigned long *dscount,
+				  char ***dsnames, rrd_value_t **data)
+{
+	return rrd_fetch(argc, (void *)xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
+}
+
+static inline int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv, 
+				  char ***calcpr, int *xsize, int *ysize, double *ymin, double *ymax)
+{ 
+	return rrd_graph(argc, (void *)xymon_rrd_api_argv(argv), calcpr, xsize, ysize, NULL, ymin, ymax);
+}
+
+#endif /* XYMON_RRD_COMPAT_H */

--- a/include/rrd_compat.h
+++ b/include/rrd_compat.h
@@ -63,9 +63,9 @@ static inline int xymon_rrd_fetch(int argc, xymon_rrd_argv_item_t *argv,
 	return rrd_fetch(argc, (void *)xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
 }
 
-static inline int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv, 
+static inline int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv,
 				  char ***calcpr, int *xsize, int *ysize, double *ymin, double *ymax)
-{ 
+{
 	return rrd_graph(argc, (void *)xymon_rrd_api_argv(argv), calcpr, xsize, ysize, NULL, ymin, ymax);
 }
 

--- a/web/perfdata.c
+++ b/web/perfdata.c
@@ -24,6 +24,7 @@ static char rcsid[] = "$Id$";
 #include <pcre.h>
 
 #include "libxymon.h"
+#include "rrd_compat.h"
 
 enum { O_NONE, O_XML, O_CSV } outform = O_NONE;
 char csvdelim = ',';
@@ -100,7 +101,7 @@ int oneset(char *hostname, char *rrdname, char *starttime, char *endtime, char *
 	int dataindex, rowcount, havemin, havemax, missingdata;
 	double sum, min = 0.0, max = 0.0, val;
 
-	char *rrdargs[10];
+	xymon_rrd_argv_item_t rrdargs[10];
 	int result;
 
 	rrdargs[0] = "rrdfetch";
@@ -111,13 +112,7 @@ int oneset(char *hostname, char *rrdname, char *starttime, char *endtime, char *
 	rrdargs[9] = NULL;
 
 	optind = opterr = 0; rrd_clear_error();
-#ifdef RRDTOOL19
-	result = rrd_fetch(9, (const char **)rrdargs,
-			   &start, &end, &step, &dscount, &dsnames, &data);
-#else
-	result = rrd_fetch(9, rrdargs,
-			   &start, &end, &step, &dscount, &dsnames, &data);
-#endif
+	result = xymon_rrd_fetch(9, rrdargs, &start, &end, &step, &dscount, &dsnames, &data);
 
 	if (result != 0) {
 		errprintf("RRD error: %s\n", rrd_get_error());
@@ -430,4 +425,3 @@ int main(int argc, char **argv)
 
 	return 0;
 }
-

--- a/web/perfdata.c
+++ b/web/perfdata.c
@@ -20,7 +20,6 @@ static char rcsid[] = "$Id$";
 #include <math.h>
 #include <dirent.h>
 
-#include <rrd.h>
 #include <pcre.h>
 
 #include "libxymon.h"

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -28,7 +28,6 @@ static char rcsid[] = "$Id$";
 #include <fcntl.h>
 
 #include <pcre.h>
-#include <rrd.h>
 
 #include "libxymon.h"
 #include "rrd_compat.h"
@@ -605,15 +604,8 @@ char *expand_tokens(char *tpl)
 			 * Graph templates should place @STACKIT@ where RRDtool expects
 			 * the stacking keyword.
 			 */
-			char numstr[10];
-
-			if (rrdidx == 0) {
-				numstr[0] = '\0';
-			}
-			else {
-				snprintf(numstr, sizeof(numstr), "STACK");
-			}
-			addtobuffer(result, numstr);
+			const char *stackkw = (rrdidx == 0) ? "" : "STACK";
+			addtobuffer(result, stackkw);
 			inp += 9;
 		}
 		else if (strncmp(inp, "@SERVICE@", 9) == 0) {

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -1180,12 +1180,12 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		printf("\n");
 
 #if HIDE_EMPTYGRAPH
-			/* It works, but we still get the "zoom" magnifying glass which looks odd */
-			if (rrddbcount == 0) {
-				/* No graph */
-				fwrite(blankimg, 1, sizeof(blankimg), stdout);
-				return;
-			}
+		/* It works, but we still get the "zoom" magnifying glass which looks odd */
+		if (rrddbcount == 0) {
+			/* No graph */
+			fwrite(blankimg, 1, sizeof(blankimg), stdout);
+			return;
+		}
 #endif
 	}
 
@@ -1251,10 +1251,6 @@ void generate_zoompage(char *selfURI)
 				n = fread(buf, 1, st.st_size, fd);
 				fclose(fd);
 
-				/*
-				 * Safe no-op when marker is absent: only patch if this exact JS field exists.
-				 * Keeping this unconditional avoids brittle RRDtool-version checks.
-				 */
 				zoomrightoffsetp = strstr(buf, zoomrightoffsetmarker);
 				if (zoomrightoffsetp) {
 					zoomrightoffsetp += strlen(zoomrightoffsetmarker);

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -31,20 +31,19 @@ static char rcsid[] = "$Id$";
 #include <rrd.h>
 
 #include "libxymon.h"
+#include "rrd_compat.h"
 
 #define HOUR_GRAPH  "e-48h"
 #define DAY_GRAPH   "e-12d"
 #define WEEK_GRAPH  "e-48d"
 #define MONTH_GRAPH "e-576d"
 
-/* RRDtool 1.0.x handles graphs with no DS definitions just fine. 1.2.x does not. */
-#ifdef RRDTOOL12
+/* Keep a blank-image fallback when no graph data is available. */
 #ifndef HIDE_EMPTYGRAPH
 #define HIDE_EMPTYGRAPH 1
 #endif
-#endif
 
-#ifdef HIDE_EMPTYGRAPH
+#if HIDE_EMPTYGRAPH
 unsigned char blankimg[] = "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\x04\x67\x41\x4d\x41\x00\x00\xb1\x8f\x0b\xfc\x61\x05\x00\x00\x00\x06\x62\x4b\x47\x44\x00\xff\x00\xff\x00\xff\xa0\xbd\xa7\x93\x00\x00\x00\x09\x70\x48\x59\x73\x00\x00\x0b\x12\x00\x00\x0b\x12\x01\xd2\xdd\x7e\xfc\x00\x00\x00\x07\x74\x49\x4d\x45\x07\xd1\x01\x14\x12\x21\x14\x7e\x4a\x3a\xd2\x00\x00\x00\x0d\x49\x44\x41\x54\x78\xda\x63\x60\x60\x60\x60\x00\x00\x00\x05\x00\x01\x7a\xa8\x57\x50\x00\x00\x00\x00\x49\x45\x4e\x44\xae\x42\x60\x82";
 #endif
 
@@ -599,34 +598,17 @@ char *expand_tokens(char *tpl)
 		else if (strncmp(inp, "@STACKIT@", 9) == 0) {
 			/* Contributed by Gildas Le Nadan <gn1@sanger.ac.uk> */
 
-			/* the STACK behavior changed between rrdtool 1.0.x
-			 * and 1.2.x, hence the ifdef:
-			 * - in 1.0.x, you replace the graph type (AREA|LINE)
-			 *  for the graph you want to stack with the  STACK
-			 *  keyword
-			 * - in 1.2.x, you add the STACK keyword at the end
-			 *  of the definition
-			 *
-			 * Please note that in both cases the first entry
-			 * mustn't contain the keyword STACK at all, so
-			 * we need a different treatment for the first rrdidx
-			 *
-			 * examples of graphs.cfg entries:
-			 *
-			 * - rrdtool 1.0.x
-			 * @STACKIT@:la@RRDIDX@#@COLOR@:@RRDPARAM@
-			 *
-			 * - rrdtool 1.2.x
-			 * AREA::la@RRDIDX@#@COLOR@:@RRDPARAM@:@STACKIT@
+			/*
+			 * Keep the first series unstacked; add "STACK" for subsequent
+			 * series. This is intentional: emitting STACK for series #0 causes
+			 * invalid/ugly output with current RRDtool graph semantics.
+			 * Graph templates should place @STACKIT@ where RRDtool expects
+			 * the stacking keyword.
 			 */
 			char numstr[10];
 
 			if (rrdidx == 0) {
-#ifdef RRDTOOL12
-				strncpy(numstr, "", sizeof(numstr));
-#else
-				snprintf(numstr, sizeof(numstr), "AREA");
-#endif
+				numstr[0] = '\0';
 			}
 			else {
 				snprintf(numstr, sizeof(numstr), "STACK");
@@ -654,8 +636,8 @@ char *expand_tokens(char *tpl)
 
 int rrd_name_compare(const void *v1, const void *v2)
 {
-	rrddb_t *r1 = (rrddb_t *)v1;
-	rrddb_t *r2 = (rrddb_t *)v2;
+	const rrddb_t *r1 = v1;
+	const rrddb_t *r2 = v2;
 	char *endptr;
 	long numkey1, numkey2;
 	int key1isnumber, key2isnumber;
@@ -801,7 +783,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 
 	/* Options for rrd_graph() */
 	int  rrdargcount;
-	char **rrdargs = NULL;	/* The full argv[] table of string pointers to arguments */
+	xymon_rrd_argv_item_t *rrdargs = NULL;	/* The full argv[] table of string pointers to arguments */
 	char heightopt[30];	/* -h HEIGHT */
 	char widthopt[30];	/* -w WIDTH */
 	char upperopt[30];	/* -u MAX */
@@ -1131,7 +1113,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	 * there are multiple RRD-files to handle).
 	 */
 	for (pcount = 0; (gdef->defs[pcount]); pcount++) ;
-	rrdargs = (char **) calloc(16 + pcount*rrddbcount + useroptcount + 1, sizeof(char *));
+	rrdargs = calloc(16 + pcount*rrddbcount + useroptcount + 1, sizeof(*rrdargs));
 
 
 	argi = 0;
@@ -1178,11 +1160,8 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		}
 	}
 
-#ifdef RRDTOOL12
+	/* Escape ':' in COMMENT text so RRDtool does not parse timestamp fields as option separators. */
 	strftime(timestamp, sizeof(timestamp), "COMMENT:Updated\\: %d-%b-%Y %H\\:%M\\:%S", localtime(&now));
-#else
-	strftime(timestamp, sizeof(timestamp), "COMMENT:Updated: %d-%b-%Y %H:%M:%S", localtime(&now));
-#endif
 	rrdargs[argi++] = strdup(timestamp);
 
 
@@ -1201,25 +1180,20 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		printf("%s\n", expirehdr);
 		printf("\n");
 
-#ifdef HIDE_EMPTYGRAPH
-		/* It works, but we still get the "zoom" magnifying glass which looks odd */
-		if (rrddbcount == 0) {
-			/* No graph */
-			fwrite(blankimg, 1, sizeof(blankimg), stdout);
-			return;
-		}
+#if HIDE_EMPTYGRAPH
+			/* It works, but we still get the "zoom" magnifying glass which looks odd */
+			if (rrddbcount == 0) {
+				/* No graph */
+				fwrite(blankimg, 1, sizeof(blankimg), stdout);
+				return;
+			}
 #endif
 	}
 
 	/* All set - generate the graph */
 	rrd_clear_error();
 
-#ifdef RRDTOOL12
-    #ifdef RRDTOOL19
-	result = rrd_graph(rrdargcount, (const char **)rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
-    #else
-	result = rrd_graph(rrdargcount, rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
-    #endif
+	result = xymon_rrd_graph(rrdargcount, rrdargs, &calcpr, &xsize, &ysize, &ymin, &ymax);
 
 	/*
 	 * If we have neither the upper- nor lower-limits of the graph, AND we allow vertical 
@@ -1230,9 +1204,6 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		upperlimit = ymax; haveupperlimit = 1;
 		lowerlimit = ymin; havelowerlimit = 1;
 	}
-#else
-	result = rrd_graph(rrdargcount, rrdargs, &calcpr, &xsize, &ysize);
-#endif
 
 	/* Was it OK ? */
 	if (rrd_test_error() || (result != 0)) {
@@ -1281,13 +1252,15 @@ void generate_zoompage(char *selfURI)
 				n = fread(buf, 1, st.st_size, fd);
 				fclose(fd);
 
-#ifdef RRDTOOL12
+				/*
+				 * Safe no-op when marker is absent: only patch if this exact JS field exists.
+				 * Keeping this unconditional avoids brittle RRDtool-version checks.
+				 */
 				zoomrightoffsetp = strstr(buf, zoomrightoffsetmarker);
 				if (zoomrightoffsetp) {
 					zoomrightoffsetp += strlen(zoomrightoffsetmarker);
 					memcpy(zoomrightoffsetp, "30", 2);
 				}
-#endif
 
 				fwrite(buf, 1, n, stdout);
 			}
@@ -1363,4 +1336,3 @@ int main(int argc, char *argv[])
 
 	return 0;
 }
-

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -604,8 +604,15 @@ char *expand_tokens(char *tpl)
 			 * Graph templates should place @STACKIT@ where RRDtool expects
 			 * the stacking keyword.
 			 */
-			const char *stackkw = (rrdidx == 0) ? "" : "STACK";
-			addtobuffer(result, stackkw);
+			char numstr[10];
+
+			if (rrdidx == 0) {
+				numstr[0] = '\0';
+			}
+			else {
+				snprintf(numstr, sizeof(numstr), "STACK");
+			}
+			addtobuffer(result, numstr);
 			inp += 9;
 		}
 		else if (strncmp(inp, "@SERVICE@", 9) == 0) {

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -22,7 +22,6 @@ static char rcsid[] = "$Id$";
 #include <errno.h>
 #include <utime.h>
 
-#include <rrd.h>
 #include <pcre.h>
 
 #include "libxymon.h"
@@ -277,7 +276,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	pollinterval = rrdinterval;
 	rrdinterval = DEFAULT_RRD_INTERVAL;
 
-	if (strlen(rrdfn) == 0) {
+	if (rrdfn[0] == '\0') {
 		errprintf("RRD update for no file\n");
 		return -1;
 	}

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -26,6 +26,7 @@ static char rcsid[] = "$Id$";
 #include <pcre.h>
 
 #include "libxymon.h"
+#include "rrd_compat.h"
 
 #include "xymond_rrd.h"
 #include "do_rrd.h"
@@ -216,11 +217,7 @@ static void setupinterval(int intvl)
 static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 {
 	/* Flush any updates we've cached */
-#ifdef RRDTOOL19
-	const char *updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
-#else
-	char *updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
-#endif
+	xymon_rrd_argv_item_t updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
 	int i, pcount, result;
 
 	dbgprintf("Flushing '%s' with %d updates pending, template '%s'\n", 
@@ -243,13 +240,12 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 
 	for (pcount = 0; (updparams[pcount]); pcount++);
 	optind = opterr = 0; rrd_clear_error();
-	result = rrd_update(pcount, updparams);
+	result = xymon_rrd_update(pcount, updparams);
 
-#if defined(LINUX) && defined(RRDTOOL12)
+#if defined(LINUX)
 	/*
-	 * RRDtool 1.2+ uses mmap'ed I/O, but the Linux kernel does not update timestamps when
-	 * doing file I/O on mmap'ed files. This breaks our check for stale/nostale RRD's.
-	 * So do an explicit timestamp update on the file here.
+	 * RRDtool >= 1.2 uses mmap'ed I/O, but Linux does not update file timestamps for
+	 * mmap writes. This breaks our stale/nostale checks, so force a timestamp update.
 	 */
 	utimes(filedir, NULL);
 #endif
@@ -281,7 +277,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	pollinterval = rrdinterval;
 	rrdinterval = DEFAULT_RRD_INTERVAL;
 
-	if ((rrdfn == NULL) || (strlen(rrdfn) == 0)) {
+	if (strlen(rrdfn) == 0) {
 		errprintf("RRD update for no file\n");
 		return -1;
 	}
@@ -334,7 +330,8 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 
 	/* If the RRD file doesn't exist, create it immediately */
 	if (stat(filedir, &st) == -1) {
-		char **rrdcreate_params, **rrddefinitions;
+		xymon_rrd_argv_item_t *rrdcreate_params;
+		char **rrddefinitions;
 		int rrddefcount, i;
 		char *rrakey = NULL;
 		char stepsetting[10];
@@ -353,7 +350,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		sprintf(stepsetting, "%d", pollinterval);
 
 		rrddefinitions = get_rrd_definition((rrakey ? rrakey : testname), &rrddefcount);
-		rrdcreate_params = (char **)calloc(4 + pcount + rrddefcount + 1, sizeof(char *));
+		rrdcreate_params = calloc(4 + pcount + rrddefcount + 1, sizeof(*rrdcreate_params));
 		rrdcreate_params[0] = "rrdcreate";
 		rrdcreate_params[1] = filedir;
 
@@ -382,11 +379,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		 * we MUST reset this before every call.
 		 */
 		optind = opterr = 0; rrd_clear_error();
-#ifdef RRDTOOL19
-		result = rrd_create(4+pcount, (const char **)rrdcreate_params);
-#else
-		result = rrd_create(4+pcount, rrdcreate_params);
-#endif
+		result = xymon_rrd_create(4+pcount, rrdcreate_params);
 		xfree(rrdcreate_params);
 		if (rrakey) xfree(rrakey);
 
@@ -598,11 +591,7 @@ static int rrddatasets(char *hostname, char ***dsnames)
 	struct stat st;
 
 	int result;
-#ifdef RRDTOOL19
-	const char *fetch_params[] = { "rrdfetch", filedir, "AVERAGE", "-s", "-30m", NULL };
-#else
-	char *fetch_params[] = { "rrdfetch", filedir, "AVERAGE", "-s", "-30m", NULL };
-#endif
+	xymon_rrd_argv_item_t fetch_params[] = { "rrdfetch", filedir, "AVERAGE", "-s", "-30m", NULL };
 	time_t starttime, endtime;
 	unsigned long steptime, dscount;
 	rrd_value_t *rrddata;
@@ -612,7 +601,7 @@ static int rrddatasets(char *hostname, char ***dsnames)
 	if (stat(filedir, &st) == -1) return 0;
 
 	optind = opterr = 0; rrd_clear_error();
-	result = rrd_fetch(5, fetch_params, &starttime, &endtime, &steptime, &dscount, dsnames, &rrddata);
+	result = xymon_rrd_fetch(5, fetch_params, &starttime, &endtime, &steptime, &dscount, dsnames, &rrddata);
 	if (result == -1) {
 		errprintf("Error while retrieving RRD dataset names from %s: %s\n",
 			  filedir, rrd_get_error());
@@ -787,4 +776,3 @@ void update_rrd(char *hostname, char *testname, char *msg, time_t tstamp, char *
 
 	MEMUNDEFINE(rrdvalues);
 }
-

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -276,7 +276,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	pollinterval = rrdinterval;
 	rrdinterval = DEFAULT_RRD_INTERVAL;
 
-	if (rrdfn[0] == '\0') {
+	if (strlen(rrdfn) == 0) {
 		errprintf("RRD update for no file\n");
 		return -1;
 	}


### PR DESCRIPTION
# RRDtool: ensure compatibility with < 1.9 and >= 1.9 (const argv ABI)

## Summary

RRDtool 1.9.x changed several APIs from `char **argv` to `const char **argv`.

This PR replaces version-based checks with ABI probing at build time and introduces a unified compatibility layer in `include/rrd_compat.h`.

All RRDtool calls now go through `xymon_rrd_*` wrappers, removing scattered `RRDTOOL19` conditionals and centralizing argv-ABI handling.

## What changed

- Added ABI detection in `build/rrd.sh`:
  - compile-time probe for mutable vs const argv signatures
  - `pkg-config` fallback when probing is inconclusive
  - emits `-DRRD_CONST_ARGS=0|1`
- Added `include/rrd_compat.h`:
  - `xymon_rrd_argv_item_t`
  - `xymon_rrd_update/create/fetch/graph` wrappers
  - manual-build guard/error if `RRD_CONST_ARGS` is not defined
- Refactored call sites to use the compatibility layer:
  - `xymond/do_rrd.c`
  - `web/perfdata.c`
  - `web/showgraph.c`
  - `build/test-rrd.c`
- Updated build probe harness:
  - `build/Makefile.test-rrd` now includes `-I../include`
- Updated docs:
  - `docs/configure.txt` now documents manual `RRD_CONST_ARGS` definition for non-configure builds
- Removed obsolete/legacy branches tied to old macros (`RRDTOOL12`/`RRDTOOL19`) in touched paths
- Removed redundant `rrdfn == NULL` check in `xymond/do_rrd.c` (`rrdfn` is a static array)

## Notes

No functional change is intended for supported RRDtool versions (`>= 1.2`, including `< 1.9` and `>= 1.9`).

## Checklist

- [x] Build without RRDtool (graphs disabled)
- [x] Build with RRDtool < 1.9
- [x] Build with RRDtool >= 1.9
- [x] No incompatible-pointer warnings
- [ ] Basic runtime validation: create / update / fetch / graph