### PR TITLE
PCRE2: fix leaks in headfoot/mailack, harden pickdata sizing

### DIFF
--- a/lib/headfoot.c
+++ b/lib/headfoot.c
@@ -409,7 +409,10 @@ static void *wanted_host(char *hostname)
 
 	if (classpattern && hinfo) {
 		char *hostclass = xmh_item(hinfo, XMH_CLASS);
-		if (!hostclass) return NULL;
+		if (!hostclass) {
+			pcre2_match_data_free(ovector);
+			return NULL;
+		}
 
 		result = pcre2_match(classpattern, hostclass, strlen(hostclass), 0, 0,
 				ovector, NULL);

--- a/lib/matching.c
+++ b/lib/matching.c
@@ -168,9 +168,11 @@ int pickdata(char *buf, pcre2_code *expr, int dupok, ...)
 
 	if (!expr) return 0;
 
-	ovector = pcre2_match_data_create(30, NULL);
+	ovector = pcre2_match_data_create_from_pattern(expr, NULL);
+	if (!ovector) return 0;
+
 	res = pcre2_match(expr, buf, strlen(buf), 0, 0, ovector, NULL);
-	if (res < 0) {
+	if (res <= 0) {
 		pcre2_match_data_free(ovector);
 		return 0;
 	}
@@ -211,5 +213,4 @@ int timematch(char *holidaykey, char *tspec)
 
 	return result;
 }
-
 

--- a/xymond/xymon-mailack.c
+++ b/xymond/xymon-mailack.c
@@ -106,11 +106,13 @@ int main(int argc, char *argv[])
 	ovector = pcre2_match_data_create(30, NULL);
 	result = pcre2_match(subjexp, subjectline, strlen(subjectline), 0, 0, ovector, NULL);
 	if (result < 0) {
+		pcre2_code_free(subjexp);
 		pcre2_match_data_free(ovector);
 		dbgprintf("Subject line did not match pattern\n");
 		return 3; /* Subject did not match what we expected */
 	}
 	if (pcre2_substring_copy_bynumber(ovector, 2, cookie, &l) <= 0) {
+		pcre2_code_free(subjexp);
 		pcre2_match_data_free(ovector);
 		dbgprintf("Could not find cookie value\n");
 		return 4; /* No cookie */
@@ -171,10 +173,12 @@ int main(int argc, char *argv[])
 
 	if (debug) {
 		printf("%s\n", ackbuf);
+		pcre2_match_data_free(ovector);
 		return 0;
 	}
 
 	sendmessage(ackbuf, NULL, XYMON_TIMEOUT, NULL);
+	pcre2_match_data_free(ovector);
 	return 0;
 }
 


### PR DESCRIPTION
Three small focused PCRE2 hardening fixes:

- **headfoot**: free match data on class-filter early return
  (per-call leak in `wanted_host()`).
- **matching**: pattern-sized match data + NULL-check in `pickdata`.
- **xymon-mailack**: free PCRE2 resources on all exit paths.

A broader uniform hardening pass across the remaining PCRE2 call sites
is staged on `fix/pcre2-bulk-hardening` and will be opened as a follow-up
PR once this one merges — it touches `lib/headfoot.c`, `lib/matching.c`
and `xymond/xymon-mailack.c` on top of the fixes here, so it must land
after.

Note: other PCRE2 call sites still use the legacy
`pcre2_match_data_create(N, NULL)` pattern without NULL-checks. These
are addressed uniformly by the bulk follow-up, not patched piecemeal
here, to avoid churn when the same lines are rewritten to use
`pcre2_match_data_create_from_pattern()`.