### PR TITLE
configure: fail server setup when RRDtool probe fails

### DIFF
--- a/configure.server
+++ b/configure.server
@@ -101,7 +101,12 @@ echo ""; echo ""
 . build/rrd.sh
 if test "$RRDOK" = "NO"
 then
-	ENABLERRD="n"
+	echo ""
+	echo "RRDtool support is required for Xymon server builds."
+	echo "Configuration aborted because the RRDtool probe failed."
+	echo "Fix the RRDtool installation or probe compatibility and rerun configure."
+	echo "If you only need the client build, use './configure --client' instead."
+	exit 1
 else
 	ENABLERRD="y"
 fi
@@ -587,4 +592,3 @@ echo ""
 echo "Configuration complete - now run $MAKE (GNU make) to build the tools"
 
 exit 0
-


### PR DESCRIPTION
## Summary

Stop `./configure --server` from silently downgrading builds when the RRDtool probe fails.

On Fedora 40, the current `make` path detects that RRDtool support is unusable, but continues with `DORRD=""` and produces a reduced server build. This change makes that configuration error explicit and aborts server setup immediately.

## Change

- in `configure.server`, exit with an error when `build/rrd.sh` reports `RRDOK=NO`
- keep the guidance explicit: fix RRDtool/probe compatibility or use `./configure --client` for client-only builds

## Why this is the simplest fix

- minimal surface area: one file, one decision point
- no probe rewrite yet
- prevents silently generating incomplete server artifacts

Closes #83