### PR TITLE
xymoncgimsg: honor $XYMSRV when forwarding to xymond (#21)

### DIFF
--- a/xymonproxy/xymoncgimsg.c
+++ b/xymonproxy/xymoncgimsg.c
@@ -20,12 +20,23 @@ int main(int argc, char *argv[])
 	int result = 1;
 	cgidata_t *cgidata = NULL;
 	sendreturn_t *sres;
+	char *xymsrv;
+
+	/*
+	 * Honor the XYMSRV environment variable so that a single CGI
+	 * deployment (typically fronted by Apache) can forward messages
+	 * to different xymond backends -- e.g. for per-vhost multi-tenant
+	 * routing. Falls back to 127.0.0.1 when not set, preserving the
+	 * original single-host behavior.
+	 */
+	xymsrv = getenv("XYMSRV");
+	if (!xymsrv || !*xymsrv) xymsrv = "127.0.0.1";
 
 	cgidata = cgi_request();
 	if (cgidata) {
 		printf("Content-Type: application/octet-stream\n\n");
 		sres = newsendreturnbuf(1, stdout);
-		result = sendmessage(cgidata->value, "127.0.0.1", XYMON_TIMEOUT, sres);
+		result = sendmessage(cgidata->value, xymsrv, XYMON_TIMEOUT, sres);
 	}
 
 	return result;


### PR DESCRIPTION
Refs #21.

`xymoncgimsg` currently hardcodes `127.0.0.1` as the address it
forwards HTTP-POST'd client messages to, which constrains a deployment
to a single `xymond` on the same host as the CGI.

This PR reads `XYMSRV` from the CGI environment when set, falling
back to `127.0.0.1` otherwise. This enables a single Apache (or
other web server) that fronts the CGI to route incoming messages to
different `xymond` instances via per-`Directory`/`Location` `SetEnv`
directives — the typical multi-tenant reverse-proxy pattern:

```apache
<Directory /var/www/customer1/cgi-bin>
    SetEnv XYMSRV 10.0.1.10
</Directory>
<Directory /var/www/customer2/cgi-bin>
    SetEnv XYMSRV 10.0.2.20
</Directory>
```

A client POSTing to `/customer1/cgi-bin/xymoncgimsg` is forwarded to
`10.0.1.10`; the same binary running under `/customer2/...` is
forwarded to `10.0.2.20`. No client-side change, no `xymond`-side
change.

## Backward compatibility

Existing single-host deployments without `XYMSRV` set keep working
unchanged — the fallback preserves the original `127.0.0.1`
behavior.

## Origin

Picked up from the `xymoncgimsg.patch` Stef Coene attached to #21
(2022, dormant). Only the `XYMSRV` portion is included here. The
`MAX_REQ_SIZE` 1 MB → 10 MB bump bundled in the same patch is
unrelated and deserves its own design discussion (see #21).