### PR TITLE
xymongrep: add --no-dialup to filter dialup hosts (#24)

### DIFF
--- a/common/xymongrep.1
+++ b/common/xymongrep.1
@@ -6,7 +6,7 @@ xymongrep \- pick out lines in hosts.cfg
 .br
 .B "xymongrep \-\-version"
 .br
-.B "xymongrep [\-\-noextras] [\-\-test\-untagged] [\-\-web] [\-\-net] [\-\-loadhostsfromxymond] TAG [TAG...]"
+.B "xymongrep [\-\-noextras] [\-\-test\-untagged] [\-\-no\-dialup] [\-\-web] [\-\-net] [\-\-loadhostsfromxymond] TAG [TAG...]"
 
 .SH DESCRIPTION
 .I xymongrep(1)
@@ -51,10 +51,19 @@ xymongrep will query the Xymon server for the current
 status of the "conn" test, and if TESTNAME is specified
 also for the current state of the specified test. If
 the status of the "conn" test for a host is non-green,
-or the status of the TESTNAME test is disabled, then this 
+or the status of the TESTNAME test is disabled, then this
 host is ignored and will not be included in the output.
 This can be used to ignore hosts that are down, or hosts
 where the custom test is disabled.
+
+.IP "\-\-no\-dialup"
+Skip hosts that have the "dialup" attribute set in the
+.I hosts.cfg(5)
+file. Unlike \fB\-\-no\-down\fR, this check does not query
+the server; it filters strictly on the host attribute and is
+independent of the host's current color. Useful for scripts
+that should never probe hosts expected to be intermittently
+offline.
 
 .IP "\-\-web"
 Search the hosts.cfg file following include statements as a

--- a/common/xymongrep.1
+++ b/common/xymongrep.1
@@ -6,7 +6,7 @@ xymongrep \- pick out lines in hosts.cfg
 .br
 .B "xymongrep \-\-version"
 .br
-.B "xymongrep [\-\-noextras] [\-\-test\-untagged] [\-\-web] [\-\-net] [\-\-loadhostsfromxymond] TAG [TAG...]"
+.B "xymongrep [\-\-noextras] [\-\-test\-untagged] [\-\-no\-dialup] [\-\-web] [\-\-net] [\-\-loadhostsfromxymond] TAG [TAG...]"
 
 .SH DESCRIPTION
 .I xymongrep(1)
@@ -55,6 +55,15 @@ or the status of the TESTNAME test is disabled, then this
 host is ignored and will not be included in the output.
 This can be used to ignore hosts that are down, or hosts
 where the custom test is disabled.
+
+.IP "\fB\-\-no\-dialup\fR"
+Skip hosts that have the "dialup" attribute set in the
+.I hosts.cfg(5)
+file. Unlike \fB\-\-no\-down\fR, this check does not query
+the server; it filters strictly on the host attribute and is
+independent of the host's current color. Useful for scripts
+that should never probe hosts expected to be intermittently
+offline.
 
 .IP "\fB\-\-web\fR"
 Search the hosts.cfg file following include statements as a

--- a/common/xymongrep.c
+++ b/common/xymongrep.c
@@ -63,6 +63,13 @@ static int netok(char *netstring, char *curnet, int testuntagged)
 		 (testuntagged && (curnet == NULL)) );
 }
 
