### PR TITLE
combostatus: no spurious error on an empty xymond board (proper bbcombotest-fix)

### DIFF
--- a/xymond/combostatus.c
+++ b/xymond/combostatus.c
@@ -207,11 +207,12 @@ static int getxymondvalue(char *hostname, char *testname, char **errptr)
 		xymondresult = sendmessage("xymondboard fields=hostname,testname,color", NULL, XYMON_TIMEOUT, sres);
 		board = getsendreturnstr(sres, 1);
 
-		if ((xymondresult != XYMONSEND_OK) || (board == NULL)) {
+		if (xymondresult != XYMONSEND_OK) {
 			board = "";
 			*errptr += sprintf(*errptr, "Could not access xymond board, error %d\n", xymondresult);
 			return COL_CLEAR;
 		}
+		if (board == NULL) board = "";	/* Empty board is not a failure; treat as no match and avoid the NULL-deref below. */
 
 		freesendreturnbuf(sres);
 	}


### PR DESCRIPTION
## Problem
`getxymondvalue()` in `xymond/combostatus.c` reports **"Could not access xymond board, error 0"** whenever the board comes back `NULL` even though the send **succeeded** (`error 0` = `XYMONSEND_OK`) — e.g. when the board is legitimately empty. The error guard

```c
if ((xymondresult != XYMONSEND_OK) || (board == NULL)) { ... }
```

conflates two different things: a real send failure, and an empty/NULL board.

## Why not just delete `|| (board == NULL)`
That's what Debian's long-standing `42_bbcombotest-fix.patch` (Christoph Berg, 2015, `Forwarded: no`) does — and the FreeBSD port carries the same patch. But that branch also did an early `return COL_CLEAR`, so simply deleting the check means a `NULL` board with `result == OK` now falls through to the later `strncmp(board, …)` and **dereferences NULL**. It fixes the cosmetic message at the cost of a latent crash.

## Fix
Split the two concerns:

```c
if (xymondresult != XYMONSEND_OK) {              /* real failure */
    board = ""; *errptr += sprintf(...); return COL_CLEAR;
}
if (board == NULL) board = "";                   /* empty board: no error, no deref */
```

- No spurious "error 0" when the send succeeded but the board is empty.
- Still NULL-safe — `board` is never dereferenced as NULL by the `strncmp()` below.

Strictly better than both the original (noisy) and the Debian patch (deref risk). Builds clean (server variant, 0 errors).

Refs #28 (Debian patch audit) and #103 (FreeBSD carries the same patch) — this is the proper upstream version of `bbcombotest-fix`.


