### PR TITLE
client/linux: env-var-controlled df/inode filesystem filter (#49)

### DIFF
--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -46,15 +46,14 @@ echo "[who]"
 who
 echo "[df]"
 # Default: exclude every nodev (pseudo) filesystem in df/inode output, except
-# rootfs, plus the historical explicit iso9660 exclusion (iso9660 is not a
-# nodev type, so it is added unconditionally at run_df below). This is the
-# historical upstream behavior.
+# rootfs. The always-100%-full read-only images (iso9660, squashfs) are not
+# nodev types and are excluded via XYMONCLIENT_FS_EXCLUDE_TYPES below.
 if [ -r /proc/filesystems ]; then
 	EXCLUDES=$(awk '$1 == "nodev" && $2 != "rootfs" { printf "%s%s", sep, $2; sep=" " }' /proc/filesystems)
 else
-	# Only the dynamic nodev exclusions are disabled here; the explicit iso9660
-	# exclusion and the local-only df -l behavior still apply.
-	echo "xymonclient-linux: /proc/filesystems not readable, dynamic nodev exclusions disabled (iso9660 exclusion and df -l still apply)" >&2
+	# Only the dynamic nodev exclusions are disabled here; the EXCLUDE_TYPES
+	# defaults (iso9660/squashfs) and the local-only df -l behavior still apply.
+	echo "xymonclient-linux: /proc/filesystems not readable, dynamic nodev exclusions disabled (EXCLUDE_TYPES and df -l still apply)" >&2
 	EXCLUDES=""
 fi
 # Filesystem types are literal tokens, so pathname expansion must not turn a
@@ -63,11 +62,15 @@ case $- in
 	*f*) FSRESTOREGLOB=no ;;
 	*) FSRESTOREGLOB=yes; set -f ;;
 esac
-# XYMONCLIENT_FS_INCLUDE_TYPES: whitespace-separated FS types that should
-# appear in the output even though they would otherwise be excluded
-# (e.g. "tmpfs zfs" to surface tmpfs/zfs mounts, or "nfs nfs4 ceph" to
-# include remote filesystems -- the latter also requires
-# XYMONCLIENT_FS_DF_LOCAL_ONLY=no since df -l hides remote mounts).
+# XYMONCLIENT_FS_INCLUDE_TYPES: whitespace-separated FS types to surface even
+# though they are flagged nodev and would otherwise be dropped. Defaults to the
+# real local filesystems that merely happen to be nodev: zfs (pools have no
+# single block device), virtiofs (VM-shared storage) and tmpfs (RAM-backed --
+# the noisy /run* tmpfs mounts are filtered server-side in analysis.cfg). Set
+# to "" to restore the historical "exclude every nodev type" behaviour, or add
+# remote types e.g. "nfs nfs4 ceph" (which also needs
+# XYMONCLIENT_FS_DF_LOCAL_ONLY=no, since df -l hides remote mounts).
+: "${XYMONCLIENT_FS_INCLUDE_TYPES=zfs virtiofs tmpfs}"
 if [ -n "$XYMONCLIENT_FS_INCLUDE_TYPES" ]; then
 	# Exact token comparison -- a type is matched literally, never as a
 	# regex/glob, so e.g. "fuse.sshfs" cannot collide with another token.
@@ -81,11 +84,15 @@ if [ -n "$XYMONCLIENT_FS_INCLUDE_TYPES" ]; then
 	done
 	EXCLUDES="$keep"
 fi
-# XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated FS types to ALSO
-# exclude, on top of the nodev default. Matching is on the exact df type
-# token; nodev types (overlay, fuse, ...) are already excluded, so an
-# effective entry names a non-nodev type, e.g. "fuse.sshfs vfat" to drop a
-# specific FUSE subtype and a device-backed mount.
+# XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated FS types to ALSO exclude,
+# on top of the nodev default. Defaults to "iso9660 squashfs" -- both are
+# read-only images reported 100% full by design (snap mounts one squashfs per
+# revision), and neither is a nodev type, so they must be named here. Matching
+# is on the exact df type token; nodev types (overlay, fuse, ...) are already
+# excluded, so other effective entries name a non-nodev type, e.g. adding
+# "fuse.sshfs vfat" to drop a specific FUSE subtype and a device-backed mount.
+# Set to "" to monitor iso9660/squashfs too.
+: "${XYMONCLIENT_FS_EXCLUDE_TYPES=iso9660 squashfs}"
 if [ -n "$XYMONCLIENT_FS_EXCLUDE_TYPES" ]; then
 	for t in $XYMONCLIENT_FS_EXCLUDE_TYPES; do
 		case " $EXCLUDES " in
@@ -126,17 +133,10 @@ case "$DFTIMEOUT" in
 		DFTIMEOUT=30
 		;;
 esac
-# Strip leading zeros so a value like 00030 is treated as decimal 30, not as
-# an over-length string (the length guard below keys on character count, not
-# magnitude, so 00001 would otherwise clamp to 3600) nor as octal in the
-# numeric comparison. The case above guarantees DFTIMEOUT is all digits with at
-# least one non-zero, so this loop always terminates with a non-empty value.
-while :; do
-	case "$DFTIMEOUT" in
-		0?*) DFTIMEOUT="${DFTIMEOUT#0}" ;;
-		*) break ;;
-	esac
-done
+# Normalise to decimal (expr is decimal by spec) so a zero-padded value like
+# 00030 becomes 30: the length guard below keys on character count, and the
+# numeric comparison would otherwise read a leading zero as octal.
+DFTIMEOUT=`expr "$DFTIMEOUT" + 0`
 # Cap at 3600s. BusyBox timeout(1) rejects an out-of-range duration with a
 # nonzero exit before df runs, which would silently empty both the df and
 # inode sections; an hour is already far past any sane df wait. The length
@@ -152,7 +152,6 @@ run_df()
 	set -- -P
 	[ "$DFLOCALONLY" = yes ] && set -- "$@" -l
 	[ "$DFINODES" = yes ] && set -- "$@" -i
-	set -- "$@" -x iso9660
 
 	case $- in
 		*f*) DFRESTOREGLOB=no ;;
@@ -170,24 +169,12 @@ run_df()
 	fi
 }
 # emit_df INODEFLAG LABEL
-# Run df (optionally in inode mode) and reproduce the historical sed join, but
-# guard the hung-filesystem case. timeout(1) reports 124 (timed out) or 137
-# (128+9, our `-s KILL` case) when it has to kill df; whatever partial output it
-# managed to print first is untrustworthy -- it can list the healthy mounts and
-# omit the very one that hung -- so we discard it and emit an explicit failure
-# marker instead of a silent (empty) section. The server reads an *empty*
-# [inode] section as green ("No filesystems reporting inode data"), so a silent
-# hang would otherwise be a false green; a non-empty marker that carries no
-# recognisable df header drives the server's yellow "expected strings not found"
-# path instead, and the same marker yellows the disk section. The same false
-# green can come from any nonzero exit that prints nothing at all -- e.g.
-# timeout(1) itself failing to launch df (status 125/126/127) or a BusyBox
-# timeout rejecting its arguments before df runs -- so an empty section is
-# emitted as a failure marker whenever the exit status was nonzero, not only for
-# the kill codes. df's own nonzero exits that still print the healthy mounts
-# (e.g. a single unreadable mount, exit 1) keep their partial output and flow
-# through unchanged, preserving prior behaviour; an empty section with a clean
-# exit 0 (the Solaris all-ZFS inode case) is also left untouched.
+# Run df (optionally in inode mode) and reproduce the historical sed join.
+# The server reads an empty section as green, so a hung/failed df must not pass
+# silently: on a timeout kill (124/137) or any nonzero exit with no output, emit
+# a failure marker (no recognisable df header) to drive the server yellow. A
+# nonzero exit that still prints mounts (e.g. one unreadable mount) and a clean
+# empty exit 0 (Solaris all-ZFS inodes) keep their output unchanged.
 emit_df()
 {
 	DFOUT=`run_df "$1"`

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -113,45 +113,6 @@ case "$DFLOCALONLY" in
 		DFLOCALONLY=yes
 		;;
 esac
-# XYMONCLIENT_FS_DF_TIMEOUT: seconds before timeout(1) sends SIGKILL to df
-# (default 30). df can hang on stale NFS/CIFS mounts -- particularly relevant
-# when XYMONCLIENT_FS_DF_LOCAL_ONLY=no. Empty or unset falls back to the
-# default; the timeout cannot be disabled through this setting, and its value
-# can be raised only up to the fixed 3600s cap below.
-DFTIMEOUT="${XYMONCLIENT_FS_DF_TIMEOUT:-30}"
-# A non-numeric value or zero is rejected (zero means "no timeout" under GNU
-# coreutils but "fire immediately" under BusyBox, so it is never safe) and
-# falls back to the 30s default with a warning.
-case "$DFTIMEOUT" in
-	*[!0-9]*)
-		echo "xymonclient-linux: invalid XYMONCLIENT_FS_DF_TIMEOUT '$DFTIMEOUT', using 30" >&2
-		DFTIMEOUT=30
-		;;
-	*[1-9]*) ;;
-	*)
-		echo "xymonclient-linux: invalid XYMONCLIENT_FS_DF_TIMEOUT '$DFTIMEOUT', using 30" >&2
-		DFTIMEOUT=30
-		;;
-esac
-# Strip leading zeros in pure shell (no external tool) so the length guard
-# below isn't fooled by padding (00001 is 1, not an over-length string) and the
-# numeric comparison doesn't read a leading zero as octal. The case above
-# guarantees at least one non-zero digit, so this terminates non-empty.
-while :; do
-	case "$DFTIMEOUT" in
-		0?*) DFTIMEOUT="${DFTIMEOUT#0}" ;;
-		*) break ;;
-	esac
-done
-# Cap at 3600s. BusyBox timeout(1) rejects an out-of-range duration with a
-# nonzero exit before df runs, which would silently empty both the df and
-# inode sections; an hour is already far past any sane df wait. The length
-# guard short-circuits the numeric comparison so it never overflows the
-# shell's integer type on an absurdly long digit string.
-if [ "${#DFTIMEOUT}" -gt 4 ] || [ "$DFTIMEOUT" -gt 3600 ]; then
-	echo "xymonclient-linux: XYMONCLIENT_FS_DF_TIMEOUT '$DFTIMEOUT' exceeds 3600, using 3600" >&2
-	DFTIMEOUT=3600
-fi
 run_df()
 {
 	DFINODES="$1"
@@ -168,30 +129,19 @@ run_df()
 	done
 	[ "$DFRESTOREGLOB" = yes ] && set +f
 
-	if command -v timeout >/dev/null 2>&1; then
-		timeout -s KILL "${DFTIMEOUT}s" df "$@"
-	else
-		df "$@"
-	fi
+	df "$@"
 }
 # emit_df INODEFLAG LABEL
 # Run df (optionally in inode mode) and reproduce the historical sed join.
-# The server reads an empty section as green, so a hung/failed df must not pass
-# silently: on a timeout kill (124/137) or any nonzero exit with no output, emit
-# a failure marker (no recognisable df header) to drive the server yellow. A
-# nonzero exit that still prints mounts (e.g. one unreadable mount) and a clean
-# empty exit 0 (Solaris all-ZFS inodes) keep their output unchanged.
+# The server reads an empty section as green, so a failed df must not pass
+# silently: on any nonzero exit with no output, emit a failure marker (no
+# recognisable df header) to drive the server yellow. A nonzero exit that still
+# prints mounts (e.g. one unreadable mount) and a clean empty exit 0 (Solaris
+# all-ZFS inodes) keep their output unchanged.
 emit_df()
 {
 	DFOUT=`run_df "$1"`
 	DFRC=$?
-	case $DFRC in
-		124|137)
-			echo "xymonclient-linux: df $2 collection timed out after ${DFTIMEOUT}s (timeout status $DFRC); reporting data as unavailable" >&2
-			echo "$2 collection failed: df timed out after ${DFTIMEOUT}s (status $DFRC)"
-			return
-			;;
-	esac
 	if [ -z "$DFOUT" ]; then
 		[ "$DFRC" -eq 0 ] && return
 		echo "xymonclient-linux: df $2 collection failed (status $DFRC) with no output; reporting data as unavailable" >&2

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -46,11 +46,15 @@ echo "[who]"
 who
 echo "[df]"
 # Default: exclude every nodev (pseudo) filesystem in df/inode output, except
-# rootfs. This is the historical upstream behavior.
+# rootfs, plus the historical explicit iso9660 exclusion (iso9660 is not a
+# nodev type, so it is added unconditionally at run_df below). This is the
+# historical upstream behavior.
 if [ -r /proc/filesystems ]; then
 	EXCLUDES=$(awk '$1 == "nodev" && $2 != "rootfs" { printf "%s%s", sep, $2; sep=" " }' /proc/filesystems)
 else
-	echo "xymonclient-linux: /proc/filesystems not readable, filesystem filter disabled" >&2
+	# Only the dynamic nodev exclusions are disabled here; the explicit iso9660
+	# exclusion and the local-only df -l behavior still apply.
+	echo "xymonclient-linux: /proc/filesystems not readable, dynamic nodev exclusions disabled (iso9660 exclusion and df -l still apply)" >&2
 	EXCLUDES=""
 fi
 # Filesystem types are literal tokens, so pathname expansion must not turn a
@@ -61,7 +65,7 @@ case $- in
 esac
 # XYMONCLIENT_FS_INCLUDE_TYPES: whitespace-separated FS types that should
 # appear in the output even though they would otherwise be excluded
-# (e.g. "tmpfs squashfs" to surface tmpfs mounts, or "nfs nfs4 ceph" to
+# (e.g. "tmpfs zfs" to surface tmpfs/zfs mounts, or "nfs nfs4 ceph" to
 # include remote filesystems -- the latter also requires
 # XYMONCLIENT_FS_DF_LOCAL_ONLY=no since df -l hides remote mounts).
 if [ -n "$XYMONCLIENT_FS_INCLUDE_TYPES" ]; then
@@ -103,7 +107,8 @@ esac
 # XYMONCLIENT_FS_DF_TIMEOUT: seconds before timeout(1) sends SIGKILL to df
 # (default 30). df can hang on stale NFS/CIFS mounts -- particularly relevant
 # when XYMONCLIENT_FS_DF_LOCAL_ONLY=no. Empty or unset falls back to the
-# default; the cap cannot be disabled, only raised.
+# default; the timeout cannot be disabled through this setting, and its value
+# can be raised only up to the fixed 3600s cap below.
 DFTIMEOUT="${XYMONCLIENT_FS_DF_TIMEOUT:-30}"
 # A non-numeric value or zero is rejected (zero means "no timeout" under GNU
 # coreutils but "fire immediately" under BusyBox, so it is never safe) and

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -82,8 +82,10 @@ if [ -n "$XYMONCLIENT_FS_INCLUDE_TYPES" ]; then
 	EXCLUDES="$keep"
 fi
 # XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated FS types to ALSO
-# exclude, on top of the nodev default (e.g. "overlay fuse" to drop
-# container-runtime mounts that would otherwise leak into the report).
+# exclude, on top of the nodev default. Matching is on the exact df type
+# token; nodev types (overlay, fuse, ...) are already excluded, so an
+# effective entry names a non-nodev type, e.g. "fuse.sshfs vfat" to drop a
+# specific FUSE subtype and a device-backed mount.
 if [ -n "$XYMONCLIENT_FS_EXCLUDE_TYPES" ]; then
 	for t in $XYMONCLIENT_FS_EXCLUDE_TYPES; do
 		case " $EXCLUDES " in

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -100,10 +100,10 @@ case "$DFLOCALONLY" in
 		DFLOCALONLY=yes
 		;;
 esac
