### PR TITLE
configure: enable SNMP by autodetect (opt-out), like LDAP

### DIFF
--- a/build/snmp.sh
+++ b/build/snmp.sh
@@ -3,7 +3,7 @@
 	SNMPINC=""
 	SNMPLIB=""
 
-	VERSION=`net-snmp-config --version`
+	VERSION=`net-snmp-config --version 2>/dev/null`
 	if test $? -eq 0
 	then
 		echo "Found Net-SNMP version $VERSION"

--- a/configure.server
+++ b/configure.server
@@ -181,7 +181,7 @@ echo ""; echo "";
 . build/clock-gettime-librt.sh
 echo ""; echo ""
 
-if test "$SNMP" = "1"
+if test "$SNMP" != "0" -a "$SNMP" != "n"
 then
 	. build/snmp.sh
 	echo ""; echo ""


### PR DESCRIPTION
## Summary
SNMP was opt-in (`if test "$SNMP" = "1"`), while LDAP/SSL auto-enable when their library is present. So default builds got `DOSNMP=no` and never exercised the `xymon-snmpcollect` path.

This makes SNMP behave like LDAP: run `build/snmp.sh` (which already probes `net-snmp-config`) by default, skip only on explicit `SNMP=0`/`SNMP=n`. One-line change, branch order kept (`then` = enable).

```diff
-if test "$SNMP" = "1"
+if test "$SNMP" != "0" -a "$SNMP" != "n"
```

- **default** → enabled if Net-SNMP present, gracefully disabled if not
- **`SNMP=0` / `SNMP=n`** → opt-out
- **`SNMP=1`** → unchanged

Second commit silences the `net-snmp-config: not found` stderr noise now that the probe runs by default (see comment below).

Refs #130, #78, #77
