### PR TITLE
svcstatus: fix path traversal via SECTION and HOSTSVC service-tail

### DIFF
--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -78,7 +78,7 @@ static int parse_query(void)
 			if (p) {
 				*p = '\0';
 				hostname = strdup(basename(cwalk->value));
-				service = strdup(p+1);
+				service = strdup(basename(p+1));
 				for (p=strchr(hostname, ','); (p); p = strchr(p, ',')) *p = '.';
 			}
 		}
@@ -95,7 +95,7 @@ static int parse_query(void)
 			outform = FRM_CLIENT;
 		}
 		else if (strcasecmp(cwalk->name, "SECTION") == 0) {
-			service = strdup(cwalk->value);
+			service = strdup(basename(cwalk->value));
 		}
 		else if (strcasecmp(cwalk->name, "NKPRIO") == 0) {
 			nkprio = strdup(cwalk->value);


### PR DESCRIPTION
Follow-up to the `CLIENT` path-traversal fix (#145), closing the last unsanitized parameters that reach the same filesystem sink.

## Problem

In `parse_query()`, the `service` value reaches a file path in the historical-log branch:

```c
snprintf(logfn, sizeof(logfn), "%s/%s/%s/%s",
         xgetenv("XYMONHISTLOGS"), hostnamedash, service, tstamp);
fopen(logfn, "r");
```

`#145` wrapped the hostname-bearing params in `basename()`, but two sources of `service` were still raw:

- **SECTION** — `service = strdup(cwalk->value)`
- **HOSTSVC tail** — `service = strdup(p+1)` (the part after the last `.`)

So a request such as

```
historylog.cgi?HOST=<valid>&SECTION=../../../../../../etc&TIMEBUF=passwd
```

escapes `XYMONHISTLOGS` and discloses an arbitrary regular file with the webserver's privileges. `historylog.cgi` ships in the unauthenticated CGI dir, so this is reachable pre-auth where the web UI is exposed. (The `SECTION` path requires a valid monitored hostname, which is discoverable from the dashboard; the `CLIENT` vector fixed in #145 had no such precondition.)

## Fix

Wrap both `service` assignments in `basename()`, mirroring #145. `basename()` is a no-op for legitimate section/service names (which contain no `/`), so valid requests are unaffected; only directory components are stripped. `<libgen.h>` is already included.

## Notes

- Minimal and consistent with #145 on purpose. As defense-in-depth one could additionally reject `.`/`..` after `basename()` (note `basename("..") == ".."` still allows a single parent-dir step — a residual shared by every already-`basename`'d param in this file); happy to add if preferred.
- Tracked privately as GHSA-cr2c-h2wg-fqq7; disclosing here per maintainer decision.

cc @hjstorner