### PR TITLE
rrd: apply Linux utimes workaround consistently

### DIFF
--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -245,11 +245,12 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 
 #if defined(LINUX)
 	/*
-	 * RRDtool 1.2+ uses mmap'ed I/O, but the Linux kernel does not update timestamps when
-	 * doing file I/O on mmap'ed files. This breaks our check for stale/nostale RRD's.
-	 * So do an explicit timestamp update on the file here.
+	 * RRDtool >= 1.2 uses mmap'ed I/O, but Linux does not update file timestamps for
+	 * mmap writes. This breaks our stale/nostale checks, so force a timestamp update --
+	 * but only on a successful update. Refreshing the mtime after a failed rrd_update()
+	 * would mask the failure from the stale/nostale detection.
 	 */
-	utimes(filedir, NULL);
+	if (result == 0) utimes(filedir, NULL);
 #endif
 
 	/* Clear the cached data */


### PR DESCRIPTION
## Summary

This updates the Linux `utimes()` workaround in `xymond/do_rrd.c::flush_cached_updates()`.

The workaround is now applied to all Linux RRDtool builds, not only builds with
`RRDTOOL12` defined. This keeps the mtime refresh behavior consistent for modern
RRDtool builds using mmap-backed updates.

The `utimes()` call is also gated on `result == 0`, so a failed `rrd_update()`
does not refresh the file mtime and hide the failure from stale/nostale checks.

## Why

This is a follow-up to #80. Once the old RRDtool ABI gate is removed, the Linux
mtime workaround should no longer depend on `RRDTOOL12`.

Gating the timestamp refresh on success avoids expanding an existing edge case:
previously, a failed `rrd_update()` could still make the RRD file look fresh.

## Scope

- touches only `xymond/do_rrd.c`
- does not change RRDtool ABI detection
- does not change the `showgraph` cleanup from #80
