### PR TITLE
build: detect macOS package-manager dependency paths in the make probes

### DIFF
--- a/build/c-ares.sh
+++ b/build/c-ares.sh
@@ -2,7 +2,7 @@
 
 	CARESINC=""
 	CARESLIB=""
-	for DIR in /opt/c*ares* /usr/local/c*ares* /usr/local /usr/pkg /opt/csw /opt/sfw
+	for DIR in /opt/c*ares* /usr/local/c*ares* /usr/local /usr/pkg /opt/csw /opt/sfw /opt/homebrew /opt/local
 	do
 		if test -f $DIR/include/ares.h
 		then
@@ -14,6 +14,10 @@
 		fi
 
 		if test -f $DIR/lib/libcares.so
+		then
+			CARESLIB=$DIR/lib
+		fi
+		if test -f $DIR/lib/libcares.dylib
 		then
 			CARESLIB=$DIR/lib
 		fi

--- a/build/fping.sh
+++ b/build/fping.sh
@@ -2,7 +2,7 @@
 
 	echo "Checking for fping ..."
 
-	for DIR in / /usr /usr/local /opt /usr/pkg /opt/csw
+	for DIR in / /usr /usr/local /opt /usr/pkg /opt/csw /opt/homebrew /opt/local
 	do
 		if test "$DIR" = "/"; then DIR=""; fi
 

--- a/build/ldap.sh
+++ b/build/ldap.sh
@@ -2,7 +2,7 @@
 
 	LDAPINC=""
 	LDAPLIB=""
-	for DIR in /opt/openldap* /opt/ldap* /usr/local/openldap* /usr/local/ldap* /usr/local /usr/pkg /opt/csw /opt/sfw
+	for DIR in /opt/openldap* /opt/ldap* /usr/local/openldap* /usr/local/ldap* /usr/local /usr/pkg /opt/csw /opt/sfw /usr/local/opt/openldap /opt/homebrew/opt/openldap /opt/local
 	do
 		if test -f $DIR/include/ldap.h
 		then
@@ -10,6 +10,10 @@
 		fi
 
 		if test -f $DIR/lib/libldap.so
+		then
+			LDAPLIB=$DIR/lib
+		fi
+		if test -f $DIR/lib/libldap.dylib
 		then
 			LDAPLIB=$DIR/lib
 		fi

--- a/build/pcre.sh
+++ b/build/pcre.sh
@@ -2,7 +2,7 @@
 
 	PCREINC=""
 	PCRELIB=""
-	for DIR in /opt/pcre* /usr/local/pcre* /usr/local /usr/pkg /opt/csw /opt/sfw
+	for DIR in /opt/pcre* /usr/local/pcre* /usr/local /usr/pkg /opt/csw /opt/sfw /opt/homebrew /opt/local
 	do
 		if test -f $DIR/include/pcre2.h
 		then
@@ -14,6 +14,10 @@
 		fi
 
 		if test -f $DIR/lib/libpcre2-8.so
+		then
+			PCRELIB=$DIR/lib
+		fi
+		if test -f $DIR/lib/libpcre2-8.dylib
 		then
 			PCRELIB=$DIR/lib
 		fi

--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -5,7 +5,7 @@
 	RRDLIB=""
 	PNGLIB=""
 	ZLIB=""
-	for DIR in /opt/rrdtool* /usr/local/rrdtool* /usr/local /usr/pkg /opt/csw /opt/sfw /usr/sfw
+	for DIR in /opt/rrdtool* /usr/local/rrdtool* /usr/local /usr/pkg /opt/csw /opt/sfw /usr/sfw /opt/homebrew /opt/local
 	do
 		if test -f $DIR/include/rrd.h
 		then
@@ -13,6 +13,10 @@
 		fi
 
 		if test -f $DIR/lib/librrd.so
