### PR TITLE
Resolve GCC build warnings properly (no pragma suppression)

### DIFF
--- a/client/logfetch.c
+++ b/client/logfetch.c
@@ -326,8 +326,8 @@ char *logdata(char *filename, logdef_t *logdef)
 
 			dbgprintf(" - Last position was %u, found curpos location at %u in current buffer.\n", logdef->lastpos[1], bytesin);
 			t = strdup(fillpos);	/* need shuffle about to insert before this line */
-			strncpy(fillpos, curpostxt, strlen(curpostxt));		/* add in the CURRENT + \n */
-			strncpy(fillpos+strlen(curpostxt), t, strlen(t));	/* add in whatever this line originally was */
+			memcpy(fillpos, curpostxt, strlen(curpostxt));		/* add in the CURRENT + \n */
+			memcpy(fillpos+strlen(curpostxt), t, strlen(t));	/* add in whatever this line originally was */
 			*(fillpos+strlen(curpostxt)+strlen(t)) = '\0';		/* and terminate it */
 			xfree(t);						/* free temp */
 			curpos = fillpos;					/* leave curpos to the beginning of the CURRENT flag */
@@ -496,11 +496,11 @@ char *logdata(char *filename, logdef_t *logdef)
 		       for (i = 0, pos = replacement; i < triggerptrs_count; i++) {
 		               dbgprintf("Copying buffer content for trigger %i.\n", (i + 1));
 
-		               strncpy(pos, skiptxt, strlen(skiptxt));
+		               memcpy(pos, skiptxt, strlen(skiptxt));
 		               pos += strlen(skiptxt);
 
 		               size = strlen(triggerptrs[i][0]) - strlen(triggerptrs[i][1]);
-		               strncpy(pos, triggerptrs[i][0], size);
+		               memcpy(pos, triggerptrs[i][0], size);
 		               pos += size;
 		       }
 
@@ -533,13 +533,13 @@ char *logdata(char *filename, logdef_t *logdef)
 
 				if (finalstartptr > lasttriggerptr) {
 					/* Add the final skip for completeness */
-					strncpy(pos, skiptxt, strlen(skiptxt));
+					memcpy(pos, skiptxt, strlen(skiptxt));
 					pos += strlen(skiptxt);
 				}
 
 				/* And copy the the rest of the original buffer content */
 				dbgprintf("Copying %zu final bytes of non-trigger content\n", nontriggerbytes);
-				strncpy(pos, finalstartptr, nontriggerbytes);
+				memcpy(pos, finalstartptr, nontriggerbytes);
 				*(pos + nontriggerbytes) = '\0';	/* re-terminate */
 		       }
 

--- a/common/xymonlaunch.c
+++ b/common/xymonlaunch.c
@@ -186,8 +186,8 @@ void load_config(char *conffn)
 					int l2 = strlen(p);
 					char *newcmd = xcalloc(1, l1+l2+1);
 
-					strncpy(newcmd,curtask->cmd,l1);
-					strncpy(newcmd+l1,p,l2);
+					memcpy(newcmd, curtask->cmd, l1);
+					memcpy(newcmd+l1, p, l2);
 					newcmd[l1]=' '; /* this also overwrites the + */
 
 					/* free and assign new */

--- a/lib/links.c
+++ b/lib/links.c
@@ -140,13 +140,13 @@ void load_all_links(void)
 	if (xgetenv("HOSTDOCURL")) hostdocurl = strdup(xgetenv("HOSTDOCURL"));
 
 	if (!hostdocurl || (strlen(hostdocurl) == 0)) {
-		strncpy(dirname, xgetenv("XYMONNOTESDIR"), sizeof(dirname));
+		snprintf(dirname, sizeof(dirname), "%s", xgetenv("XYMONNOTESDIR"));
 		load_links(dirname, notesskin);
 	}
 
 	/* Change xxx/xxx/xxx/notes into xxx/xxx/xxx/help */
