### PR TITLE
build/rrd.sh: find RRDtool under MacPorts/Homebrew prefixes on macOS (fixes #132)

### DIFF
--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -64,6 +64,40 @@
 		fi
 	done
 
+	# MacPorts (/opt/local) and Homebrew (/opt/homebrew) install RRDtool outside the
+	# prefixes scanned above. Consult them only when the standard search found nothing,
+	# so this stays a pure fallback that leaves detection on other systems unchanged.
+	# macOS shared libraries use the .dylib extension.
+	if test "$RRDINC" = ""
+	then
+		for DIR in /opt/local /opt/homebrew
+		do
+			if test -f $DIR/include/rrd.h
+			then
+				RRDINC=$DIR/include
+			fi
+
+			if test -f $DIR/lib/librrd.dylib
+			then
+				RRDLIB=$DIR/lib
+			fi
+			if test -f $DIR/lib/librrd.a
+			then
+				RRDLIB=$DIR/lib
+			fi
+
+			if test -f $DIR/lib/libpng.dylib
+			then
+				PNGLIB="-L$DIR/lib -lpng"
+			fi
+
+			if test -f $DIR/lib/libz.dylib
+			then
+				ZLIB="-L$DIR/lib -lz"
+			fi
+		done
+	fi
+
 	if test "$USERRRDINC" != ""; then
 		RRDINC="$USERRRDINC"
 	fi


### PR DESCRIPTION
Fixes #132.

## Problem

On macOS, `configure.server` aborts at the RRDtool step with "Unable to determine the RRDtool argv API from the installed headers", even when RRDtool is installed via MacPorts (`/opt/local`) or Homebrew on Apple Silicon (`/opt/homebrew`).

The argv-API autodetection added in `cbe373ec0` probes the API by compiling `#include <rrd.h>`, so it needs the header on the include path. The prefix-search loop in `build/rrd.sh` never listed the macOS package-manager prefixes, so the header was not found, both candidate prototypes failed to compile, and configure aborted. The old `pkg-config librrd` check did not need the header path, which is why this only surfaced after the rework. See #132 for the full analysis.

## Fix

Add a fallback scan of `/opt/local` and `/opt/homebrew` that runs **only when the standard search found no headers**, recognising the `.dylib` extension for `librrd`/`libpng`/`libz`.

Because it is gated on an empty `RRDINC` and placed after the existing loop, the original search loop is left **byte-for-byte unchanged** — detection on every non-macOS platform is unaffected. An explicit `--rrdinclude`/`--rrdlib` still takes precedence (applied afterwards).

`/opt/local` and `/opt/homebrew` are the default prefixes for MacPorts and Homebrew, so both macOS cases are covered; the compile probe still determines the argv API (`const char **` vs `char **`) exactly as before.

## Testing

CI (server lanes) on **macOS 14, 15 and 26**, RRDtool from MacPorts:

```
Checking for RRDtool ...
Detected RRDtool argv API: const char **
Compiling with RRDtool works OK
Linking with RRDtool works OK
```

All three macOS lanes pass; non-macOS lanes are unaffected (the standard search path is unchanged).
