### PR TITLE
web: default HTMLCONTENTTYPE to UTF-8 charset (fixes #34)

### DIFF
--- a/RELEASENOTES
+++ b/RELEASENOTES
@@ -19,6 +19,13 @@ including problems with hostnames with dashes in them.
 Combostatus tests propagated up from other combostatus tests should now
 display properly.
 
+The default web charset is now UTF-8: HTMLCONTENTTYPE defaults to
+"text/html; charset=UTF-8" so non-ASCII status content renders correctly
+without relying on the web server to supply a default charset (which Debian's
+Apache does but FreeBSD's does not). Sites whose hosts emit a different encoding
+(e.g. iso-8859-1, euc-jp) and relied on browser auto-detection should set
+HTMLCONTENTTYPE explicitly in xymonserver.cfg.
+
 
 Changes for 4.3.29
 ==================

--- a/lib/environ.c
+++ b/lib/environ.c
@@ -148,7 +148,7 @@ const static struct {
 	{ "XYMONPAGEHTACCESS", "" },
 	{ "XYMONSUBPAGEHTACCESS", "" },
 	{ "XYMONNETSVCS", "smtp telnet ftp pop pop3 pop-3 ssh imap ssh1 ssh2 imap2 imap3 imap4 pop2 pop-2 nntp" },
-	{ "HTMLCONTENTTYPE", "text/html" },
+	{ "HTMLCONTENTTYPE", "text/html; charset=UTF-8" },
 	{ "HOLIDAYFORMAT", "%d/%m" },
 	{ "WEEKSTART", "1" },
 	{ "XYMONBODYCSS", "$XYMONSKIN/xymonbody.css" },

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -199,7 +199,7 @@ COLUMNDOCURL="$CGIBINURL/columndoc.sh?%s"	# URL formatting string for column-lin
 
 
 # HTML content
-HTMLCONTENTTYPE="text/html"                     # You can add charset options here.
+HTMLCONTENTTYPE="text/html; charset=UTF-8"      # Change the charset if your hosts emit a different encoding (e.g. iso-8859-1, euc-jp).
 
 # Fonts and texts
 XYMONLOGO="Xymon"                               # HTML inserted on all header pages at top-left corner.


### PR DESCRIPTION
Resolves #34.

## Problem
The CGIs emit the HTTP `Content-Type` header directly from `HTMLCONTENTTYPE`, which defaulted to `text/html` — **no charset**. Non-ASCII status content (accented filenames, log lines, banners) then renders as mojibake unless the web server adds a default charset itself: Debian/Ubuntu's Apache does (`AddDefaultCharset utf-8`), FreeBSD's does not — which is why the breakage looked FreeBSD-specific when it's actually universal.

The bytes are already fine — clients run `LANG=C` (so tool framing is ASCII) and `htmlquoted()` passes high bytes through raw, so the output is valid UTF-8 on modern hosts. It was just never *labelled* UTF-8.

## Fix
Default `HTMLCONTENTTYPE` to `text/html; charset=UTF-8` (`lib/environ.c` + `xymonserver.cfg.DIST`). Xymon now declares the charset in the CGI HTTP header (and the templates' `<META … &HTMLCONTENTTYPE>`), correct regardless of web-server config. This is a label, **not** a transcode — nothing is converted.

`HTMLCONTENTTYPE` stays configurable, so sites whose hosts emit a different encoding (iso-8859-1, euc-jp, …) can override it.

## Compatibility
Declaring an explicit charset removes the browser's auto-detection. A site whose hosts emit non-UTF-8 bytes and relied on browser guessing should now set `HTMLCONTENTTYPE` explicitly — noted in RELEASENOTES.
