### PR TITLE
Update github workflows: actions/checkout v4->6, gh-release 2->3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/workflow-release.yaml
+++ b/.github/workflows/workflow-release.yaml
@@ -45,7 +45,7 @@ jobs:
           | gzip -9 > "${{ steps.vars.outputs.asset }}"
 #---------------------------------------------------
       - name: Create GitHub Release and upload tarball
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.vars.outputs.tag }}
           name: ${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
This is required, since the older ones are based on node20, which is deprecated and will be removed in June 2026.