### PR TITLE
Fix github release workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# exclude .gitignore and .github from archive
+.git* export-ignore

--- a/.github/workflows/workflow-release.yaml
+++ b/.github/workflows/workflow-release.yaml
@@ -40,7 +40,6 @@ jobs:
           git archive \
             --format=tar \
             --prefix="${PREFIX}" \
-            --exclude='.github/*' \
             "${{ steps.vars.outputs.tag }}" \
           | gzip -9 > "${{ steps.vars.outputs.asset }}"
 #---------------------------------------------------

--- a/.github/workflows/workflow-release.yaml
+++ b/.github/workflows/workflow-release.yaml
@@ -49,6 +49,7 @@ jobs:
         with:
           tag_name: ${{ steps.vars.outputs.tag }}
           name: ${{ steps.vars.outputs.tag }}
+          draft: true
           generate_release_notes: "true"
           files: |
             ${{ steps.vars.outputs.asset }}


### PR DESCRIPTION
Get rid of non existing option `--exclude` of `git archive` and use `.gitattributes` instead, which also keeps .gitignore out of tarball.

Additionally activate `draft: true`, to release mechanism, to avoid accidentally releasing (I think, we usually want to add release notes to the release page before releaseing).

Fixes #86