### PR TITLE
lib: size each PCRE2 match block from its pattern, and free it on every path

### DIFF
--- a/lib/acknowledgementslog.c
+++ b/lib/acknowledgementslog.c
@@ -94,7 +94,7 @@ void do_acknowledgementslog(FILE *output,
 		  char *testregex, char *extestregex,
 		  char *rcptregex, char *exrcptregex)
 {
-	FILE *acknowledgementslog;
+	FILE *acknowledgementslog = NULL;
 	char acknowledgementslogfilename[PATH_MAX];
 	time_t firstevent = 0;
 	time_t lastevent = getcurrenttime(NULL);
@@ -114,7 +114,8 @@ void do_acknowledgementslog(FILE *output,
 	pcre2_code *extestregexp = NULL;
 	pcre2_code *rcptregexp = NULL;
 	pcre2_code *exrcptregexp = NULL;
-	pcre2_match_data *ovector;
+	pcre2_match_data *ovector = NULL;
+	pcre2_code *match_re;
 
 	if (maxminutes && (fromtime || totime)) {
 		fprintf(output, "<B>Only one time interval type is allowed!</B>");
@@ -157,6 +158,14 @@ void do_acknowledgementslog(FILE *output,
 	if (extestregex && *extestregex) extestregexp = pcre2_compile(extestregex, strlen(extestregex), PCRE2_CASELESS, &err, &errofs, NULL);
 	if (rcptregex && *rcptregex) rcptregexp = pcre2_compile(rcptregex, strlen(rcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
 	if (exrcptregex && *exrcptregex) exrcptregexp = pcre2_compile(exrcptregex, strlen(exrcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	match_re = (pageregexp ? pageregexp :
+		    expageregexp ? expageregexp :
+		    hostregexp ? hostregexp :
+		    exhostregexp ? exhostregexp :
+		    testregexp ? testregexp :
+		    extestregexp ? extestregexp :
+		    rcptregexp ? rcptregexp :
+		    exrcptregexp);
 
 	snprintf(acknowledgementslogfilename, sizeof(acknowledgementslogfilename), "%s/acknowledge.log", xgetenv("XYMONSERVERLOGS"));
 	acknowledgementslog = fopen(acknowledgementslogfilename, "r");
@@ -185,7 +194,7 @@ void do_acknowledgementslog(FILE *output,
 				}
 				else { 
 					fprintf(output, "Error reading logfile %s: %s\n", acknowledgementslogfilename, strerror(errno));
-					return;
+					goto cleanup;
 				}
 			}
 			else {
@@ -196,7 +205,13 @@ void do_acknowledgementslog(FILE *output,
 	}
 	
 	head = NULL;
-	ovector = pcre2_match_data_create(30, NULL);
+	/* ovector sized from match_re but reused across all page/host/test patterns below; safe because we only check match/no-match, not substrings */
+	ovector = (match_re ? pcre2_match_data_create_from_pattern(match_re, NULL) : NULL);
+	if (match_re && !ovector) {
+		errprintf("Cannot allocate PCRE match data for acknowledgements log\n");
+		fprintf(output, "<B>Internal error allocating regex match data</B>");
+		goto cleanup;
+	}
 
 	while (acknowledgementslog && (fgets(l, sizeof(l), acknowledgementslog))) {
 
@@ -405,6 +420,7 @@ void do_acknowledgementslog(FILE *output,
 		fprintf(output, "</CENTER>\n");
 	}
 
+cleanup:
 	if (acknowledgementslog) fclose(acknowledgementslog);
 
 	if (pageregexp)   pcre2_code_free(pageregexp);
@@ -415,6 +431,5 @@ void do_acknowledgementslog(FILE *output,
 	if (extestregexp) pcre2_code_free(extestregexp);
 	if (rcptregexp)   pcre2_code_free(rcptregexp);
 	if (exrcptregexp) pcre2_code_free(exrcptregexp);
-	pcre2_match_data_free(ovector);
+	if (ovector) pcre2_match_data_free(ovector);
 }
-

--- a/lib/acknowledgementslog.c
+++ b/lib/acknowledgementslog.c
@@ -26,8 +26,7 @@ static char rcsid[] = "$Id: acknowledgementslog.c 7085 2012-07-16 11:08:37Z stor
 #include <errno.h>
 #include <time.h>
 
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "pcre2_api_compat.h"
 
 #include "libxymon.h"
 
@@ -150,14 +149,14 @@ void do_acknowledgementslog(FILE *output,
 
 	if (!maxcount) maxcount = 100;
 
-	if (pageregex && *pageregex) pageregexp = pcre2_compile(pageregex, strlen(pageregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (expageregex && *expageregex) expageregexp = pcre2_compile(expageregex, strlen(expageregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (hostregex && *hostregex) hostregexp = pcre2_compile(hostregex, strlen(hostregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (exhostregex && *exhostregex) exhostregexp = pcre2_compile(exhostregex, strlen(exhostregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (testregex && *testregex) testregexp = pcre2_compile(testregex, strlen(testregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (extestregex && *extestregex) extestregexp = pcre2_compile(extestregex, strlen(extestregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (rcptregex && *rcptregex) rcptregexp = pcre2_compile(rcptregex, strlen(rcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (exrcptregex && *exrcptregex) exrcptregexp = pcre2_compile(exrcptregex, strlen(exrcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (pageregex && *pageregex) pageregexp = pcre2_compile(PCRE2STR(pageregex), strlen(pageregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (expageregex && *expageregex) expageregexp = pcre2_compile(PCRE2STR(expageregex), strlen(expageregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (hostregex && *hostregex) hostregexp = pcre2_compile(PCRE2STR(hostregex), strlen(hostregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (exhostregex && *exhostregex) exhostregexp = pcre2_compile(PCRE2STR(exhostregex), strlen(exhostregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (testregex && *testregex) testregexp = pcre2_compile(PCRE2STR(testregex), strlen(testregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (extestregex && *extestregex) extestregexp = pcre2_compile(PCRE2STR(extestregex), strlen(extestregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (rcptregex && *rcptregex) rcptregexp = pcre2_compile(PCRE2STR(rcptregex), strlen(rcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (exrcptregex && *exrcptregex) exrcptregexp = pcre2_compile(PCRE2STR(exrcptregex), strlen(exrcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
 	match_re = (pageregexp ? pageregexp :
 		    expageregexp ? expageregexp :
 		    hostregexp ? hostregexp :
@@ -271,7 +270,7 @@ void do_acknowledgementslog(FILE *output,
 			pagename = xmh_item_multi(eventhost, XMH_PAGEPATH);
 			pagematch = 0;
 			while (!pagematch && pagename) {
-			pagematch = (pcre2_match(pageregexp, pagename, strlen(pagename), 0, 0,
+			pagematch = (pcre2_match(pageregexp, PCRE2STR(pagename), strlen(pagename), 0, 0,
 					ovector, NULL) >= 0);
 				pagename = xmh_item_multi(NULL, XMH_PAGEPATH);
 			}
@@ -286,7 +285,7 @@ void do_acknowledgementslog(FILE *output,
 			pagename = xmh_item_multi(eventhost, XMH_PAGEPATH);
 			pagematch = 0;
 			while (!pagematch && pagename) {
-			pagematch = (pcre2_match(expageregexp, pagename, strlen(pagename), 0, 0,
+			pagematch = (pcre2_match(expageregexp, PCRE2STR(pagename), strlen(pagename), 0, 0,
 					ovector, NULL) >= 0);
 				pagename = xmh_item_multi(NULL, XMH_PAGEPATH);
 			}
@@ -296,42 +295,42 @@ void do_acknowledgementslog(FILE *output,
 		if (pagematch) continue;
 
 		if (hostregexp)
-			hostmatch = (pcre2_match(hostregexp, hostname, strlen(hostname), 0, 0,
+			hostmatch = (pcre2_match(hostregexp, PCRE2STR(hostname), strlen(hostname), 0, 0,
 					ovector, NULL) >= 0);
 		else
 			hostmatch = 1;
 		if (!hostmatch) continue;
 
 		if (exhostregexp)
-			hostmatch = (pcre2_match(exhostregexp, hostname, strlen(hostname), 0, 0,
+			hostmatch = (pcre2_match(exhostregexp, PCRE2STR(hostname), strlen(hostname), 0, 0,
 					ovector, NULL) >= 0);
 		else
 			hostmatch = 0;
 		if (hostmatch) continue;
 
 		if (testregexp)
-			testmatch = (pcre2_match(testregexp, svcname, strlen(svcname), 0, 0,
+			testmatch = (pcre2_match(testregexp, PCRE2STR(svcname), strlen(svcname), 0, 0,
 					ovector, NULL) >= 0);
 		else
 			testmatch = 1;
 		if (!testmatch) continue;
 
 		if (extestregexp)
-			testmatch = (pcre2_match(extestregexp, svcname, strlen(svcname), 0, 0,
+			testmatch = (pcre2_match(extestregexp, PCRE2STR(svcname), strlen(svcname), 0, 0,
 					ovector, NULL) >= 0);
 		else
 			testmatch = 0;
 		if (testmatch) continue;
 
 		if (rcptregexp)
-			rcptmatch = (pcre2_match(rcptregexp, recipient, strlen(recipient), 0, 0,
+			rcptmatch = (pcre2_match(rcptregexp, PCRE2STR(recipient), strlen(recipient), 0, 0,
 					ovector, NULL) >= 0);
 		else
 			rcptmatch = 1;
 		if (!rcptmatch) continue;
 
 		if (exrcptregexp)
-			rcptmatch = (pcre2_match(exrcptregexp, recipient, strlen(recipient), 0, 0,
+			rcptmatch = (pcre2_match(exrcptregexp, PCRE2STR(recipient), strlen(recipient), 0, 0,
 					ovector, NULL) >= 0);
 		else
 			rcptmatch = 0;

--- a/lib/clientlocal.c
+++ b/lib/clientlocal.c
@@ -16,8 +16,7 @@ static char rcsid[] = "$Id$";
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "pcre2_api_compat.h"
 
 #include "libxymon.h"
 

--- a/lib/eventlog.c
+++ b/lib/eventlog.c
@@ -182,14 +182,27 @@ static int  eventfilter(void *hinfo, char *testname,
 			pcre2_code *testregexp, pcre2_code *extestregexp,
 			int ignoredialups, f_hostcheck hostcheck)
 {
-	int pagematch, hostmatch, testmatch;
+	int pagematch, hostmatch, testmatch, result = 1;
 	char *hostname = xmh_item(hinfo, XMH_HOSTNAME);
-	pcre2_match_data *ovector;
+	pcre2_match_data *ovector = NULL;
+	pcre2_code *match_re;
 
 	if (ignoredialups && xmh_item(hinfo, XMH_FLAG_DIALUP)) return 0;
 	if (hostcheck && (hostcheck(hostname) == 0)) return 0;
 
-	ovector = pcre2_match_data_create(30, NULL);
+	match_re = (pageregexp ? pageregexp :
+		    expageregexp ? expageregexp :
+		    hostregexp ? hostregexp :
+		    exhostregexp ? exhostregexp :
+		    testregexp ? testregexp :
+		    extestregexp);
+	/* ovector sized from match_re but reused across all page/host/test patterns below; safe because we only check match/no-match, not substrings */
+	ovector = (match_re ? pcre2_match_data_create_from_pattern(match_re, NULL) : NULL);
+	if (match_re && !ovector) {
+		errprintf("Cannot allocate PCRE match data for event filter\n");
+		result = 0;
+		goto cleanup;
+	}
 	if (pageregexp) {
 		char *pagename;
 
@@ -204,8 +217,8 @@ static int  eventfilter(void *hinfo, char *testname,
 	else
 		pagematch = 1;
 	if (!pagematch) {
-		pcre2_match_data_free(ovector);
-		return 0;
+		result = 0;
+		goto cleanup;
 	}
 
 	if (expageregexp) {
@@ -222,8 +235,8 @@ static int  eventfilter(void *hinfo, char *testname,
 	else
 		pagematch = 0;
 	if (pagematch) {
-		pcre2_match_data_free(ovector);
-		return 0;
+		result = 0;
+		goto cleanup;
 	}
 
 	if (hostregexp)
@@ -232,8 +245,8 @@ static int  eventfilter(void *hinfo, char *testname,
 	else
 		hostmatch = 1;
 	if (!hostmatch) {
-		pcre2_match_data_free(ovector);
-		return 0;
+		result = 0;
+		goto cleanup;
 	}
 
 	if (exhostregexp)
@@ -242,8 +255,8 @@ static int  eventfilter(void *hinfo, char *testname,
 	else
 		hostmatch = 0;
 	if (hostmatch) {
-		pcre2_match_data_free(ovector);
-		return 0;
+		result = 0;
+		goto cleanup;
 	}
 
 	if (testregexp)
@@ -252,8 +265,8 @@ static int  eventfilter(void *hinfo, char *testname,
 	else
 		testmatch = 1;
 	if (!testmatch) {
-		pcre2_match_data_free(ovector);
-		return 0;
+		result = 0;
+		goto cleanup;
 	}
 
 	if (extestregexp)
@@ -262,12 +275,14 @@ static int  eventfilter(void *hinfo, char *testname,
 	else
 		testmatch = 0;
 	if (testmatch) {
-		pcre2_match_data_free(ovector);
-		return 0;
+		result = 0;
+		goto cleanup;
 	}
-	pcre2_match_data_free(ovector);
 
-	return 1;
+cleanup:
+	if (ovector) pcre2_match_data_free(ovector);
+
+	return result;
 }
 
 
@@ -526,7 +541,7 @@ void do_eventlog(FILE *output, int maxcount, int maxminutes, char *fromtime, cha
 		event_t **eventlist, countlist_t **hostcounts, countlist_t **servicecounts,
 		countsummary_t counttype, eventsummary_t sumtype, char *periodstring)
 {
-	FILE *eventlog;
+	FILE *eventlog = NULL;
 	char eventlogfilename[PATH_MAX];
 	time_t firstevent = 0;
 	time_t lastevent = getcurrenttime(NULL);
@@ -545,7 +560,8 @@ void do_eventlog(FILE *output, int maxcount, int maxminutes, char *fromtime, cha
 	pcre2_code *testregexp = NULL;
 	pcre2_code *extestregexp = NULL;
 	pcre2_code *colrregexp = NULL;
-	pcre2_match_data *ovector;
+	pcre2_match_data *ovector = NULL;
+	pcre2_code *match_re;
 	countlist_t *hostcounthead = NULL, *svccounthead = NULL;
 
 	if (eventlist) *eventlist = NULL;
@@ -598,6 +614,13 @@ void do_eventlog(FILE *output, int maxcount, int maxminutes, char *fromtime, cha
 	if (testregex && *testregex) testregexp = pcre2_compile(testregex, strlen(testregex), PCRE2_CASELESS, &err, &errofs, NULL);
 	if (extestregex && *extestregex) extestregexp = pcre2_compile(extestregex, strlen(extestregex), PCRE2_CASELESS, &err, &errofs, NULL);
 	if (colrregex && *colrregex) colrregexp = pcre2_compile(colrregex, strlen(colrregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	match_re = (pageregexp ? pageregexp :
+		    expageregexp ? expageregexp :
+		    hostregexp ? hostregexp :
+		    exhostregexp ? exhostregexp :
+		    testregexp ? testregexp :
+		    extestregexp ? extestregexp :
+		    colrregexp);
 
 	snprintf(eventlogfilename, sizeof(eventlogfilename), "%s/allevents", xgetenv("XYMONHISTDIR"));
 	eventlog = fopen(eventlogfilename, "r");
@@ -625,7 +648,7 @@ void do_eventlog(FILE *output, int maxcount, int maxminutes, char *fromtime, cha
 					}
 					else {
 						if (output) fprintf(output,"Error reading eventlog file %s: %s\n", eventlogfilename, strerror(errno));
-						return;
+						goto cleanup;
 					}
 				}
 				else {
@@ -640,7 +663,12 @@ void do_eventlog(FILE *output, int maxcount, int maxminutes, char *fromtime, cha
 	}
 	
 	eventhead = NULL;
-	ovector = pcre2_match_data_create(30, NULL);
+	ovector = (match_re ? pcre2_match_data_create_from_pattern(match_re, NULL) : NULL);
+	if (match_re && !ovector) {
+		errprintf("Cannot allocate PCRE match data for event log\n");
+		if (output) fprintf(output, "<B>Internal error allocating regex match data</B>");
+		goto cleanup;
+	}
 
 	while (eventlog && (fgets(l, sizeof(l), eventlog))) {
 
@@ -862,13 +890,17 @@ void do_eventlog(FILE *output, int maxcount, int maxminutes, char *fromtime, cha
 		fprintf(output, "</CENTER>\n");
 	}
 
+cleanup:
 	if (eventlog) fclose(eventlog);
 
 	if (pageregexp) pcre2_code_free(pageregexp);
+	if (expageregexp) pcre2_code_free(expageregexp);
 	if (hostregexp) pcre2_code_free(hostregexp);
+	if (exhostregexp) pcre2_code_free(exhostregexp);
 	if (testregexp) pcre2_code_free(testregexp);
+	if (extestregexp) pcre2_code_free(extestregexp);
 	if (colrregexp) pcre2_code_free(colrregexp);
-	pcre2_match_data_free(ovector);
+	if (ovector) pcre2_match_data_free(ovector);
 
 	/* Return the event- and count-lists, if wanted - or clean them up */
 	if (eventlist) {
@@ -896,4 +928,3 @@ void do_eventlog(FILE *output, int maxcount, int maxminutes, char *fromtime, cha
 		while (swalk) { zombie = swalk; swalk = swalk->next; xfree(zombie); }
 	}
 }
-

--- a/lib/eventlog.c
+++ b/lib/eventlog.c
@@ -28,8 +28,7 @@ static char rcsid[] = "$Id$";
 #include <errno.h>
 #include <time.h>
 
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "pcre2_api_compat.h"
 
 #include "libxymon.h"
 
@@ -209,7 +208,7 @@ static int  eventfilter(void *hinfo, char *testname,
 		pagename = xmh_item_multi(hinfo, XMH_PAGEPATH);
 		pagematch = 0;
 		while (!pagematch && pagename) {
-			pagematch = (pcre2_match(pageregexp, pagename, strlen(pagename), 0, 0,
+			pagematch = (pcre2_match(pageregexp, PCRE2STR(pagename), strlen(pagename), 0, 0,
 					ovector, NULL) >= 0);
 			pagename = xmh_item_multi(NULL, XMH_PAGEPATH);
 		}
@@ -227,7 +226,7 @@ static int  eventfilter(void *hinfo, char *testname,
 		pagename = xmh_item_multi(hinfo, XMH_PAGEPATH);
 		pagematch = 0;
 		while (!pagematch && pagename) {
-			pagematch = (pcre2_match(expageregexp, pagename, strlen(pagename), 0, 0,
+			pagematch = (pcre2_match(expageregexp, PCRE2STR(pagename), strlen(pagename), 0, 0,
 					ovector, NULL) >= 0);
 			pagename = xmh_item_multi(NULL, XMH_PAGEPATH);
 		}
@@ -240,7 +239,7 @@ static int  eventfilter(void *hinfo, char *testname,
 	}
 
 	if (hostregexp)
-		hostmatch = (pcre2_match(hostregexp, hostname, strlen(hostname), 0, 0,
+		hostmatch = (pcre2_match(hostregexp, PCRE2STR(hostname), strlen(hostname), 0, 0,
 				ovector, NULL) >= 0);
 	else
 		hostmatch = 1;
@@ -250,7 +249,7 @@ static int  eventfilter(void *hinfo, char *testname,
 	}
 
 	if (exhostregexp)
-		hostmatch = (pcre2_match(exhostregexp, hostname, strlen(hostname), 0, 0,
+		hostmatch = (pcre2_match(exhostregexp, PCRE2STR(hostname), strlen(hostname), 0, 0,
 				ovector, NULL) >= 0);
 	else
 		hostmatch = 0;
@@ -260,7 +259,7 @@ static int  eventfilter(void *hinfo, char *testname,
 	}
 
 	if (testregexp)
-		testmatch = (pcre2_match(testregexp, testname, strlen(testname), 0, 0,
+		testmatch = (pcre2_match(testregexp, PCRE2STR(testname), strlen(testname), 0, 0,
 				ovector, NULL) >= 0);
 	else
 		testmatch = 1;
@@ -270,7 +269,7 @@ static int  eventfilter(void *hinfo, char *testname,
 	}
 
 	if (extestregexp)
-		testmatch = (pcre2_match(extestregexp, testname, strlen(testname), 0, 0,
+		testmatch = (pcre2_match(extestregexp, PCRE2STR(testname), strlen(testname), 0, 0,
 				ovector, NULL) >= 0);
 	else
 		testmatch = 0;
@@ -607,13 +606,13 @@ void do_eventlog(FILE *output, int maxcount, int maxminutes, char *fromtime, cha
 
 	if (!maxcount) maxcount = 100;
 
-	if (pageregex && *pageregex) pageregexp = pcre2_compile(pageregex, strlen(pageregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (expageregex && *expageregex) expageregexp = pcre2_compile(expageregex, strlen(expageregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (hostregex && *hostregex) hostregexp = pcre2_compile(hostregex, strlen(hostregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (exhostregex && *exhostregex) exhostregexp = pcre2_compile(exhostregex, strlen(exhostregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (testregex && *testregex) testregexp = pcre2_compile(testregex, strlen(testregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (extestregex && *extestregex) extestregexp = pcre2_compile(extestregex, strlen(extestregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (colrregex && *colrregex) colrregexp = pcre2_compile(colrregex, strlen(colrregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (pageregex && *pageregex) pageregexp = pcre2_compile(PCRE2STR(pageregex), strlen(pageregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (expageregex && *expageregex) expageregexp = pcre2_compile(PCRE2STR(expageregex), strlen(expageregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (hostregex && *hostregex) hostregexp = pcre2_compile(PCRE2STR(hostregex), strlen(hostregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (exhostregex && *exhostregex) exhostregexp = pcre2_compile(PCRE2STR(exhostregex), strlen(exhostregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (testregex && *testregex) testregexp = pcre2_compile(PCRE2STR(testregex), strlen(testregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (extestregex && *extestregex) extestregexp = pcre2_compile(PCRE2STR(extestregex), strlen(extestregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (colrregex && *colrregex) colrregexp = pcre2_compile(PCRE2STR(colrregex), strlen(colrregex), PCRE2_CASELESS, &err, &errofs, NULL);
 	match_re = (pageregexp ? pageregexp :
 		    expageregexp ? expageregexp :
 		    hostregexp ? hostregexp :
@@ -707,9 +706,9 @@ void do_eventlog(FILE *output, int maxcount, int maxminutes, char *fromtime, cha
 
 			/* For duration counts, record all events. We'll filter out the colors later. */
 			if (colrregexp && (counttype != XYMON_COUNT_DURATION)) {
-				colrmatch = ( (pcre2_match(colrregexp, newcolname, strlen(newcolname), 0, 0,
+				colrmatch = ( (pcre2_match(colrregexp, PCRE2STR(newcolname), strlen(newcolname), 0, 0,
 							ovector, NULL) >= 0) ||
-					      (pcre2_match(colrregexp, oldcolname, strlen(oldcolname), 0, 0,
+					      (pcre2_match(colrregexp, PCRE2STR(oldcolname), strlen(oldcolname), 0, 0,
 							ovector, NULL) >= 0) );
 			}
 			else

--- a/lib/headfoot.c
+++ b/lib/headfoot.c
@@ -371,19 +371,30 @@ char *wkdayselect(char wkday, char *valtxt, int isdefault)
 
 static void *wanted_host(char *hostname)
 {
-	void *hinfo = hostinfo(hostname);
+	void *hinfo = hostinfo(hostname), *wanted = NULL;
 	int result;
-	pcre2_match_data *ovector;
+	pcre2_match_data *ovector = NULL;
+	pcre2_code *match_re;
 
 	if (!hinfo) return NULL;
+	wanted = hinfo;
 
-	ovector = pcre2_match_data_create(30, NULL);
+	match_re = (hostpattern ? hostpattern :
+		    pagepattern ? pagepattern :
+		    ippattern ? ippattern :
+		    classpattern);
+	ovector = (match_re ? pcre2_match_data_create_from_pattern(match_re, NULL) : NULL);
+	if (match_re && !ovector) {
+		errprintf("Cannot allocate PCRE match data for host filter\n");
+		wanted = NULL;
+		goto cleanup;
+	}
 	if (hostpattern) {
 		result = pcre2_match(hostpattern, hostname, strlen(hostname), 0, 0,
 				ovector, NULL);
 		if (result < 0) {
-			pcre2_match_data_free(ovector);
-			return NULL;
+			wanted = NULL;
+			goto cleanup;
 		}
 	}
 
@@ -392,8 +403,8 @@ static void *wanted_host(char *hostname)
 		result = pcre2_match(pagepattern, pname, strlen(pname), 0, 0,
 				ovector, NULL);
 		if (result < 0) {
-			pcre2_match_data_free(ovector);
-			return NULL;
+			wanted = NULL;
+			goto cleanup;
 		}
 	}
 
@@ -402,28 +413,30 @@ static void *wanted_host(char *hostname)
 		result = pcre2_match(ippattern, hostip, strlen(hostip), 0, 0,
 				ovector, NULL);
 		if (result < 0) {
-			pcre2_match_data_free(ovector);
-			return NULL;
+			wanted = NULL;
+			goto cleanup;
 		}
 	}
 
 	if (classpattern && hinfo) {
 		char *hostclass = xmh_item(hinfo, XMH_CLASS);
 		if (!hostclass) {
-			pcre2_match_data_free(ovector);
-			return NULL;
+			wanted = NULL;
+			goto cleanup;
 		}
 
 		result = pcre2_match(classpattern, hostclass, strlen(hostclass), 0, 0,
 				ovector, NULL);
 		if (result < 0) {
-			pcre2_match_data_free(ovector);
-			return NULL;
+			wanted = NULL;
+			goto cleanup;
 		}
 	}
-	pcre2_match_data_free(ovector);
 
-	return hinfo;
+cleanup:
+	if (ovector) pcre2_match_data_free(ovector);
+
+	return wanted;
 }
 
 
@@ -1674,4 +1687,3 @@ void showform(FILE *output, char *headertemplate, char *formtemplate, int color,
 		xfree(inbuf);
 	}
 }
-

--- a/lib/headfoot.c
+++ b/lib/headfoot.c
@@ -22,8 +22,7 @@ static char rcsid[] = "$Id$";
 #include <stdio.h>
 #include <string.h>
 #include <fcntl.h>
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "pcre2_api_compat.h"
 
 #include "libxymon.h"
 #include "version.h"
@@ -174,19 +173,19 @@ void sethostenv_filter(char *hostptn, char *pageptn, char *ipptn, char *classptn
 	/* Setup the pattern to match names against */
 	if (hostptn) {
 		hostpattern_text = strdup(hostptn);
-		hostpattern = pcre2_compile(hostptn, strlen(hostptn), PCRE2_CASELESS, &err, &errofs, NULL);
+		hostpattern = pcre2_compile(PCRE2STR(hostptn), strlen(hostptn), PCRE2_CASELESS, &err, &errofs, NULL);
 	}
 	if (pageptn) {
 		pagepattern_text = strdup(pageptn);
-		pagepattern = pcre2_compile(pageptn, strlen(pageptn), PCRE2_CASELESS, &err, &errofs, NULL);
+		pagepattern = pcre2_compile(PCRE2STR(pageptn), strlen(pageptn), PCRE2_CASELESS, &err, &errofs, NULL);
 	}
 	if (ipptn) {
 		ippattern_text = strdup(ipptn);
-		ippattern = pcre2_compile(ipptn, strlen(ipptn), PCRE2_CASELESS, &err, &errofs, NULL);
+		ippattern = pcre2_compile(PCRE2STR(ipptn), strlen(ipptn), PCRE2_CASELESS, &err, &errofs, NULL);
 	}
 	if (classptn) {
 		classpattern_text = strdup(classptn);
-		classpattern = pcre2_compile(classptn, strlen(classptn), PCRE2_CASELESS, &err, &errofs, NULL);
+		classpattern = pcre2_compile(PCRE2STR(classptn), strlen(classptn), PCRE2_CASELESS, &err, &errofs, NULL);
 	}
 }
 
@@ -390,7 +389,7 @@ static void *wanted_host(char *hostname)
 		goto cleanup;
 	}
 	if (hostpattern) {
-		result = pcre2_match(hostpattern, hostname, strlen(hostname), 0, 0,
+		result = pcre2_match(hostpattern, PCRE2STR(hostname), strlen(hostname), 0, 0,
 				ovector, NULL);
 		if (result < 0) {
 			wanted = NULL;
@@ -400,7 +399,7 @@ static void *wanted_host(char *hostname)
 
 	if (pagepattern && hinfo) {
 		char *pname = xmh_item(hinfo, XMH_PAGEPATH);
-		result = pcre2_match(pagepattern, pname, strlen(pname), 0, 0,
+		result = pcre2_match(pagepattern, PCRE2STR(pname), strlen(pname), 0, 0,
 				ovector, NULL);
 		if (result < 0) {
 			wanted = NULL;
@@ -410,7 +409,7 @@ static void *wanted_host(char *hostname)
 
 	if (ippattern && hinfo) {
 		char *hostip = xmh_item(hinfo, XMH_IP);
-		result = pcre2_match(ippattern, hostip, strlen(hostip), 0, 0,
+		result = pcre2_match(ippattern, PCRE2STR(hostip), strlen(hostip), 0, 0,
 				ovector, NULL);
 		if (result < 0) {
 			wanted = NULL;
@@ -425,7 +424,7 @@ static void *wanted_host(char *hostname)
 			goto cleanup;
 		}
 
-		result = pcre2_match(classpattern, hostclass, strlen(hostclass), 0, 0,
+		result = pcre2_match(classpattern, PCRE2STR(hostclass), strlen(hostclass), 0, 0,
 				ovector, NULL);
 		if (result < 0) {
 			wanted = NULL;

--- a/lib/loadalerts.c
+++ b/lib/loadalerts.c
@@ -25,8 +25,7 @@ static char rcsid[] = "$Id$";
 #include <limits.h>
 #include <errno.h>
 
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "pcre2_api_compat.h"
 
 #include "libxymon.h"
 

--- a/lib/loadalerts.h
+++ b/lib/loadalerts.h
@@ -16,8 +16,7 @@
 
 /* The clients probably don't have the pcre headers */
 #if defined(LOCALCLIENT) || !defined(CLIENTONLY)
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "pcre2_api_compat.h"
 
 typedef enum { A_PAGING, A_NORECIP, A_ACKED, A_RECOVERED, A_DISABLED, A_NOTIFY, A_DEAD } astate_t;
 

--- a/lib/matching.c
+++ b/lib/matching.c
@@ -58,7 +58,8 @@ int matchregex(const char *needle, pcre2_code *pcrecode)
 
 	if (!needle || !pcrecode) return 0;
 
-	ovector = pcre2_match_data_create(30, NULL);
+	ovector = pcre2_match_data_create_from_pattern(pcrecode, NULL);
+	if (!ovector) return 0;
 	result = pcre2_match(pcrecode, needle, strlen(needle), 0, 0, ovector, NULL);
 	pcre2_match_data_free(ovector);
 	return (result >= 0);
@@ -213,4 +214,3 @@ int timematch(char *holidaykey, char *tspec)
 
 	return result;
 }
-

--- a/lib/matching.c
+++ b/lib/matching.c
@@ -18,8 +18,7 @@ static char rcsid[] = "$Id$";
 #include <string.h>
 #include <stdlib.h>
 
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "pcre2_api_compat.h"
 
 #include "libxymon.h"
 
@@ -37,9 +36,9 @@ pcre2_code *compileregex_ext(const char *pattern, uint32_t flags, int *errcode, 
 	PCRE2_SIZE errofs;
 
 	dbgprintf("Compiling regex %s\n", pattern);
-	result = pcre2_compile(pattern, strlen(pattern), flags, &err, &errofs, NULL);
+	result = pcre2_compile(PCRE2STR(pattern), strlen(pattern), flags, &err, &errofs, NULL);
 	if (result == NULL) {
-		pcre2_get_error_message(err, errmsg, sizeof(errmsg));
+		pcre2_get_error_message(err, PCRE2BUF(errmsg), sizeof(errmsg));
 		errprintf("pcre compile '%s' failed (offset %zu): %s\n", pattern, errofs, errmsg);
 		if (errcode) *errcode = err;
 		if (erroffset) *erroffset = errofs;
@@ -76,7 +75,7 @@ int matchregex(const char *needle, pcre2_code *pcrecode)
 
 	ovector = pcre2_match_data_create_from_pattern(pcrecode, NULL);
 	if (!ovector) return 0;
-	result = pcre2_match(pcrecode, needle, strlen(needle), 0, 0, ovector, NULL);
+	result = pcre2_match(pcrecode, PCRE2STR(needle), strlen(needle), 0, 0, ovector, NULL);
 	pcre2_match_data_free(ovector);
 	return (result >= 0);
 }
@@ -196,7 +195,7 @@ int pickdata(char *buf, pcre2_code *expr, int dupok, int nargs, ...)
 	ovector = pcre2_match_data_create_from_pattern(expr, NULL);
 	if (!ovector) return 0;
 
-	res = pcre2_match(expr, buf, strlen(buf), 0, 0, ovector, NULL);
+	res = pcre2_match(expr, PCRE2STR(buf), strlen(buf), 0, 0, ovector, NULL);
 	if (res <= 0) {
 		pcre2_match_data_free(ovector);
 		return 0;
@@ -208,7 +207,7 @@ int pickdata(char *buf, pcre2_code *expr, int dupok, int nargs, ...)
 	for (i=1; (i < res); i++) {
 		*w = '\0';
 		l = sizeof(w);
-		pcre2_substring_copy_bynumber(ovector, i, w, &l);
+		pcre2_substring_copy_bynumber(ovector, i, PCRE2BUF(w), &l);
 		ptr = va_arg(ap, char **);
 		if (dupok) {
 			if (*ptr) xfree(*ptr);

--- a/lib/matching.c
+++ b/lib/matching.c
@@ -74,7 +74,8 @@ int matchregex(const char *needle, pcre2_code *pcrecode)
 
 	if (!needle || !pcrecode) return 0;
 
-	ovector = pcre2_match_data_create(30, NULL);
+	ovector = pcre2_match_data_create_from_pattern(pcrecode, NULL);
+	if (!ovector) return 0;
 	result = pcre2_match(pcrecode, needle, strlen(needle), 0, 0, ovector, NULL);
 	pcre2_match_data_free(ovector);
 	return (result >= 0);
@@ -238,4 +239,3 @@ int timematch(char *holidaykey, char *tspec)
 
 	return result;
 }
-

--- a/lib/matching.h
+++ b/lib/matching.h
@@ -13,8 +13,7 @@
 
 /* The clients probably don't have the pcre headers */
 #if defined(LOCALCLIENT) || !defined(CLIENTONLY)
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "pcre2_api_compat.h"
 #include <stdarg.h>
 
 extern pcre2_code *compileregex(const char *pattern);

--- a/lib/notifylog.c
+++ b/lib/notifylog.c
@@ -92,7 +92,7 @@ void do_notifylog(FILE *output,
 		  char *testregex, char *extestregex,
 		  char *rcptregex, char *exrcptregex)
 {
-	FILE *notifylog;
+	FILE *notifylog = NULL;
 	char notifylogfilename[PATH_MAX];
 	time_t firstevent = 0;
 	time_t lastevent = getcurrenttime(NULL);
@@ -112,7 +112,8 @@ void do_notifylog(FILE *output,
 	pcre2_code *extestregexp = NULL;
 	pcre2_code *rcptregexp = NULL;
 	pcre2_code *exrcptregexp = NULL;
-	pcre2_match_data *ovector;
+	pcre2_match_data *ovector = NULL;
+	pcre2_code *match_re;
 
 	if (maxminutes && (fromtime || totime)) {
 		fprintf(output, "<B>Only one time interval type is allowed!</B>");
@@ -155,6 +156,14 @@ void do_notifylog(FILE *output,
 	if (extestregex && *extestregex) extestregexp = pcre2_compile(extestregex, strlen(extestregex), PCRE2_CASELESS, &err, &errofs, NULL);
 	if (rcptregex && *rcptregex) rcptregexp = pcre2_compile(rcptregex, strlen(rcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
 	if (exrcptregex && *exrcptregex) exrcptregexp = pcre2_compile(exrcptregex, strlen(exrcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	match_re = (pageregexp ? pageregexp :
+		    expageregexp ? expageregexp :
+		    hostregexp ? hostregexp :
+		    exhostregexp ? exhostregexp :
+		    testregexp ? testregexp :
+		    extestregexp ? extestregexp :
+		    rcptregexp ? rcptregexp :
+		    exrcptregexp);
 
 	snprintf(notifylogfilename, sizeof(notifylogfilename), "%s/notifications.log", xgetenv("XYMONSERVERLOGS"));
 	notifylog = fopen(notifylogfilename, "r");
@@ -179,7 +188,7 @@ void do_notifylog(FILE *output,
 				}
 				else { 
 					fprintf(output, "Error reading logfile %s: %s\n", notifylogfilename, strerror(errno));
-					return;
+					goto cleanup;
 				}
 			}
 			else {
@@ -190,7 +199,13 @@ void do_notifylog(FILE *output,
 	}
 	
 	head = NULL;
-	ovector = pcre2_match_data_create(30, NULL);
+	/* ovector sized from match_re but reused across all page/host/test patterns below; safe because we only check match/no-match, not substrings */
+	ovector = (match_re ? pcre2_match_data_create_from_pattern(match_re, NULL) : NULL);
+	if (match_re && !ovector) {
+		errprintf("Cannot allocate PCRE match data for notification log\n");
+		fprintf(output, "<B>Internal error allocating regex match data</B>");
+		goto cleanup;
+	}
 
 	while (notifylog && (fgets(l, sizeof(l), notifylog))) {
 
@@ -367,6 +382,7 @@ void do_notifylog(FILE *output,
 		fprintf(output, "</CENTER>\n");
 	}
 
+cleanup:
 	if (notifylog) fclose(notifylog);
 
 	if (pageregexp)   pcre2_code_free(pageregexp);
@@ -377,6 +393,5 @@ void do_notifylog(FILE *output,
 	if (extestregexp) pcre2_code_free(extestregexp);
 	if (rcptregexp)   pcre2_code_free(rcptregexp);
 	if (exrcptregexp) pcre2_code_free(exrcptregexp);
-	pcre2_match_data_free(ovector);
+	if (ovector) pcre2_match_data_free(ovector);
 }
-

--- a/lib/notifylog.c
+++ b/lib/notifylog.c
@@ -26,8 +26,7 @@ static char rcsid[] = "$Id$";
 #include <errno.h>
 #include <time.h>
 
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "pcre2_api_compat.h"
 
 #include "libxymon.h"
 
@@ -148,14 +147,14 @@ void do_notifylog(FILE *output,
 
 	if (!maxcount) maxcount = 100;
 
-	if (pageregex && *pageregex) pageregexp = pcre2_compile(pageregex, strlen(pageregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (expageregex && *expageregex) expageregexp = pcre2_compile(expageregex, strlen(expageregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (hostregex && *hostregex) hostregexp = pcre2_compile(hostregex, strlen(hostregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (exhostregex && *exhostregex) exhostregexp = pcre2_compile(exhostregex, strlen(exhostregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (testregex && *testregex) testregexp = pcre2_compile(testregex, strlen(testregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (extestregex && *extestregex) extestregexp = pcre2_compile(extestregex, strlen(extestregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (rcptregex && *rcptregex) rcptregexp = pcre2_compile(rcptregex, strlen(rcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
-	if (exrcptregex && *exrcptregex) exrcptregexp = pcre2_compile(exrcptregex, strlen(exrcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (pageregex && *pageregex) pageregexp = pcre2_compile(PCRE2STR(pageregex), strlen(pageregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (expageregex && *expageregex) expageregexp = pcre2_compile(PCRE2STR(expageregex), strlen(expageregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (hostregex && *hostregex) hostregexp = pcre2_compile(PCRE2STR(hostregex), strlen(hostregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (exhostregex && *exhostregex) exhostregexp = pcre2_compile(PCRE2STR(exhostregex), strlen(exhostregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (testregex && *testregex) testregexp = pcre2_compile(PCRE2STR(testregex), strlen(testregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (extestregex && *extestregex) extestregexp = pcre2_compile(PCRE2STR(extestregex), strlen(extestregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (rcptregex && *rcptregex) rcptregexp = pcre2_compile(PCRE2STR(rcptregex), strlen(rcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
+	if (exrcptregex && *exrcptregex) exrcptregexp = pcre2_compile(PCRE2STR(exrcptregex), strlen(exrcptregex), PCRE2_CASELESS, &err, &errofs, NULL);
 	match_re = (pageregexp ? pageregexp :
 		    expageregexp ? expageregexp :
 		    hostregexp ? hostregexp :
@@ -238,7 +237,7 @@ void do_notifylog(FILE *output,
 			pagename = xmh_item_multi(eventhost, XMH_PAGEPATH);
 			pagematch = 0;
 			while (!pagematch && pagename) {
-			pagematch = (pcre2_match(pageregexp, pagename, strlen(pagename), 0, 0,
+			pagematch = (pcre2_match(pageregexp, PCRE2STR(pagename), strlen(pagename), 0, 0,
 					ovector, NULL) >= 0);
 				pagename = xmh_item_multi(NULL, XMH_PAGEPATH);
 			}
@@ -253,7 +252,7 @@ void do_notifylog(FILE *output,
 			pagename = xmh_item_multi(eventhost, XMH_PAGEPATH);
 			pagematch = 0;
 			while (!pagematch && pagename) {
-			pagematch = (pcre2_match(expageregexp, pagename, strlen(pagename), 0, 0,
+			pagematch = (pcre2_match(expageregexp, PCRE2STR(pagename), strlen(pagename), 0, 0,
 					ovector, NULL) >= 0);
 				pagename = xmh_item_multi(NULL, XMH_PAGEPATH);
 			}
@@ -263,42 +262,42 @@ void do_notifylog(FILE *output,
 		if (pagematch) continue;
 
 		if (hostregexp)
-			hostmatch = (pcre2_match(hostregexp, hostname, strlen(hostname), 0, 0,
+			hostmatch = (pcre2_match(hostregexp, PCRE2STR(hostname), strlen(hostname), 0, 0,
 					ovector, NULL) >= 0);
 		else
 			hostmatch = 1;
 		if (!hostmatch) continue;
 
 		if (exhostregexp)
-			hostmatch = (pcre2_match(exhostregexp, hostname, strlen(hostname), 0, 0,
+			hostmatch = (pcre2_match(exhostregexp, PCRE2STR(hostname), strlen(hostname), 0, 0,
 					ovector, NULL) >= 0);
 		else
 			hostmatch = 0;
 		if (hostmatch) continue;
 
 		if (testregexp)
-			testmatch = (pcre2_match(testregexp, svcname, strlen(svcname), 0, 0,
+			testmatch = (pcre2_match(testregexp, PCRE2STR(svcname), strlen(svcname), 0, 0,
 					ovector, NULL) >= 0);
 		else
 			testmatch = 1;
 		if (!testmatch) continue;
 
 		if (extestregexp)
-			testmatch = (pcre2_match(extestregexp, svcname, strlen(svcname), 0, 0,
+			testmatch = (pcre2_match(extestregexp, PCRE2STR(svcname), strlen(svcname), 0, 0,
 					ovector, NULL) >= 0);
 		else
 			testmatch = 0;
 		if (testmatch) continue;
 
 		if (rcptregexp)
-			rcptmatch = (pcre2_match(rcptregexp, recipient, strlen(recipient), 0, 0,
+			rcptmatch = (pcre2_match(rcptregexp, PCRE2STR(recipient), strlen(recipient), 0, 0,
 					ovector, NULL) >= 0);
 		else
 			rcptmatch = 1;
 		if (!rcptmatch) continue;
 
 		if (exrcptregexp)
-			rcptmatch = (pcre2_match(exrcptregexp, recipient, strlen(recipient), 0, 0,
+			rcptmatch = (pcre2_match(exrcptregexp, PCRE2STR(recipient), strlen(recipient), 0, 0,
 					ovector, NULL) >= 0);
 		else
 			rcptmatch = 0;

--- a/lib/pcre2_api_compat.h
+++ b/lib/pcre2_api_compat.h
@@ -1,0 +1,16 @@
+#ifndef __PCRE2_API_COMPAT_H__
+#define __PCRE2_API_COMPAT_H__
+
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+/*
+ * PCRE2 strings are unsigned (PCRE2_SPTR is "const unsigned char *"), C
+ * strings are not, and the two stay distinct types however the compiler is
+ * flagged. One cast at the boundary, written once: PCRE2STR() for pattern
+ * and subject inputs, PCRE2BUF() for output buffers.
+ */
+#define PCRE2STR(s) ((PCRE2_SPTR)(s))
+#define PCRE2BUF(s) ((PCRE2_UCHAR *)(s))
+
+#endif

--- a/web/perfdata.c
+++ b/web/perfdata.c
@@ -21,8 +21,7 @@ static char rcsid[] = "$Id$";
 #include <dirent.h>
 
 #include <rrd.h>
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "../lib/pcre2_api_compat.h"
 
 #include "libxymon.h"
 #include "../lib/rrd_api_compat.h"

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -961,7 +961,8 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		rrddbsize = 5;
 		rrddbs = (rrddb_t *) malloc((rrddbsize+1) * sizeof(rrddb_t));
 
-		ovector = pcre2_match_data_create(30, NULL);
+		ovector = pcre2_match_data_create_from_pattern(pat, NULL);
+		if (!ovector) errormsg("Internal error allocating regex match data");
 		while ((d = readdir(dir)) != NULL) {
 			char *ext;
 			char param[PATH_MAX];
@@ -1326,4 +1327,3 @@ int main(int argc, char *argv[])
 
 	return 0;
 }
-

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -1019,7 +1019,8 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		rrddbsize = 5;
 		rrddbs = (rrddb_t *) malloc((rrddbsize+1) * sizeof(rrddb_t));
 
-		ovector = pcre2_match_data_create(30, NULL);
+		ovector = pcre2_match_data_create_from_pattern(pat, NULL);
+		if (!ovector) errormsg("Internal error allocating regex match data");
 		while ((d = readdir(dir)) != NULL) {
 			char *ext;
 			char param[PATH_MAX];

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -27,8 +27,7 @@ static char rcsid[] = "$Id$";
 #include <sys/un.h>
 #include <fcntl.h>
 
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "../lib/pcre2_api_compat.h"
 #include <rrd.h>
 
 #include "libxymon.h"
@@ -993,21 +992,21 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		dir = opendir("."); if (dir == NULL) errormsg("Unexpected error while accessing RRD directory");
 
 		/* Setup the pattern to match filenames against */
-		pat = pcre2_compile(gdef->fnpat, strlen(gdef->fnpat), PCRE2_CASELESS, &err, &errofs, NULL);
+		pat = pcre2_compile(PCRE2STR(gdef->fnpat), strlen(gdef->fnpat), PCRE2_CASELESS, &err, &errofs, NULL);
 		if (!pat) {
 			char msg[8192];
 
-			pcre2_get_error_message(err, errmsg, sizeof(errmsg));
+			pcre2_get_error_message(err, PCRE2BUF(errmsg), sizeof(errmsg));
 			snprintf(msg, sizeof(msg), "graphs.cfg error, PCRE pattern %s invalid: %s, offset %zu\n",
 				 htmlquoted(gdef->fnpat), errmsg, errofs);
 			errormsg(msg);
 		}
 		if (gdef->exfnpat) {
-			expat = pcre2_compile(gdef->exfnpat, strlen(gdef->exfnpat), PCRE2_CASELESS, &err, &errofs, NULL);
+			expat = pcre2_compile(PCRE2STR(gdef->exfnpat), strlen(gdef->exfnpat), PCRE2_CASELESS, &err, &errofs, NULL);
 			if (!expat) {
 				char msg[8192];
 
-				pcre2_get_error_message(err, errmsg, sizeof(errmsg));
+				pcre2_get_error_message(err, PCRE2BUF(errmsg), sizeof(errmsg));
 				snprintf(msg, sizeof(msg), 
 					 "graphs.cfg error, PCRE pattern %s invalid: %s, offset %zu\n",
 					 htmlquoted(gdef->exfnpat), errmsg, errofs);
@@ -1034,16 +1033,16 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 
 			/* First check the exclude pattern. */
 			if (expat) {
-				result = pcre2_match(expat, d->d_name, strlen(d->d_name), 0, 0,
+				result = pcre2_match(expat, PCRE2STR(d->d_name), strlen(d->d_name), 0, 0,
 						     ovector, NULL);
 				if (result >= 0) continue;
 			}
 
 			/* Then see if the include pattern matches. */
-			result = pcre2_match(pat, d->d_name, strlen(d->d_name), 0, 0,
+			result = pcre2_match(pat, PCRE2STR(d->d_name), strlen(d->d_name), 0, 0,
 					     ovector, NULL);
 			if (result < 0) continue;
-			haveparam = (pcre2_substring_copy_bynumber(ovector, 1, param, &l) == 0);
+			haveparam = (pcre2_substring_copy_bynumber(ovector, 1, PCRE2BUF(param), &l) == 0);
 
 			if (rrdparamisservice && haveparam) {
 				/* Single service out of a bundle (tcp): match against the FNPATTERN

--- a/xymond/client_config.c
+++ b/xymond/client_config.c
@@ -28,8 +28,7 @@ static char rcsid[] = "$Id$";
 #include <limits.h>
 #include <errno.h>
 
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "../lib/pcre2_api_compat.h"
 
 #include "libxymon.h"
 #include "client_config.h"

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -23,8 +23,7 @@ static char rcsid[] = "$Id$";
 #include <utime.h>
 
 #include <rrd.h>
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "../lib/pcre2_api_compat.h"
 
 #include "libxymon.h"
 #include "../lib/rrd_api_compat.h"

--- a/xymond/rrd/do_dbcheck.c
+++ b/xymond/rrd/do_dbcheck.c
@@ -226,6 +226,7 @@ int do_dbcheck_tablespace_rrd(char *hostname, char *testname, char *classname, c
        static pcre2_code *inclpattern = NULL;
        static pcre2_code *exclpattern = NULL;
        pcre2_match_data *ovector;
+       pcre2_code *match_re;
 
        if (tablespace_tpl == NULL) tablespace_tpl = setup_template(tablespace_params);
 
@@ -269,7 +270,13 @@ int do_dbcheck_tablespace_rrd(char *hostname, char *testname, char *classname, c
                eoln = strchr(curline, '\n');
                curline = (eoln ? (eoln+1) : NULL);
        }
-       ovector = pcre2_match_data_create(30, NULL);
+       match_re = (exclpattern ? exclpattern : inclpattern);
+       /* ovector sized from match_re but reused for matches against both incl/excl patterns; safe because we only check match/no-match, not substrings */
+       ovector = (match_re ? pcre2_match_data_create_from_pattern(match_re, NULL) : NULL);
+       if (match_re && !ovector) {
+               errprintf("Cannot allocate PCRE match data for dbcheck tablespace filtering\n");
+               return 0;
+       }
 
        while (curline)  {
                char *fsline, *p;
@@ -357,9 +364,7 @@ int do_dbcheck_tablespace_rrd(char *hostname, char *testname, char *classname, c
 nextline:
                curline = (eoln ? (eoln+1) : NULL);
        }
-       pcre2_match_data_free(ovector);
+       if (ovector) pcre2_match_data_free(ovector);
 
        return 0;
 }
-
-

--- a/xymond/rrd/do_dbcheck.c
+++ b/xymond/rrd/do_dbcheck.c
@@ -239,18 +239,18 @@ int do_dbcheck_tablespace_rrd(char *hostname, char *testname, char *classname, c
                ptnsetup = 1;
                ptn = getenv("RRDDISKS");
                if (ptn && strlen(ptn)) {
-                       inclpattern = pcre2_compile(ptn, strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
+                       inclpattern = pcre2_compile(PCRE2STR(ptn), strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
                        if (!inclpattern) {
-                               pcre2_get_error_message(err, errmsg, sizeof(errmsg));
+                               pcre2_get_error_message(err, PCRE2BUF(errmsg), sizeof(errmsg));
                                errprintf("PCRE compile of RRDDISKS='%s' failed, error %s, offset %zu\n",
                                                    ptn, errmsg, errofs);
                        }
                }
                ptn = getenv("NORRDDISKS");
                if (ptn && strlen(ptn)) {
-                       exclpattern = pcre2_compile(ptn, strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
+                       exclpattern = pcre2_compile(PCRE2STR(ptn), strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
                        if (!exclpattern) {
-                               pcre2_get_error_message(err, errmsg, sizeof(errmsg));
+                               pcre2_get_error_message(err, PCRE2BUF(errmsg), sizeof(errmsg));
                                errprintf("PCRE compile of NORRDDISKS='%s' failed, error %s, offset %zu\n",
                                                    ptn, errmsg, errofs);
                        }
@@ -325,7 +325,7 @@ int do_dbcheck_tablespace_rrd(char *hostname, char *testname, char *classname, c
                if (exclpattern) {
                        int result;
 
-                       result = pcre2_match(exclpattern, diskname, strlen(diskname),
+                       result = pcre2_match(exclpattern, PCRE2STR(diskname), strlen(diskname),
                                             0, 0, ovector, NULL);
 
                        wanteddisk = (result < 0);
@@ -333,7 +333,7 @@ int do_dbcheck_tablespace_rrd(char *hostname, char *testname, char *classname, c
                if (wanteddisk && inclpattern) {
                        int result;
 
-                       result = pcre2_match(inclpattern, diskname, strlen(diskname),
+                       result = pcre2_match(inclpattern, PCRE2STR(diskname), strlen(diskname),
                                             0, 0, ovector, NULL);
 
                        wanteddisk = (result >= 0);

--- a/xymond/rrd/do_disk.c
+++ b/xymond/rrd/do_disk.c
@@ -21,6 +21,7 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 	static pcre2_code *inclpattern = NULL;
 	static pcre2_code *exclpattern = NULL;
 	pcre2_match_data *ovector;
+	pcre2_code *match_re;
 
 	if (strstr(msg, "netapp.pl")) return do_netapp_disk_rrd(hostname, testname, classname, pagepaths, msg, tstamp);
 	if (strstr(msg, "dbcheck.pl")) return do_dbcheck_tablespace_rrd(hostname, testname, classname, pagepaths, msg, tstamp);
@@ -79,7 +80,13 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 	 * line - we never have any disk reports there anyway.
 	 */
 	curline = strchr(msg, '\n'); if (curline) curline++;
-	ovector = pcre2_match_data_create(30, NULL);
+	match_re = (exclpattern ? exclpattern : inclpattern);
+	/* ovector sized from match_re but reused for matches against both incl/excl patterns; safe because we only check match/no-match, not substrings */
+	ovector = (match_re ? pcre2_match_data_create_from_pattern(match_re, NULL) : NULL);
+	if (match_re && !ovector) {
+		errprintf("Cannot allocate PCRE match data for disk filtering\n");
+		return 0;
+	}
 	while (curline)  {
 		char *fsline, *p;
 		char *columns[20];
@@ -214,8 +221,7 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 nextline:
 		curline = (eoln ? (eoln+1) : NULL);
 	}
-	pcre2_match_data_free(ovector);
+	if (ovector) pcre2_match_data_free(ovector);
 
 	return 0;
 }
-

--- a/xymond/rrd/do_disk.c
+++ b/xymond/rrd/do_disk.c
@@ -21,6 +21,7 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 	static pcre2_code *inclpattern = NULL;
 	static pcre2_code *exclpattern = NULL;
 	pcre2_match_data *ovector;
+	pcre2_code *match_re;
 
 	if (strstr(msg, "netapp.pl")) return do_netapp_disk_rrd(hostname, testname, classname, pagepaths, msg, tstamp);
 	if (strstr(msg, "dbcheck.pl")) return do_dbcheck_tablespace_rrd(hostname, testname, classname, pagepaths, msg, tstamp);
@@ -79,7 +80,13 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 	 * line - we never have any disk reports there anyway.
 	 */
 	curline = strchr(msg, '\n'); if (curline) curline++;
-	ovector = pcre2_match_data_create(30, NULL);
+	match_re = (exclpattern ? exclpattern : inclpattern);
+	/* ovector sized from match_re but reused for matches against both incl/excl patterns; safe because we only check match/no-match, not substrings */
+	ovector = (match_re ? pcre2_match_data_create_from_pattern(match_re, NULL) : NULL);
+	if (match_re && !ovector) {
+		errprintf("Cannot allocate PCRE match data for disk filtering\n");
+		return 0;
+	}
 	while (curline)  {
 		char *fsline, *p;
 		char *columns[20];
@@ -227,8 +234,7 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 nextline:
 		curline = (eoln ? (eoln+1) : NULL);
 	}
-	pcre2_match_data_free(ovector);
+	if (ovector) pcre2_match_data_free(ovector);
 
 	return 0;
 }
-

--- a/xymond/rrd/do_disk.c
+++ b/xymond/rrd/do_disk.c
@@ -37,18 +37,18 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 		ptnsetup = 1;
 		ptn = getenv("RRDDISKS");
 		if (ptn && strlen(ptn)) {
-			inclpattern = pcre2_compile(ptn, strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
+			inclpattern = pcre2_compile(PCRE2STR(ptn), strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
 			if (!inclpattern) {
-				pcre2_get_error_message(err, errmsg, sizeof(errmsg));
+				pcre2_get_error_message(err, PCRE2BUF(errmsg), sizeof(errmsg));
 				errprintf("PCRE compile of RRDDISKS='%s' failed, error %s, offset %zu\n",
 						    ptn, errmsg, errofs);
 			}
 		}
 		ptn = getenv("NORRDDISKS");
 		if (ptn && strlen(ptn)) {
-			exclpattern = pcre2_compile(ptn, strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
+			exclpattern = pcre2_compile(PCRE2STR(ptn), strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
 			if (!exclpattern) {
-				pcre2_get_error_message(err, errmsg, sizeof(errmsg));
+				pcre2_get_error_message(err, PCRE2BUF(errmsg), sizeof(errmsg));
 				errprintf("PCRE compile of NORRDDISKS='%s' failed, error %s, offset %zu\n",
 						    ptn, errmsg, errofs);
 			}
@@ -195,7 +195,7 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 		if (exclpattern) {
 			int result;
 
-			result = pcre2_match(exclpattern, diskname, strlen(diskname),
+			result = pcre2_match(exclpattern, PCRE2STR(diskname), strlen(diskname),
 					     0, 0, ovector, NULL);
 
 			wanteddisk = (result < 0);
@@ -203,7 +203,7 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 		if (wanteddisk && inclpattern) {
 			int result;
 
-			result = pcre2_match(inclpattern, diskname, strlen(diskname),
+			result = pcre2_match(inclpattern, PCRE2STR(diskname), strlen(diskname),
 					     0, 0, ovector, NULL);
 
 			wanteddisk = (result >= 0);

--- a/xymond/rrd/do_la.c
+++ b/xymond/rrd/do_la.c
@@ -77,8 +77,13 @@ int do_la_rrd(char *hostname, char *testname, char *classname, char *pagepaths, 
 
 			zVM_exp = pcre2_compile(".* CPU Utilization *([0-9]+)%", PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
 		}
+		if (zVM_exp == NULL) goto done_parsing;
 
-		ovector = pcre2_match_data_create(30, NULL);
+		ovector = pcre2_match_data_create_from_pattern(zVM_exp, NULL);
+		if (!ovector) {
+			errprintf("Cannot allocate PCRE match data for z/VM load parsing\n");
+			goto done_parsing;
+		}
 		res = pcre2_match(zVM_exp, msg, strlen(msg), 0, 0, ovector, NULL);
 		if (res >= 0) {
 			/* We have a match - pick up the data. */
@@ -154,8 +159,13 @@ int do_la_rrd(char *hostname, char *testname, char *classname, char *pagepaths, 
 			as400_exp = pcre2_compile(".* ([0-9]+) users ([0-9]+) jobs.* load=([0-9]+)\\%",
 			                          PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
 		}
+		if (as400_exp == NULL) goto done_parsing;
 
-		ovector = pcre2_match_data_create(30, NULL);
+		ovector = pcre2_match_data_create_from_pattern(as400_exp, NULL);
+		if (!ovector) {
+			errprintf("Cannot allocate PCRE match data for AS/400 load parsing\n");
+			goto done_parsing;
+		}
 		res = pcre2_match(as400_exp, msg, strlen(msg), 0, 0, ovector, NULL);
 		if (res >= 0) {
 			/* We have a match - pick up the AS/400 data. */
@@ -275,4 +285,3 @@ done_parsing:
 
 	return 0;
 }
-

--- a/xymond/rrd/do_la.c
+++ b/xymond/rrd/do_la.c
@@ -75,7 +75,7 @@ int do_la_rrd(char *hostname, char *testname, char *classname, char *pagepaths, 
 			int err;
 			PCRE2_SIZE errofs;
 
-			zVM_exp = pcre2_compile(".* CPU Utilization *([0-9]+)%", PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
+			zVM_exp = pcre2_compile(PCRE2STR(".* CPU Utilization *([0-9]+)%"), PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
 		}
 		if (zVM_exp == NULL) goto done_parsing;
 
@@ -84,10 +84,10 @@ int do_la_rrd(char *hostname, char *testname, char *classname, char *pagepaths, 
 			errprintf("Cannot allocate PCRE match data for z/VM load parsing\n");
 			goto done_parsing;
 		}
-		res = pcre2_match(zVM_exp, msg, strlen(msg), 0, 0, ovector, NULL);
+		res = pcre2_match(zVM_exp, PCRE2STR(msg), strlen(msg), 0, 0, ovector, NULL);
 		if (res >= 0) {
 			/* We have a match - pick up the data. */
-			*w = '\0'; if (res > 0) pcre2_substring_copy_bynumber(ovector, 1, w, &l);
+			*w = '\0'; if (res > 0) pcre2_substring_copy_bynumber(ovector, 1, PCRE2BUF(w), &l);
 			if (strlen(w)) {
 				load = atoi(w); gotload = 1;
 			}
@@ -156,7 +156,7 @@ int do_la_rrd(char *hostname, char *testname, char *classname, char *pagepaths, 
 			int err;
 			PCRE2_SIZE errofs;
 
-			as400_exp = pcre2_compile(".* ([0-9]+) users ([0-9]+) jobs.* load=([0-9]+)\\%",
+			as400_exp = pcre2_compile(PCRE2STR(".* ([0-9]+) users ([0-9]+) jobs.* load=([0-9]+)\\%"),
 			                          PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
 		}
 		if (as400_exp == NULL) goto done_parsing;
@@ -166,15 +166,15 @@ int do_la_rrd(char *hostname, char *testname, char *classname, char *pagepaths, 
 			errprintf("Cannot allocate PCRE match data for AS/400 load parsing\n");
 			goto done_parsing;
 		}
-		res = pcre2_match(as400_exp, msg, strlen(msg), 0, 0, ovector, NULL);
+		res = pcre2_match(as400_exp, PCRE2STR(msg), strlen(msg), 0, 0, ovector, NULL);
 		if (res >= 0) {
 			/* We have a match - pick up the AS/400 data. */
-			*w = '\0'; if (res > 0) pcre2_substring_copy_bynumber(ovector, 1, w, &l);
+			*w = '\0'; if (res > 0) pcre2_substring_copy_bynumber(ovector, 1, PCRE2BUF(w), &l);
 			if (strlen(w)) {
 				users = atoi(w); gotusers = 1;
 			}
 
-			*w = '\0'; l = sizeof(w); if (res > 0) pcre2_substring_copy_bynumber(ovector, 3, w, &l);
+			*w = '\0'; l = sizeof(w); if (res > 0) pcre2_substring_copy_bynumber(ovector, 3, PCRE2BUF(w), &l);
 			if (strlen(w)) {
 				load = atoi(w); gotload = 1;
 			}

--- a/xymond/rrd/do_netapp.c
+++ b/xymond/rrd/do_netapp.c
@@ -495,6 +495,7 @@ int do_netapp_disk_rrd(char *hostname, char *testname, char *classname, char *pa
        static pcre2_code *inclpattern = NULL;
        static pcre2_code *exclpattern = NULL;
        pcre2_match_data *ovector;
+       pcre2_code *match_re;
        int newdfreport;
 
 	newdfreport = (strstr(msg,"netappnewdf") != NULL);
@@ -535,7 +536,13 @@ int do_netapp_disk_rrd(char *hostname, char *testname, char *classname, char *pa
         * line - we never have any disk reports there anyway.
         */
        curline = strchr(msg, '\n'); if (curline) curline++;
-       ovector = pcre2_match_data_create(30, NULL);
+       match_re = (exclpattern ? exclpattern : inclpattern);
+       /* ovector sized from match_re but reused for matches against both incl/excl patterns; safe because we only check match/no-match, not substrings */
+       ovector = (match_re ? pcre2_match_data_create_from_pattern(match_re, NULL) : NULL);
+       if (match_re && !ovector) {
+               errprintf("Cannot allocate PCRE match data for NetApp disk filtering\n");
+               return 0;
+       }
 
        while (curline)  {
                char *fsline, *p;
@@ -642,9 +649,7 @@ int do_netapp_disk_rrd(char *hostname, char *testname, char *classname, char *pa
 nextline:
                curline = (eoln ? (eoln+1) : NULL);
        }
-       pcre2_match_data_free(ovector);
+       if (ovector) pcre2_match_data_free(ovector);
 
        return 0;
 }
-
-

--- a/xymond/rrd/do_netapp.c
+++ b/xymond/rrd/do_netapp.c
@@ -511,18 +511,18 @@ int do_netapp_disk_rrd(char *hostname, char *testname, char *classname, char *pa
                ptnsetup = 1;
                ptn = getenv("RRDDISKS");
                if (ptn && strlen(ptn)) {
-                       inclpattern = pcre2_compile(ptn, strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
+                       inclpattern = pcre2_compile(PCRE2STR(ptn), strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
                        if (!inclpattern) {
-                               pcre2_get_error_message(err, errmsg, sizeof(errmsg));
+                               pcre2_get_error_message(err, PCRE2BUF(errmsg), sizeof(errmsg));
                                errprintf("PCRE compile of RRDDISKS='%s' failed, error %s, offset %zu\n",
                                                    ptn, errmsg, errofs);
                        }
                }
                ptn = getenv("NORRDDISKS");
                if (ptn && strlen(ptn)) {
-                       exclpattern = pcre2_compile(ptn, strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
+                       exclpattern = pcre2_compile(PCRE2STR(ptn), strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
                        if (!exclpattern) {
-                               pcre2_get_error_message(err, errmsg, sizeof(errmsg));
+                               pcre2_get_error_message(err, PCRE2BUF(errmsg), sizeof(errmsg));
                                errprintf("PCRE compile of NORRDDISKS='%s' failed, error %s, offset %zu\n",
                                                    ptn, errmsg, errofs);
                        }
@@ -610,7 +610,7 @@ int do_netapp_disk_rrd(char *hostname, char *testname, char *classname, char *pa
                if (exclpattern) {
                        int result;
 
-                       result = pcre2_match(exclpattern, diskname, strlen(diskname),
+                       result = pcre2_match(exclpattern, PCRE2STR(diskname), strlen(diskname),
                                             0, 0, ovector, NULL);
 
                        wanteddisk = (result < 0);
@@ -618,7 +618,7 @@ int do_netapp_disk_rrd(char *hostname, char *testname, char *classname, char *pa
                if (wanteddisk && inclpattern) {
                        int result;
 
-                       result = pcre2_match(inclpattern, diskname, strlen(diskname),
+                       result = pcre2_match(inclpattern, PCRE2STR(diskname), strlen(diskname),
                                             0, 0, ovector, NULL);
 
                        wanteddisk = (result >= 0);

--- a/xymond/xymon-mailack.c
+++ b/xymond/xymon-mailack.c
@@ -103,7 +103,12 @@ int main(int argc, char *argv[])
 		dbgprintf("pcre compile failed - 1\n");
 		return 2;
 	}
-	ovector = pcre2_match_data_create(30, NULL);
+	ovector = pcre2_match_data_create_from_pattern(subjexp, NULL);
+	if (ovector == NULL) {
+		pcre2_code_free(subjexp);
+		dbgprintf("pcre match-data allocation failed - 1\n");
+		return 2;
+	}
 	result = pcre2_match(subjexp, subjectline, strlen(subjectline), 0, 0, ovector, NULL);
 	if (result < 0) {
 		pcre2_code_free(subjexp);
@@ -117,13 +122,19 @@ int main(int argc, char *argv[])
 		dbgprintf("Could not find cookie value\n");
 		return 4; /* No cookie */
 	}
+	pcre2_match_data_free(ovector);
 	pcre2_code_free(subjexp);
 
 	/* See if there's a "DELAY=" delay-value also */
 	subjexp = pcre2_compile(".*DELAY[ =]+([0-9]+[mhdw]*)", PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
 	if (subjexp == NULL) {
-		pcre2_match_data_free(ovector);
 		dbgprintf("pcre compile failed - 2\n");
+		return 2;
+	}
+	ovector = pcre2_match_data_create_from_pattern(subjexp, NULL);
+	if (ovector == NULL) {
+		pcre2_code_free(subjexp);
+		dbgprintf("pcre match-data allocation failed - 2\n");
 		return 2;
 	}
 	result = pcre2_match(subjexp, subjectline, strlen(subjectline), 0, 0, ovector, NULL);
@@ -134,13 +145,19 @@ int main(int argc, char *argv[])
 			duration = durationvalue(delaytxt);
 		}
 	}
+	pcre2_match_data_free(ovector);
 	pcre2_code_free(subjexp);
 
 	/* See if there's a "msg" text also */
 	subjexp = pcre2_compile(".*MSG[ =]+(.*)", PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
 	if (subjexp == NULL) {
-		pcre2_match_data_free(ovector);
 		dbgprintf("pcre compile failed - 3\n");
+		return 2;
+	}
+	ovector = pcre2_match_data_create_from_pattern(subjexp, NULL);
+	if (ovector == NULL) {
+		pcre2_code_free(subjexp);
+		dbgprintf("pcre match-data allocation failed - 3\n");
 		return 2;
 	}
 	result = pcre2_match(subjexp, subjectline, strlen(subjectline), 0, 0, ovector, NULL);
@@ -151,6 +168,7 @@ int main(int argc, char *argv[])
 			firsttxtline = strdup(msgtxt);
 		}
 	}
+	pcre2_match_data_free(ovector);
 	pcre2_code_free(subjexp);
 
 	/* Use the "return-path:" header if we didn't see a From: line */
@@ -173,12 +191,10 @@ int main(int argc, char *argv[])
 
 	if (debug) {
 		printf("%s\n", ackbuf);
-		pcre2_match_data_free(ovector);
 		return 0;
 	}
 
 	sendmessage(ackbuf, NULL, XYMON_TIMEOUT, NULL);
-	pcre2_match_data_free(ovector);
 	return 0;
 }
 

--- a/xymond/xymon-mailack.c
+++ b/xymond/xymon-mailack.c
@@ -17,8 +17,7 @@ static char rcsid[] = "$Id$";
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
+#include "../lib/pcre2_api_compat.h"
 
 #include "libxymon.h"
 
@@ -98,7 +97,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Get the alert cookie */
-	subjexp = pcre2_compile(".*(Xymon|Hobbit|BB)[ -]* \\[*(-*[0-9]+)[\\]!]*", PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
+	subjexp = pcre2_compile(PCRE2STR(".*(Xymon|Hobbit|BB)[ -]* \\[*(-*[0-9]+)[\\]!]*"), PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
 	if (subjexp == NULL) {
 		dbgprintf("pcre compile failed - 1\n");
 		return 2;
@@ -109,14 +108,14 @@ int main(int argc, char *argv[])
 		dbgprintf("pcre match-data allocation failed - 1\n");
 		return 2;
 	}
-	result = pcre2_match(subjexp, subjectline, strlen(subjectline), 0, 0, ovector, NULL);
+	result = pcre2_match(subjexp, PCRE2STR(subjectline), strlen(subjectline), 0, 0, ovector, NULL);
 	if (result < 0) {
 		pcre2_code_free(subjexp);
 		pcre2_match_data_free(ovector);
 		dbgprintf("Subject line did not match pattern\n");
 		return 3; /* Subject did not match what we expected */
 	}
-	if (pcre2_substring_copy_bynumber(ovector, 2, cookie, &l) != 0) {
+	if (pcre2_substring_copy_bynumber(ovector, 2, PCRE2BUF(cookie), &l) != 0) {
 		pcre2_code_free(subjexp);
 		pcre2_match_data_free(ovector);
 		dbgprintf("Could not find cookie value\n");
@@ -126,7 +125,7 @@ int main(int argc, char *argv[])
 	pcre2_code_free(subjexp);
 
 	/* See if there's a "DELAY=" delay-value also */
-	subjexp = pcre2_compile(".*DELAY[ =]+([0-9]+[mhdw]*)", PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
+	subjexp = pcre2_compile(PCRE2STR(".*DELAY[ =]+([0-9]+[mhdw]*)"), PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
 	if (subjexp == NULL) {
 		dbgprintf("pcre compile failed - 2\n");
 		return 2;
@@ -137,11 +136,11 @@ int main(int argc, char *argv[])
 		dbgprintf("pcre match-data allocation failed - 2\n");
 		return 2;
 	}
-	result = pcre2_match(subjexp, subjectline, strlen(subjectline), 0, 0, ovector, NULL);
+	result = pcre2_match(subjexp, PCRE2STR(subjectline), strlen(subjectline), 0, 0, ovector, NULL);
 	if (result >= 0) {
 		char delaytxt[4096];
 		l = sizeof(delaytxt);
-		if (pcre2_substring_copy_bynumber(ovector, 1, delaytxt, &l) == 0) {
+		if (pcre2_substring_copy_bynumber(ovector, 1, PCRE2BUF(delaytxt), &l) == 0) {
 			duration = durationvalue(delaytxt);
 		}
 	}
@@ -149,7 +148,7 @@ int main(int argc, char *argv[])
 	pcre2_code_free(subjexp);
 
 	/* See if there's a "msg" text also */
-	subjexp = pcre2_compile(".*MSG[ =]+(.*)", PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
+	subjexp = pcre2_compile(PCRE2STR(".*MSG[ =]+(.*)"), PCRE2_ZERO_TERMINATED, PCRE2_CASELESS, &err, &errofs, NULL);
 	if (subjexp == NULL) {
 		dbgprintf("pcre compile failed - 3\n");
 		return 2;
@@ -160,11 +159,11 @@ int main(int argc, char *argv[])
 		dbgprintf("pcre match-data allocation failed - 3\n");
 		return 2;
 	}
-	result = pcre2_match(subjexp, subjectline, strlen(subjectline), 0, 0, ovector, NULL);
+	result = pcre2_match(subjexp, PCRE2STR(subjectline), strlen(subjectline), 0, 0, ovector, NULL);
 	if (result >= 0) {
 		char msgtxt[4096];
 		l = sizeof(msgtxt);
-		if (pcre2_substring_copy_bynumber(ovector, 1, msgtxt, &l) == 0) {
+		if (pcre2_substring_copy_bynumber(ovector, 1, PCRE2BUF(msgtxt), &l) == 0) {
 			firsttxtline = strdup(msgtxt);
 		}
 	}

--- a/xymond/xymond_capture.c
+++ b/xymond/xymond_capture.c
@@ -40,6 +40,7 @@ int main(int argc, char *argv[])
 	pcre2_code *extestexp = NULL;
 	pcre2_code *colorexp = NULL;
 	pcre2_match_data *ovector;
+	pcre2_code *match_re = NULL;
 	int err;
 	PCRE2_SIZE errofs;
 	FILE *logfd = stdout;
@@ -122,13 +123,28 @@ int main(int argc, char *argv[])
 		else {
 			printf("Unknown option %s\n", argv[argi]);
 			printf("Usage: %s [--hosts=EXP] [--tests=EXP] [--exhosts=EXP] [--extests=EXP] [--color=EXP] [--outfile=FILENAME] [--batch-timeout=N] [--batch-command=COMMAND]\n", argv[0]);
+			if (hostexp) pcre2_code_free(hostexp);
+			if (exhostexp) pcre2_code_free(exhostexp);
+			if (testexp) pcre2_code_free(testexp);
+			if (extestexp) pcre2_code_free(extestexp);
+			if (colorexp) pcre2_code_free(colorexp);
 			return 0;
 		}
 	}
 
 	signal(SIGCHLD, SIG_IGN);
 
-	ovector = pcre2_match_data_create(30, NULL);
+	match_re = (hostexp ? hostexp :
+		    exhostexp ? exhostexp :
+		    testexp ? testexp :
+		    extestexp ? extestexp :
+		    colorexp);
+	/* ovector sized from match_re but reused across all patterns below; safe because we only check match/no-match, not substrings */
+	ovector = (match_re ? pcre2_match_data_create_from_pattern(match_re, NULL) : NULL);
+	if (match_re && !ovector) {
+		errprintf("Cannot allocate PCRE match data for capture filtering\n");
+		return 1;
+	}
 	running = 1;
 	while (running) {
 		char *eoln, *restofmsg, *p;
@@ -339,8 +355,7 @@ int main(int argc, char *argv[])
 			}
 		}
 	}
-	pcre2_match_data_free(ovector);
+	if (ovector) pcre2_match_data_free(ovector);
 
 	return 0;
 }
-

--- a/xymond/xymond_capture.c
+++ b/xymond/xymond_capture.c
@@ -77,27 +77,27 @@ int main(int argc, char *argv[])
 		}
 		else if (argnmatch(argv[argi], "--hosts=")) {
 			char *exp = strchr(argv[argi], '=') + 1;
-			hostexp = pcre2_compile(exp, strlen(exp), PCRE2_CASELESS, &err, &errofs, NULL);
+			hostexp = pcre2_compile(PCRE2STR(exp), strlen(exp), PCRE2_CASELESS, &err, &errofs, NULL);
 			if (hostexp == NULL) printf("Invalid expression '%s'\n", exp);
 		}
 		else if (argnmatch(argv[argi], "--exhosts=")) {
 			char *exp = strchr(argv[argi], '=') + 1;
-			exhostexp = pcre2_compile(exp, strlen(exp), PCRE2_CASELESS, &err, &errofs, NULL);
+			exhostexp = pcre2_compile(PCRE2STR(exp), strlen(exp), PCRE2_CASELESS, &err, &errofs, NULL);
 			if (exhostexp == NULL) printf("Invalid expression '%s'\n", exp);
 		}
 		else if (argnmatch(argv[argi], "--tests=")) {
 			char *exp = strchr(argv[argi], '=') + 1;
-			testexp = pcre2_compile(exp, strlen(exp), PCRE2_CASELESS, &err, &errofs, NULL);
+			testexp = pcre2_compile(PCRE2STR(exp), strlen(exp), PCRE2_CASELESS, &err, &errofs, NULL);
 			if (testexp == NULL) printf("Invalid expression '%s'\n", exp);
 		}
 		else if (argnmatch(argv[argi], "--extests=")) {
 			char *exp = strchr(argv[argi], '=') + 1;
-			extestexp = pcre2_compile(exp, strlen(exp), PCRE2_CASELESS, &err, &errofs, NULL);
+			extestexp = pcre2_compile(PCRE2STR(exp), strlen(exp), PCRE2_CASELESS, &err, &errofs, NULL);
 			if (extestexp == NULL) printf("Invalid expression '%s'\n", exp);
 		}
 		else if (argnmatch(argv[argi], "--colors=")) {
 			char *exp = strchr(argv[argi], '=') + 1;
-			colorexp = pcre2_compile(exp, strlen(exp), PCRE2_CASELESS, &err, &errofs, NULL);
+			colorexp = pcre2_compile(PCRE2STR(exp), strlen(exp), PCRE2_CASELESS, &err, &errofs, NULL);
 			if (colorexp == NULL) printf("Invalid expression '%s'\n", exp);
 		}
 		else if (argnmatch(argv[argi], "--outfile=")) {
@@ -315,23 +315,23 @@ int main(int argc, char *argv[])
 
 
 			if (hostexp) {
-				match = (pcre2_match(hostexp, hostname, strlen(hostname), 0, 0, ovector, NULL) >= 0);
+				match = (pcre2_match(hostexp, PCRE2STR(hostname), strlen(hostname), 0, 0, ovector, NULL) >= 0);
 				if (!match) continue;
 			}
 			if (exhostexp) {
-				match = (pcre2_match(exhostexp, hostname, strlen(hostname), 0, 0, ovector, NULL) >= 0);
+				match = (pcre2_match(exhostexp, PCRE2STR(hostname), strlen(hostname), 0, 0, ovector, NULL) >= 0);
 				if (match) continue;
 			}
 			if (testexp) {
-				match = (pcre2_match(testexp, testname, strlen(testname), 0, 0, ovector, NULL) >= 0);
+				match = (pcre2_match(testexp, PCRE2STR(testname), strlen(testname), 0, 0, ovector, NULL) >= 0);
 				if (!match) continue;
 			}
 			if (extestexp) {
-				match = (pcre2_match(extestexp, testname, strlen(testname), 0, 0, ovector, NULL) >= 0);
+				match = (pcre2_match(extestexp, PCRE2STR(testname), strlen(testname), 0, 0, ovector, NULL) >= 0);
 				if (match) continue;
 			}
 			if (colorexp) {
-				match = (pcre2_match(colorexp, color, strlen(color), 0, 0, ovector, NULL) >= 0);
+				match = (pcre2_match(colorexp, PCRE2STR(color), strlen(color), 0, 0, ovector, NULL) >= 0);
 				if (!match) continue;
 			}
 


### PR DESCRIPTION
Two commits, both PCRE2 discipline.

**Pattern-sized match data + cleanup** (rebased onto current main, clean). Hardcoded
`pcre2_match_data_create(N, NULL)` becomes `pcre2_match_data_create_from_pattern()`, so capture
buffers fit each pattern's real group count; every creation gets a NULL-check; multi-resource
functions move to one cleanup path so the compiled regex and match data are freed on every exit.
Incidental pre-existing leaks fixed: `lib/eventlog.c` never freed expage/exhost/extest regexes;
`xymond_capture.c` leaked already-compiled regexes on the unknown-option early return. Sites
where one ovector is reused across patterns are annotated (safe: only match/no-match is read).

**One signedness cast at the boundary, written once.** PCRE2 strings are
`const unsigned char *`; xymon passes C strings; the ~100 direct call sites each warned under
`-Wpointer-sign`, and pcre2.h's macro-built declarations turn every warning into a ~20-line note
chain — that is the warning wall in the CI logs. `lib/pcre2_api_compat.h` (same shape as
`rrd_api_compat.h`) does the `PCRE2_CODE_UNIT_WIDTH` dance once and owns `PCRE2STR()` /
`PCRE2BUF()`; the direct callers include it and wrap their arguments. Mechanical, no behavior
change. Every touched TU now compiles with zero `-Wpointer-sign` warnings; the remaining ones in
the tree are different boundaries with the same disease (`nldecode()`, `get_xymond_message()`),
left for their own change.
