### PR TITLE
build/clock-gettime-librt.sh: always call clean at the end.

### DIFF
--- a/build/clock-gettime-librt.sh
+++ b/build/clock-gettime-librt.sh
@@ -13,9 +13,8 @@
 		else
 			echo "clock_gettime() not present, but this should be OK"
 		fi
-
-		OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-clockgettime-librt clean
 	fi
+	OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-clockgettime-librt clean
 
 	cd ..
 


### PR DESCRIPTION
Otherwise build/test-clockgettime-librt persists after distclean.