### PR TITLE
Resolve GCC build warnings (safe, no-behavior-change subset)

### DIFF
--- a/lib/acknowledgementslog.c
+++ b/lib/acknowledgementslog.c
@@ -224,12 +224,12 @@ void do_acknowledgementslog(FILE *output,
 		    p = strrchr(host, '.');
 		    if (p) {
                         *p = '\0';
-			strncpy(svc,p+1,  sizeof(svc));
+			snprintf(svc, sizeof(svc), "%s", p+1);
                     }
 		    /* Xymon uses \n in the ack message, for the "acked by" data. Cut it off. */
 		    p = strstr(message, "\\nAcked by:");
 		    if (p) {
-			strncpy(recipient,p+12, sizeof(recipient));
+			snprintf(recipient, sizeof(recipient), "%s", p+12);
                         *(p-1) = '\0';
 		    }
 		    else {

--- a/lib/loadhosts_file.c
+++ b/lib/loadhosts_file.c
@@ -110,7 +110,7 @@ static int prepare_fromnet(void)
 
 	if (contentbuffer) freestrbuffer(contentbuffer);
 	contentbuffer = convertstrbuffer(fdata, 0);
-	strncpy(contentmd5, fhash, sizeof(contentmd5));
+	snprintf(contentmd5, sizeof(contentmd5), "%s", fhash);
 
 	return 0;
 }

--- a/lib/locator.c
+++ b/lib/locator.c
@@ -206,7 +206,7 @@ char *locator_cmd(char *cmd)
 	static char pingbuf[512];
 	int res;
 
-	strncpy(pingbuf, cmd, sizeof(pingbuf));
+	snprintf(pingbuf, sizeof(pingbuf), "%s", cmd);
 	res = call_locator(pingbuf, sizeof(pingbuf));
 
 	return (res == 0) ? pingbuf : NULL;

--- a/lib/stackio.c
+++ b/lib/stackio.c
@@ -204,11 +204,11 @@ FILE *stackfopen(char *filename, char *mode, void **v_listhead)
 
 		stackfd_mode = strdup(mode);
 
-		strncpy(stackfd_filename, filename, sizeof(stackfd_filename));
+		snprintf(stackfd_filename, sizeof(stackfd_filename), "%s", filename);
 	}
 	else {
 		if (*filename == '/')
-			strncpy(stackfd_filename, filename, sizeof(stackfd_filename));
+			snprintf(stackfd_filename, sizeof(stackfd_filename), "%s", filename);
 		else
 			snprintf(stackfd_filename, sizeof(stackfd_filename), "%s/%s", stackfd_base, filename);
 	}
@@ -335,7 +335,10 @@ static void addtofnlist(char *dirname, int is_optional, void **v_listhead)
 	int fnsz = 0;
 	int i;
 