+		then
+			RRDLIB=$DIR/lib
+		fi
+		if test -f $DIR/lib/librrd.dylib
 		then
 			RRDLIB=$DIR/lib
 		fi
@@ -33,6 +37,10 @@
 		then
 			PNGLIB="-L$DIR/lib -lpng"
 		fi
+		if test -f $DIR/lib/libpng.dylib
+		then
+			PNGLIB="-L$DIR/lib -lpng"
+		fi
 		if test -f $DIR/lib/libpng.a
 		then
 			PNGLIB="-L$DIR/lib -lpng"
@@ -47,6 +55,10 @@
 		fi
 
 		if test -f $DIR/lib/libz.so
+		then
+			ZLIB="-L$DIR/lib -lz"
+		fi
+		if test -f $DIR/lib/libz.dylib
 		then
 			ZLIB="-L$DIR/lib -lz"
 		fi

--- a/build/ssl.sh
+++ b/build/ssl.sh
@@ -2,7 +2,7 @@
 
 	OSSLINC=""
 	OSSLLIB=""
-	for DIR in /opt/openssl* /opt/ssl* /usr/local/openssl* /usr/local/ssl* /usr/local /usr/pkg /opt/csw /opt/sfw/*ssl* /usr/sfw /usr/sfw/*ssl*
+	for DIR in /opt/openssl* /opt/ssl* /usr/local/openssl* /usr/local/ssl* /usr/local /usr/pkg /opt/csw /opt/sfw/*ssl* /usr/sfw /usr/sfw/*ssl* /usr/local/opt/openssl@3 /opt/homebrew/opt/openssl@3 /opt/local
 	do
 		if test -d $DIR/include/openssl
 		then
@@ -10,6 +10,10 @@
 		fi
 
 		if test -f $DIR/lib/libcrypto.so
+		then
+			OSSLLIB=$DIR/lib
+		fi
+		if test -f $DIR/lib/libcrypto.dylib
 		then
 			OSSLLIB=$DIR/lib
 		fi


### PR DESCRIPTION
## Problem

The `make` build had no awareness of the macOS package-manager prefixes
(`/opt/local` for MacPorts, `/opt/homebrew` for Homebrew on Apple Silicon),
so on a stock macOS install the dependency probes don't find their headers
and libraries:

- `build/pcre.sh` (mandatory) aborts the build,
- `ssl`/`ldap`/`c-ares` silently disable their features,
- `build/rrd.sh`'s argv-API probe aborts with *"Unable to determine the
  RRDtool argv API"*.

## Change

Teach each `build/*.sh` dependency probe (pcre, ssl, ldap, c-ares, fping,
rrd) to look under the macOS package-manager prefixes, reusing the
per-script prefix lists already used for the other platforms, and add the
`.dylib` checks alongside the existing `.so`/`.a` ones.

- The macOS paths are **appended at the end** of each existing search list.
  Because the probes are last-match-wins, this keeps the established
  non-macOS ordering (e.g. NetBSD `/usr/pkg`) intact and only changes the
  result on macOS.
- Non-keg-only formulae (`pcre2`, `c-ares`, `rrdtool`, `fping`) resolve from
  the prefix itself: `/opt/homebrew` (Apple Silicon) and `/opt/local`
  (MacPorts); Intel Homebrew `/usr/local` is already in the lists.
- Keg-only formulae get their version-stable opt paths:
  `…/opt/openssl@3` and `…/opt/openldap` for both `/usr/local/opt` (Intel)
  and `/opt/homebrew/opt` (Apple Silicon).

Detection stays in the individual probes — where the rest of the
per-library discovery lives — rather than bolting a single global prefix
onto `Makefile.Darwin`.

## Testing

Built the make **server** variant on the project's macOS. On a MacPorts runner all dependencies (PCRE, c-ares,
RRDtool, OpenSSL, LDAP) resolved under `/opt/local` and both compiled and
linked; RRDtool's argv API was autodetected correctly.

Closes #134.