-# XYMONCLIENT_FS_DF_TIMEOUT: seconds before df is killed by timeout(1) (default
-# 30). df can hang on stale NFS/CIFS mounts -- particularly relevant when
-# XYMONCLIENT_FS_DF_LOCAL_ONLY=no. Empty or unset falls back to the default; the
-# cap cannot be disabled, only raised.
+# XYMONCLIENT_FS_DF_TIMEOUT: seconds before timeout(1) sends SIGKILL to df
+# (default 30). df can hang on stale NFS/CIFS mounts -- particularly relevant
+# when XYMONCLIENT_FS_DF_LOCAL_ONLY=no. Empty or unset falls back to the
+# default; the cap cannot be disabled, only raised.
 DFTIMEOUT="${XYMONCLIENT_FS_DF_TIMEOUT:-30}"
 # A non-numeric value or zero is rejected (zero means "no timeout" under GNU
 # coreutils but "fire immediately" under BusyBox, so it is never safe) and
@@ -119,6 +119,26 @@ case "$DFTIMEOUT" in
 		DFTIMEOUT=30
 		;;
 esac
+# Strip leading zeros so a value like 00030 is treated as decimal 30, not as
+# an over-length string (the length guard below keys on character count, not
+# magnitude, so 00001 would otherwise clamp to 3600) nor as octal in the
+# numeric comparison. The case above guarantees DFTIMEOUT is all digits with at
+# least one non-zero, so this loop always terminates with a non-empty value.
+while :; do
+	case "$DFTIMEOUT" in
+		0?*) DFTIMEOUT="${DFTIMEOUT#0}" ;;
+		*) break ;;
+	esac
+done
+# Cap at 3600s. BusyBox timeout(1) rejects an out-of-range duration with a
+# nonzero exit before df runs, which would silently empty both the df and
+# inode sections; an hour is already far past any sane df wait. The length
+# guard short-circuits the numeric comparison so it never overflows the
+# shell's integer type on an absurdly long digit string.
+if [ "${#DFTIMEOUT}" -gt 4 ] || [ "$DFTIMEOUT" -gt 3600 ]; then
+	echo "xymonclient-linux: XYMONCLIENT_FS_DF_TIMEOUT '$DFTIMEOUT' exceeds 3600, using 3600" >&2
+	DFTIMEOUT=3600
+fi
 run_df()
 {
 	DFINODES="$1"
@@ -137,7 +157,7 @@ run_df()
 	[ "$DFRESTOREGLOB" = yes ] && set +f
 
 	if command -v timeout >/dev/null 2>&1; then
-		timeout "${DFTIMEOUT}s" df "$@"
+		timeout -s KILL "${DFTIMEOUT}s" df "$@"
 	else
 		df "$@"
 	fi

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -133,10 +133,16 @@ case "$DFTIMEOUT" in
 		DFTIMEOUT=30
 		;;
 esac
-# Normalise to decimal (expr is decimal by spec) so a zero-padded value like
-# 00030 becomes 30: the length guard below keys on character count, and the
-# numeric comparison would otherwise read a leading zero as octal.
-DFTIMEOUT=`expr "$DFTIMEOUT" + 0`
+# Strip leading zeros in pure shell (no external tool) so the length guard
+# below isn't fooled by padding (00001 is 1, not an over-length string) and the
+# numeric comparison doesn't read a leading zero as octal. The case above
+# guarantees at least one non-zero digit, so this terminates non-empty.
+while :; do
+	case "$DFTIMEOUT" in
+		0?*) DFTIMEOUT="${DFTIMEOUT#0}" ;;
+		*) break ;;
+	esac
+done
 # Cap at 3600s. BusyBox timeout(1) rejects an out-of-range duration with a
 # nonzero exit before df runs, which would silently empty both the df and
 # inode sections; an hour is already far past any sane df wait. The length

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -162,16 +162,51 @@ run_df()
 		df "$@"
 	fi
 }
+# emit_df INODEFLAG LABEL
+# Run df (optionally in inode mode) and reproduce the historical sed join, but
+# guard the hung-filesystem case. timeout(1) reports 124 (timed out) or 137
+# (128+9, our `-s KILL` case) when it has to kill df; whatever partial output it
+# managed to print first is untrustworthy -- it can list the healthy mounts and
+# omit the very one that hung -- so we discard it and emit an explicit failure
+# marker instead of a silent (empty) section. The server reads an *empty*
+# [inode] section as green ("No filesystems reporting inode data"), so a silent
+# hang would otherwise be a false green; a non-empty marker that carries no
+# recognisable df header drives the server's yellow "expected strings not found"
+# path instead, and the same marker yellows the disk section. The same false
+# green can come from any nonzero exit that prints nothing at all -- e.g.
+# timeout(1) itself failing to launch df (status 125/126/127) or a BusyBox
+# timeout rejecting its arguments before df runs -- so an empty section is
+# emitted as a failure marker whenever the exit status was nonzero, not only for
+# the kill codes. df's own nonzero exits that still print the healthy mounts
+# (e.g. a single unreadable mount, exit 1) keep their partial output and flow
+# through unchanged, preserving prior behaviour; an empty section with a clean
+# exit 0 (the Solaris all-ZFS inode case) is also left untouched.
+emit_df()
+{
+	DFOUT=`run_df "$1"`
+	DFRC=$?
+	case $DFRC in
+		124|137)
+			echo "xymonclient-linux: df $2 collection timed out after ${DFTIMEOUT}s (timeout status $DFRC); reporting data as unavailable" >&2
+			echo "$2 collection failed: df timed out after ${DFTIMEOUT}s (status $DFRC)"
+			return
+			;;
+	esac
+	if [ -z "$DFOUT" ]; then
+		[ "$DFRC" -eq 0 ] && return
+		echo "xymonclient-linux: df $2 collection failed (status $DFRC) with no output; reporting data as unavailable" >&2
+		echo "$2 collection failed: df exited $DFRC with no output"
+		return
+	fi
+	printf '%s\n' "$DFOUT" | sed -e '/^[^ 	][^ 	]*$/{
+N
+s/[ 	]*\n[ 	]*/ /
+}' -e "s&^rootfs&${ROOTFS}&"
+}
 ROOTFS=`readlink -m /dev/root`
-run_df no | sed -e '/^[^ 	][^ 	]*$/{
-N
-s/[ 	]*\n[ 	]*/ /
-}' -e "s&^rootfs&${ROOTFS}&"
+emit_df no Disk
 echo "[inode]"
-run_df yes | sed -e '/^[^ 	][^ 	]*$/{
-N
-s/[ 	]*\n[ 	]*/ /
-}' -e "s&^rootfs&${ROOTFS}&"
+emit_df yes Inode
 echo "[mount]"
 mount
 echo "[free]"

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -45,14 +45,110 @@ uptime
 echo "[who]"
 who
 echo "[df]"
-EXCLUDES=`cat /proc/filesystems | grep nodev | grep -v rootfs | awk '{print $2}' | xargs echo | sed -e 's! ! -x !g'`
+# Default: exclude every nodev (pseudo) filesystem in df/inode output, except
+# rootfs. This is the historical upstream behavior.
+if [ -r /proc/filesystems ]; then
+	EXCLUDES=$(awk '$1 == "nodev" && $2 != "rootfs" { printf "%s%s", sep, $2; sep=" " }' /proc/filesystems)
+else
+	echo "xymonclient-linux: /proc/filesystems not readable, filesystem filter disabled" >&2
+	EXCLUDES=""
+fi
+# Filesystem types are literal tokens, so pathname expansion must not turn a
+# configured type such as "fuse.*" into filenames from the working directory.
+case $- in
+	*f*) FSRESTOREGLOB=no ;;
+	*) FSRESTOREGLOB=yes; set -f ;;
+esac
+# XYMONCLIENT_FS_INCLUDE_TYPES: whitespace-separated FS types that should
+# appear in the output even though they would otherwise be excluded
+# (e.g. "tmpfs squashfs" to surface tmpfs mounts, or "nfs nfs4 ceph" to
+# include remote filesystems -- the latter also requires
+# XYMONCLIENT_FS_DF_LOCAL_ONLY=no since df -l hides remote mounts).
+if [ -n "$XYMONCLIENT_FS_INCLUDE_TYPES" ]; then
+	# Exact token comparison -- a type is matched literally, never as a
+	# regex/glob, so e.g. "fuse.sshfs" cannot collide with another token.
+	keep=""
+	for e in $EXCLUDES; do
+		drop=no
+		for t in $XYMONCLIENT_FS_INCLUDE_TYPES; do
+			[ "$e" = "$t" ] && { drop=yes; break; }
+		done
+		[ "$drop" = no ] && keep="$keep $e"
+	done
+	EXCLUDES="$keep"
+fi
+# XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated FS types to ALSO
+# exclude, on top of the nodev default (e.g. "overlay fuse" to drop
+# container-runtime mounts that would otherwise leak into the report).
+if [ -n "$XYMONCLIENT_FS_EXCLUDE_TYPES" ]; then
+	for t in $XYMONCLIENT_FS_EXCLUDE_TYPES; do
+		case " $EXCLUDES " in
+			*" $t "*) ;;  # already in list
+			*) EXCLUDES="$EXCLUDES $t" ;;
+		esac
+	done
+fi
+[ "$FSRESTOREGLOB" = yes ] && set +f
+# XYMONCLIENT_FS_DF_LOCAL_ONLY: defaults to "yes" (current upstream behavior,
+# passes -l to df). Set to "no" to drop -l so that remote filesystems
+# (nfs, ceph, ...) appear in the output.
+DFLOCALONLY="${XYMONCLIENT_FS_DF_LOCAL_ONLY:-yes}"
+case "$DFLOCALONLY" in
+	yes|no) ;;
+	*)
+		echo "xymonclient-linux: invalid XYMONCLIENT_FS_DF_LOCAL_ONLY '$DFLOCALONLY', using yes" >&2
+		DFLOCALONLY=yes
+		;;
+esac
+# XYMONCLIENT_FS_DF_TIMEOUT: seconds before df is killed by timeout(1) (default
+# 30). df can hang on stale NFS/CIFS mounts -- particularly relevant when
+# XYMONCLIENT_FS_DF_LOCAL_ONLY=no. Empty or unset falls back to the default; the
+# cap cannot be disabled, only raised.
+DFTIMEOUT="${XYMONCLIENT_FS_DF_TIMEOUT:-30}"
+# A non-numeric value or zero is rejected (zero means "no timeout" under GNU
+# coreutils but "fire immediately" under BusyBox, so it is never safe) and
+# falls back to the 30s default with a warning.
+case "$DFTIMEOUT" in
+	*[!0-9]*)
+		echo "xymonclient-linux: invalid XYMONCLIENT_FS_DF_TIMEOUT '$DFTIMEOUT', using 30" >&2
+		DFTIMEOUT=30
+		;;
+	*[1-9]*) ;;
+	*)
+		echo "xymonclient-linux: invalid XYMONCLIENT_FS_DF_TIMEOUT '$DFTIMEOUT', using 30" >&2
+		DFTIMEOUT=30
+		;;
+esac
+run_df()
+{
+	DFINODES="$1"
+	set -- -P
+	[ "$DFLOCALONLY" = yes ] && set -- "$@" -l
+	[ "$DFINODES" = yes ] && set -- "$@" -i
+	set -- "$@" -x iso9660
+
+	case $- in
+		*f*) DFRESTOREGLOB=no ;;
+		*) DFRESTOREGLOB=yes; set -f ;;
+	esac
+	for t in $EXCLUDES; do
+		set -- "$@" -x "$t"
+	done
+	[ "$DFRESTOREGLOB" = yes ] && set +f
+
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "${DFTIMEOUT}s" df "$@"
+	else
+		df "$@"
+	fi
+}
 ROOTFS=`readlink -m /dev/root`
-df -Pl -x iso9660 -x $EXCLUDES | sed -e '/^[^ 	][^ 	]*$/{
+run_df no | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
 }' -e "s&^rootfs&${ROOTFS}&"
 echo "[inode]"
-df -Pil -x iso9660 -x $EXCLUDES | sed -e '/^[^ 	][^ 	]*$/{
+run_df yes | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
 }' -e "s&^rootfs&${ROOTFS}&"
@@ -104,4 +200,3 @@ sleep 5
 if test -f $XYMONTMP/xymon_vmstat.$MACHINEDOTS; then echo "[vmstat]"; cat $XYMONTMP/xymon_vmstat.$MACHINEDOTS; rm -f $XYMONTMP/xymon_vmstat.$MACHINEDOTS; fi
 
 exit
-

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -85,14 +85,14 @@ if [ -n "$XYMONCLIENT_FS_INCLUDE_TYPES" ]; then
 	EXCLUDES="$keep"
 fi
 # XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated FS types to ALSO exclude,
-# on top of the nodev default. Defaults to "iso9660 squashfs" -- both are
-# read-only images reported 100% full by design (snap mounts one squashfs per
-# revision), and neither is a nodev type, so they must be named here. Matching
-# is on the exact df type token; nodev types (overlay, fuse, ...) are already
-# excluded, so other effective entries name a non-nodev type, e.g. adding
-# "fuse.sshfs vfat" to drop a specific FUSE subtype and a device-backed mount.
-# Set to "" to monitor iso9660/squashfs too.
-: "${XYMONCLIENT_FS_EXCLUDE_TYPES=iso9660 squashfs}"
+# on top of the nodev default. Defaults to "iso9660 squashfs fuse.snapfuse" --
+# read-only images reported 100% full by design (snaps mount as squashfs, or as
+# fuse.snapfuse where snapd falls back to FUSE), none a nodev type, so they must
+# be named here. Matching is on the exact df type token; nodev types (overlay,
+# bare fuse, ...) are already excluded, so other effective entries name a
+# non-nodev type, e.g. adding "fuse.sshfs vfat" to drop a specific FUSE subtype
+# and a device-backed mount. Set to "" to monitor these too.
+: "${XYMONCLIENT_FS_EXCLUDE_TYPES=iso9660 squashfs fuse.snapfuse}"
 if [ -n "$XYMONCLIENT_FS_EXCLUDE_TYPES" ]; then
 	for t in $XYMONCLIENT_FS_EXCLUDE_TYPES; do
 		case " $EXCLUDES " in
@@ -198,10 +198,17 @@ emit_df()
 		echo "$2 collection failed: df exited $DFRC with no output"
 		return
 	fi
+	# Inode report ("$1" = yes) only: drop filesystems with no inode limit. df
+	# prints "-" in the IUse% column (field 5) for them (btrfs, zfs, 9p, many
+	# fuse); they can never run out of inodes, so the row is noise and may carry
+	# bogus counts (e.g. a negative IUsed on 9p). The header (NR==1) is kept; for
+	# the disk report the awk is a pass-through. (awk is already required above,
+	# so this adds no new dependency.)
 	printf '%s\n' "$DFOUT" | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
-}' -e "s&^rootfs&${ROOTFS}&"
+}' -e "s&^rootfs&${ROOTFS}&" \
+	| awk -v ino="$1" 'NR == 1 || ino != "yes" || $5 != "-"'
 }
 ROOTFS=`readlink -m /dev/root`
 emit_df no Disk

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -53,20 +53,19 @@ LOGFETCHOPTS=""
 # XYMONCLIENT_FS_DF_LOCAL_ONLY: "yes" (default) passes -l to df, hiding
 #    remote filesystems. Set to "no" to report nfs/ceph/etc. Any other
 #    value produces a warning and falls back to "yes".
-#    WARNING: with "no", df can hang for the whole client cycle if any
-#    remote mount is stale. Use XYMONCLIENT_FS_DF_TIMEOUT to cap the wait.
+#    WARNING: with "no", a stale or hard-blocked remote mount can wedge df
+#    indefinitely (an uninterruptible D-state wait). The client run never
+#    finishes, so the whole host goes PURPLE -- no data for ALL metrics,
+#    not just disk -- until the mount recovers or the host reboots.
 #
-# XYMONCLIENT_FS_DF_TIMEOUT: positive integer seconds before timeout(1) sends
-#    SIGKILL to df, default "30" (applied per df invocation -- disk and inode
-#    are separate, so two stale mounts can cost up to twice this). Empty/unset
-#    or an invalid value falls back to "30" (with a warning); it cannot be
-#    disabled and is capped at 3600. On a kill, that report is marked failed
-#    (yellow) rather than left empty, so a hung filesystem is not reported green.
+#    A df that *exits* non-zero with no output (a real error, not a hang)
+#    is marked failed (yellow) rather than left empty, so a failed probe is
+#    not silently reported green. This does not cover the hang above: a
+#    wedged df never exits.
 #
 # XYMONCLIENT_FS_INCLUDE_TYPES="zfs virtiofs tmpfs"
 # XYMONCLIENT_FS_EXCLUDE_TYPES="iso9660 squashfs fuse.snapfuse"
 # XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
