### PR TITLE
rrd: detect argv const-API (1.9+/1.8 backports) and drop RRDtool <1.2 gates

### DIFF
--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -75,11 +75,54 @@
 	RRDOK="YES"
 	if test "$RRDINC" != ""; then INCOPT="-I$RRDINC"; fi
 	if test "$RRDLIB" != ""; then LIBOPT="-L$RRDLIB"; fi
-	if pkg-config --atleast-version=1.9.0 librrd > /dev/null 2>&1; then
-		echo "Found RRDtool >= 1.9.0 via pkg-config"
-		RRDDEF="-DRRDTOOL19"
+
+	# Detect the RRDtool argv API by probing rrd.h directly, rather than
+	# inferring it from the RRDtool version (which is unreliable: e.g. some
+	# 1.8 backports already use the "const char **" prototype). We try to
+	# redeclare rrd_update() both ways and keep the one that matches.
+	probe_rrd_const_args() {
+		${CC:-cc} ${INCOPT} -x c -c -o /dev/null - >/dev/null 2>&1 <<'PROBE'
+#include <rrd.h>
+int rrd_update(int, const char **);
+int main(void) { return 0; }
+PROBE
+	}
+	probe_rrd_mutable_args() {
+		${CC:-cc} ${INCOPT} -x c -c -o /dev/null - >/dev/null 2>&1 <<'PROBE'
+#include <rrd.h>
+int rrd_update(int, char **);
+int main(void) { return 0; }
+PROBE
+	}
+
+	if test "$RRD_CONST_ARGS" != ""; then
+		case "$RRD_CONST_ARGS" in
+		0|1)
+			echo "Using user-specified RRDtool argv API: RRD_CONST_ARGS=$RRD_CONST_ARGS"
+			RRDDEF="$RRDDEF -DRRD_CONST_ARGS=$RRD_CONST_ARGS"
+			;;
+		*)
+			echo "ERROR: Invalid RRD_CONST_ARGS value '$RRD_CONST_ARGS' (expected 0 or 1)."
+			echo "Use RRD_CONST_ARGS=1 for rrd.h prototypes with 'const char **'."
+			echo "Use RRD_CONST_ARGS=0 for rrd.h prototypes with 'char **'."
+			exit 1
+			;;
+		esac
 	else
-		echo "Found RRDtool < 1.9.0 via pkg-config"
+		PROBE_CONST=0; PROBE_MUTABLE=0
+		probe_rrd_const_args   && PROBE_CONST=1
+		probe_rrd_mutable_args && PROBE_MUTABLE=1
+		case "${PROBE_CONST}:${PROBE_MUTABLE}" in
+		1:0) echo "Detected RRDtool argv API: const char **"; RRDDEF="$RRDDEF -DRRD_CONST_ARGS=1" ;;
+		0:1) echo "Detected RRDtool argv API: char **";       RRDDEF="$RRDDEF -DRRD_CONST_ARGS=0" ;;
+		*)
+			echo "ERROR: Unable to determine the RRDtool argv API from the installed headers."
+			echo "Re-run configure with an explicit override:"
+			echo "  RRD_CONST_ARGS=1 ./configure.server   # rrd.h uses const char **"
+			echo "  RRD_CONST_ARGS=0 ./configure.server   # rrd.h uses char **"
+			exit 1
+			;;
+		esac
 	fi
 	cd build
 	OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -83,14 +83,7 @@
 	fi
 	cd build
 	OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
-	OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile 2>/dev/null
-	if test $? -ne 0; then
-		# See if it's the new RRDtool 1.2.x
-		echo "Not RRDtool 1.0.x, checking for 1.2.x"
-		RRDDEF="$RRDDEF -DRRDTOOL12"
-		OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean
-		OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile
-	fi
+	OS=`uname -s | sed -e's@/@_@g'` RRDDEF="$RRDDEF" RRDINC="$INCOPT" $MAKE -f Makefile.test-rrd test-compile
 	if test $? -eq 0; then
 		echo "Compiling with RRDtool works OK"
 	else

