### PR TITLE
docs: use /var/log/syslog in analysis.cfg(5) LOG example

### DIFF
--- a/docs/manpages/man5/analysis.cfg.5.html
+++ b/docs/manpages/man5/analysis.cfg.5.html
@@ -309,10 +309,10 @@ filter out any unwanted strings that happen to match &quot;pattern&quot;.
 The <B>OPTIONAL</B> keyword causes the check to be skipped if the logfile
 does not exist.
 <P>
-Example: Trigger a red alert when the string &quot;ERROR&quot; appears in the &quot;/var/adm/syslog&quot; file:
+Example: Trigger a red alert when the string &quot;ERROR&quot; appears in the &quot;/var/log/syslog&quot; file:
 <BR>
 
-<TT>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TT>LOG /var/adm/syslog ERROR<BR>
+<TT>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TT>LOG /var/log/syslog ERROR<BR>
 <P>
 Example: Trigger a yellow warning on all occurrences of the word &quot;WARNING&quot;
 or &quot;NOTICE&quot; in the &quot;daemon.log&quot; file, except those from the &quot;lpr&quot; system:

--- a/xymond/analysis.cfg.5
+++ b/xymond/analysis.cfg.5
@@ -247,9 +247,9 @@ filter out any unwanted strings that happen to match "pattern".
 The \fBOPTIONAL\fR keyword causes the check to be skipped if the logfile
 does not exist.
 .sp
-Example: Trigger a red alert when the string "ERROR" appears in the "/var/adm/syslog" file:
+Example: Trigger a red alert when the string "ERROR" appears in the "/var/log/syslog" file:
 .br
-	LOG /var/adm/syslog ERROR
+	LOG /var/log/syslog ERROR
 .sp
 Example: Trigger a yellow warning on all occurrences of the word "WARNING"
 or "NOTICE" in the "daemon.log" file, except those from the "lpr" system:


### PR DESCRIPTION
The example used `/var/adm/syslog`, which is the SVR4-era path still
found on some legacy Unix variants (Solaris, HP-UX). On Linux — by
far the dominant Xymon platform — the canonical path under FHS is
`/var/log/syslog`. Switch the example accordingly so users can copy
the LOG line verbatim instead of having to translate it.

The companion example on the next paragraph already uses
`/var/log/daemon.log`, so this also makes the two examples consistent
within the same manpage section.

Picked up from Debian's `21_FHS-instead-FSSTND-in-example-in-man-page.patch`.