-# XYMONCLIENT_FS_DF_TIMEOUT="30"
 
 
 # Local Mode (Only) Options

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -36,15 +36,15 @@ LOGFETCHOPTS=""
 #                               df -l hides remote mounts).
 #
 # XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated FS types to also exclude,
-#    on top of the nodev default. Defaults to "iso9660 squashfs" -- read-only
-#    images always reported 100% full by design (snap mounts one squashfs per
-#    revision). Matching is on the exact df type token, and nodev types
-#    (overlay, fuse, ...) are already excluded by default, so other effective
-#    entries name a type that is NOT a nodev default -- a device-backed type, or
-#    a specific FUSE subtype the bare nodev "fuse" default cannot match.
-#    Examples:
-#      ""                    -- monitor iso9660/squashfs too.
-#      "iso9660 squashfs fuse.sshfs vfat"
+#    on top of the nodev default. Defaults to "iso9660 squashfs fuse.snapfuse"
+#    -- read-only images always reported 100% full by design (snaps mount as
+#    squashfs, or as fuse.snapfuse where snapd falls back to FUSE). Matching is
+#    on the exact df type token, and nodev types (overlay, bare fuse, ...) are
+#    already excluded by default, so other effective entries name a type that is
+#    NOT a nodev default -- a device-backed type, or a specific FUSE subtype the
+#    bare nodev "fuse" default cannot match. Examples:
+#      ""                    -- monitor iso9660/squashfs/snaps too.
+#      "iso9660 squashfs fuse.snapfuse fuse.sshfs vfat"
 #                            -- keep the defaults and also drop a specific FUSE
 #                               subtype and a device-backed mount.
 #    If a type appears in both lists, EXCLUDE wins (it is applied after
@@ -64,7 +64,7 @@ LOGFETCHOPTS=""
 #    (yellow) rather than left empty, so a hung filesystem is not reported green.
 #
 # XYMONCLIENT_FS_INCLUDE_TYPES="zfs virtiofs tmpfs"
-# XYMONCLIENT_FS_EXCLUDE_TYPES="iso9660 squashfs"
+# XYMONCLIENT_FS_EXCLUDE_TYPES="iso9660 squashfs fuse.snapfuse"
 # XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
 # XYMONCLIENT_FS_DF_TIMEOUT="30"
 

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -19,28 +19,34 @@ LOGFETCHOPTS=""
 
 
 # Filesystem reporting (Linux client) -- used by xymonclient-linux.sh when
-# collecting df and inode data. Unset (the default) means current behavior:
-# exclude every nodev pseudo filesystem except rootfs, and pass -l to df.
+# collecting df and inode data. By default it excludes the nodev pseudo
+# filesystems (except rootfs) and the always-full iso9660/squashfs images,
+# reports the real local filesystems including zfs/virtiofs/tmpfs, and passes
+# -l to df. The noisy tmpfs mounts (/run, /run/lock, /run/user/N) are filtered
+# server-side by the CLASS=linux block in analysis.cfg, not here.
 #
-# XYMONCLIENT_FS_INCLUDE_TYPES: whitespace-separated FS types that should
-#    appear in the report even though they would otherwise be excluded as
-#    nodev. Examples:
-#      "tmpfs zfs"           -- surface tmpfs and zfs mounts.
-#      "nfs nfs4 ceph"       -- include remote filesystems (requires
+# XYMONCLIENT_FS_INCLUDE_TYPES: whitespace-separated nodev FS types to surface
+#    (they would otherwise be dropped). Defaults to "zfs virtiofs tmpfs" -- the
+#    real local filesystems that merely happen to be nodev. Examples:
+#      ""                    -- restore the historical "exclude every nodev
+#                               type" behaviour (drops zfs/virtiofs/tmpfs too).
+#      "zfs virtiofs tmpfs nfs nfs4 ceph"
+#                            -- also include remote filesystems (requires
 #                               XYMONCLIENT_FS_DF_LOCAL_ONLY=no, since
 #                               df -l hides remote mounts).
 #
-# XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated FS types to also
-#    exclude, on top of the nodev default. Useful when container runtimes
-#    or other tools register filesystem types that you do not want to see
-#    in the disk report. Matching is on the exact df type token, and nodev
-#    types (overlay, fuse, ...) are already excluded by default, so an
-#    effective entry names a type that is NOT a nodev default -- a device-backed
-#    type, or a specific FUSE subtype the bare nodev "fuse" default cannot
-#    match. Examples:
-#      "fuse.sshfs vfat"     -- drop a specific FUSE subtype (the nodev "fuse"
-#                               default does not match the "fuse.sshfs" token)
-#                               and a device-backed mount.
+# XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated FS types to also exclude,
+#    on top of the nodev default. Defaults to "iso9660 squashfs" -- read-only
+#    images always reported 100% full by design (snap mounts one squashfs per
+#    revision). Matching is on the exact df type token, and nodev types
+#    (overlay, fuse, ...) are already excluded by default, so other effective
+#    entries name a type that is NOT a nodev default -- a device-backed type, or
+#    a specific FUSE subtype the bare nodev "fuse" default cannot match.
+#    Examples:
+#      ""                    -- monitor iso9660/squashfs too.
+#      "iso9660 squashfs fuse.sshfs vfat"
+#                            -- keep the defaults and also drop a specific FUSE
+#                               subtype and a device-backed mount.
 #    If a type appears in both lists, EXCLUDE wins (it is applied after
 #    INCLUDE), so the type stays excluded.
 #
@@ -51,20 +57,14 @@ LOGFETCHOPTS=""
 #    remote mount is stale. Use XYMONCLIENT_FS_DF_TIMEOUT to cap the wait.
 #
 # XYMONCLIENT_FS_DF_TIMEOUT: positive integer seconds before timeout(1) sends
-#    SIGKILL to df, default "30". The limit applies per df invocation, and the
-#    disk and inode reports are two separate invocations, so two stale mounts
-#    can delay the client by up to twice this value. Empty or unset falls back
-#    to "30"; zero or another invalid value produces a warning and also falls
-#    back to "30". The timeout cannot be disabled through this setting and may
-#    be set up to a maximum of 3600 seconds -- df must never hang the client
-#    cycle. A process
-#    stuck in an uninterruptible kernel wait cannot be terminated until the
-#    kernel call returns. If timeout(1) has to kill df, the affected df and
-#    inode report is marked failed (yellow) instead of being left empty, so a
-#    hung filesystem is not silently reported green.
+#    SIGKILL to df, default "30" (applied per df invocation -- disk and inode
+#    are separate, so two stale mounts can cost up to twice this). Empty/unset
+#    or an invalid value falls back to "30" (with a warning); it cannot be
+#    disabled and is capped at 3600. On a kill, that report is marked failed
+#    (yellow) rather than left empty, so a hung filesystem is not reported green.
 #
-# XYMONCLIENT_FS_INCLUDE_TYPES=""
-# XYMONCLIENT_FS_EXCLUDE_TYPES=""
+# XYMONCLIENT_FS_INCLUDE_TYPES="zfs virtiofs tmpfs"
+# XYMONCLIENT_FS_EXCLUDE_TYPES="iso9660 squashfs"
 # XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
 # XYMONCLIENT_FS_DF_TIMEOUT="30"
 

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -25,7 +25,7 @@ LOGFETCHOPTS=""
 # XYMONCLIENT_FS_INCLUDE_TYPES: whitespace-separated FS types that should
 #    appear in the report even though they would otherwise be excluded as
 #    nodev. Examples:
-#      "tmpfs squashfs"      -- surface tmpfs and squashfs mounts.
+#      "tmpfs zfs"           -- surface tmpfs and zfs mounts.
 #      "nfs nfs4 ceph"       -- include remote filesystems (requires
 #                               XYMONCLIENT_FS_DF_LOCAL_ONLY=no, since
 #                               df -l hides remote mounts).
@@ -47,12 +47,12 @@ LOGFETCHOPTS=""
 # XYMONCLIENT_FS_DF_TIMEOUT: positive integer seconds before timeout(1) sends
 #    SIGKILL to df, default "30". Empty or unset falls back to "30"; zero or
 #    another invalid value produces a warning and also falls back to "30". The
-#    cap cannot be disabled, only raised, up to a maximum of 3600 -- df must
-#    never hang the client cycle. A process stuck in an uninterruptible kernel
-#    wait cannot be terminated until the kernel call returns. If timeout(1) has
-#    to kill df, the affected df and inode report is marked failed (yellow)
-#    instead of being left empty, so a hung filesystem is not silently reported
-#    green.
+#    timeout cannot be disabled through this setting and may be set up to a
+#    maximum of 3600 seconds -- df must never hang the client cycle. A process
+#    stuck in an uninterruptible kernel wait cannot be terminated until the
+#    kernel call returns. If timeout(1) has to kill df, the affected df and
+#    inode report is marked failed (yellow) instead of being left empty, so a
+#    hung filesystem is not silently reported green.
 #
 # XYMONCLIENT_FS_INCLUDE_TYPES=""
 # XYMONCLIENT_FS_EXCLUDE_TYPES=""

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -33,8 +33,14 @@ LOGFETCHOPTS=""
 # XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated FS types to also
 #    exclude, on top of the nodev default. Useful when container runtimes
 #    or other tools register filesystem types that you do not want to see
-#    in the disk report. Examples:
-#      "overlay fuse"        -- drop container-runtime mounts.
+#    in the disk report. Matching is on the exact df type token, and nodev
+#    types (overlay, fuse, ...) are already excluded by default, so an
+#    effective entry names a type that is NOT a nodev default -- a device-backed
+#    type, or a specific FUSE subtype the bare nodev "fuse" default cannot
+#    match. Examples:
+#      "fuse.sshfs vfat"     -- drop a specific FUSE subtype (the nodev "fuse"
+#                               default does not match the "fuse.sshfs" token)
+#                               and a device-backed mount.
 #    If a type appears in both lists, EXCLUDE wins (it is applied after
 #    INCLUDE), so the type stays excluded.
 #
@@ -45,10 +51,13 @@ LOGFETCHOPTS=""
 #    remote mount is stale. Use XYMONCLIENT_FS_DF_TIMEOUT to cap the wait.
 #
 # XYMONCLIENT_FS_DF_TIMEOUT: positive integer seconds before timeout(1) sends
-#    SIGKILL to df, default "30". Empty or unset falls back to "30"; zero or
-#    another invalid value produces a warning and also falls back to "30". The
-#    timeout cannot be disabled through this setting and may be set up to a
-#    maximum of 3600 seconds -- df must never hang the client cycle. A process
+#    SIGKILL to df, default "30". The limit applies per df invocation, and the
+#    disk and inode reports are two separate invocations, so two stale mounts
+#    can delay the client by up to twice this value. Empty or unset falls back
+#    to "30"; zero or another invalid value produces a warning and also falls
+#    back to "30". The timeout cannot be disabled through this setting and may
+#    be set up to a maximum of 3600 seconds -- df must never hang the client
+#    cycle. A process
 #    stuck in an uninterruptible kernel wait cannot be terminated until the
 #    kernel call returns. If timeout(1) has to kill df, the affected df and
 #    inode report is marked failed (yellow) instead of being left empty, so a

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -18,6 +18,48 @@ XYMONCLIENTLOGS="$XYMONHOME/logs"     # Where we store the client logfiles
 LOGFETCHOPTS=""
 
 
+# Filesystem reporting (Linux client) -- used by xymonclient-linux.sh when
+# collecting df and inode data. Unset (the default) means current behavior:
+# exclude every nodev pseudo filesystem except rootfs, and pass -l to df.
+#
+# XYMONCLIENT_FS_INCLUDE_TYPES: whitespace-separated FS types that should
+#    appear in the report even though they would otherwise be excluded as
+#    nodev. Examples:
+#      "tmpfs squashfs"      -- surface tmpfs and squashfs mounts.
+#      "nfs nfs4 ceph"       -- include remote filesystems (requires
+#                               XYMONCLIENT_FS_DF_LOCAL_ONLY=no, since
+#                               df -l hides remote mounts).
+#
+# XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated FS types to also
+#    exclude, on top of the nodev default. Useful when container runtimes
+#    or other tools register filesystem types that you do not want to see
+#    in the disk report. Examples:
+#      "overlay fuse"        -- drop container-runtime mounts.
+#    If a type appears in both lists, EXCLUDE wins (it is applied after
+#    INCLUDE), so the type stays excluded.
+#
+# XYMONCLIENT_FS_DF_LOCAL_ONLY: "yes" (default) passes -l to df, hiding
+#    remote filesystems. Set to "no" to report nfs/ceph/etc. Any other
+#    value produces a warning and falls back to "yes".
+#    WARNING: with "no", df can hang for the whole client cycle if any
+#    remote mount is stale. Use XYMONCLIENT_FS_DF_TIMEOUT to cap the wait.
+#
+# XYMONCLIENT_FS_DF_TIMEOUT: positive integer seconds before timeout(1) sends
+#    SIGKILL to df, default "30". Empty or unset falls back to "30"; zero or
+#    another invalid value produces a warning and also falls back to "30". The
+#    cap cannot be disabled, only raised, up to a maximum of 3600 -- df must
+#    never hang the client cycle. A process stuck in an uninterruptible kernel
+#    wait cannot be terminated until the kernel call returns. If timeout(1) has
+#    to kill df, the affected df and inode report is marked failed (yellow)
+#    instead of being left empty, so a hung filesystem is not silently reported
+#    green.
+#
+# XYMONCLIENT_FS_INCLUDE_TYPES=""
+# XYMONCLIENT_FS_EXCLUDE_TYPES=""
+# XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
+# XYMONCLIENT_FS_DF_TIMEOUT="30"
+
+
 # Local Mode (Only) Options
 #
 # Running the Xymon client in local-config mode will cause threshold evaluation to
@@ -51,4 +93,3 @@ BBHOME="$XYMONHOME"
 BB="$XYMON"
 BBTMP="$XYMONTMP"
 BBCLIENTLOGS="$XYMONCLIENTLOGS"
-

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -35,6 +35,40 @@ $XYMONHOME/logs
 .IP XYMONTMP
 Directory used for temporary files. Default: $XYMONHOME/tmp/
 