-	if (*dirname == '/') strncpy(dirfn, dirname, sizeof(dirfn)); else snprintf(dirfn, sizeof(dirfn), "%s/%s", stackfd_base, dirname);
+	if (*dirname == '/')
+		snprintf(dirfn, sizeof(dirfn), "%s", dirname);
+	else
+		snprintf(dirfn, sizeof(dirfn), "%s/%s", stackfd_base, dirname);
 
 	if ((dirfd = opendir(dirfn)) == NULL) {
 		if (!is_optional) errprintf("WARNING: Cannot open directory %s\n", dirfn);

--- a/lib/xymonrrd.c
+++ b/lib/xymonrrd.c
@@ -241,7 +241,7 @@ static char *xymon_graph_text(char *hostname, char *dispname, char *service, int
 		snprintf(rrdservicename, sizeof(rrdservicename), "devmon:%s", service);
 	}
 	else {
-		strncpy(rrdservicename, graphdef->xymonrrdname, sizeof(rrdservicename));
+		snprintf(rrdservicename, sizeof(rrdservicename), "%s", graphdef->xymonrrdname);
 	}
 
 	SBUF_MALLOC(svcurl, 

--- a/web/confreport.c
+++ b/web/confreport.c
@@ -123,7 +123,7 @@ static void print_disklist(char *hostname)
 
 	while ((de = readdir(d)) != NULL) {
 		if (strncmp(de->d_name, "disk,", 5) == 0) {
-			strncpy(fn, de->d_name + 4, sizeof(fn));
+			snprintf(fn, sizeof(fn), "%s", de->d_name + 4);
 			p = strstr(fn, ".rrd"); if (!p) continue;
 			*p = '\0';
 			p = fn; while ((p = strchr(p, ',')) != NULL) *p = '/';

--- a/xymond/client/darwin.c
+++ b/xymond/client/darwin.c
@@ -79,13 +79,17 @@ void handle_darwin_client(char *hostname, char *clienttype, enum ostype_t os,
 
 		if (pgsize != -1) {
 			p = strstr(meminfostr, "\nPages free:");
-			if (p) p = strchr(p, ':'); if (p) pagesfree = atol(p+1);
+			if (p) p = strchr(p, ':');
+			if (p) pagesfree = atol(p+1);
 			p = strstr(meminfostr, "\nPages active:");
-			if (p) p = strchr(p, ':'); if (p) pagesactive = atol(p+1);
+			if (p) p = strchr(p, ':');
+			if (p) pagesactive = atol(p+1);
 			p = strstr(meminfostr, "\nPages inactive:");
-			if (p) p = strchr(p, ':'); if (p) pagesinactive = atol(p+1);
+			if (p) p = strchr(p, ':');
+			if (p) pagesinactive = atol(p+1);
 			p = strstr(meminfostr, "\nPages wired down:");
-			if (p) p = strchr(p, ':'); if (p) pageswireddown = atol(p+1);
+			if (p) p = strchr(p, ':');
+			if (p) pageswireddown = atol(p+1);
 
 			if ((pagesfree >= 0) && (pagesactive >= 0) && (pagesinactive >= 0) && (pageswireddown >= 0)) {
 				unsigned long memphystotal, memphysused;

--- a/xymond/client/zvse.c
+++ b/xymond/client/zvse.c
@@ -532,6 +532,7 @@ static void zvse_getvis_report(char *hostname, char *clientclass, enum ostype_t 
                 q = strchr(jinfo, '-');              /* Check if jobname passed  */
                 if (q) {
                         strncpy(pid, jinfo, 2);          /*  Copy partition ID  */
+			pid[2] = '\0';                   /*  Terminate right after the 2-char partition ID (not pid[sizeof-1], which would leave pid[2] uninitialized) */
                         q++;                             /*  Increment pointer  */
 			strcpy(jobname,q);		 /*  Copy jobname       */
                         }

--- a/xymond/rrd/do_netstat.c
+++ b/xymond/rrd/do_netstat.c
@@ -415,7 +415,8 @@ static int do_valbeforemarker(char *layout[], char *msg, char *outp)
 			while (ln && (ln > msg) && (*ln != '\n')) ln--;
 			if (ln) {
 				int numlen;
-				if (*ln == '\n') ln++; ln += strspn(ln, " \t");
+				if (*ln == '\n') ln++;
+				ln += strspn(ln, " \t");
 				numlen = strspn(ln, "0123456789");
 				*outp = ':'; outp++; memcpy(outp, ln, numlen); outp += numlen; *outp = '\0';
 				gotany = gotval = 1;

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -4531,7 +4531,8 @@ void do_message(conn_t *msg, char *origin)
 		line1 = strdup(msg->buf); if (p) *p = savech;
 
 		p = strtok(line1, " \t"); /* Skip the client keyword */
-		if (p) collectorid = strchr(p, '/'); if (collectorid) collectorid++;
+		if (p) collectorid = strchr(p, '/');
+		if (collectorid) collectorid++;
 		if (p) hostname = strtok(NULL, " \t"); /* Actually, HOSTNAME.CLIENTOS */
 		if (hostname) {
 			clientos = strrchr(hostname, '.'); 

--- a/xymond/xymond_client.c
+++ b/xymond/xymond_client.c
@@ -1876,7 +1876,8 @@ void testmode(char *configfn)
 		oldhinfo = hinfo;
 
 		printf("Test (cpu, mem, disk, proc, log, port): "); fflush(stdout); 
-		if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+		if (!fgets(s, sizeof(s), stdin)) return;
+		clean_instr(s);
 		if (strcmp(s, "cpu") == 0) {
 			float loadyellow, loadred;
 			int recentlimit, ancientlimit, uptimecolor;
@@ -1904,7 +1905,8 @@ void testmode(char *configfn)
 			char *groups;
 
 			printf("Filesystem: "); fflush(stdout);
-			if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+			if (!fgets(s, sizeof(s), stdin)) return;
+			clean_instr(s);
 			get_disk_thresholds(hinfo, clientclass, s, &warnlevel, &paniclevel, 
 						   &abswarn, &abspanic, &ignored, &groups);
 			if (ignored) 
@@ -1929,7 +1931,8 @@ void testmode(char *configfn)
 			printf("To read 'ps' data from a file, enter '@FILENAME' at the prompt\n");
 			do {
 				printf("ps command string: "); fflush(stdout);
-				if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+				if (!fgets(s, sizeof(s), stdin)) return;
+				clean_instr(s);
 				if (*s == '@') {
 					fd = fopen(s+1, "r");
 					while (fd && fgets(s, sizeof(s), fd)) {
@@ -1955,7 +1958,8 @@ void testmode(char *configfn)
 			int logcolor;
 
 			printf("log filename: "); fflush(stdout);
-			if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+			if (!fgets(s, sizeof(s), stdin)) return;
+			clean_instr(s);
 			sectname = (char *)malloc(strlen(s) + 20);
 			sprintf(sectname, "msgs:%s", s);
 
@@ -1965,7 +1969,8 @@ void testmode(char *configfn)
 			printf("To read log data from a file, enter '@FILENAME' at the prompt\n");
 			do {
 				printf("log line: "); fflush(stdout);
-				if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+				if (!fgets(s, sizeof(s), stdin)) return;
+				clean_instr(s);
 				if (*s == '@') {
 					fd = fopen(s+1, "r");
 					while (fd && fgets(s, sizeof(s), fd)) {
@@ -1999,13 +2004,15 @@ void testmode(char *configfn)
 
 			printf("Need to know netstat columns for 'Local address', 'Remote address' and 'State'\n");
 			printf("Enter columns [%d %d %d]: ", localcol, remotecol, statecol); fflush(stdout);
-			if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+			if (!fgets(s, sizeof(s), stdin)) return;
+			clean_instr(s);
 			if (*s) sscanf(s, "%d %d %d", &localcol, &remotecol, &statecol);
 
 			printf("To read 'netstat' data from a file, enter '@FILENAME' at the prompt\n");
 			do {
 				printf("netstat line: "); fflush(stdout);
-				if (!fgets(s, sizeof(s), stdin)) return; clean_instr(s);
+				if (!fgets(s, sizeof(s), stdin)) return;
+				clean_instr(s);
 				if (*s == '@') {
 					FILE *fd;
 

--- a/xymongen/process.c
+++ b/xymongen/process.c
@@ -107,7 +107,7 @@ void calc_pagecolors(xymongen_page_t *phead)
 						     (e->color > color) &&
 						     wantedcolumn(e->column->name, g->onlycols) )
 							color = e->color;
-							oldage &= e->oldage;
+						oldage &= e->oldage;
 					}
 
 					/* Blue and clear is not propagated upwards */
@@ -127,7 +127,7 @@ void calc_pagecolors(xymongen_page_t *phead)
 						     (e->color > color) &&
 						     !wantedcolumn(e->column->name, g->exceptcols) )
 							color = e->color;
-							oldage &= e->oldage;
+						oldage &= e->oldage;
 					}
 
 					/* Blue and clear is not propagated upwards */

--- a/xymonnet/beastat.c
+++ b/xymonnet/beastat.c
@@ -107,7 +107,7 @@ char *getstring(char *databuf, char *beaindex, char *key)
 	if (p) {
 		eol = strchr(p, '\n');
 		if (eol) *eol = '\0';
-		strncpy(result, p, sizeof(result));
+		snprintf(result, sizeof(result), "%s", p);
 		if (eol) *eol = '\n';
 	}
 

--- a/xymonnet/xymonnet.c
+++ b/xymonnet/xymonnet.c
@@ -1126,8 +1126,7 @@ void run_rpcinfo_service(service_t *service)
 	char		cmdpath[PATH_MAX];
 
 	p = xgetenv("RPCINFO");
-	strncpy(cmdpath, (p ? p : "rpcinfo"), sizeof(cmdpath));
-	cmdpath[sizeof(cmdpath)-1] = '\0';	/* strncpy may not terminate */
+	snprintf(cmdpath, sizeof(cmdpath), "%s", (p ? p : "rpcinfo"));
 	for (t=service->items; (t); t = t->next) {
 		/* Do not run RPCINFO test if host does not resolve in DNS or is down */
 		if (!t->host->dnserror && (t->host->downcount == 0) && !t->host->pingerror) {
@@ -1417,7 +1416,7 @@ int finish_ping_service(service_t *service)
 		if (!t->open && t->host->routerdeps) {
 			testitem_t *router;
 
-			strncpy(l, t->host->routerdeps, sizeof(l));
+			snprintf(l, sizeof(l), "%s", t->host->routerdeps);
 			p = strtok(l, ",");
 			while (p && (t->host->deprouterdown == NULL)) {
 				for (router=service->items; 
@@ -2414,7 +2413,7 @@ int main(int argc, char *argv[])
 
 			for (t = s->items; (t); t = t->next) {
 				if (!t->host->dnserror) {
-					strncpy(tname, s->testname, sizeof(tname));
+					snprintf(tname, sizeof(tname), "%s", s->testname);
 					if (s->namelen) tname[s->namelen] = '\0';
 					t->privdata = (void *)add_tcp_test(ip_to_test(t->host), s->portnum, tname, NULL,
 									   t->srcip,

--- a/xymonproxy/xymonproxy.c
+++ b/xymonproxy/xymonproxy.c
@@ -456,7 +456,7 @@ int main(int argc, char *argv[])
 			int ccount = 0;
 			unsigned long bufspace = 0;
 			unsigned long avgtime;	/* In millisecs */
-			char runtime_s[30];
+			char runtime_s[31];	/* Include room for null termination */
 			unsigned long runt = (unsigned long) (now-startuptime);
 			char *p;
 			unsigned long msgs_sent = msgs_total - msgs_total_last;


### PR DESCRIPTION
The safe subset extracted from #60: warning fixes with no behavior change.

## What it does

- **`-Wstringop-truncation`** — bounded string copies use `snprintf(dst, sizeof(dst), "%s", src)`, which truncates and NUL-terminates in one self-documenting call, rather than `strncpy` + a separate `dst[sizeof(dst)-1] = '\0'`. This is byte-for-byte identical to a terminated `strncpy` for every value anything reads (in the truncation case both drop the same final byte), and matches the `snprintf` already used on the same buffers in `stackio.c`. This also absorbs the `strncpy` + manual terminator that #186 added on the xymonnet rpcinfo `cmdpath` — same semantics, one call.
- **`xymond/client/zvse.c`** keeps its explicit `pid[2] = '\0'` — a deliberate 2-char partial copy, not a whole-string copy — corrected from #60's `pid[sizeof(pid)-1]`, which left `pid[2]` uninitialised.
- **`-Wmisleading-indentation`** — split compound one-line `if` statements and de-indent one misleadingly-indented unconditional statement; control flow unchanged.
- Enlarge `xymonproxy` `runtime_s[30]->[31]` to fit the worst-case `sprintf`.

## Relation to #60

Same fixes as #60 minus the warning-suppression pragmas and behaviour-sensitive changes (those go to #114). The `zvse.c` `pid` correction above is the one deviation from #60.

## Note

Reviewing this PR surfaced a pre-existing, unrelated stack overflow in the same `zvse_getvis_report()` function (`strcpy(pid, jinfo)` / `strcpy(jobname, q)` / width-less `sscanf` on untrusted `[getvis]` data) — tracked separately as #216, out of scope here.

## Validation

* Each touched file compiles clean with `-Wstringop-truncation` (0 warnings).
* `git diff --check` clean; rebased on current `main`.