--- a/build/test-rrd.c
+++ b/build/test-rrd.c
@@ -1,14 +1,11 @@
 #include <stdio.h>
 
 #include <rrd.h>
+#include "../lib/rrd_api_compat.h"
 
-int main(int argc, char *argv[])
+int main(void)
 {
-#ifdef RRDTOOL19
-	const char *rrdargs[] = {
-#else
-	char *rrdargs[] = {
-#endif
+	xymon_rrd_argv_item_t rrdargs[] = {
 		"rrdgraph",
 		"xymongen.png",
 		"-s", "e - 48d",
@@ -28,7 +25,8 @@ int main(int argc, char *argv[])
 
 	for (pcount = 0; (rrdargs[pcount]); pcount++);
 	rrd_clear_error();
-	result = rrd_graph(pcount, rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
+	result = xymon_rrd_graph(pcount, rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
+	(void)result;
 
 	return 0;
 }

--- a/build/test-rrd.c
+++ b/build/test-rrd.c
@@ -28,11 +28,7 @@ int main(int argc, char *argv[])
 
 	for (pcount = 0; (rrdargs[pcount]); pcount++);
 	rrd_clear_error();
-#ifdef RRDTOOL12
 	result = rrd_graph(pcount, rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
-#else
-	result = rrd_graph(pcount, rrdargs, &calcpr, &xsize, &ysize);
-#endif
 
 	return 0;
 }

--- a/configure.server
+++ b/configure.server
@@ -29,6 +29,10 @@ do
 
   The script will search a number of standard directories for
   all of these files, so you normally do not have to specify any options.
+
+  RRDtool argv API override (normally auto-detected):
+     RRD_CONST_ARGS=1 ./configure.server   # rrd.h uses const char **
+     RRD_CONST_ARGS=0 ./configure.server   # rrd.h uses char **
 EOF
 		exit 0
 		;;

--- a/docs/configure.txt
+++ b/docs/configure.txt
@@ -22,6 +22,12 @@ Found RRDtool include files in /usr/include
 Found RRDtool libraries in /usr/lib
 Linking RRD with PNG library: -L/usr/lib -lpng
 
+RRDtool argv API note:
+The build probes rrd.h to decide whether RRDtool's argv parameters are
+"char **" (RRD_CONST_ARGS=0) or "const char **" (RRD_CONST_ARGS=1). If the
+probe is ambiguous, re-run configure with RRD_CONST_ARGS set explicitly. If
+you compile without running configure, define RRD_CONST_ARGS manually.
+
 
 Checking for PCRE ...
 Found PCRE include files in /usr/include

--- a/lib/rrd_api_compat.h
+++ b/lib/rrd_api_compat.h
@@ -1,0 +1,51 @@
+#ifndef __RRD_API_COMPAT_H__
+#define __RRD_API_COMPAT_H__
+
+#include <rrd.h>
+
+/*
+ * RRDtool changed the argv parameter of its public API from "char **" to
+ * "const char **". This header hides that difference behind a single argv
+ * item type and a set of thin wrappers, so callers do not need their own
+ * per-call casts or #ifdefs.
+ */
+
+#ifdef RRDTOOL19
+typedef const char *xymon_rrd_argv_item_t;
+static const char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
+{
+	return (const char **)argv;
+}
+#else
+typedef char *xymon_rrd_argv_item_t;
+static char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
+{
+	return argv;
+}
+#endif
+
+static int xymon_rrd_update(int argc, xymon_rrd_argv_item_t *argv)
+{
+	return rrd_update(argc, xymon_rrd_api_argv(argv));
+}
+
+static int xymon_rrd_create(int argc, xymon_rrd_argv_item_t *argv)
+{
+	return rrd_create(argc, xymon_rrd_api_argv(argv));
+}
+
+static int xymon_rrd_fetch(int argc, xymon_rrd_argv_item_t *argv,
+				  time_t *start, time_t *end, unsigned long *step,
+				  unsigned long *dscount, char ***dsnames, rrd_value_t **data)
+{
+	return rrd_fetch(argc, xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
+}
+
+static int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv,
+				  char ***calcpr, int *xsize, int *ysize,
+				  void *prdata, double *ymin, double *ymax)
+{
+	return rrd_graph(argc, xymon_rrd_api_argv(argv), calcpr, xsize, ysize, prdata, ymin, ymax);
+}
+
+#endif

--- a/lib/rrd_api_compat.h
+++ b/lib/rrd_api_compat.h
@@ -8,9 +8,15 @@
  * "const char **". This header hides that difference behind a single argv
  * item type and a set of thin wrappers, so callers do not need their own
  * per-call casts or #ifdefs.
+ *
+ * RRD_CONST_ARGS (0 or 1) is determined by build/rrd.sh, which probes rrd.h.
  */
 
-#ifdef RRDTOOL19
+#ifndef RRD_CONST_ARGS
+#error "RRD_CONST_ARGS is not defined. Run configure or define RRD_CONST_ARGS (0 or 1)."
+#endif
+
+#if RRD_CONST_ARGS
 typedef const char *xymon_rrd_argv_item_t;
 static const char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
 {

--- a/web/perfdata.c
+++ b/web/perfdata.c
@@ -25,6 +25,7 @@ static char rcsid[] = "$Id$";
 #include <pcre2.h>
 
 #include "libxymon.h"
+#include "../lib/rrd_api_compat.h"
 
 enum { O_NONE, O_XML, O_CSV } outform = O_NONE;
 char csvdelim = ',';
@@ -101,7 +102,7 @@ int oneset(char *hostname, char *rrdname, char *starttime, char *endtime, char *
 	int dataindex, rowcount, havemin, havemax, missingdata;
 	double sum, min = 0.0, max = 0.0, val;
 
-	char *rrdargs[10];
+	xymon_rrd_argv_item_t rrdargs[10];
 	int result;
 
 	rrdargs[0] = "rrdfetch";
@@ -112,13 +113,7 @@ int oneset(char *hostname, char *rrdname, char *starttime, char *endtime, char *
 	rrdargs[9] = NULL;
 
 	optind = opterr = 0; rrd_clear_error();
-#ifdef RRDTOOL19
-	result = rrd_fetch(9, (const char **)rrdargs,
-			   &start, &end, &step, &dscount, &dsnames, &data);
-#else
-	result = rrd_fetch(9, rrdargs,
-			   &start, &end, &step, &dscount, &dsnames, &data);
-#endif
+	result = xymon_rrd_fetch(9, rrdargs, &start, &end, &step, &dscount, &dsnames, &data);
 
 	if (result != 0) {
 		errprintf("RRD error: %s\n", rrd_get_error());

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -38,16 +38,7 @@ static char rcsid[] = "$Id$";
 #define WEEK_GRAPH  "e-48d"
 #define MONTH_GRAPH "e-576d"
 
-/* RRDtool 1.0.x handles graphs with no DS definitions just fine. 1.2.x does not. */
-#ifdef RRDTOOL12
-#ifndef HIDE_EMPTYGRAPH
-#define HIDE_EMPTYGRAPH 1
-#endif
-#endif
-
-#ifdef HIDE_EMPTYGRAPH
 unsigned char blankimg[] = "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\x04\x67\x41\x4d\x41\x00\x00\xb1\x8f\x0b\xfc\x61\x05\x00\x00\x00\x06\x62\x4b\x47\x44\x00\xff\x00\xff\x00\xff\xa0\xbd\xa7\x93\x00\x00\x00\x09\x70\x48\x59\x73\x00\x00\x0b\x12\x00\x00\x0b\x12\x01\xd2\xdd\x7e\xfc\x00\x00\x00\x07\x74\x49\x4d\x45\x07\xd1\x01\x14\x12\x21\x14\x7e\x4a\x3a\xd2\x00\x00\x00\x0d\x49\x44\x41\x54\x78\xda\x63\x60\x60\x60\x60\x00\x00\x00\x05\x00\x01\x7a\xa8\x57\x50\x00\x00\x00\x00\x49\x45\x4e\x44\xae\x42\x60\x82";
-#endif
 
 
 char *hostname = NULL;
@@ -600,34 +591,14 @@ char *expand_tokens(char *tpl)
 		else if (strncmp(inp, "@STACKIT@", 9) == 0) {
 			/* Contributed by Gildas Le Nadan <gn1@sanger.ac.uk> */
 
-			/* the STACK behavior changed between rrdtool 1.0.x
-			 * and 1.2.x, hence the ifdef:
-			 * - in 1.0.x, you replace the graph type (AREA|LINE)
-			 *  for the graph you want to stack with the  STACK
-			 *  keyword
-			 * - in 1.2.x, you add the STACK keyword at the end
-			 *  of the definition
-			 *
-			 * Please note that in both cases the first entry
-			 * mustn't contain the keyword STACK at all, so
-			 * we need a different treatment for the first rrdidx
-			 *
-			 * examples of graphs.cfg entries:
-			 *
-			 * - rrdtool 1.0.x
-			 * @STACKIT@:la@RRDIDX@#@COLOR@:@RRDPARAM@
-			 *
-			 * - rrdtool 1.2.x
-			 * AREA::la@RRDIDX@#@COLOR@:@RRDPARAM@:@STACKIT@
+			/* Note that the first entry mustn't contain the keyword
+			 * STACK at all, so we need a different treatment for the
+			 * first rrdidx.
 			 */
 			char numstr[10];
 
 			if (rrdidx == 0) {
-#ifdef RRDTOOL12
 				strncpy(numstr, "", sizeof(numstr));
-#else
-				snprintf(numstr, sizeof(numstr), "AREA");
-#endif
 			}
 			else {
 				snprintf(numstr, sizeof(numstr), "STACK");
@@ -1185,11 +1156,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		}
 	}
 
-#ifdef RRDTOOL12
 	strftime(timestamp, sizeof(timestamp), "COMMENT:Updated\\: %d-%b-%Y %H\\:%M\\:%S", localtime(&now));
-#else
-	strftime(timestamp, sizeof(timestamp), "COMMENT:Updated: %d-%b-%Y %H:%M:%S", localtime(&now));
-#endif
 	rrdargs[argi++] = strdup(timestamp);
 
 
@@ -1208,38 +1175,32 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		printf("%s\n", expirehdr);
 		printf("\n");
 
-#ifdef HIDE_EMPTYGRAPH
 		/* It works, but we still get the "zoom" magnifying glass which looks odd */
 		if (rrddbcount == 0) {
 			/* No graph */
 			fwrite(blankimg, 1, sizeof(blankimg), stdout);
 			return;
 		}
-#endif
 	}
 
 	/* All set - generate the graph */
 	rrd_clear_error();
 
-#ifdef RRDTOOL12
-    #ifdef RRDTOOL19
+#ifdef RRDTOOL19
 	result = rrd_graph(rrdargcount, (const char **)rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
-    #else
+#else
 	result = rrd_graph(rrdargcount, rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
-    #endif
+#endif
 
 	/*
-	 * If we have neither the upper- nor lower-limits of the graph, AND we allow vertical 
-	 * zooming of this graph, then save the upper/lower limit values and flag that we have 
+	 * If we have neither the upper- nor lower-limits of the graph, AND we allow vertical
+	 * zooming of this graph, then save the upper/lower limit values and flag that we have
 	 * them. The values are then used for the zoom URL we construct later on.
 	 */
 	if (!haveupperlimit && !havelowerlimit) {
 		upperlimit = ymax; haveupperlimit = 1;
 		lowerlimit = ymin; havelowerlimit = 1;
 	}
-#else
-	result = rrd_graph(rrdargcount, rrdargs, &calcpr, &xsize, &ysize);
-#endif
 
 	/* Was it OK ? */
 	if (rrd_test_error() || (result != 0)) {
@@ -1288,13 +1249,11 @@ void generate_zoompage(char *selfURI)
 				n = fread(buf, 1, st.st_size, fd);
 				fclose(fd);
 
-#ifdef RRDTOOL12
 				zoomrightoffsetp = strstr(buf, zoomrightoffsetmarker);
 				if (zoomrightoffsetp) {
 					zoomrightoffsetp += strlen(zoomrightoffsetmarker);
 					memcpy(zoomrightoffsetp, "30", 2);
 				}
-#endif
 
 				fwrite(buf, 1, n, stdout);
 			}

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -32,6 +32,7 @@ static char rcsid[] = "$Id$";
 #include <rrd.h>
 
 #include "libxymon.h"
+#include "../lib/rrd_api_compat.h"
 
 #define HOUR_GRAPH  "e-48h"
 #define DAY_GRAPH   "e-12d"
@@ -773,7 +774,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 
 	/* Options for rrd_graph() */
 	int  rrdargcount;
-	char **rrdargs = NULL;	/* The full argv[] table of string pointers to arguments */
+	xymon_rrd_argv_item_t *rrdargs = NULL;	/* The full argv[] table of string pointers to arguments */
 	char heightopt[30];	/* -h HEIGHT */
 	char widthopt[30];	/* -w WIDTH */
 	char upperopt[30];	/* -u MAX */
@@ -1109,7 +1110,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	 * there are multiple RRD-files to handle).
 	 */
 	for (pcount = 0; (gdef->defs[pcount]); pcount++) ;
-	rrdargs = (char **) calloc(16 + pcount*rrddbcount + useroptcount + 1, sizeof(char *));
+	rrdargs = calloc(16 + pcount*rrddbcount + useroptcount + 1, sizeof(*rrdargs));
 
 
 	argi = 0;
@@ -1186,11 +1187,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	/* All set - generate the graph */
 	rrd_clear_error();
 
-#ifdef RRDTOOL19
-	result = rrd_graph(rrdargcount, (const char **)rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
-#else
-	result = rrd_graph(rrdargcount, rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
-#endif
+	result = xymon_rrd_graph(rrdargcount, rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
 
 	/*
 	 * If we have neither the upper- nor lower-limits of the graph, AND we allow vertical

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -246,7 +246,7 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 	optind = opterr = 0; rrd_clear_error();
 	result = rrd_update(pcount, updparams);
 
-#if defined(LINUX) && defined(RRDTOOL12)
+#if defined(LINUX)
 	/*
 	 * RRDtool 1.2+ uses mmap'ed I/O, but the Linux kernel does not update timestamps when
 	 * doing file I/O on mmap'ed files. This breaks our check for stale/nostale RRD's.

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -27,6 +27,7 @@ static char rcsid[] = "$Id$";
 #include <pcre2.h>
 
 #include "libxymon.h"
+#include "../lib/rrd_api_compat.h"
 
 #include "xymond_rrd.h"
 #include "do_rrd.h"
@@ -217,11 +218,7 @@ static void setupinterval(int intvl)
 static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 {
 	/* Flush any updates we've cached */
-#ifdef RRDTOOL19
-	const char *updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
-#else
-	char *updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
-#endif
+	xymon_rrd_argv_item_t updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
 	int i, pcount, result;
 
 	dbgprintf("Flushing '%s' with %d updates pending, template '%s'\n", 
@@ -244,7 +241,7 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 
 	for (pcount = 0; (updparams[pcount]); pcount++);
 	optind = opterr = 0; rrd_clear_error();
-	result = rrd_update(pcount, updparams);
+	result = xymon_rrd_update(pcount, updparams);
 
 #if defined(LINUX)
 	/*
@@ -335,7 +332,8 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 
 	/* If the RRD file doesn't exist, create it immediately */
 	if (stat(filedir, &st) == -1) {
-		char **rrdcreate_params, **rrddefinitions;
+		xymon_rrd_argv_item_t *rrdcreate_params;
+		char **rrddefinitions;
 		int rrddefcount, i;
 		char *rrakey = NULL;
 		char stepsetting[10];
@@ -354,7 +352,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		sprintf(stepsetting, "%d", pollinterval);
 
 		rrddefinitions = get_rrd_definition((rrakey ? rrakey : testname), &rrddefcount);
-		rrdcreate_params = (char **)calloc(4 + pcount + rrddefcount + 1, sizeof(char *));
+		rrdcreate_params = calloc(4 + pcount + rrddefcount + 1, sizeof(*rrdcreate_params));
 		rrdcreate_params[0] = "rrdcreate";
 		rrdcreate_params[1] = filedir;
 
@@ -383,11 +381,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		 * we MUST reset this before every call.
 		 */
 		optind = opterr = 0; rrd_clear_error();
-#ifdef RRDTOOL19
-		result = rrd_create(4+pcount, (const char **)rrdcreate_params);
-#else
-		result = rrd_create(4+pcount, rrdcreate_params);
-#endif
+		result = xymon_rrd_create(4+pcount, rrdcreate_params);
 		xfree(rrdcreate_params);
 		if (rrakey) xfree(rrakey);
 
@@ -599,11 +593,7 @@ static int rrddatasets(char *hostname, char ***dsnames)
 	struct stat st;
 
 	int result;
-#ifdef RRDTOOL19
-	const char *fetch_params[] = { "rrdfetch", filedir, "AVERAGE", "-s", "-30m", NULL };
-#else
-	char *fetch_params[] = { "rrdfetch", filedir, "AVERAGE", "-s", "-30m", NULL };
-#endif
+	xymon_rrd_argv_item_t fetch_params[] = { "rrdfetch", filedir, "AVERAGE", "-s", "-30m", NULL };
 	time_t starttime, endtime;
 	unsigned long steptime, dscount;
 	rrd_value_t *rrddata;
@@ -613,7 +603,7 @@ static int rrddatasets(char *hostname, char ***dsnames)
 	if (stat(filedir, &st) == -1) return 0;
 
 	optind = opterr = 0; rrd_clear_error();
-	result = rrd_fetch(5, fetch_params, &starttime, &endtime, &steptime, &dscount, dsnames, &rrddata);
+	result = xymon_rrd_fetch(5, fetch_params, &starttime, &endtime, &steptime, &dscount, dsnames, &rrddata);
 	if (result == -1) {
 		errprintf("Error while retrieving RRD dataset names from %s: %s\n",
 			  filedir, rrd_get_error());


### PR DESCRIPTION
## Summary

This PR updates Xymon's RRDtool integration to key off the ABI exposed by
`rrd.h`, instead of guessing from the RRDtool version number.

It does three things together:

- detect whether the installed RRDtool headers use `char **argv` or `const char **argv`
- remove the old `RRDTOOL19` argument-type gate by routing callers through a shared ABI shim
- remove the legacy `RRDTOOL12` graph path and keep the modern `rrd_graph()` path

## Why

Version-based detection is not reliable enough here.

A concrete example is Oracle Linux 10, which ships RRDtool 1.8.0 headers with a
`const char **` ABI. In that environment, checking for "1.9+" is not sufficient;
the build has to detect the API that the headers actually expose.

## Changes

- detect the RRDtool argv ABI in `build/rrd.sh`
- export `RRD_CONST_ARGS`, with an explicit manual override when detection is ambiguous
- update the configure help and documentation for that override
- add a private compatibility shim in `lib/rrd_abi_compat.h`
- migrate RRD callers in:
  - `xymond/do_rrd.c`
  - `web/perfdata.c`
  - `web/showgraph.c`
  - `build/test-rrd.c`
- remove obsolete `RRDTOOL19` branches from the migrated code
- remove obsolete `RRDTOOL12` graph branches from the migrated code

## Notes

- this branch intentionally keeps the ABI detection and the runtime caller migration together, because they are part of the same compatibility change
- tested successfully on Oracle Linux 10 with RRDtool 1.8.0

## Supersedes

Supersedes #57.

## Tracking

Fixes #81