+static int dialupok(void *hinfo, int nodialup)
+{
+	if (!nodialup) return 1;
+	if (xmh_item(hinfo, XMH_FLAG_DIALUP)) return 0;
+	return 1;
+}
+
 static int downok(char *hostname, int nodownhosts)
 {
 	char *mark, *colorstr;
@@ -112,6 +119,7 @@ int main(int argc, char *argv[])
 	int extras = 1;
 	int testuntagged = 0;
 	int nodownhosts = 0;
+	int nodialup = 0;
 	int loadhostsfromxymond = 0;
 	int onlypreferredentry = 0;
 	char *p;
@@ -145,6 +153,9 @@ int main(int argc, char *argv[])
 			nodownhosts = 1;
 			p = strchr(argv[argi], '=');
 			if (p) testcolumn = strdup(p+1);
+		}
+		else if (strcmp(argv[argi], "--no-dialup") == 0) {
+			nodialup = 1;
 		}
 		else if (strcmp(argv[argi], "--version") == 0) {
 			printf("xymongrep version %s\n", VERSION);
@@ -213,7 +224,7 @@ int main(int argc, char *argv[])
 		 * Must also check if the host is currently down (not responding to ping).
 		 * And if the host is OK with knownhost(), because it may be time-limited.
 		 */
-		if (netok(netstring, curnet, testuntagged) && downok(curname, nodownhosts) && knownhost(curname, hostip, GH_IGNORE)) {
+		if (netok(netstring, curnet, testuntagged) && downok(curname, nodownhosts) && dialupok(hwalk, nodialup) && knownhost(curname, hostip, GH_IGNORE)) {
 			char *item;
 
 			clearstrbuffer(wantedtags);

--- a/docs/manpages/man1/xymongrep.1.html
+++ b/docs/manpages/man1/xymongrep.1.html
@@ -24,7 +24,7 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
   <br/>
   <b>xymongrep --version</b>
   <br/>
-  <b>xymongrep [--noextras] [--test-untagged] [--web] [--net]
+  <b>xymongrep [--noextras] [--test-untagged] [--no-dialup] [--web] [--net]
     [--loadhostsfromxymond] TAG [TAG...]</b></p>
 <p class="Pp"></p>
 </section>
@@ -77,6 +77,14 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
       then this host is ignored and will not be included in the output. This can
       be used to ignore hosts that are down, or hosts where the custom test is
       disabled.
+    <p class="Pp"></p>
+  </dd>
+  <dt id="no-dialup"><a class="permalink" href="#no-dialup"><b>--no-dialup</b></a></dt>
+  <dd>Skip hosts that have the &quot;dialup&quot; attribute set in the
+      <i><a href="../man5/hosts.cfg.5.html">hosts.cfg</a>(5)</i> file. Unlike <b>--no-down</b>, this check does not
+      query the server; it filters strictly on the host attribute and is
+      independent of the host's current color. Useful for scripts that should
+      never probe hosts expected to be intermittently offline.
     <p class="Pp"></p>
   </dd>
   <dt id="web"><a class="permalink" href="#web"><b>--web</b></a></dt>


### PR DESCRIPTION
Fixes #24.

`xymongrep --no-down` filters hosts whose `conn` status is RED or BLUE. Hosts declared `dialup` in hosts.cfg are typically shown as CLEAR when offline, so they slip through `--no-down` even though the user already knows they cannot be reached.

`--no-dialup` excludes them on the `dialup` **attribute** rather than on the current colour, so it cannot be confused with hosts that are CLEAR for another reason — scheduled downtime, manual suppression.

## Implementation

- new helper `dialupok()` using `xmh_item(hinfo, XMH_FLAG_DIALUP)`
- one added condition in the existing host filter: `... && dialupok(hwalk, nodialup) && knownhost(...)`
- argv parsing for `--no-dialup`, plus the man page entry under OPTIONS and the flag in SYNOPSIS

Without `--no-dialup`, behaviour is unchanged; existing options, output reconstruction and `--noextras` are left alone.

## Compared to the patch proposed in #24

The issue proposed `--no-down-dialup` driven by `color == COL_CLEAR`, which would also match non-dialup hosts that are CLEAR for other reasons. Checking the static host attribute directly makes the option do exactly what its name says.

## Testing

Manual fixture only — a `hosts.cfg` with 5 hosts tagged `ssh`, 2 of them also tagged `dialup`:

| Command | Result |
| --- | --- |
| `xymongrep ssh` | 5 hosts, including the 2 dialup |
| `xymongrep --no-dialup ssh` | the 3 non-dialup only |
| `xymongrep --no-down --no-dialup ssh` | both filters apply |
| `xymongrep --noextras --no-dialup ssh` | works with compact output |

No regression test is added under `tests/`, so the option is exercised by neither the suite nor CI — worth adding before this lands if the suite is expected to guard it.
