### PR TITLE
showgraph: anchor single-service RRD match to the FNPATTERN component (#20)

### DIFF
--- a/tests/web/showgraph-single-service.sh
+++ b/tests/web/showgraph-single-service.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/showgraph-single-service.sh
+#
+# Regression guard for issue #20: viewing one service out of a bundle
+# (service=tcp:conn) must select only that service's RRD file, not every
+# file whose name contains the service as a substring. Drives the real
+# showgraph CGI with --debug against a fake RRD directory and asserts on
+# the rrd_graph argument dump.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+command -v make >/dev/null 2>&1 || skip "make not available"
+
+# Needs a configured/built tree (bare-tree CI skips; the post-build suite
+# runs it for real) and one built WITH RRD support.
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+[ -f "$ROOT/web/showgraph.cgi" ] || skip "tree built without RRD support (no showgraph.cgi)"
+
+# RRD and SSL build flags as configure detected them (SSLLIBS is empty
+# on a tree built without SSL - don't force -lssl on such a link)
+rrddef=$(sed -n 's/^RRDDEF *= *//p' "$ROOT/Makefile")
+rrdlibs=$(sed -n 's/^RRDLIBS *= *//p' "$ROOT/Makefile")
+[ -n "$rrdlibs" ] || rrdlibs="-lrrd"
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+
+pcre_libs=${PCRELIBS:-}
+if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+fi
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-showgraph.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" $rrddef -o "$work/showgraph" \
+	"$ROOT/web/showgraph.c" "$ROOT/lib/libxymoncomm.a" \
+	$pcre_libs $rrdlibs $ssllibs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "showgraph does not compile"; }
+
+# Fake RRD directory; selection is by filename, empty stubs suffice
+rrds="$work/rrd/testhost"
+mkdir -p "$rrds"
+touch "$rrds/tcp.conn.rrd" "$rrds/tcp.proxyconn.rrd" \
+	"$rrds/tcp.connfoo.rrd" "$rrds/tcp.conn.extra.rrd" \
+	"$rrds/tcp.dns.rrd" "$rrds/tcp.dnsmadeeasy.rrd" \
+	"$rrds/tcp.http.a.rrd" "$rrds/tcp.http.b.rrd" \
+	"$rrds/nocap.x.rrd" "$rrds/nocap.y.rrd"
+
+# Stock graphs.cfg plus a fall-back definition without a capture group
+cp "$ROOT/xymond/etcfiles/graphs.cfg.DIST" "$work/graphs.cfg"
+cat >>"$work/graphs.cfg" <<'EOF'
+
+[nocap]
+	FNPATTERN ^nocap.*.rrd
+	TITLE No capture group
+	YAXIS x
+	DEF:p@RRDIDX@=@RRDFN@:sec:AVERAGE
+	LINE2:p@RRDIDX@#@COLOR@:x
+EOF
+
+# Run one CGI request; rrd_graph fails on the stub files, but the --debug
+# argument dump (which carries the selected filenames) comes out first.
+render() {
+	REQUEST_METHOD=GET \
+	QUERY_STRING="host=testhost&service=$1&graph=hourly&action=view" \
+	XYMONHOME="$work" TEST2RRD="dns=tcp" \
+		"$work/showgraph" --debug --config="$work/graphs.cfg" \
+		--rrddir="$rrds" 2>/dev/null || true
+}
+
+# The issue #20 case: bundle fall-back selects on the FNPATTERN capture
+out=$(render "tcp:conn")
+assert_contains     "=tcp.conn.rrd:"  "$out" "single service from bundle"
+assert_not_contains "proxyconn.rrd"   "$out" "single service from bundle"
+assert_not_contains "connfoo.rrd"     "$out" "single service from bundle"
+assert_not_contains "conn.extra.rrd"  "$out" "single service from bundle"
+
+# Same path via a bare TEST2RRD-mapped service (dns -> [tcp])
+out=$(render "dns")
+assert_contains     "=tcp.dns.rrd:"   "$out" "bare TEST2RRD service"
+assert_not_contains "dnsmadeeasy.rrd" "$out" "bare TEST2RRD service"
+
+# A request resolving to its own gdef (tcp.http -> [http]) keeps the
+# substring match: the capture is a subitem (URL), not the service
+out=$(render "tcp.http")
+assert_contains     "=tcp.http.a.rrd:" "$out" "own-gdef request"
+assert_contains     "=tcp.http.b.rrd:" "$out" "own-gdef request"
+
+# A fall-back definition without a capture group falls back to the
+# substring match instead of keeping the whole bundle
+out=$(render "nocap:x")
+assert_contains     "=nocap.x.rrd:"   "$out" "no-capture fall-back"
+assert_not_contains "nocap.y.rrd"     "$out" "no-capture fall-back"
+
+# An empty service component is rejected up front
+out=$(render "tcp:")
+assert_contains "Missing graph service name" "$out" "empty service rejected"
+
+pass "showgraph selects single-service RRDs by FNPATTERN component"

--- a/web/graphs.cfg.5
+++ b/web/graphs.cfg.5
@@ -37,6 +37,11 @@ file in the set. "@RRDPARAM@" contains the first word extracted from the
 pattern of files (see e.g. "[memory]" how this is used). "@COLOR@" picks
 a new color for each graph automatically.
 
+For a bundle viewed one service at a time (e.g. "tcp:conn"), FNPATTERN
+capture group 1 must be exactly the service component: showgraph uses it
+both as the legend (@RRDPARAM@) and to select the single service \- see
+"[tcp]", where "^tcp.(.+).rrd" captures "conn" from tcp.conn.rrd.
+
 The remainder of the lines in each definition are passed directly to the
 RRDtool rrd_graph() routine.
 

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -646,6 +646,14 @@ int rrd_name_compare(const void *v1, const void *v2)
 	return strcmp(r1->key, r2->key);
 }
 
