### PR TITLE
svcstatus: fix path traversal issue

### DIFF
--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -89,7 +89,7 @@ static int parse_query(void)
 		else if (strcasecmp(cwalk->name, "CLIENT") == 0) {
 			char *p;
 
-			hostname = strdup(cwalk->value);
+			hostname = strdup(basename(cwalk->value));
 			p = hostname; while ((p = strchr(p, ',')) != NULL) *p = '.';
 			service = strdup("");
 			outform = FRM_CLIENT;


### PR DESCRIPTION
Fixes a security issue with the svcstatus CGI - a classic path traversal issue where you can manipulate one of the parameters to read arbitrary files on the webserver with the privileges of the webserver process.

This patch came directly from Henrik