### PR TITLE
4.3.31 release notes: refresh draft + add Migration notes (DRAFT)

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,6 +25,10 @@ Changes from 4.3.30 -> 4.3.31 (XX Xxx XXXX)
 * Fix vmstat rrd graphing for FreeBSD (#39)
 * Filter out autofs for df and inode on FreeBSD (#40)
 * Fix parallel legacy builds (make -j4) (#76)
+* Update github workflows: actions/checkout v4->6, gh-release 2->3 (#87)
+* Fix github release workflow (#88)
+* PCRE2: fix leaks in headfoot/mailack, harden pickdata sizing (#89)
+* Fix parallel race: serialize common-client after common-build (#92)
 
 
 Changes from 4.3.29 -> 4.3.30 (05 Sep 2019)
@@ -309,7 +313,7 @@ Changes from 4.3.19 -> 4.3.20 (15 May 2015)
   (Thanks, Torsten Richter)
 * Column documentation links should be working again (Reported by Andy Smith)
 * Fix missing null termination in certain logfetch situations (Reported by
-  Johan Sjšberg)
+  Johan Sjï¿½berg)
 * New httphead tag to force an http request using HEAD instead of GET
 * Fix a memory leak introduced in parsing Windows SVCS test data
 * A divide-by-zero condition when systems erroneously report 0MB of physical

--- a/Changes
+++ b/Changes
@@ -1,3 +1,32 @@
+Changes from 4.3.30 -> 4.3.31 (XX Xxx XXXX)
+===========================================
+
+* Fix typo \fb (instead of \fB) in some man pages (#10)
+* Fix typos in man pages (#11)
+* Fix buffer overflow in md5hash() (#8)
+* Fix Snapshort and Availability Report on Firefox (#6)
+* Create a build pipeline for server and client. (#4)
+* Write backslash in man pages as \e (not \\) (#9)
+* Added a build pipeline for new release versions that triggers on rel-*
+* Send (reformatted) dpkg -l output with client message (#48)
+* Make the date header of html man pages reproducible (#52)
+* Fix compatibility errors with rrdtool 1.9.0 (#57)
+* Add missing stdlib.h include to lib/suid.c (#59)
+* Convert unknown-recent.gif and unknown.gif from PNG to GIF (#63)
+* Fix reading service banners from TLS-1.3-enabled hosts (#7)
+* Fix ldap build problems on newer GCC versions (#62)
+* Allow specifying TLSv1.3 for xymonnet tests (#33)
+* Improve explanation of escaping hex chars in man page (#67)
+* Fix NetBSD meminfo build (#65)
+* Fix handling of $CARESLIB in configure.server (#69)
+* Use cc on OpenBSD (#73)
+* Use PCRE2 and drop PCRE1 support (#5)
+* Hard fail if RRDtool is not available on server build (#84)
+* Fix vmstat rrd graphing for FreeBSD (#39)
+* Filter out autofs for df and inode on FreeBSD (#40)
+* Fix parallel legacy builds (make -j4) (#76)
+
+
 Changes from 4.3.29 -> 4.3.30 (05 Sep 2019)
 ===========================================
 

--- a/Changes
+++ b/Changes
@@ -30,6 +30,21 @@ Changes from 4.3.30 -> 4.3.31 (XX Xxx XXXX)
 * PCRE2: fix leaks in headfoot/mailack, harden pickdata sizing (#89)
 * Fix parallel race: serialize common-client after common-build (#92)
 
+Migration notes (DRAFT — finalise when the underlying PRs land):
+
+* PCRE2: PCRE1 is no longer supported. Configurations using regex
+  features specific to PCRE1 syntax should be reviewed for PCRE2
+  compatibility (most patterns are unaffected). See PRs #5, #89, #93.
+
+* RRDtool: argv ABI is now detected by header signature rather than
+  RRDtool version. Both upstream RRDtool >= 1.9 and distro-backported
+  1.8 (e.g. Oracle Linux 10) are supported automatically. See PR #80.
+
+* Net-SNMP: when Net-SNMP is built without MD5 (NETSNMP_DISABLE_MD5),
+  an MD5-requested SNMPv3 auth falls back to SHA1 with a one-time
+  runtime warning. Update SNMPv3 auth to SHA1 to silence the warning.
+  See PR #75.
+
 
 Changes from 4.3.29 -> 4.3.30 (05 Sep 2019)
 ===========================================


### PR DESCRIPTION
PR-ifying the 4.3.31 release-notes draft so it's review-able and discoverable from the PR queue (one of milestone **4.3.31**'s exit criteria).

The `Changes` branch (originally Roland's draft, `2b31cb32`) had no PR open and had drifted from `main`. This PR brings the 4.3.31 section up to date and adds a Migration notes subsection.

## What's in this PR

- The 4.3.31 release-notes entries Roland drafted (covering merged PRs #4–#84, etc.).
- **+ 4 entries** added on the branch for PRs that merged after the original draft and were missing:
  - `#87` Update github workflows: actions/checkout v4→6, gh-release 2→3
  - `#88` Fix github release workflow
  - `#89` PCRE2: fix leaks in headfoot/mailack, harden pickdata sizing
  - `#92` Fix parallel race: serialize common-client after common-build
- **Migration notes (DRAFT)** — covers the three areas milestone 4.3.31 calls out as needing explicit migration documentation:
  - **PCRE2** (PRs #5, #89, #93) — PCRE1 dropped; config-side regex review.
  - **RRDtool argv ABI** (PR #80) — detection by header signature; covers ≥ 1.9 *and* 1.8 with const-argv backports.
  - **Net-SNMP MD5/SHA1 fallback** (PR #75) — runtime warning + admin action.

## Status

- The Migration notes are marked **DRAFT** — wording will be finalised when the underlying PRs (#80, #75, #93) merge.
- Release date placeholder `(XX Xxx XXXX)` will be filled at tag time (see #99 / PR #102 pre-tag mechanism).
- New entries for **PR #108** (UTF-8 charset) and **PR #109** (combostatus empty-board) will be added to this branch when they merge.

Refs milestone **4.3.31**, #99 (release workflow).