+.IP XYMONCLIENT_FS_INCLUDE_TYPES
+Whitespace-separated Linux filesystem types to include in the
+client's disk and inode reports even when they are normally excluded
+as pseudo filesystems. For example, \fBtmpfs squashfs\fR includes
+those types. Including remote filesystems also requires
+XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
+
+.IP XYMONCLIENT_FS_EXCLUDE_TYPES
+Whitespace-separated Linux filesystem types to exclude in addition
+to the default pseudo-filesystem exclusions. If a type appears in
+both include and exclude settings, exclusion takes precedence.
+The default exclusion list is derived from the \fBnodev\fR entries in
+/proc/filesystems (rootfs is always kept). When /proc/filesystems is
+not readable the default filter is disabled and no filesystem types are
+excluded by default; the script does not fall back to deriving
+exclusions from mount(8), so it is not a drop-in replacement for distro
+patches (such as Debian's) that do.
+
+.IP XYMONCLIENT_FS_DF_LOCAL_ONLY
+Set to \fByes\fR (the default) to pass \fB\-l\fR to df and report
+local filesystems only. Set to \fBno\fR to report remote filesystems
+as well. Invalid values produce a warning and use the safe default.
+
+.IP XYMONCLIENT_FS_DF_TIMEOUT
+Positive integer seconds before timeout(1) sends SIGKILL to each df
+invocation. The default is 30 seconds when timeout(1) is available.
+An empty or unset value falls back to the default; zero and other
+invalid values produce a warning and also use the default. The cap
+cannot be disabled, only raised, up to a maximum of 3600. A process
+stuck in an uninterruptible kernel wait cannot be terminated until the
+kernel call returns. If timeout(1) has to kill df, the affected df and
+inode report is marked failed (yellow) instead of being left empty, so a
+hung filesystem is not silently reported green.
+
 .IP XYMON
 Full path to the 
 .I xymon(1)
@@ -66,4 +100,3 @@ of the "runclient.sh" script.
 
 .SH "SEE ALSO"
 xymon(7)
-

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -38,9 +38,9 @@ Directory used for temporary files. Default: $XYMONHOME/tmp/
 .IP XYMONCLIENT_FS_INCLUDE_TYPES
 Whitespace-separated Linux filesystem types to include in the
 client's disk and inode reports even when they are normally excluded
-as pseudo filesystems. For example, \fBtmpfs zfs\fR includes
-those types. Including remote filesystems also requires
-XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
+as pseudo filesystems. Types are matched as exact df type tokens.
+For example, \fBtmpfs zfs\fR includes those types. Including remote
+filesystems also requires XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
 
 .IP XYMONCLIENT_FS_EXCLUDE_TYPES
 Whitespace-separated Linux filesystem types to exclude in addition
@@ -64,6 +64,8 @@ patches (such as Debian's) that do.
 Set to \fByes\fR (the default) to pass \fB\-l\fR to df and report
 local filesystems only. Set to \fBno\fR to report remote filesystems
 as well. Invalid values produce a warning and use the safe default.
+With \fBno\fR, df can hang for the whole client cycle if a remote mount
+is stale; use XYMONCLIENT_FS_DF_TIMEOUT to cap the wait.
 
 .IP XYMONCLIENT_FS_DF_TIMEOUT
 Positive integer seconds before timeout(1) sends SIGKILL to each df
@@ -75,9 +77,10 @@ invalid values produce a warning and also use the default. The timeout
 cannot be disabled through this setting and may be set up to a maximum
 of 3600 seconds. A process
 stuck in an uninterruptible kernel wait cannot be terminated until the
-kernel call returns. If timeout(1) has to kill df, the affected df and
-inode report is marked failed (yellow) instead of being left empty, so a
-hung filesystem is not silently reported green.
+kernel call returns. If df is killed on timeout, or otherwise exits
+non-zero while producing no output, the affected df or inode report is
+marked failed (yellow) instead of being left empty, so a hung or failed
+filesystem probe is not silently reported green.
 
 .IP XYMON
 Full path to the 

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -38,7 +38,7 @@ Directory used for temporary files. Default: $XYMONHOME/tmp/
 .IP XYMONCLIENT_FS_INCLUDE_TYPES
 Whitespace-separated Linux filesystem types to include in the
 client's disk and inode reports even when they are normally excluded
-as pseudo filesystems. For example, \fBtmpfs squashfs\fR includes
+as pseudo filesystems. For example, \fBtmpfs zfs\fR includes
 those types. Including remote filesystems also requires
 XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
 
@@ -47,9 +47,11 @@ Whitespace-separated Linux filesystem types to exclude in addition
 to the default pseudo-filesystem exclusions. If a type appears in
 both include and exclude settings, exclusion takes precedence.
 The default exclusion list is derived from the \fBnodev\fR entries in
-/proc/filesystems (rootfs is always kept). When /proc/filesystems is
-not readable the default filter is disabled and no filesystem types are
-excluded by default; the script does not fall back to deriving
+/proc/filesystems (rootfs is always kept), together with an explicit
+\fBiso9660\fR exclusion (iso9660 is not a nodev type). When
+/proc/filesystems is not readable the dynamic nodev exclusions are
+disabled; the explicit iso9660 exclusion and the local-only \fBdf \-l\fR
+behaviour remain active. The script does not fall back to deriving
 exclusions from mount(8), so it is not a drop-in replacement for distro
 patches (such as Debian's) that do.
 
@@ -62,8 +64,9 @@ as well. Invalid values produce a warning and use the safe default.
 Positive integer seconds before timeout(1) sends SIGKILL to each df
 invocation. The default is 30 seconds when timeout(1) is available.
 An empty or unset value falls back to the default; zero and other
-invalid values produce a warning and also use the default. The cap
-cannot be disabled, only raised, up to a maximum of 3600. A process
+invalid values produce a warning and also use the default. The timeout
+cannot be disabled through this setting and may be set up to a maximum
+of 3600 seconds. A process
 stuck in an uninterruptible kernel wait cannot be terminated until the
 kernel call returns. If timeout(1) has to kill df, the affected df and
 inode report is marked failed (yellow) instead of being left empty, so a

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -64,23 +64,15 @@ patches (such as Debian's) that do.
 Set to \fByes\fR (the default) to pass \fB\-l\fR to df and report
 local filesystems only. Set to \fBno\fR to report remote filesystems
 as well. Invalid values produce a warning and use the safe default.
-With \fBno\fR, df can hang for the whole client cycle if a remote mount
-is stale; use XYMONCLIENT_FS_DF_TIMEOUT to cap the wait.
-
-.IP XYMONCLIENT_FS_DF_TIMEOUT
-Positive integer seconds before timeout(1) sends SIGKILL to each df
-invocation. The disk and inode reports are two separate invocations, so
-two stale mounts can delay the client by up to twice this value.
-The default is 30 seconds when timeout(1) is available.
-An empty or unset value falls back to the default; zero and other
-invalid values produce a warning and also use the default. The timeout
-cannot be disabled through this setting and may be set up to a maximum
-of 3600 seconds. A process
-stuck in an uninterruptible kernel wait cannot be terminated until the
-kernel call returns. If df is killed on timeout, or otherwise exits
-non-zero while producing no output, the affected df or inode report is
-marked failed (yellow) instead of being left empty, so a hung or failed
-filesystem probe is not silently reported green.
+With \fBno\fR, a stale or hard-blocked remote mount can wedge df
+indefinitely (an uninterruptible D-state wait): the client run never
+finishes, so the whole host goes purple \(em no data for all metrics,
+not just disk \(em until the mount recovers or the host reboots.
+.IP
+A df that \fIexits\fR non-zero with no output (a real error, not a hang)
+is marked failed (yellow) rather than left empty, so a failed filesystem
+probe is not silently reported green. This does not cover the hang
+above: a wedged df never exits.
 
 .IP XYMON
 Full path to the 

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -38,8 +38,10 @@ Directory used for temporary files. Default: $XYMONHOME/tmp/
 .IP XYMONCLIENT_FS_INCLUDE_TYPES
 Whitespace-separated Linux filesystem types to include in the
 client's disk and inode reports even when they are normally excluded
-as pseudo filesystems. Types are matched as exact df type tokens.
-For example, \fBtmpfs zfs\fR includes those types. Including remote
+as pseudo (\fBnodev\fR) filesystems. Types are matched as exact df type
+tokens. Defaults to \fBzfs virtiofs tmpfs\fR \(em real local filesystems
+that merely happen to be flagged nodev. Set to "" to restore the
+historical behaviour of dropping every nodev type. Including remote
 filesystems also requires XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
 
 .IP XYMONCLIENT_FS_EXCLUDE_TYPES
@@ -51,14 +53,19 @@ default \(em a device-backed type, or a specific FUSE subtype such as
 \fBfuse.sshfs\fR that the bare nodev \fBfuse\fR default cannot match.
 If a type appears in
 both include and exclude settings, exclusion takes precedence.
-The default exclusion list is derived from the \fBnodev\fR entries in
-/proc/filesystems (rootfs is always kept), together with an explicit
-\fBiso9660\fR exclusion (iso9660 is not a nodev type). When
+Defaults to \fBiso9660 squashfs fuse.snapfuse\fR \(em read-only images
+reported 100% full by design (snaps mount as squashfs, or as
+fuse.snapfuse where snapd falls back to FUSE); none is a nodev type, so
+they must be named here. Set to "" to monitor these too.
+The full default exclusion list is the \fBnodev\fR entries in
+/proc/filesystems (rootfs is always kept, and the
+XYMONCLIENT_FS_INCLUDE_TYPES above are kept back), together with the
+explicit XYMONCLIENT_FS_EXCLUDE_TYPES above. When
 /proc/filesystems is not readable the dynamic nodev exclusions are
-disabled; the explicit iso9660 exclusion and the local-only \fBdf \-l\fR
-behaviour remain active. The script does not fall back to deriving
-exclusions from mount(8), so it is not a drop-in replacement for distro
-patches (such as Debian's) that do.
+disabled; the explicit XYMONCLIENT_FS_EXCLUDE_TYPES and the local-only
+\fBdf \-l\fR behaviour remain active. The script does not fall back to
+deriving exclusions from mount(8), so it is not a drop-in replacement for
+distro patches (such as Debian's) that do.
 
 .IP XYMONCLIENT_FS_DF_LOCAL_ONLY
 Set to \fByes\fR (the default) to pass \fB\-l\fR to df and report

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -44,7 +44,12 @@ XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
 
 .IP XYMONCLIENT_FS_EXCLUDE_TYPES
 Whitespace-separated Linux filesystem types to exclude in addition
-to the default pseudo-filesystem exclusions. If a type appears in
+to the default pseudo-filesystem exclusions. Matching is on the exact
+df type token, and nodev types (overlay, fuse, ...) are already excluded
+by default, so an effective entry names a type that is not a nodev
+default \(em a device-backed type, or a specific FUSE subtype such as
+\fBfuse.sshfs\fR that the bare nodev \fBfuse\fR default cannot match.
+If a type appears in
 both include and exclude settings, exclusion takes precedence.
 The default exclusion list is derived from the \fBnodev\fR entries in
 /proc/filesystems (rootfs is always kept), together with an explicit
@@ -62,7 +67,9 @@ as well. Invalid values produce a warning and use the safe default.
 
 .IP XYMONCLIENT_FS_DF_TIMEOUT
 Positive integer seconds before timeout(1) sends SIGKILL to each df
-invocation. The default is 30 seconds when timeout(1) is available.
+invocation. The disk and inode reports are two separate invocations, so
+two stale mounts can delay the client by up to twice this value.
+The default is 30 seconds when timeout(1) is available.
 An empty or unset value falls back to the default; zero and other
 invalid values produce a warning and also use the default. The timeout
 cannot be disabled through this setting and may be set up to a maximum

--- a/docs/manpages/man5/xymonclient.cfg.5.html
+++ b/docs/manpages/man5/xymonclient.cfg.5.html
@@ -57,7 +57,12 @@ XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
 <P>
 <DT>XYMONCLIENT_FS_EXCLUDE_TYPES<DD>
 Whitespace-separated Linux filesystem types to exclude in addition
-to the default pseudo-filesystem exclusions. If a type appears in
+to the default pseudo-filesystem exclusions. Matching is on the exact
+df type token, and nodev types (overlay, fuse, ...) are already excluded
+by default, so an effective entry names a type that is not a nodev
+default &mdash; a device-backed type, or a specific FUSE subtype such as
+<B>fuse.sshfs</B> that the bare nodev <B>fuse</B> default cannot match.
+If a type appears in
 both include and exclude settings, exclusion takes precedence.
 The default exclusion list is derived from the <B>nodev</B> entries in
 /proc/filesystems (rootfs is always kept), together with an explicit
@@ -75,7 +80,9 @@ as well. Invalid values produce a warning and use the safe default.
 <P>
 <DT>XYMONCLIENT_FS_DF_TIMEOUT<DD>
 Positive integer seconds before timeout(1) sends SIGKILL to each df
-invocation. The default is 30 seconds when timeout(1) is available.
+invocation. The disk and inode reports are two separate invocations, so
+two stale mounts can delay the client by up to twice this value.
+The default is 30 seconds when timeout(1) is available.
 An empty or unset value falls back to the default; zero and other
 invalid values produce a warning and also use the default. The timeout
 cannot be disabled through this setting and may be set up to a maximum

--- a/docs/manpages/man5/xymonclient.cfg.5.html
+++ b/docs/manpages/man5/xymonclient.cfg.5.html
@@ -48,6 +48,40 @@ $XYMONHOME/logs
 <DT>XYMONTMP<DD>
 Directory used for temporary files. Default: $XYMONHOME/tmp/
 <P>
+<DT>XYMONCLIENT_FS_INCLUDE_TYPES<DD>
+Whitespace-separated Linux filesystem types to include in the
+client's disk and inode reports even when they are normally excluded
+as pseudo filesystems. For example, <B>tmpfs squashfs</B> includes
+those types. Including remote filesystems also requires
+XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
+<P>
+<DT>XYMONCLIENT_FS_EXCLUDE_TYPES<DD>
+Whitespace-separated Linux filesystem types to exclude in addition
+to the default pseudo-filesystem exclusions. If a type appears in
+both include and exclude settings, exclusion takes precedence.
+The default exclusion list is derived from the <B>nodev</B> entries in
+/proc/filesystems (rootfs is always kept). When /proc/filesystems is
+not readable the default filter is disabled and no filesystem types are
+excluded by default; the script does not fall back to deriving
+exclusions from mount(8), so it is not a drop-in replacement for distro
+patches (such as Debian's) that do.
+<P>
+<DT>XYMONCLIENT_FS_DF_LOCAL_ONLY<DD>
+Set to <B>yes</B> (the default) to pass <B>-l</B> to df and report
+local filesystems only. Set to <B>no</B> to report remote filesystems
+as well. Invalid values produce a warning and use the safe default.
+<P>
+<DT>XYMONCLIENT_FS_DF_TIMEOUT<DD>
+Positive integer seconds before timeout(1) sends SIGKILL to each df
+invocation. The default is 30 seconds when timeout(1) is available.
+An empty or unset value falls back to the default; zero and other
+invalid values produce a warning and also use the default. The cap
+cannot be disabled, only raised, up to a maximum of 3600. A process
+stuck in an uninterruptible kernel wait cannot be terminated until the
+kernel call returns. If timeout(1) has to kill df, the affected df and
+inode report is marked failed (yellow) instead of being left empty, so a
+hung filesystem is not silently reported green.
+<P>
 <DT>XYMON<DD>
 Full path to the 
 <I><A HREF="../man1/xymon.1.html">xymon</A>(1)</I>

--- a/docs/manpages/man5/xymonclient.cfg.5.html
+++ b/docs/manpages/man5/xymonclient.cfg.5.html
@@ -51,9 +51,9 @@ Directory used for temporary files. Default: $XYMONHOME/tmp/
 <DT>XYMONCLIENT_FS_INCLUDE_TYPES<DD>
 Whitespace-separated Linux filesystem types to include in the
 client's disk and inode reports even when they are normally excluded
-as pseudo filesystems. For example, <B>tmpfs zfs</B> includes
-those types. Including remote filesystems also requires
-XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
+as pseudo filesystems. Types are matched as exact df type tokens.
+For example, <B>tmpfs zfs</B> includes those types. Including remote
+filesystems also requires XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
 <P>
 <DT>XYMONCLIENT_FS_EXCLUDE_TYPES<DD>
 Whitespace-separated Linux filesystem types to exclude in addition
@@ -77,6 +77,8 @@ patches (such as Debian's) that do.
 Set to <B>yes</B> (the default) to pass <B>-l</B> to df and report
 local filesystems only. Set to <B>no</B> to report remote filesystems
 as well. Invalid values produce a warning and use the safe default.
+With <B>no</B>, df can hang for the whole client cycle if a remote mount
+is stale; use XYMONCLIENT_FS_DF_TIMEOUT to cap the wait.
 <P>
 <DT>XYMONCLIENT_FS_DF_TIMEOUT<DD>
 Positive integer seconds before timeout(1) sends SIGKILL to each df
@@ -88,9 +90,10 @@ invalid values produce a warning and also use the default. The timeout
 cannot be disabled through this setting and may be set up to a maximum
 of 3600 seconds. A process
 stuck in an uninterruptible kernel wait cannot be terminated until the
-kernel call returns. If timeout(1) has to kill df, the affected df and
-inode report is marked failed (yellow) instead of being left empty, so a
-hung filesystem is not silently reported green.
+kernel call returns. If df is killed on timeout, or otherwise exits
+non-zero while producing no output, the affected df or inode report is
+marked failed (yellow) instead of being left empty, so a hung or failed
+filesystem probe is not silently reported green.
 <P>
 <DT>XYMON<DD>
 Full path to the 

--- a/docs/manpages/man5/xymonclient.cfg.5.html
+++ b/docs/manpages/man5/xymonclient.cfg.5.html
@@ -51,8 +51,10 @@ Directory used for temporary files. Default: $XYMONHOME/tmp/
 <DT>XYMONCLIENT_FS_INCLUDE_TYPES<DD>
 Whitespace-separated Linux filesystem types to include in the
 client's disk and inode reports even when they are normally excluded
-as pseudo filesystems. Types are matched as exact df type tokens.
-For example, <B>tmpfs zfs</B> includes those types. Including remote
+as pseudo (<B>nodev</B>) filesystems. Types are matched as exact df type
+tokens. Defaults to <B>zfs virtiofs tmpfs</B> &mdash; real local filesystems
+that merely happen to be flagged nodev. Set to "" to restore the
+historical behaviour of dropping every nodev type. Including remote
 filesystems also requires XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
 <P>
 <DT>XYMONCLIENT_FS_EXCLUDE_TYPES<DD>
@@ -64,14 +66,19 @@ default &mdash; a device-backed type, or a specific FUSE subtype such as
 <B>fuse.sshfs</B> that the bare nodev <B>fuse</B> default cannot match.
 If a type appears in
 both include and exclude settings, exclusion takes precedence.
-The default exclusion list is derived from the <B>nodev</B> entries in
-/proc/filesystems (rootfs is always kept), together with an explicit
-<B>iso9660</B> exclusion (iso9660 is not a nodev type). When
+Defaults to <B>iso9660 squashfs fuse.snapfuse</B> &mdash; read-only images
+reported 100% full by design (snaps mount as squashfs, or as
+fuse.snapfuse where snapd falls back to FUSE); none is a nodev type, so
+they must be named here. Set to "" to monitor these too.
+The full default exclusion list is the <B>nodev</B> entries in
+/proc/filesystems (rootfs is always kept, and the
+XYMONCLIENT_FS_INCLUDE_TYPES above are kept back), together with the
+explicit XYMONCLIENT_FS_EXCLUDE_TYPES above. When
 /proc/filesystems is not readable the dynamic nodev exclusions are
-disabled; the explicit iso9660 exclusion and the local-only <B>df -l</B>
-behaviour remain active. The script does not fall back to deriving
-exclusions from mount(8), so it is not a drop-in replacement for distro
-patches (such as Debian's) that do.
+disabled; the explicit XYMONCLIENT_FS_EXCLUDE_TYPES and the local-only
+<B>df -l</B> behaviour remain active. The script does not fall back to
+deriving exclusions from mount(8), so it is not a drop-in replacement for
+distro patches (such as Debian's) that do.
 <P>
 <DT>XYMONCLIENT_FS_DF_LOCAL_ONLY<DD>
 Set to <B>yes</B> (the default) to pass <B>-l</B> to df and report

--- a/docs/manpages/man5/xymonclient.cfg.5.html
+++ b/docs/manpages/man5/xymonclient.cfg.5.html
@@ -51,7 +51,7 @@ Directory used for temporary files. Default: $XYMONHOME/tmp/
 <DT>XYMONCLIENT_FS_INCLUDE_TYPES<DD>
 Whitespace-separated Linux filesystem types to include in the
 client's disk and inode reports even when they are normally excluded
-as pseudo filesystems. For example, <B>tmpfs squashfs</B> includes
+as pseudo filesystems. For example, <B>tmpfs zfs</B> includes
 those types. Including remote filesystems also requires
 XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
 <P>
@@ -60,9 +60,11 @@ Whitespace-separated Linux filesystem types to exclude in addition
 to the default pseudo-filesystem exclusions. If a type appears in
 both include and exclude settings, exclusion takes precedence.
 The default exclusion list is derived from the <B>nodev</B> entries in
-/proc/filesystems (rootfs is always kept). When /proc/filesystems is
-not readable the default filter is disabled and no filesystem types are
-excluded by default; the script does not fall back to deriving
+/proc/filesystems (rootfs is always kept), together with an explicit
+<B>iso9660</B> exclusion (iso9660 is not a nodev type). When
+/proc/filesystems is not readable the dynamic nodev exclusions are
+disabled; the explicit iso9660 exclusion and the local-only <B>df -l</B>
+behaviour remain active. The script does not fall back to deriving
 exclusions from mount(8), so it is not a drop-in replacement for distro
 patches (such as Debian's) that do.
 <P>
@@ -75,8 +77,9 @@ as well. Invalid values produce a warning and use the safe default.
 Positive integer seconds before timeout(1) sends SIGKILL to each df
 invocation. The default is 30 seconds when timeout(1) is available.
 An empty or unset value falls back to the default; zero and other
-invalid values produce a warning and also use the default. The cap
-cannot be disabled, only raised, up to a maximum of 3600. A process
+invalid values produce a warning and also use the default. The timeout
+cannot be disabled through this setting and may be set up to a maximum
+of 3600 seconds. A process
 stuck in an uninterruptible kernel wait cannot be terminated until the
 kernel call returns. If timeout(1) has to kill df, the affected df and
 inode report is marked failed (yellow) instead of being left empty, so a

--- a/docs/manpages/man5/xymonclient.cfg.5.html
+++ b/docs/manpages/man5/xymonclient.cfg.5.html
@@ -77,23 +77,15 @@ patches (such as Debian's) that do.
 Set to <B>yes</B> (the default) to pass <B>-l</B> to df and report
 local filesystems only. Set to <B>no</B> to report remote filesystems
 as well. Invalid values produce a warning and use the safe default.
-With <B>no</B>, df can hang for the whole client cycle if a remote mount
-is stale; use XYMONCLIENT_FS_DF_TIMEOUT to cap the wait.
+With <B>no</B>, a stale or hard-blocked remote mount can wedge df
+indefinitely (an uninterruptible D-state wait): the client run never
+finishes, so the whole host goes purple &mdash; no data for all metrics,
+not just disk &mdash; until the mount recovers or the host reboots.
 <P>
-<DT>XYMONCLIENT_FS_DF_TIMEOUT<DD>
-Positive integer seconds before timeout(1) sends SIGKILL to each df
-invocation. The disk and inode reports are two separate invocations, so
-two stale mounts can delay the client by up to twice this value.
-The default is 30 seconds when timeout(1) is available.
-An empty or unset value falls back to the default; zero and other
-invalid values produce a warning and also use the default. The timeout
-cannot be disabled through this setting and may be set up to a maximum
-of 3600 seconds. A process
-stuck in an uninterruptible kernel wait cannot be terminated until the
-kernel call returns. If df is killed on timeout, or otherwise exits
-non-zero while producing no output, the affected df or inode report is
-marked failed (yellow) instead of being left empty, so a hung or failed
-filesystem probe is not silently reported green.
+A df that <I>exits</I> non-zero with no output (a real error, not a hang)
+is marked failed (yellow) rather than left empty, so a failed filesystem
+probe is not silently reported green. This does not cover the hang above:
+a wedged df never exits.
 <P>
 <DT>XYMON<DD>
 Full path to the 

--- a/tests/client/fs-filter.sh
+++ b/tests/client/fs-filter.sh
@@ -10,7 +10,7 @@
 #   XYMONCLIENT_FS_INCLUDE_TYPES   types to un-exclude (e.g. tmpfs)
 #   XYMONCLIENT_FS_EXCLUDE_TYPES   additional types to exclude
 #   XYMONCLIENT_FS_DF_LOCAL_ONLY   yes (default, df -l) vs no
-#   XYMONCLIENT_FS_DF_TIMEOUT      seconds (default 30) or "" to disable
+#   XYMONCLIENT_FS_DF_TIMEOUT      seconds (default 30); empty/invalid -> 30
 #
 # The script reads /proc/filesystems directly and shells out to df.
 # To test in isolation we extract the [df] section from the script,
@@ -128,17 +128,16 @@ echo "/dev/sda1"
 EOF
 chmod +x "$STUB/readlink"
 
-# timeout stub: #49 wraps df in `timeout <n>s df ...` (default 30s) so df
-# can't hang forever on a stale NFS/CIFS mount. timeout exec's df with the
-# same argv, so the df stub above cannot tell whether it was wrapped --
-# record here the duration timeout was handed, then exec the wrapped command
-# so every df assertion above still holds with the wrapper active.
+# timeout stub: #49 wraps df in `timeout -s KILL <n>s df ...` (default 30s).
+# timeout exec's df with the same argv, so the df stub above cannot tell
+# whether it was wrapped. Record the timeout options, then exec the wrapped
+# command so every df assertion above still holds with the wrapper active.
 TIMEOUT_LOG="$TMP/timeout.args"
 STDERR_LOG="$TMP/stderr"
 cat > "$STUB/timeout" <<EOF
 #!/usr/bin/env bash
-echo "\$1" >> "$TIMEOUT_LOG"
-shift
+echo "\$1 \$2 \$3" >> "$TIMEOUT_LOG"
+shift 3
 exec "\$@"
 EOF
 chmod +x "$STUB/timeout"
@@ -247,6 +246,15 @@ assert_contains " -x fuse.* " "$args" \
 assert_not_contains " -x fuse.sshfs " "$args" \
 	"exclude type glob must not expand to a working-directory filename"
 
+# --- include + exclude precedence: exclude wins -----------------------------
+#
+# INCLUDE is applied first (un-excludes the type), then EXCLUDE re-adds it,
+# so a type named in both lists stays excluded -- the documented contract
+# ("If a type appears in both lists, EXCLUDE wins").
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=tmpfs XYMONCLIENT_FS_EXCLUDE_TYPES=tmpfs run_snippet)
+assert_contains " -x tmpfs " "$args" \
+	"a type in both include and exclude lists must stay excluded (exclude wins)"
+
 # --- XYMONCLIENT_FS_DF_LOCAL_ONLY=no drops the -l flag ----------------------
 
 args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=no run_snippet)
@@ -263,31 +271,31 @@ assert_contains " -l " "$args" \
 assert_contains "invalid XYMONCLIENT_FS_DF_LOCAL_ONLY" "$(cat "$STDERR_LOG")" \
 	"invalid DF_LOCAL_ONLY value must produce a warning"
 
-# --- XYMONCLIENT_FS_DF_TIMEOUT wraps df in `timeout <n>s` --------------------
+# --- XYMONCLIENT_FS_DF_TIMEOUT wraps df in timeout with SIGKILL ---------------
 #
 # df can hang on stale NFS/CIFS mounts, so #49 runs it under timeout(1).
-# TIMEOUT_LOG holds the duration the timeout stub was handed (empty if df
+# TIMEOUT_LOG holds the options the timeout stub was handed (empty if df
 # was invoked directly). Assertions read the log after each run rather than
 # the returned df args, since the wrapper is invisible at the df layer.
 
-# Default (variable unset): df is wrapped in `timeout 30s`.
+# Default (variable unset): df is wrapped in `timeout -s KILL 30s`.
 run_snippet >/dev/null
-assert_equal "30s" "$(cat "$TIMEOUT_LOG")" \
-	"default must wrap df in 'timeout 30s'"
+assert_equal "-s KILL 30s" "$(cat "$TIMEOUT_LOG")" \
+	"default must wrap df in 'timeout -s KILL 30s'"
 
 # A custom value is honoured verbatim.
 XYMONCLIENT_FS_DF_TIMEOUT=5 run_snippet >/dev/null
-assert_equal "5s" "$(cat "$TIMEOUT_LOG")" \
-	"XYMONCLIENT_FS_DF_TIMEOUT=5 must wrap df in 'timeout 5s'"
+assert_equal "-s KILL 5s" "$(cat "$TIMEOUT_LOG")" \
+	"XYMONCLIENT_FS_DF_TIMEOUT=5 must wrap df in 'timeout -s KILL 5s'"
 
 # Empty string falls back to the default: the cap cannot be disabled.
 XYMONCLIENT_FS_DF_TIMEOUT="" run_snippet >/dev/null
-assert_equal "30s" "$(cat "$TIMEOUT_LOG")" \
+assert_equal "-s KILL 30s" "$(cat "$TIMEOUT_LOG")" \
 	'XYMONCLIENT_FS_DF_TIMEOUT="" must fall back to the default timeout'
 
 # Invalid values must not prevent df from running.
 XYMONCLIENT_FS_DF_TIMEOUT=invalid run_snippet >/dev/null
-assert_equal "30s" "$(cat "$TIMEOUT_LOG")" \
+assert_equal "-s KILL 30s" "$(cat "$TIMEOUT_LOG")" \
 	"invalid XYMONCLIENT_FS_DF_TIMEOUT must fall back to 30 seconds"
 assert_contains "invalid XYMONCLIENT_FS_DF_TIMEOUT" "$(cat "$STDERR_LOG")" \
 	"invalid timeout value must produce a warning"
@@ -295,10 +303,51 @@ assert_contains "invalid XYMONCLIENT_FS_DF_TIMEOUT" "$(cat "$STDERR_LOG")" \
 # Zero has incompatible semantics across timeout implementations (disabled by
 # GNU coreutils, immediate timeout by BusyBox), so it must use the safe default.
 XYMONCLIENT_FS_DF_TIMEOUT=0 run_snippet >/dev/null
-assert_equal "30s" "$(cat "$TIMEOUT_LOG")" \
+assert_equal "-s KILL 30s" "$(cat "$TIMEOUT_LOG")" \
 	"XYMONCLIENT_FS_DF_TIMEOUT=0 must fall back to 30 seconds"
 assert_contains "invalid XYMONCLIENT_FS_DF_TIMEOUT" "$(cat "$STDERR_LOG")" \
 	"zero timeout value must produce a warning"
+
+# Values past the 3600s ceiling are clamped: an out-of-range duration makes
+# BusyBox timeout(1) exit nonzero before df runs, which would silently empty
+# both the df and inode sections.
+XYMONCLIENT_FS_DF_TIMEOUT=99999 run_snippet >/dev/null
+assert_equal "-s KILL 3600s" "$(cat "$TIMEOUT_LOG")" \
+	"timeout above 3600 must be clamped to 3600"
+assert_contains "exceeds 3600" "$(cat "$STDERR_LOG")" \
+	"clamped timeout must produce a warning"
+
+# An absurdly long digit string must clamp too, without overflowing the
+# shell's integer arithmetic in the range check.
+XYMONCLIENT_FS_DF_TIMEOUT=18446744073709551616 run_snippet >/dev/null
+assert_equal "-s KILL 3600s" "$(cat "$TIMEOUT_LOG")" \
+	"oversized timeout must clamp to 3600 without an arithmetic error"
+
+# The 3600s ceiling itself is honoured verbatim (boundary).
+XYMONCLIENT_FS_DF_TIMEOUT=3600 run_snippet >/dev/null
+assert_equal "-s KILL 3600s" "$(cat "$TIMEOUT_LOG")" \
+	"3600 is the maximum and must pass through unchanged"
+
+# Leading zeros are decimal, not octal, and must not trip the length-based
+# clamp: 00001 is one second, not an over-length (5-char) string that the
+# guard would otherwise force to 3600 -- a 3600x inflation of the operator's
+# intended timeout.
+XYMONCLIENT_FS_DF_TIMEOUT=00001 run_snippet >/dev/null
+assert_equal "-s KILL 1s" "$(cat "$TIMEOUT_LOG")" \
+	"leading-zero 00001 must normalize to 1 second, not clamp to 3600"
+
+XYMONCLIENT_FS_DF_TIMEOUT=000030 run_snippet >/dev/null
+assert_equal "-s KILL 30s" "$(cat "$TIMEOUT_LOG")" \
+	"leading-zero 000030 must normalize to 30 seconds"
+
+# A leading-zero value at/above the ceiling still clamps on magnitude.
+XYMONCLIENT_FS_DF_TIMEOUT=03600 run_snippet >/dev/null
+assert_equal "-s KILL 3600s" "$(cat "$TIMEOUT_LOG")" \
+	"leading-zero 03600 must normalize to the 3600 boundary"
+
+XYMONCLIENT_FS_DF_TIMEOUT=03601 run_snippet >/dev/null
+assert_equal "-s KILL 3600s" "$(cat "$TIMEOUT_LOG")" \
+	"leading-zero 03601 must clamp to 3600"
 
 # --- [inode] report must be filtered the same way as [df] -------------------
 #
@@ -345,3 +394,37 @@ assert_contains "xymonclient-linux:" "$(cat "$TMP/stderr")" \
 	"warning must be tagged so it's identifiable in client logs"
 assert_contains     " -x iso9660 " "$args" "iso9660 must still be excluded"
 assert_not_contains " -x sysfs "   "$args" "no nodev excludes when /proc/filesystems unreadable"
+
+# --- timeout(1) absent: df runs unwrapped, never errors ---------------------
+#
+# When no timeout(1) is on PATH the script must fall back to the
+# `else df "$@"` branch rather than failing. Build a PATH holding the df and
+# readlink stubs plus the real interpreters/tools the snippet needs, but NO
+# timeout, and confirm df still receives the full argv while TIMEOUT_LOG
+# stays empty. (The default PATH always has a real /usr/bin/timeout, so this
+# branch is otherwise never exercised.)
+NOTIMEOUT="$TMP/bin-notimeout"
+mkdir -p "$NOTIMEOUT"
+ln -s "$STUB/df" "$NOTIMEOUT/df"
+ln -s "$STUB/readlink" "$NOTIMEOUT/readlink"
+# sh/bash run the snippet and the bash-shebang stubs; awk/sed are used inside
+# the [df] block. Anything missing here would fail for a reason unrelated to
+# the timeout fallback, so resolve each from the real PATH up front.
+for prog in sh bash awk sed; do
+	p=$(command -v "$prog") || fail "no-timeout test needs '$prog' on PATH"
+	ln -s "$p" "$NOTIMEOUT/$prog"
+done
+: > "$DF_LOG"
+: > "$TIMEOUT_LOG"
+: > "$STDERR_LOG"
+(
+	cd "$TMP"
+	PATH="$NOTIMEOUT" /bin/sh "$SNIPPET" >/dev/null 2>"$STDERR_LOG"
+)
+args=$(printf ' %s ' "$(cat "$DF_LOG")")
+assert_contains " -x iso9660 " "$args" \
+	"df must still run when timeout(1) is absent"
+assert_contains " -x tmpfs " "$args" \
+	"nodev excludes must still apply when timeout(1) is absent"
+assert_equal "" "$(cat "$TIMEOUT_LOG")" \
+	"timeout wrapper must be skipped when timeout(1) is absent"

--- a/tests/client/fs-filter.sh
+++ b/tests/client/fs-filter.sh
@@ -196,6 +196,7 @@ assert_contains " -P "        "$args" "default must pass -P to df"
 assert_contains " -l "        "$args" "default must pass -l to df (local only)"
 assert_contains " -x iso9660 " "$args" "default must exclude iso9660 (always-full image)"
 assert_contains " -x squashfs " "$args" "default must exclude squashfs (always-full image)"
+assert_contains " -x fuse.snapfuse " "$args" "default must exclude fuse.snapfuse (snap FUSE image, always 100%)"
 assert_contains " -x sysfs "  "$args" "default must exclude sysfs (pseudo nodev)"
 assert_contains " -x overlay " "$args" "default must exclude overlay (pseudo nodev)"
 assert_contains " -x nfs "    "$args" "default must exclude nfs (pseudo nodev)"
@@ -516,3 +517,48 @@ assert_contains "Inode collection failed: df exited 127" "$fail_out" \
 	"a nonzero df with empty output must emit an inode failure marker (empty inode reads as green)"
 assert_not_contains "Capacity" "$fail_out" \
 	"failed-df output must not contain df headers that could parse as a healthy report"
+
+# --- inode report drops filesystems with no inode limit (df prints "-") -------
+#
+# btrfs/zfs/9p/many-fuse have no fixed inode table; df -i prints "-" in the
+# IUse% column (and sometimes bogus counts, e.g. a negative IUsed on 9p). Such a
+# filesystem can never run out of inodes, so emit_df must drop it from the
+# [inode] report -- while its disk row (a real %) stays in [df]. Drive the
+# combined block with a df stub that returns a "-" inode row for "dynfs".
+INODEDIR="$TMP/bin-inode"
+mkdir -p "$INODEDIR"
+cat > "$INODEDIR/df" <<'EOF'
+#!/bin/sh
+case " $* " in
+  *" -i "*)
+	printf 'Filesystem Inodes IUsed IFree IUse%% Mounted on\n'
+	printf '/dev/sda1 1000 100 900 10%% /\n'
+	printf 'dynfs 0 0 0 - /data\n'
+	;;
+  *)
+	printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+	printf '/dev/sda1 1000000 500000 500000 50%% /\n'
+	printf 'dynfs 2000 1000 1000 50%% /data\n'
+	;;
+esac
+EOF
+chmod +x "$INODEDIR/df"
+ln -s "$STUB/readlink" "$INODEDIR/readlink"
+ln -s "$STUB/timeout"  "$INODEDIR/timeout"
+for prog in sh bash awk sed; do
+	p=$(PATH="$REALPATH" command -v "$prog") \
+		|| fail "inode-drop test needs a real '$prog' on PATH"
+	ln -s "$p" "$INODEDIR/$prog"
+done
+
+inode_out=$(
+	cd "$TMP"
+	PATH="$INODEDIR" /bin/sh "$COMBINED" 2>/dev/null
+)
+inode_section=$(printf '%s\n' "$inode_out" | sed -n '/^\[inode\]/,$p')
+assert_contains     "/dev/sda1" "$inode_section" \
+	"inode report keeps a normal filesystem"
+assert_not_contains "dynfs" "$inode_section" \
+	"inode report drops a no-inode-limit filesystem (IUse% '-')"
+assert_contains "dynfs" "$inode_out" \
+	"the same filesystem still appears in [df] (it has a real disk %)"

--- a/tests/client/fs-filter.sh
+++ b/tests/client/fs-filter.sh
@@ -44,13 +44,10 @@ if [ ! -f "$SCRIPT" ]; then
 	[ -z "${XYMONCLIENT_LINUX:-}" ] || fail "XYMONCLIENT_LINUX explicitly set to '$SCRIPT' but no such file -- broken package layout, not a skip"
 	skip "$SCRIPT missing"
 fi
-# The #49 env-var FS filter is a separate feature (PR #96) that is not yet
-# merged into this branch, so its absence here is "feature not landed", not a
-# regression of in-tree code -- this guard skips green until #49 arrives, then
-# starts exercising the env-var logic, including the [inode] block guarded
-# alongside the [df] block below.
-grep -q XYMONCLIENT_FS_INCLUDE_TYPES "$SCRIPT" \
-	|| skip "xymonclient-linux.sh has no #49 env-var FS filter yet (PR #96 not in this branch)"
+# The #49 env-var FS filter has landed (PR #96), so this is now a real
+# regression guard: if the env-var logic ever disappears from the script the
+# assertions below must FAIL, not skip. Do not reinstate a "feature not landed"
+# skip here -- absence of the filter is a regression, per tests/README.md.
 
 TMP=$(mktempdir)
 
@@ -428,3 +425,89 @@ assert_contains " -x tmpfs " "$args" \
 	"nodev excludes must still apply when timeout(1) is absent"
 assert_equal "" "$(cat "$TIMEOUT_LOG")" \
 	"timeout wrapper must be skipped when timeout(1) is absent"
+
+# --- a hung df must yellow, never false-green --------------------------------
+#
+# Regression for the inode false-green (xymon-monitoring/xymon#96 review): when
+# df hangs on a stale mount, timeout(1) kills it (exit 137 under -s KILL) and df
+# emits nothing. The server reads an *empty* [inode] section as green ("No
+# filesystems reporting inode data"), so the collection failure must instead
+# surface as a non-empty marker line the server cannot mistake for a healthy
+# report. Unlike the argv-only assertions above, this drives the REAL timeout(1)
+# against a df stub that sleeps past a 1s deadline -- only the genuine kill path
+# proves the right payload is emitted.
+HANGDIR="$TMP/bin-hang"
+mkdir -p "$HANGDIR"
+# df stub that hangs: sleep well past the 1s deadline, so the header below is
+# never printed and timeout must SIGKILL it.
+cat > "$HANGDIR/df" <<'EOF'
+#!/usr/bin/env bash
+sleep 5
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+EOF
+chmod +x "$HANGDIR/df"
+ln -s "$STUB/readlink" "$HANGDIR/readlink"
+# Resolve the REAL timeout/sleep (and shells/tools) from the PATH as it was
+# before $STUB was prepended -- a plain `command -v timeout` would find the
+# argv-recording timeout stub above, which exec's df without enforcing any
+# deadline, so df would never be killed and this test would silently pass even
+# if the guard regressed.
+REALPATH=${PATH#"$STUB:"}
+for prog in sh bash awk sed timeout sleep; do
+	p=$(PATH="$REALPATH" command -v "$prog") \
+		|| fail "sleeping-df test needs a real '$prog' on PATH"
+	ln -s "$p" "$HANGDIR/$prog"
+done
+
+# Run the combined [df]+[inode] block with a 1s cap; both df invocations hang
+# and are killed, so the block should take ~2s and emit two markers.
+hang_out=$(
+	cd "$TMP"
+	PATH="$HANGDIR" XYMONCLIENT_FS_DF_TIMEOUT=1 /bin/sh "$COMBINED" 2>/dev/null
+)
+assert_contains "Disk collection failed: df timed out" "$hang_out" \
+	"a hung df must emit an explicit disk failure marker, not an empty section"
+assert_contains "Inode collection failed: df timed out" "$hang_out" \
+	"a hung df must emit an explicit inode failure marker (an empty inode section reads as green)"
+# The marker carries none of df's column headers, so the server's header
+# detection fails and the section yellows rather than greens. If "Capacity"
+# leaked through, df had printed real output and the kill path was not taken.
+assert_not_contains "Capacity" "$hang_out" \
+	"hung-df output must not contain df headers that could parse as a healthy report"
+
+# --- a non-kill df failure with empty output must yellow too -----------------
+#
+# Regression for the second inode false-green (xymon-monitoring/xymon#96
+# review): the kill codes 124/137 are not the only way to get a nonzero exit
+# with no output. timeout(1) itself can fail to launch df -- status 125 (timeout
+# error), 126 (df not invocable), 127 (df not found) -- and a BusyBox timeout
+# rejecting its duration exits nonzero before df runs. Each leaves an empty
+# section the server reads as green. emit_df must surface ANY nonzero exit with
+# empty output as a failure marker, not just the kill codes. Drive this with the
+# argv-recording timeout stub (it exec's df, preserving df's exit status) and a
+# df stub that exits 127 while printing nothing.
+FAILDIR="$TMP/bin-fail"
+mkdir -p "$FAILDIR"
+cat > "$FAILDIR/df" <<'EOF'
+#!/usr/bin/env bash
+exit 127
+EOF
+chmod +x "$FAILDIR/df"
+ln -s "$STUB/readlink" "$FAILDIR/readlink"
+ln -s "$STUB/timeout"  "$FAILDIR/timeout"
+for prog in sh bash awk sed; do
+	p=$(PATH="$REALPATH" command -v "$prog") \
+		|| fail "failing-df test needs a real '$prog' on PATH"
+	ln -s "$p" "$FAILDIR/$prog"
+done
+
+fail_out=$(
+	cd "$TMP"
+	PATH="$FAILDIR" /bin/sh "$COMBINED" 2>/dev/null
+)
+assert_contains "Disk collection failed: df exited 127" "$fail_out" \
+	"a nonzero df with empty output must emit a disk failure marker, not an empty section"
+assert_contains "Inode collection failed: df exited 127" "$fail_out" \
+	"a nonzero df with empty output must emit an inode failure marker (empty inode reads as green)"
+assert_not_contains "Capacity" "$fail_out" \
+	"failed-df output must not contain df headers that could parse as a healthy report"

--- a/tests/client/fs-filter.sh
+++ b/tests/client/fs-filter.sh
@@ -71,6 +71,11 @@ nodev	nfs4
 nodev	rootfs
 EOF
 
+# Matching filenames expose accidental pathname expansion of configured
+# filesystem type tokens when snippets run with $TMP as their working directory.
+: > "$TMP/tmpfs"
+: > "$TMP/fuse.sshfs"
+
 # Extract just the [df] block from xymonclient-linux.sh and rewrite the
 # /proc/filesystems reference. Drop the trailing `echo "[inode]"` line with
 # `sed '$d'` (portable last-line delete; `head -n -1` is a GNU extension and
@@ -129,6 +134,7 @@ chmod +x "$STUB/readlink"
 # record here the duration timeout was handed, then exec the wrapped command
 # so every df assertion above still holds with the wrapper active.
 TIMEOUT_LOG="$TMP/timeout.args"
+STDERR_LOG="$TMP/stderr"
 cat > "$STUB/timeout" <<EOF
 #!/usr/bin/env bash
 echo "\$1" >> "$TIMEOUT_LOG"
@@ -151,7 +157,11 @@ run_snippet() {
 	: > "$DF_LOG"
 	: > "$INODE_LOG"
 	: > "$TIMEOUT_LOG"
-	/bin/sh "$SNIPPET" >/dev/null 2>&1
+	: > "$STDERR_LOG"
+	(
+		cd "$TMP"
+		/bin/sh "$SNIPPET" >/dev/null 2>"$STDERR_LOG"
+	)
 	# Pad with spaces so substring assertions for " -x tmpfs " work even
 	# at the ends of the line.
 	printf ' %s ' "$(cat "$DF_LOG")"
@@ -164,7 +174,11 @@ run_inode() {
 	: > "$DF_LOG"
 	: > "$INODE_LOG"
 	: > "$TIMEOUT_LOG"
-	/bin/sh "$COMBINED" >/dev/null 2>&1
+	: > "$STDERR_LOG"
+	(
+		cd "$TMP"
+		/bin/sh "$COMBINED" >/dev/null 2>"$STDERR_LOG"
+	)
 	printf ' %s ' "$(cat "$INODE_LOG")"
 }
 
@@ -204,6 +218,12 @@ assert_not_contains " -x tmpfs "   "$args" "multi-include must drop tmpfs"
 assert_not_contains " -x overlay " "$args" "multi-include must drop overlay"
 assert_contains     " -x sysfs "   "$args" "multi-include must leave sysfs"
 
+# Type tokens are literal, not shell globs. The matching $TMP/tmpfs file must
+# not turn "tmp*" into "tmpfs" and accidentally un-exclude tmpfs.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES='tmp*' run_snippet)
+assert_contains " -x tmpfs " "$args" \
+	"include type tokens must not undergo pathname expansion"
+
 # --- XYMONCLIENT_FS_EXCLUDE_TYPES adds extra exclusions ---------------------
 
 args=$(XYMONCLIENT_FS_EXCLUDE_TYPES=ext4 run_snippet)
@@ -220,6 +240,13 @@ tmpfs_count=$((tmpfs_count))
 assert_equal 1 "$tmpfs_count" \
 	"XYMONCLIENT_FS_EXCLUDE_TYPES=tmpfs must not duplicate an existing exclude"
 
+# The matching $TMP/fuse.sshfs file must not rewrite the configured literal.
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES='fuse.*' run_snippet)
+assert_contains " -x fuse.* " "$args" \
+	"exclude type tokens must not undergo pathname expansion"
+assert_not_contains " -x fuse.sshfs " "$args" \
+	"exclude type glob must not expand to a working-directory filename"
+
 # --- XYMONCLIENT_FS_DF_LOCAL_ONLY=no drops the -l flag ----------------------
 
 args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=no run_snippet)
@@ -228,6 +255,13 @@ assert_not_contains " -l " "$args" "DF_LOCAL_ONLY=no must drop -l"
 
 args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=yes run_snippet)
 assert_contains " -l " "$args" "DF_LOCAL_ONLY=yes must still pass -l"
+
+# An invalid value must fail safe rather than silently exposing remote mounts.
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=YES run_snippet)
+assert_contains " -l " "$args" \
+	"invalid DF_LOCAL_ONLY value must fall back to local-only mode"
+assert_contains "invalid XYMONCLIENT_FS_DF_LOCAL_ONLY" "$(cat "$STDERR_LOG")" \
+	"invalid DF_LOCAL_ONLY value must produce a warning"
 
 # --- XYMONCLIENT_FS_DF_TIMEOUT wraps df in `timeout <n>s` --------------------
 #
@@ -246,10 +280,25 @@ XYMONCLIENT_FS_DF_TIMEOUT=5 run_snippet >/dev/null
 assert_equal "5s" "$(cat "$TIMEOUT_LOG")" \
 	"XYMONCLIENT_FS_DF_TIMEOUT=5 must wrap df in 'timeout 5s'"
 
-# Empty string disables the wrapper: df is invoked directly, timeout untouched.
+# Empty string falls back to the default: the cap cannot be disabled.
 XYMONCLIENT_FS_DF_TIMEOUT="" run_snippet >/dev/null
-assert_equal "" "$(cat "$TIMEOUT_LOG")" \
-	'XYMONCLIENT_FS_DF_TIMEOUT="" must invoke df without a timeout wrapper'
+assert_equal "30s" "$(cat "$TIMEOUT_LOG")" \
+	'XYMONCLIENT_FS_DF_TIMEOUT="" must fall back to the default timeout'
+
+# Invalid values must not prevent df from running.
+XYMONCLIENT_FS_DF_TIMEOUT=invalid run_snippet >/dev/null
+assert_equal "30s" "$(cat "$TIMEOUT_LOG")" \
+	"invalid XYMONCLIENT_FS_DF_TIMEOUT must fall back to 30 seconds"
+assert_contains "invalid XYMONCLIENT_FS_DF_TIMEOUT" "$(cat "$STDERR_LOG")" \
+	"invalid timeout value must produce a warning"
+
+# Zero has incompatible semantics across timeout implementations (disabled by
+# GNU coreutils, immediate timeout by BusyBox), so it must use the safe default.
+XYMONCLIENT_FS_DF_TIMEOUT=0 run_snippet >/dev/null
+assert_equal "30s" "$(cat "$TIMEOUT_LOG")" \
+	"XYMONCLIENT_FS_DF_TIMEOUT=0 must fall back to 30 seconds"
+assert_contains "invalid XYMONCLIENT_FS_DF_TIMEOUT" "$(cat "$STDERR_LOG")" \
+	"zero timeout value must produce a warning"
 
 # --- [inode] report must be filtered the same way as [df] -------------------
 #

--- a/tests/client/fs-filter.sh
+++ b/tests/client/fs-filter.sh
@@ -10,7 +10,6 @@
 #   XYMONCLIENT_FS_INCLUDE_TYPES   types to un-exclude (e.g. tmpfs)
 #   XYMONCLIENT_FS_EXCLUDE_TYPES   additional types to exclude
 #   XYMONCLIENT_FS_DF_LOCAL_ONLY   yes (default, df -l) vs no
-#   XYMONCLIENT_FS_DF_TIMEOUT      seconds (default 30); empty/invalid -> 30
 #
 # The script reads /proc/filesystems directly and shells out to df.
 # To test in isolation we extract the [df] section from the script,
@@ -127,34 +126,19 @@ echo "/dev/sda1"
 EOF
 chmod +x "$STUB/readlink"
 
-# timeout stub: #49 wraps df in `timeout -s KILL <n>s df ...` (default 30s).
-# timeout exec's df with the same argv, so the df stub above cannot tell
-# whether it was wrapped. Record the timeout options, then exec the wrapped
-# command so every df assertion above still holds with the wrapper active.
-TIMEOUT_LOG="$TMP/timeout.args"
 STDERR_LOG="$TMP/stderr"
-cat > "$STUB/timeout" <<EOF
-#!/usr/bin/env bash
-echo "\$1 \$2 \$3" >> "$TIMEOUT_LOG"
-shift 3
-exec "\$@"
-EOF
-chmod +x "$STUB/timeout"
 
 export PATH="$STUB:$PATH"
 
 # --- runner ------------------------------------------------------------------
 
 # run_snippet: invoke the extracted block in a fresh subshell, return the
-# command-line df was called with. The default timeout wrapper is left in
-# place (the timeout stub records it and exec's df), so the exclude/include
-# assertions and the dedicated timeout assertions share one code path.
-# Per-case env vars are passed via an inline prefix on the caller's
-# `args=$(VAR=val run_snippet)`; see the leak warning below.
+# command-line df was called with. Per-case env vars are passed via an inline
+# prefix on the caller's `args=$(VAR=val run_snippet)`; see the leak warning
+# below.
 run_snippet() {
 	: > "$DF_LOG"
 	: > "$INODE_LOG"
-	: > "$TIMEOUT_LOG"
 	: > "$STDERR_LOG"
 	(
 		cd "$TMP"
@@ -171,7 +155,6 @@ run_snippet() {
 run_inode() {
 	: > "$DF_LOG"
 	: > "$INODE_LOG"
-	: > "$TIMEOUT_LOG"
 	: > "$STDERR_LOG"
 	(
 		cd "$TMP"
@@ -273,84 +256,6 @@ assert_contains " -l " "$args" \
 assert_contains "invalid XYMONCLIENT_FS_DF_LOCAL_ONLY" "$(cat "$STDERR_LOG")" \
 	"invalid DF_LOCAL_ONLY value must produce a warning"
 
-# --- XYMONCLIENT_FS_DF_TIMEOUT wraps df in timeout with SIGKILL ---------------
-#
-# df can hang on stale NFS/CIFS mounts, so #49 runs it under timeout(1).
-# TIMEOUT_LOG holds the options the timeout stub was handed (empty if df
-# was invoked directly). Assertions read the log after each run rather than
-# the returned df args, since the wrapper is invisible at the df layer.
-
-# Default (variable unset): df is wrapped in `timeout -s KILL 30s`.
-run_snippet >/dev/null
-assert_equal "-s KILL 30s" "$(cat "$TIMEOUT_LOG")" \
-	"default must wrap df in 'timeout -s KILL 30s'"
-
-# A custom value is honoured verbatim.
-XYMONCLIENT_FS_DF_TIMEOUT=5 run_snippet >/dev/null
-assert_equal "-s KILL 5s" "$(cat "$TIMEOUT_LOG")" \
-	"XYMONCLIENT_FS_DF_TIMEOUT=5 must wrap df in 'timeout -s KILL 5s'"
-
-# Empty string falls back to the default: the cap cannot be disabled.
-XYMONCLIENT_FS_DF_TIMEOUT="" run_snippet >/dev/null
-assert_equal "-s KILL 30s" "$(cat "$TIMEOUT_LOG")" \
-	'XYMONCLIENT_FS_DF_TIMEOUT="" must fall back to the default timeout'
-
-# Invalid values must not prevent df from running.
-XYMONCLIENT_FS_DF_TIMEOUT=invalid run_snippet >/dev/null
-assert_equal "-s KILL 30s" "$(cat "$TIMEOUT_LOG")" \
-	"invalid XYMONCLIENT_FS_DF_TIMEOUT must fall back to 30 seconds"
-assert_contains "invalid XYMONCLIENT_FS_DF_TIMEOUT" "$(cat "$STDERR_LOG")" \
-	"invalid timeout value must produce a warning"
-
-# Zero has incompatible semantics across timeout implementations (disabled by
-# GNU coreutils, immediate timeout by BusyBox), so it must use the safe default.
-XYMONCLIENT_FS_DF_TIMEOUT=0 run_snippet >/dev/null
-assert_equal "-s KILL 30s" "$(cat "$TIMEOUT_LOG")" \
-	"XYMONCLIENT_FS_DF_TIMEOUT=0 must fall back to 30 seconds"
-assert_contains "invalid XYMONCLIENT_FS_DF_TIMEOUT" "$(cat "$STDERR_LOG")" \
-	"zero timeout value must produce a warning"
-
-# Values past the 3600s ceiling are clamped: an out-of-range duration makes
-# BusyBox timeout(1) exit nonzero before df runs, which would silently empty
-# both the df and inode sections.
-XYMONCLIENT_FS_DF_TIMEOUT=99999 run_snippet >/dev/null
-assert_equal "-s KILL 3600s" "$(cat "$TIMEOUT_LOG")" \
-	"timeout above 3600 must be clamped to 3600"
-assert_contains "exceeds 3600" "$(cat "$STDERR_LOG")" \
-	"clamped timeout must produce a warning"
-
-# An absurdly long digit string must clamp too, without overflowing the
-# shell's integer arithmetic in the range check.
-XYMONCLIENT_FS_DF_TIMEOUT=18446744073709551616 run_snippet >/dev/null
-assert_equal "-s KILL 3600s" "$(cat "$TIMEOUT_LOG")" \
-	"oversized timeout must clamp to 3600 without an arithmetic error"
-
-# The 3600s ceiling itself is honoured verbatim (boundary).
-XYMONCLIENT_FS_DF_TIMEOUT=3600 run_snippet >/dev/null
-assert_equal "-s KILL 3600s" "$(cat "$TIMEOUT_LOG")" \
-	"3600 is the maximum and must pass through unchanged"
-
-# Leading zeros are decimal, not octal, and must not trip the length-based
-# clamp: 00001 is one second, not an over-length (5-char) string that the
-# guard would otherwise force to 3600 -- a 3600x inflation of the operator's
-# intended timeout.
-XYMONCLIENT_FS_DF_TIMEOUT=00001 run_snippet >/dev/null
-assert_equal "-s KILL 1s" "$(cat "$TIMEOUT_LOG")" \
-	"leading-zero 00001 must normalize to 1 second, not clamp to 3600"
-
-XYMONCLIENT_FS_DF_TIMEOUT=000030 run_snippet >/dev/null
-assert_equal "-s KILL 30s" "$(cat "$TIMEOUT_LOG")" \
-	"leading-zero 000030 must normalize to 30 seconds"
-
-# A leading-zero value at/above the ceiling still clamps on magnitude.
-XYMONCLIENT_FS_DF_TIMEOUT=03600 run_snippet >/dev/null
-assert_equal "-s KILL 3600s" "$(cat "$TIMEOUT_LOG")" \
-	"leading-zero 03600 must normalize to the 3600 boundary"
-
-XYMONCLIENT_FS_DF_TIMEOUT=03601 run_snippet >/dev/null
-assert_equal "-s KILL 3600s" "$(cat "$TIMEOUT_LOG")" \
-	"leading-zero 03601 must clamp to 3600"
-
 # --- [inode] report must be filtered the same way as [df] -------------------
 #
 # The [inode] block runs `df -Pil -x iso9660 -x $EXCLUDES`, reusing the exact
@@ -384,7 +289,7 @@ MISSING_SNIPPET="$TMP/df-section-missing.sh"
 sed "s!$TMP/proc.filesystems!$TMP/does-not-exist!g" "$SNIPPET" > "$MISSING_SNIPPET"
 
 : > "$DF_LOG"
-XYMONCLIENT_FS_DF_TIMEOUT="" /bin/sh "$MISSING_SNIPPET" >/dev/null 2>"$TMP/stderr"
+/bin/sh "$MISSING_SNIPPET" >/dev/null 2>"$TMP/stderr"
 args=$(printf ' %s ' "$(cat "$DF_LOG")")
 
 # NB: our sed rewrite of /proc/filesystems also rewrites the warning text,
@@ -398,100 +303,14 @@ assert_contains     " -x iso9660 " "$args" "iso9660 must still be excluded (EXCL
 assert_contains     " -x squashfs " "$args" "squashfs must still be excluded (EXCLUDE_TYPES default)"
 assert_not_contains " -x sysfs "   "$args" "no nodev excludes when /proc/filesystems unreadable"
 
-# --- timeout(1) absent: df runs unwrapped, never errors ---------------------
+# --- a df failure with empty output must yellow, never false-green -----------
 #
-# When no timeout(1) is on PATH the script must fall back to the
-# `else df "$@"` branch rather than failing. Build a PATH holding the df and
-# readlink stubs plus the real interpreters/tools the snippet needs, but NO
-# timeout, and confirm df still receives the full argv while TIMEOUT_LOG
-# stays empty. (The default PATH always has a real /usr/bin/timeout, so this
-# branch is otherwise never exercised.)
-NOTIMEOUT="$TMP/bin-notimeout"
-mkdir -p "$NOTIMEOUT"
-ln -s "$STUB/df" "$NOTIMEOUT/df"
-ln -s "$STUB/readlink" "$NOTIMEOUT/readlink"
-# sh/bash run the snippet and the bash-shebang stubs; awk/sed are used inside
-# the [df] block. Anything missing here would fail for a reason unrelated to
-# the timeout fallback, so resolve each from the real PATH up front.
-for prog in sh bash awk sed; do
-	p=$(command -v "$prog") || fail "no-timeout test needs '$prog' on PATH"
-	ln -s "$p" "$NOTIMEOUT/$prog"
-done
-: > "$DF_LOG"
-: > "$TIMEOUT_LOG"
-: > "$STDERR_LOG"
-(
-	cd "$TMP"
-	PATH="$NOTIMEOUT" /bin/sh "$SNIPPET" >/dev/null 2>"$STDERR_LOG"
-)
-args=$(printf ' %s ' "$(cat "$DF_LOG")")
-assert_contains " -x iso9660 " "$args" \
-	"df must still run when timeout(1) is absent"
-assert_contains " -x sysfs " "$args" \
-	"nodev excludes must still apply when timeout(1) is absent"
-assert_equal "" "$(cat "$TIMEOUT_LOG")" \
-	"timeout wrapper must be skipped when timeout(1) is absent"
-
-# --- a hung df must yellow, never false-green --------------------------------
-#
-# Regression for the inode false-green (xymon-monitoring/xymon#96 review): when
-# df hangs on a stale mount, timeout(1) kills it (exit 137 under -s KILL) and df
-# emits nothing. The server reads an *empty* [inode] section as green ("No
-# filesystems reporting inode data"), so the collection failure must instead
-# surface as a non-empty marker line the server cannot mistake for a healthy
-# report. Unlike the argv-only assertions above, this drives the REAL timeout(1)
-# against a df stub that sleeps past a 1s deadline -- only the genuine kill path
-# proves the right payload is emitted.
-HANGDIR="$TMP/bin-hang"
-mkdir -p "$HANGDIR"
-# df stub that hangs: sleep well past the 1s deadline, so the header below is
-# never printed and timeout must SIGKILL it.
-cat > "$HANGDIR/df" <<'EOF'
-#!/usr/bin/env bash
-sleep 5
-printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
-EOF
-chmod +x "$HANGDIR/df"
-ln -s "$STUB/readlink" "$HANGDIR/readlink"
-# Resolve the REAL timeout/sleep (and shells/tools) from the PATH as it was
-# before $STUB was prepended -- a plain `command -v timeout` would find the
-# argv-recording timeout stub above, which exec's df without enforcing any
-# deadline, so df would never be killed and this test would silently pass even
-# if the guard regressed.
+# Regression for the inode false-green (xymon-monitoring/xymon#96 review): a df
+# that exits nonzero while printing nothing leaves an empty section the server
+# reads as green ("No filesystems reporting inode data"). emit_df must surface
+# ANY nonzero exit with empty output as a failure marker, not pass it silently.
+# Drive this with a df stub that exits 127 while printing nothing.
 REALPATH=${PATH#"$STUB:"}
-for prog in sh bash awk sed timeout sleep; do
-	p=$(PATH="$REALPATH" command -v "$prog") \
-		|| fail "sleeping-df test needs a real '$prog' on PATH"
-	ln -s "$p" "$HANGDIR/$prog"
-done
-
-# Run the combined [df]+[inode] block with a 1s cap; both df invocations hang
-# and are killed, so the block should take ~2s and emit two markers.
-hang_out=$(
-	cd "$TMP"
-	PATH="$HANGDIR" XYMONCLIENT_FS_DF_TIMEOUT=1 /bin/sh "$COMBINED" 2>/dev/null
-)
-assert_contains "Disk collection failed: df timed out" "$hang_out" \
-	"a hung df must emit an explicit disk failure marker, not an empty section"
-assert_contains "Inode collection failed: df timed out" "$hang_out" \
-	"a hung df must emit an explicit inode failure marker (an empty inode section reads as green)"
-# The marker carries none of df's column headers, so the server's header
-# detection fails and the section yellows rather than greens. If "Capacity"
-# leaked through, df had printed real output and the kill path was not taken.
-assert_not_contains "Capacity" "$hang_out" \
-	"hung-df output must not contain df headers that could parse as a healthy report"
-
-# --- a non-kill df failure with empty output must yellow too -----------------
-#
-# Regression for the second inode false-green (xymon-monitoring/xymon#96
-# review): the kill codes 124/137 are not the only way to get a nonzero exit
-# with no output. timeout(1) itself can fail to launch df -- status 125 (timeout
-# error), 126 (df not invocable), 127 (df not found) -- and a BusyBox timeout
-# rejecting its duration exits nonzero before df runs. Each leaves an empty
-# section the server reads as green. emit_df must surface ANY nonzero exit with
-# empty output as a failure marker, not just the kill codes. Drive this with the
-# argv-recording timeout stub (it exec's df, preserving df's exit status) and a
-# df stub that exits 127 while printing nothing.
 FAILDIR="$TMP/bin-fail"
 mkdir -p "$FAILDIR"
 cat > "$FAILDIR/df" <<'EOF'
@@ -500,7 +319,6 @@ exit 127
 EOF
 chmod +x "$FAILDIR/df"
 ln -s "$STUB/readlink" "$FAILDIR/readlink"
-ln -s "$STUB/timeout"  "$FAILDIR/timeout"
 for prog in sh bash awk sed; do
 	p=$(PATH="$REALPATH" command -v "$prog") \
 		|| fail "failing-df test needs a real '$prog' on PATH"
@@ -544,7 +362,6 @@ esac
 EOF
 chmod +x "$INODEDIR/df"
 ln -s "$STUB/readlink" "$INODEDIR/readlink"
-ln -s "$STUB/timeout"  "$INODEDIR/timeout"
 for prog in sh bash awk sed; do
 	p=$(PATH="$REALPATH" command -v "$prog") \
 		|| fail "inode-drop test needs a real '$prog' on PATH"

--- a/tests/client/fs-filter.sh
+++ b/tests/client/fs-filter.sh
@@ -258,8 +258,9 @@ assert_contains "invalid XYMONCLIENT_FS_DF_LOCAL_ONLY" "$(cat "$STDERR_LOG")" \
 
 # --- [inode] report must be filtered the same way as [df] -------------------
 #
-# The [inode] block runs `df -Pil -x iso9660 -x $EXCLUDES`, reusing the exact
-# exclude set the [df] block built. Extracting [df] alone (the SNIPPET above)
+# The [inode] block runs `df -Pil -x $EXCLUDES`, reusing the exact exclude set
+# the [df] block built (iso9660 is part of that set via the EXCLUDE_TYPES
+# default, no longer a separate hardcoded -x). Extracting [df] alone (the SNIPPET above)
 # never exercises this second df invocation, so a regression that leaves the
 # inode report unfiltered would go unnoticed. run_inode runs both blocks and
 # returns the *inode* invocation's argv; assert the same nodev/rootfs/real-FS

--- a/tests/client/fs-filter.sh
+++ b/tests/client/fs-filter.sh
@@ -53,12 +53,14 @@ TMP=$(mktempdir)
 
 # --- fixtures ----------------------------------------------------------------
 
-# Representative /proc/filesystems: pseudo-FS that should default-exclude
-# (sysfs, tmpfs, proc, overlay, nfs, nfs4), one that must never be excluded
-# (rootfs), and two real disk FS that must not appear in the nodev list.
+# Representative /proc/filesystems. Genuine pseudo-FS that must default-exclude
+# (sysfs, proc, overlay, nfs, nfs4); real local FS that merely happen to be nodev
+# and so are default-INCLUDED (tmpfs, zfs); the never-excluded special case
+# (rootfs); and two device-backed FS that must not appear in the nodev list.
 cat > "$TMP/proc.filesystems" <<'EOF'
 nodev	sysfs
 nodev	tmpfs
+nodev	zfs
 nodev	proc
 	ext4
 	xfs
@@ -192,13 +194,15 @@ args=$(run_snippet)
 
 assert_contains " -P "        "$args" "default must pass -P to df"
 assert_contains " -l "        "$args" "default must pass -l to df (local only)"
-assert_contains " -x iso9660 " "$args" "default must exclude iso9660"
-assert_contains " -x sysfs "  "$args" "default must exclude sysfs (nodev)"
-assert_contains " -x tmpfs "  "$args" "default must exclude tmpfs (nodev)"
-assert_contains " -x overlay " "$args" "default must exclude overlay (nodev)"
-assert_contains " -x nfs "    "$args" "default must exclude nfs (nodev)"
+assert_contains " -x iso9660 " "$args" "default must exclude iso9660 (always-full image)"
+assert_contains " -x squashfs " "$args" "default must exclude squashfs (always-full image)"
+assert_contains " -x sysfs "  "$args" "default must exclude sysfs (pseudo nodev)"
+assert_contains " -x overlay " "$args" "default must exclude overlay (pseudo nodev)"
+assert_contains " -x nfs "    "$args" "default must exclude nfs (pseudo nodev)"
+assert_not_contains " -x tmpfs " "$args" "default must INCLUDE tmpfs (real local fs that is nodev)"
+assert_not_contains " -x zfs "   "$args" "default must INCLUDE zfs (real local fs that is nodev)"
 assert_not_contains " -x rootfs " "$args" "default must NOT exclude rootfs (special case)"
-assert_not_contains " -x ext4 " "$args" "default must NOT exclude ext4 (non-nodev)"
+assert_not_contains " -x ext4 " "$args" "default must NOT exclude ext4 (device-backed)"
 
 # --- XYMONCLIENT_FS_INCLUDE_TYPES un-excludes one type ----------------------
 
@@ -356,9 +360,9 @@ assert_equal "-s KILL 3600s" "$(cat "$TIMEOUT_LOG")" \
 # rules hold there.
 
 iargs=$(run_inode)
-assert_contains     " -x sysfs "  "$iargs" "inode report must exclude sysfs (nodev), same as df"
-assert_contains     " -x tmpfs "  "$iargs" "inode report must exclude tmpfs (nodev), same as df"
-assert_contains     " -x overlay " "$iargs" "inode report must exclude overlay (nodev), same as df"
+assert_contains     " -x sysfs "  "$iargs" "inode report must exclude sysfs (pseudo nodev), same as df"
+assert_not_contains " -x tmpfs "  "$iargs" "inode report must INCLUDE tmpfs (real local fs), same as df"
+assert_contains     " -x overlay " "$iargs" "inode report must exclude overlay (pseudo nodev), same as df"
 assert_not_contains " -x ext4 "   "$iargs" "inode report must NOT exclude ext4 (non-nodev)"
 assert_not_contains " -x rootfs " "$iargs" "inode report must NOT exclude rootfs (special case)"
 
@@ -389,7 +393,8 @@ assert_contains "not readable, dynamic nodev exclusions disabled" "$(cat "$TMP/s
 	"unreadable filesystem-list must produce a warning on stderr"
 assert_contains "xymonclient-linux:" "$(cat "$TMP/stderr")" \
 	"warning must be tagged so it's identifiable in client logs"
-assert_contains     " -x iso9660 " "$args" "iso9660 must still be excluded"
+assert_contains     " -x iso9660 " "$args" "iso9660 must still be excluded (EXCLUDE_TYPES default)"
+assert_contains     " -x squashfs " "$args" "squashfs must still be excluded (EXCLUDE_TYPES default)"
 assert_not_contains " -x sysfs "   "$args" "no nodev excludes when /proc/filesystems unreadable"
 
 # --- timeout(1) absent: df runs unwrapped, never errors ---------------------
@@ -421,7 +426,7 @@ done
 args=$(printf ' %s ' "$(cat "$DF_LOG")")
 assert_contains " -x iso9660 " "$args" \
 	"df must still run when timeout(1) is absent"
-assert_contains " -x tmpfs " "$args" \
+assert_contains " -x sysfs " "$args" \
 	"nodev excludes must still apply when timeout(1) is absent"
 assert_equal "" "$(cat "$TIMEOUT_LOG")" \
 	"timeout wrapper must be skipped when timeout(1) is absent"

--- a/tests/client/fs-filter.sh
+++ b/tests/client/fs-filter.sh
@@ -383,9 +383,9 @@ XYMONCLIENT_FS_DF_TIMEOUT="" /bin/sh "$MISSING_SNIPPET" >/dev/null 2>"$TMP/stder
 args=$(printf ' %s ' "$(cat "$DF_LOG")")
 
 # NB: our sed rewrite of /proc/filesystems also rewrites the warning text,
-# so we assert on the surviving "not readable, filesystem filter disabled"
-# tail rather than the path.
-assert_contains "not readable, filesystem filter disabled" "$(cat "$TMP/stderr")" \
+# so we assert on the surviving "not readable, dynamic nodev exclusions
+# disabled" tail rather than the path.
+assert_contains "not readable, dynamic nodev exclusions disabled" "$(cat "$TMP/stderr")" \
 	"unreadable filesystem-list must produce a warning on stderr"
 assert_contains "xymonclient-linux:" "$(cat "$TMP/stderr")" \
 	"warning must be tagged so it's identifiable in client logs"

--- a/xymond/etcfiles/analysis.cfg
+++ b/xymond/etcfiles/analysis.cfg
@@ -352,14 +352,21 @@
 
 
 CLASS=linux
-	# Ignore some usually uninteresting tmpfs mounts.
+	# Ignore some usually uninteresting tmpfs mounts. The Linux client reports
+	# tmpfs by default; /run and friends are RAM-backed scratch space sized at
+	# total RAM, so suppress them here rather than have them clutter the report.
+	# /dev/shm is intentionally left monitored (a full one is a real incident).
 	DISK	/dev IGNORE
 	DISK	/lib/init/rw IGNORE
 	DISK	/sys/fs/cgroup IGNORE
+	DISK	/run IGNORE
+	DISK	/run/lock IGNORE
 	DISK	%^/run/user/\d+$ IGNORE
 	INODE	/dev IGNORE
 	INODE	/lib/init/rw IGNORE
 	INODE	/sys/fs/cgroup IGNORE
+	INODE	/run IGNORE
+	INODE	/run/lock IGNORE
 	INODE	%^/run/user/\d+$ IGNORE
 
 


### PR DESCRIPTION
Closes #49.

## Summary

This PR makes Linux client filesystem filtering configurable, and updates the
default filesystem-selection policy so the common "real but `nodev`" and
"always-100%-full" cases are handled out of the box.

Previously `client/xymonclient-linux.sh` decided internally which filesystems
appeared in the `df` and `inode` sections: it excluded every `nodev` type from
`/proc/filesystems` plus a hardcoded `iso9660`, keeping `rootfs`. That policy
was too rigid for hosts using `tmpfs`, `zfs`, `virtiofs`, `nfs`, `ceph`,
`overlay`, `fuse`, snaps, etc. Downstreams already patch it locally, e.g.
Debian's `24_hobbitclient-tmpfs.patch`.

## Defaults

With none of the new variables set, the client now:

- excludes `nodev` filesystems listed by `/proc/filesystems`, **except** the
  real local types `zfs virtiofs tmpfs`, which are surfaced
  (`XYMONCLIENT_FS_INCLUDE_TYPES` default);
- additionally excludes `iso9660 squashfs fuse.snapfuse`
  (`XYMONCLIENT_FS_EXCLUDE_TYPES` default) -- read-only images reported 100% full
  by design (snaps mount as `squashfs`, or as `fuse.snapfuse` where snapd falls
  back to FUSE); none is a `nodev` type, so each must be named explicitly;
- keeps `rootfs`;
- passes `-P -l` to `df` (local filesystems only);
- in the **inode** report only, drops filesystems with no inode limit (df prints
  `-` in the `IUse%` column for them, e.g. btrfs/zfs/9p/many fuse) -- they can
  never run out of inodes, so the row is noise and may carry bogus counts.

This is a deliberate change of default behavior from the old "hide all nodev +
iso9660" policy: `zfs`/`virtiofs`/`tmpfs` now appear, and `squashfs`/snaps no
longer do. Remote filesystems (`nfs`, `ceph`, ...) are still hidden by default.

The earlier draft of this PR added a per-invocation `df` timeout; that has been
**dropped** in favor of the non-blocking df sentinel, so there is no longer any
`XYMONCLIENT_FS_DF_TIMEOUT` variable or timeout-related behavior.

When `/proc/filesystems` is **not** readable, the client disables the dynamic
nodev derivation and warns; the explicit `XYMONCLIENT_FS_EXCLUDE_TYPES`
exclusions and the local-only `df -l` behavior remain active. This replaces the
empty `df`/`inode` sections the previous code produced in that case (see Safety).

## Configuration

The following variables are documented in `xymonclient.cfg` and
`xymonclient.cfg(5)`:

| Variable | Default | Purpose |
| --- | --- | --- |
| `XYMONCLIENT_FS_INCLUDE_TYPES` | `zfs virtiofs tmpfs` | `nodev` types to surface anyway. Set to `""` to restore the historical "drop every nodev type" behavior. |
| `XYMONCLIENT_FS_EXCLUDE_TYPES` | `iso9660 squashfs fuse.snapfuse` | Non-nodev types to also hide. Set to `""` to monitor these too. |
| `XYMONCLIENT_FS_DF_LOCAL_ONLY` | `yes` | Set to `no` to drop `df -l` and report remote filesystems. |

Matching is on the exact `df` type token (literal, never glob/regex). If a type
appears in both include and exclude lists, exclusion wins. All three variables
reach both the `df` and the `inode` report.

To include remote storage, both parts of the default filtering policy must be
changed:

```sh
XYMONCLIENT_FS_INCLUDE_TYPES="zfs virtiofs tmpfs nfs nfs4 ceph"
XYMONCLIENT_FS_DF_LOCAL_ONLY="no"
```

### Relationship to Debian's `24_hobbitclient-tmpfs.patch`

The new defaults already reproduce that patch's filesystem-**type** policy
(`tmpfs`/`zfs` shown). It is still **not** a drop-in replacement for the whole
patch, which also:

- derives exclusions from `mount` when `/proc/filesystems` is unavailable -- this
  PR instead **disables** the dynamic nodev filter in that case (a behavioral
  difference);
- filters `/sys`;
- carries related `analysis.cfg` ignores (see Upgrade note below).

The mechanism does not silently adopt a downstream distribution's defaults
upstream; it just makes the common cases the shipped default.

## Safety

- Invalid `XYMONCLIENT_FS_DF_LOCAL_ONLY` values warn and fall back to `yes`.
- A `df` that exits non-zero with **no output** is reported as an explicit
  failure marker (yellow) rather than a silent empty section. An empty `inode`
  section would otherwise be read by the server as a false green ("No
  filesystems reporting inode data"); a `df` exit that still prints the healthy
  mounts (e.g. one unreadable mount, exit 1) flows through unchanged.
- If `/proc/filesystems` is unreadable, the client warns and disables the
  dynamic nodev filter.
- Filesystem type settings are handled as literal tokens, without pathname
  expansion.

## Upgrade note

Because the default now surfaces `tmpfs`, fresh installs ship `analysis.cfg`
rules that ignore the noisy `/run*` tmpfs mounts (`/run`, `/run/lock`,
`/run/user/N`) server-side. **Existing servers keep their preserved
`analysis.cfg`, which will not receive these new ignores automatically** -- after
upgrading clients, expect extra `/run*` rows on the disk report until those
ignore rules are added to the existing `analysis.cfg` manually (or it is
regenerated from the shipped default).

The client settings themselves are read from the normal client environment file.
Native installs preserve active local values through `merge-lines`; Debian
installs expose that file as `/etc/xymon/xymonclient.cfg`.

## Tests

`tests/client/fs-filter.sh` covers:

- the new default filtering policy (nodev excluded, `zfs`/`virtiofs`/`tmpfs`
  kept, `iso9660`/`squashfs`/`fuse.snapfuse` excluded, `rootfs` kept)
- include and exclude lists and precedence
- literal token handling
- local-only and remote filesystem modes, including invalid-value fallback
- a non-zero `df` with empty output emitting a non-empty, header-free failure
  marker rather than the empty section that would false-green the inode report
- consistent `df` and inode filtering (settings reach both reports)
- missing `/proc/filesystems`

All build and shell regression workflows pass.