-	strncpy(dirname, xgetenv("XYMONNOTESDIR"), sizeof(dirname));
-	p = strrchr(dirname, '/'); *p = '\0'; strncat(dirname, "/help", (sizeof(dirname) - strlen(dirname)));
+	snprintf(dirname, sizeof(dirname), "%s", xgetenv("XYMONNOTESDIR"));
+	p = strrchr(dirname, '/'); *p = '\0'; strncat(dirname, "/help", (sizeof(dirname) - strlen(dirname) - 1));
 	load_links(dirname, helpskin);
 
 	linksloaded = 1;

--- a/lib/loadalerts.c
+++ b/lib/loadalerts.c
@@ -205,7 +205,10 @@ int load_alertconfig(char *configfn, int defcolors, int defaultinterval)
 
 	MEMDEFINE(fn);
 
-	if (configfn) strncpy(fn, configfn, sizeof(fn)); else snprintf(fn, sizeof(fn), "%s/etc/alerts.cfg", xgetenv("XYMONHOME"));
+	if (configfn) {
+		snprintf(fn, sizeof(fn), "%s", configfn);
+	}
+	else snprintf(fn, sizeof(fn), "%s/etc/alerts.cfg", xgetenv("XYMONHOME"));
 
 	/* First check if there were no modifications at all */
 	if (configfiles) {
@@ -866,7 +869,7 @@ static int criteriamatch(activealerts_t *alert, criteria_t *crit, criteria_t *ru
 
 		if ((alert->groups && (*(alert->groups)))) {
 			SBUF_MALLOC(grouplist, strlen(alert->groups));
-			strncpy(grouplist, alert->groups, grouplist_buflen);
+			snprintf(grouplist, grouplist_buflen+1, "%s", alert->groups);
 		}
 
 		if (crit->groupspec) {
@@ -899,7 +902,7 @@ static int criteriamatch(activealerts_t *alert, criteria_t *crit, criteria_t *ru
 
 			/* Excluded groups are only handled when the alert does have a group list */
 
-			strncpy(grouplist, alert->groups, grouplist_buflen); /* Might have been used in the include list */
+			snprintf(grouplist, grouplist_buflen+1, "%s", alert->groups); /* Might have been used in the include list */
 			onegroup = strtok_r(grouplist, ",", &tokptr);
 			while (onegroup) {
 				if (namematch(onegroup, crit->exgroupspec, crit->exgroupspecre)) { 
@@ -1143,7 +1146,6 @@ void print_alert_recipients(activealerts_t *alert, strbuffer_t *buf)
 	int count = 0;
 	char *p, *fontspec;
 	char codes[25];
-	unsigned int codes_bytesleft;
 
 	MEMDEFINE(l);
 	MEMDEFINE(codes);
@@ -1214,15 +1216,15 @@ void print_alert_recipients(activealerts_t *alert, strbuffer_t *buf)
 		     (recip->criteria && (recip->criteria->sendnotice == SR_WANTED)) ) notice = 1;
 
 		*codes = '\0';
-		codes_bytesleft = sizeof(codes);
 		if (recip->method == M_IGNORE) {
 			recip->recipient = "-- ignored --";
 		}
-		if (recip->noalerts) { if (*codes) strncat(codes, ",A", codes_bytesleft); else strncat(codes, "-A", codes_bytesleft); codes_bytesleft -= 2; }
-		if (recovered && !recip->noalerts) { if (*codes) strncat(codes, ",R", codes_bytesleft); else strncat(codes, "R", codes_bytesleft); codes_bytesleft -= 2; }
-		if (notice) { if (*codes) strncat(codes, ",N", codes_bytesleft); else strncat(codes, "N", codes_bytesleft); codes_bytesleft -= 2; }
-		if (recip->stoprule) { if (*codes) strncat(codes, ",S", codes_bytesleft); else strncat(codes, "S", codes_bytesleft); codes_bytesleft -= 2; }
-		if (recip->unmatchedonly) { if (*codes) strncat(codes, ",U", codes_bytesleft); else strncat(codes, "U", codes_bytesleft); codes_bytesleft -= 2; }
+		/* Append flag codes, always bounding strncat by the space actually left in codes[] */
+		if (recip->noalerts) strncat(codes, (*codes ? ",A" : "-A"), sizeof(codes)-strlen(codes)-1);
+		if (recovered && !recip->noalerts) strncat(codes, (*codes ? ",R" : "R"), sizeof(codes)-strlen(codes)-1);
+		if (notice) strncat(codes, (*codes ? ",N" : "N"), sizeof(codes)-strlen(codes)-1);
+		if (recip->stoprule) strncat(codes, (*codes ? ",S" : "S"), sizeof(codes)-strlen(codes)-1);
+		if (recip->unmatchedonly) strncat(codes, (*codes ? ",U" : "U"), sizeof(codes)-strlen(codes)-1);
 
 		if (strlen(codes) == 0)
 			snprintf(l, sizeof(l), "<td><font %s>%s</font></td>", fontspec, recip->recipient);

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -164,15 +164,15 @@ char *commafy(char *hostname)
 
 	if (s == NULL) {
 		SBUF_MALLOC(s, strlen(hostname)+1);
-		strncpy(s, hostname, s_buflen);
+		snprintf(s, s_buflen, "%s", hostname);
 	}
 	else if (strlen(hostname) > strlen(s)) {
 		xfree(s);
 		SBUF_MALLOC(s, strlen(hostname)+1);
-		strncpy(s, hostname, s_buflen);
+		snprintf(s, s_buflen, "%s", hostname);
 	}
 	else {
-		strncpy(s, hostname, s_buflen);
+		snprintf(s, s_buflen, "%s", hostname);
 	}
 
 	for (p = strchr(s, '.'); (p); p = strchr(s, '.')) *p = ',';

--- a/lib/sig.c
+++ b/lib/sig.c
@@ -98,9 +98,9 @@ void setup_signalhandler(char *programname)
 	 * Used inside signal-handler. Must be setup in
 	 * advance.
 	 */
-	strncpy(signal_xymoncmd, xgetenv("XYMON"), sizeof(signal_xymoncmd));
-	strncpy(signal_xymondserver, xgetenv("XYMSRV"), sizeof(signal_xymondserver));
-	strncpy(signal_tmpdir, xgetenv("XYMONTMP"), sizeof(signal_tmpdir));
+	snprintf(signal_xymoncmd, sizeof(signal_xymoncmd), "%s", xgetenv("XYMON"));
+	snprintf(signal_xymondserver, sizeof(signal_xymondserver), "%s", xgetenv("XYMSRV"));
+	snprintf(signal_tmpdir, sizeof(signal_tmpdir), "%s", xgetenv("XYMONTMP"));
 	snprintf(signal_msg, sizeof(signal_msg), "status %s.%s red - Program crashed\n\nFatal signal caught!\n", 
 		(xgetenv("MACHINE") ? xgetenv("MACHINE") : "XYMSERVERS"), programname);
 

--- a/lib/xymonrrd.c
+++ b/lib/xymonrrd.c
@@ -82,9 +82,9 @@ static void rrd_setup(void)
 	/* Get the tcp services, and count how many there are */
 	services = strdup(init_tcp_services());
 	SBUF_MALLOC(tcptests, strlen(services)+1);
-	strncpy(tcptests, services, tcptests_buflen);
+	snprintf(tcptests, tcptests_buflen, "%s", services);
 	count = 0; p = strtok(tcptests, " "); while (p) { count++; p = strtok(NULL, " "); }
-	strncpy(tcptests, services, tcptests_buflen);
+	snprintf(tcptests, tcptests_buflen, "%s", services);
 
 	/* Setup the xymonrrds table, mapping test-names to RRD files */
 	SBUF_MALLOC(lenv, strlen(xgetenv("TEST2RRD")) + strlen(tcptests) + count*strlen(",=tcp") + 1);

--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -152,9 +152,9 @@ static int parse_query(void)
 
 		req = getenv("SCRIPT_NAME");
 		SBUF_MALLOC(clienturi, strlen(req) + 10 + strlen(hostquoted));
-		strncpy(clienturi, req, clienturi_buflen);
+		strcpy(clienturi, req);
 		p = strchr(clienturi, '?'); if (p) *p = '\0'; else p = clienturi + strlen(clienturi);
-		snprintf(p, (clienturi_buflen - (clienturi - p)), "?CLIENT=%s", hostquoted);
+		snprintf(p, (clienturi_buflen + 1 - (p - clienturi)), "?CLIENT=%s", hostquoted);
 	}
 
 	return 0;

--- a/xymond/combostatus.c
+++ b/xymond/combostatus.c
@@ -351,7 +351,7 @@ static long evaluate(char *symbolicexpr, char **resultexpr, value_t **valuelist,
 	result = compute(expr, &error);
 
 	if (error) {
-		sprintf(errtext, "compute(%s) returned error %d\n", expr, error);
+		snprintf(errtext, sizeof(errtext), "compute(%s) returned error %d\n", expr, error);
 		if (*errbuf == NULL) {
 			*errbuf = strdup(errtext);
 		}

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -263,6 +263,16 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 	return result;
 }
 
+/* Build "rrddir/hostname/rrdfn" into buf; returns -1 (and logs) if it would not fit. */
+static int build_rrd_filedir(char *buf, size_t bufsz, char *hostname, char *rrdfn)
+{
+	if (snprintf(buf, bufsz, "%s/%s/%s", rrddir, hostname, rrdfn) >= (int)bufsz) {
+		errprintf("RRD path truncated, skipping: %s/%s/%s\n", rrddir, hostname, rrdfn);
+		return -1;
+	}
+	return 0;
+}
+
 static int create_and_update_rrd(char *hostname, char *testname, char *classname, char *pagepaths, char *creparams[], void *template)
 {
 	static int callcounter = 0;
@@ -287,7 +297,12 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	MEMDEFINE(rrdvalues);
 	MEMDEFINE(filedir);
 
-	sprintf(filedir, "%s/%s", rrddir, hostname);
+	if (snprintf(filedir, sizeof(filedir), "%s/%s", rrddir, hostname) >= (int)sizeof(filedir)) {
+		errprintf("RRD directory path truncated, skipping: %s/%s\n", rrddir, hostname);
+		MEMUNDEFINE(filedir);
+		MEMUNDEFINE(rrdvalues);
+		return -1;
+	}
 	if (stat(filedir, &st) == -1) {
 		if (mkdir(filedir, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH) == -1) {
 			errprintf("Cannot create rrd directory %s : %s\n", filedir, strerror(errno));
@@ -297,8 +312,11 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		}
 	}
 	/* Watch out here - "rrdfn" may be very large. */
-	snprintf(filedir, sizeof(filedir)-1, "%s/%s/%s", rrddir, hostname, rrdfn);
-	filedir[sizeof(filedir)-1] = '\0'; /* Make sure it is null terminated */
+	if (build_rrd_filedir(filedir, sizeof(filedir), hostname, rrdfn)) {
+		MEMUNDEFINE(filedir);
+		MEMUNDEFINE(rrdvalues);
+		return -1;
+	}
 
 	/* 
 	 * Prepare to cache the update. Create the cache tree, and find/create a cache record.
@@ -598,8 +616,7 @@ static int rrddatasets(char *hostname, char ***dsnames)
 	unsigned long steptime, dscount;
 	rrd_value_t *rrddata;
 
-	snprintf(filedir, sizeof(filedir)-1, "%s/%s/%s", rrddir, hostname, rrdfn);
-	filedir[sizeof(filedir)-1] = '\0';
+	if (build_rrd_filedir(filedir, sizeof(filedir), hostname, rrdfn)) return 0;
 	if (stat(filedir, &st) == -1) return 0;
 
 	optind = opterr = 0; rrd_clear_error();

--- a/xymond/trimhistory.c
+++ b/xymond/trimhistory.c
@@ -333,7 +333,7 @@ void trim_logs(time_t cutoff)
 
 					ltime = logtime(lent->d_name);
 					if ((ltime > 0) && (ltime < cutoff)) {
-						sprintf(fn2, "%s/%s", fn1, lent->d_name);
+						snprintf(fn2, sizeof(fn2), "%s/%s", fn1, lent->d_name);
 						if (unlink(fn2) == -1) {
 							errprintf("Failed to unlink %s: %s\n", fn2, strerror(errno));
 						}

--- a/xymond/xymond_hostdata.c
+++ b/xymond/xymond_hostdata.c
@@ -208,9 +208,9 @@ int main(int argc, char *argv[])
 				for (i = 10; (i > 0); i--) itm->tstamp[i+1] = itm->tstamp[i];
 				itm->tstamp[0] = now;
 
-				sprintf(hostdir, "%s/%s", clientlogdir, metadata[3]);
+				snprintf(hostdir, sizeof(hostdir), "%s/%s", clientlogdir, metadata[3]);
 				mkdir(hostdir, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
-				sprintf(fn, "%s/%s", hostdir, metadata[4]);
+				snprintf(fn, sizeof(fn), "%s/%s", hostdir, metadata[4]);
 				fd = fopen(fn, "w");
 				if (fd == NULL) {
 					errprintf("Cannot create file %s: %s\n", fn, strerror(errno));

--- a/xymongen/pagegen.c
+++ b/xymongen/pagegen.c
@@ -641,7 +641,7 @@ void do_hosts(host_t *head, int sorthosts, char *onlycols, char *exceptcols, FIL
 								pagepath, h->hostname, e->column->name, htmlextension);
 							sprintf(textrepfn, "%savail-%s-%s.txt",
 								pagepath, h->hostname, e->column->name);
-							sprintf(textrepurl, "%s/%s", 
+							snprintf(textrepurl, sizeof(textrepurl), "%s/%s",
 								xgetenv("XYMONWEB"), textrepfn);
 
 							htmlrep = fopen(htmlrepfn, "w");
@@ -922,9 +922,9 @@ void do_one_page(xymongen_page_t *page, dispsummary_t *sums, int embedded)
 			char	indexfilename[PATH_MAX];
 
 			/* top level page */
-			sprintf(filename, "xymon%s", htmlextension);
-			sprintf(rssfilename, "xymon%s", rssextension);
-			sprintf(indexfilename, "index%s", htmlextension);
+			snprintf(filename, sizeof(filename), "xymon%s", htmlextension);
+			snprintf(rssfilename, sizeof(rssfilename), "xymon%s", rssextension);
+			snprintf(indexfilename, sizeof(indexfilename), "index%s", htmlextension);
 			unlink(indexfilename); 
 			if (symlink(filename, indexfilename)) {
 				dbgprintf("Symlinking %s -> %s\n", filename, indexfilename);
@@ -936,16 +936,16 @@ void do_one_page(xymongen_page_t *page, dispsummary_t *sums, int embedded)
 	
 			for (pgwalk = page; (pgwalk); pgwalk = pgwalk->parent) {
 				if (strlen(pgwalk->name)) {
-					sprintf(tmppath, "%s/%s/", pgwalk->name, pagepath);
+					snprintf(tmppath, sizeof(tmppath), "%s/%s/", pgwalk->name, pagepath);
 					strcpy(pagepath, tmppath);
 				}
 			}
 	
-			sprintf(filename, "%s/%s%s", pagepath, page->name, htmlextension);
-			sprintf(rssfilename, "%s/%s%s", pagepath, page->name, rssextension);
+			snprintf(filename, sizeof(filename), "%s/%s%s", pagepath, page->name, htmlextension);
+			snprintf(rssfilename, sizeof(rssfilename), "%s/%s%s", pagepath, page->name, rssextension);
 		}
-		sprintf(tmpfilename, "%s.tmp", filename);
-		sprintf(tmprssfilename, "%s.tmp", rssfilename);
+		snprintf(tmpfilename, sizeof(tmpfilename), "%s.tmp", filename);
+		snprintf(tmprssfilename, sizeof(tmprssfilename), "%s.tmp", rssfilename);
 
 
 		/* Try creating the output file. If it fails, we may need to create the directories */
@@ -1239,16 +1239,16 @@ int do_nongreen_page(char *nssidebarfilename, int summarytype, char *filenamebas
 
 	switch (summarytype) {
 	  case PAGE_NONGREEN:
-		sprintf(filename, "%s%s", filenamebase, htmlextension);
-		sprintf(rssfilename, "%s%s", filenamebase, rssextension);
+		snprintf(filename, sizeof(filename), "%s%s", filenamebase, htmlextension);
+		snprintf(rssfilename, sizeof(rssfilename), "%s%s", filenamebase, rssextension);
 		break;
 	  case PAGE_CRITICAL:
-		sprintf(filename, "%s%s", filenamebase, htmlextension);
-		sprintf(rssfilename, "%s%s", filenamebase, rssextension);
+		snprintf(filename, sizeof(filename), "%s%s", filenamebase, htmlextension);
+		snprintf(rssfilename, sizeof(rssfilename), "%s%s", filenamebase, rssextension);
 		break;
 	}
 
-	sprintf(tmpfilename, "%s.tmp", filename);
+	snprintf(tmpfilename, sizeof(tmpfilename), "%s.tmp", filename);
 	output = fopen(tmpfilename, "w");
 	if (output == NULL) {
 		errprintf("Cannot create file %s: %s\n", tmpfilename, strerror(errno));
@@ -1256,7 +1256,7 @@ int do_nongreen_page(char *nssidebarfilename, int summarytype, char *filenamebas
 	}
 
 	if (wantrss) {
-		sprintf(tmprssfilename, "%s.tmp", rssfilename);
+		snprintf(tmprssfilename, sizeof(tmprssfilename), "%s.tmp", rssfilename);
 		rssoutput = fopen(tmprssfilename, "w");
 		if (rssoutput == NULL) {
 			errprintf("Cannot create RSS file %s: %s\n", tmpfilename, strerror(errno));

--- a/xymongen/util.c
+++ b/xymongen/util.c
@@ -40,16 +40,16 @@ char *hostpage_link(host_t *host)
 	xymongen_page_t *pgwalk;
 
 	if (host->parent && (strlen(((xymongen_page_t *)host->parent)->name) > 0)) {
-		sprintf(pagelink, "%s%s", ((xymongen_page_t *)host->parent)->name, htmlextension);
+		snprintf(pagelink, sizeof(pagelink), "%s%s", ((xymongen_page_t *)host->parent)->name, htmlextension);
 		for (pgwalk = host->parent; (pgwalk); pgwalk = pgwalk->parent) {
 			if (strlen(pgwalk->name)) {
-				sprintf(tmppath, "%s/%s", pgwalk->name, pagelink);
-				strcpy(pagelink, tmppath);
+				snprintf(tmppath, sizeof(tmppath), "%s/%s", pgwalk->name, pagelink);
+				snprintf(pagelink, sizeof(pagelink), "%s", tmppath);
 			}
 		}
 	}
 	else {
-		sprintf(pagelink, "xymon%s", htmlextension);
+		snprintf(pagelink, sizeof(pagelink), "xymon%s", htmlextension);
 	}
 
 	return pagelink;

--- a/xymongen/wmlgen.c
+++ b/xymongen/wmlgen.c
@@ -119,7 +119,7 @@ static void generate_wml_statuscard(host_t *host, entry_t *entry)
 	nextline = msg;
 	l[MAX_LINE_LEN - 1] = '\0';
 
-	sprintf(fn, "%s/%s.%s.wml", wmldir, host->hostname, entry->column->name);
+	snprintf(fn, sizeof(fn), "%s/%s.%s.wml", wmldir, host->hostname, entry->column->name);
 	fd = fopen(fn, "w");
 	if (fd == NULL) {
 		errprintf("Cannot create file %s\n", fn);
@@ -312,7 +312,7 @@ void do_wml_cards(char *webdir)
 	}
 
 	/* Start the non-green WML card */
-	sprintf(nongreenfn, "%s/nongreen.wml.tmp", wmldir);
+	snprintf(nongreenfn, sizeof(nongreenfn), "%s/nongreen.wml.tmp", wmldir);
 	nongreenfd = fopen(nongreenfn, "w");
 	if (nongreenfd == NULL) {
 		errprintf("Cannot open non-green WML file %s\n", nongreenfn);
@@ -336,7 +336,7 @@ void do_wml_cards(char *webdir)
 		if (h->hostentry->anywaps) {
 
 			/* Create the host WAP card, with links to individual test results */
-			sprintf(hostfn, "%s/%s.wml", wmldir, h->hostentry->hostname);
+			snprintf(hostfn, sizeof(hostfn), "%s/%s.wml", wmldir, h->hostentry->hostname);
 			hostfd = fopen(hostfn, "w");
 			if (hostfd == NULL) {
 				errprintf("Cannot create file %s\n", hostfn);
@@ -386,7 +386,7 @@ void do_wml_cards(char *webdir)
 				fclose(nongreenfd);
 
 				/* Start a new Nongreen WML card */
-				sprintf(nongreenfn, "%s/nongreen-%d.wml", wmldir, nongreenpart);
+				snprintf(nongreenfn, sizeof(nongreenfn), "%s/nongreen-%d.wml", wmldir, nongreenpart);
 				nongreenfd = fopen(nongreenfn, "w");
 				if (nongreenfd == NULL) {
 					errprintf("Cannot open Nongreen WML file %s\n", nongreenfd);


### PR DESCRIPTION
The remaining root-cause warning-fix subset from #60: fix the code rather than hide warnings. No `#pragma GCC diagnostic ignored`, and none of #60's unrelated behaviour changes (`XYMONHELPDIR`, `sig.c` crash-message/`getenv`).

## What it does

- **Bounded string copies** use `snprintf(dst, sizeof dst, "%s", src)` (the idiom shared with #113), or `memcpy` + manual NUL where a fixed byte count is copied. No `strncpy` is left with a hand-written terminator, so the two PRs speak one idiom.
- **`lib/loadalerts.c` — real behaviour fix.** The `grouplist` copy used `strncpy(dst, src, strlen(src))`, which writes **no** terminator; `strtok_r` then read past the buffer and the **last alert group matched against heap garbage**. `snprintf` fixes both the include- and exclude-group copies. This makes group-scoped alert routing (`GROUP=` / `EXGROUP=` in alerts.cfg) **deterministic where it was previously non-deterministic** — worth noting for anyone whose alert rules key off the last group. Also replaces the fragile hand-tracked `strncat` bounds with remaining-space bounds.
- **`xymond/do_rrd.c`.** The RRD path is now built through one helper that checks for truncation; on truncation it logs and **skips the update** (`return -1` / no datasets) instead of creating/updating a truncated, possibly-colliding path. The host-directory path is bounded the same way. *(Behaviour note: pre-existing code detected-and-continued or silently truncated; this drops the update instead — the safe choice for a path that can't be represented.)*
- **`xymongen/util.c`, `pagegen.c`, `xymond/trimhistory.c`, `xymond/xymond_hostdata.c`.** Fixed-buffer `sprintf` → `snprintf`, including the remaining page-link writes so the whole function is bounded (not just one call).
- **`lib/sig.c`, `lib/links.c`.** Only NUL-terminate the affected buffers (via `snprintf`); `xgetenv()` and crash-message behaviour unchanged, per the PR's charter.
- **`web/svcstatus.c`.** Keep the copy safe and correct the CLIENT-uri `snprintf` remaining-space expression (the operands were reversed — harmless in practice due to allocation slack, but now correct).

## Relation to #60 / #113

Same real fixes as #60, minus the pragma suppression and the behaviour changes. Together with #113 (the mechanical, no-behaviour-change subset) this supersedes #60.

## Validation

* Each touched file compiles clean of `-Wstringop-truncation`; the cleanup introduces no new warnings.
* `git diff --check` clean; rebased on current `main`.