+static int rrd_param_matches_service(const char *param, const char *svc)
+{
+	if ((param == NULL) || (svc == NULL) || (*svc == '\0')) return 0;
+
+	/* For bundle fall-backs, FNPATTERN group 1 is exactly the service component */
+	return (strcmp(param, svc) == 0);
+}
+
 void graph_link(FILE *output, char *uri, char *grtype, time_t seconds)
 {
 	time_t gstart, gend;
@@ -767,6 +775,8 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 {
 	gdef_t *gdef = NULL, *gdefuser = NULL;
 	int wantsingle = 0;
+	int rrdparamisservice = 0;
+	int svcrejects = 0;
 	DIR *dir;
 	time_t now = getcurrenttime(NULL);
 
@@ -813,6 +823,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		char *realservice;
 
 		*delim = '\0';
+		if (*(delim+1) == '\0') errormsg("Missing graph service name");
 		realservice = strdup(delim+1);
 
 		/* The requested gdef only acts as a fall-back solution so don't set gdef here. */
@@ -832,12 +843,14 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	if (gdef == NULL) {
 		if (gdefuser) {
 			gdef = gdefuser;
+			rrdparamisservice = 1;
 		}
 		else {
 			xymonrrd_t *ldef = find_xymon_rrd(service, NULL);
 			if (ldef) {
 				for (gdef = gdefs; (gdef && strcmp(ldef->xymonrrdname, gdef->name)); gdef = gdef->next) ;
 				wantsingle = 1;
+				rrdparamisservice = 1;
 			}
 		}
 	}
@@ -966,6 +979,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 			char *ext;
 			char param[PATH_MAX];
 			PCRE2_SIZE l = sizeof(param);
+			int haveparam;
 
 			/* Ignore dot-files and files with names shorter than ".rrd" */
 			if (*(d->d_name) == '.') continue;
@@ -983,10 +997,19 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 			result = pcre2_match(pat, d->d_name, strlen(d->d_name), 0, 0,
 					     ovector, NULL);
 			if (result < 0) continue;
+			haveparam = (pcre2_substring_copy_bynumber(ovector, 1, param, &l) == 0);
 
-			if (wantsingle) {
-				/* "Single" graph, i.e. a graph for a service normally included in a bundle (tcp) */
-				if (strstr(d->d_name, service) == NULL) continue;
+			if (rrdparamisservice && haveparam) {
+				/* Single service out of a bundle (tcp): match against the FNPATTERN
+				 * capture, not an unanchored substring - "conn" must not pick up
+				 * tcp.proxyconn.rrd (issue #20). */
+				if (!rrd_param_matches_service(param, service)) { svcrejects++; continue; }
+			}
+			else if (wantsingle) {
+				/* Resolved to its own gdef (tcp.http -> [http], ncv:slab -> [slab]),
+				 * where the capture is a subitem rather than the service - or a
+				 * fall-back without a capture group: keep the substring match. */
+				if (strstr(d->d_name, service) == NULL) { svcrejects++; continue; }
 			}
 
 			/* 
@@ -999,7 +1022,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 
 			/* We have a matching file! */
 			rrddbs[rrddbcount].rrdfn = strdup(d->d_name);
-			if (pcre2_substring_copy_bynumber(ovector, 1, param, &l) == 0) {
+			if (haveparam) {
 				/*
 				 * This is ugly, but I cannot find a pretty way of un-mangling
 				 * the disk- and http-data that has been molested by the back-end.
@@ -1043,6 +1066,13 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		closedir(dir);
 	}
 	rrddbs[rrddbcount].key = rrddbs[rrddbcount].rrdfn = rrddbs[rrddbcount].rrdparam = NULL;
+
+	if ((rrddbcount == 0) && svcrejects) {
+		if (rrdparamisservice)
+			errprintf("showgraph: no RRD file matched service '%s' - check that FNPATTERN group 1 captures the service component\n", service);
+		else
+			errprintf("showgraph: no RRD file matched service '%s'\n", service);
+	}
 
 	/* Sort them so the display looks prettier */
 	qsort(&rrddbs[0], rrddbcount, sizeof(rrddb_t), rrd_name_compare);
@@ -1326,4 +1356,3 @@ int main(int argc, char *argv[])
 
 	return 0;
 }
-

--- a/xymond/etcfiles/graphs.cfg.DIST
+++ b/xymond/etcfiles/graphs.cfg.DIST
@@ -19,6 +19,11 @@
 # pattern of files (see e.g. "[memory]" how this is used). "@COLOR@" picks
 # a new color for each graph automatically.
 #
+# For a bundle viewed one service at a time (e.g. "tcp:conn"), FNPATTERN
+# capture group 1 must be exactly the service component: showgraph uses it
+# both as the legend (@RRDPARAM@) and to select the single service - see
+# "[tcp]", where "^tcp.(.+).rrd" captures "conn" from tcp.conn.rrd.
+#
 # The "foo-multi" graph definitions are used by the "Metrics report"
 # utility. The have an FNPATTERN definition, but in this case you can NOT
 # use a regular expression pattern. The FNPATTERN definition for multi-


### PR DESCRIPTION
## Problem

When a bundled service is viewed as a single graph (e.g. `tcp:conn`), `showgraph` filtered the RRD directory with an unanchored `strstr(d->d_name, service)`. So service `conn` also matched `tcp.proxyconn.rrd` and `tcp.connfoo.rrd`, plotting unrelated series on the conn page; same for `dns`, `ssh`, etc. It only triggers with custom `protocols.cfg` tests whose names are substrings of (or contain) another test name.

Closes #20.

## Fix

A request can resolve to a "single" graph two different ways, which need different matching. A new `rrdparamisservice` flag distinguishes them:

1. **The bundle graph is used as a fall-back** (`tcp:conn` → `[tcp]`, or a bare test mapped via `TEST2RRD` such as `dns`). A bundle is named `<bundle>.<service>.rrd`, so the `FNPATTERN` group-1 capture is exactly the service — require an exact match: `conn` matches `tcp.conn.rrd` but no longer `tcp.proxyconn.rrd`, `tcp.connfoo.rrd` or `tcp.conn.extra.rrd`.
2. **The request resolves to its own graph definition** (`tcp.http` → `[http]`, `ncv:slab` → `[slab]`). There group 1 is a subitem (a URL, a slab name), not the service, so the unanchored `strstr` match is kept. A fall-back whose `FNPATTERN` has no capture group also keeps the substring match — there is no capture to compare, and keeping everything would *widen* selection.

Two guard rails around the new invariant:

- If the exact match rejects every candidate file, showgraph logs `no RRD file matched service 'X' - check that FNPATTERN group 1 captures the service component` instead of leaving only a silently blank image.
- An empty service name (`tcp:`) is rejected up front. Behavior change: such a URL previously rendered the entire bundle (`strstr` with an empty needle matches everything); no in-tree producer emits that form.

The fix relies on **`FNPATTERN` capture group 1 being exactly the service component** for a bundle; this holds for everything shipped. A custom definition that violates it loses series — possibly all of them — but never gains contaminated ones, and the errprintf above names the cause. The invariant is documented in `graphs.cfg` and `graphs.cfg.5`.

## Regression coverage

`tests/web/showgraph-single-service.sh` drives the real showgraph CGI with `--debug` against a fake RRD directory and asserts on the rrd_graph argument dump (using the stock `assert_contains`/`assert_not_contains` helpers): exact selection for `tcp:conn` and bare `dns`, substring match preserved for `tcp.http`, capture-less fall-back keeps `nocap.x.rrd` and excludes `nocap.y.rrd`, `tcp:` rejected. The test fails on current main and passes with this fix; full suite: 15 passed, 0 failed.
