### PR TITLE
xymonnet: build against OpenSSL 4.0

### DIFF
--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -406,8 +406,13 @@ static char *xymon_ASN1_UTCTIME(ASN1_UTCTIME *tm)
 	int len, i;
 	int century=0,year=0,month=0,day=0,hour=0,minute=0,second=0;
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	len=ASN1_STRING_length(tm);
+	asn1_string=(char *)ASN1_STRING_get0_data(tm);
+#else
 	len=tm->length;
 	asn1_string=(char *)tm->data;
+#endif
 
 	result[0] = '\0';
 	if (len < 10) return result;

--- a/xymonnet/httptest.h
+++ b/xymonnet/httptest.h
@@ -10,7 +10,7 @@
 /*                                                                            */
 /*----------------------------------------------------------------------------*/
 
-#ifndef __HTTPTESTT_H_
+#ifndef __HTTPTEST_H_
 #define __HTTPTEST_H_
 
 extern int  tcp_http_data_callback(unsigned char *buf, unsigned int len, void *priv);


### PR DESCRIPTION
## Summary

- use the public ASN.1 string accessors with OpenSSL 1.1.0 and later
- retain direct structure access for older supported OpenSSL releases
- fix the mismatched include guard in `xymonnet/httptest.h`

## Root cause

OpenSSL 4.0 makes `ASN1_STRING` opaque, so direct access to
`ASN1_UTCTIME` members no longer compiles. This caused the build failure
reported in issue #143 and Debian bug #1139228.

## Impact

`xymonnet` builds against OpenSSL 4.0 while preserving compatibility with
older OpenSSL versions.

## Validation

- compiled `xymonnet/contest.c` with Ubuntu OpenSSL 3.0.2 headers
- compiled `xymonnet/contest.c` and `xymonnet/httptest.c` with Debian
  experimental OpenSSL 4.0.0-1 headers
- confirmed `upstream/main` reproduces the incomplete `ASN1_UTCTIME` build
  error with the same OpenSSL 4.0 headers
- ran `git diff --check`

Closes #143
