### PR TITLE
web: add safe_basename() and route CGI path components through it (refs #146)

### DIFF
--- a/lib/cgi.c
+++ b/lib/cgi.c
@@ -20,10 +20,34 @@ static char rcsid[] = "$Id$";
 #include <unistd.h>
 #include <limits.h>
 #include <errno.h>
+#include <libgen.h>
 
 #include "libxymon.h"
 
 #define MAX_REQ_SIZE (1024*1024)
+
+/*
+ * basename() that also neutralizes "." and "..".
+ *
+ * POSIX basename() strips directory components, so "../../etc/passwd"
+ * becomes "passwd" -- but it returns ".." for "..", and "." for "." or an
+ * empty/"/" input. A lone ".." pasted into a filesystem path is still a
+ * single-level traversal, so basename() alone is not enough to keep
+ * attacker-controlled CGI parameters from escaping their intended directory.
+ *
+ * This returns "" for those cases, leaving every other result untouched.
+ * Callers that strdup() the result get a safe single path component (or an
+ * empty string, which their existing validation rejects or which collapses
+ * harmlessly in the constructed path). Like basename(3), it may modify the
+ * string pointed to by path, so callers must not rely on path afterwards.
+ */
+char *safe_basename(char *path)
+{
+	char *b = basename(path);
+
+	if (!b || (strcmp(b, ".") == 0) || (strcmp(b, "..") == 0)) return "";
+	return b;
+}
 
 enum cgi_method_t cgi_method = CGI_OTHER;
 

--- a/lib/cgi.c
+++ b/lib/cgi.c
@@ -25,6 +25,125 @@ static char rcsid[] = "$Id$";
 
 #define MAX_REQ_SIZE (1024*1024)
 
+/*
+ * Validate a CGI value as a single path component. A validator, not a
+ * normalizer: '/' (even in "../realhost", which basename() would reduce to
+ * a legitimate name), ".", ".." and "" all yield "", everything else is
+ * returned unchanged. Callers MUST reject the empty result -- appended to a
+ * path it collapses onto the parent dir and still serves a file. path is
+ * never modified and the result is read-only; copy it (callers strdup()).
+ */
+char *safe_basename(char *path)
+{
+	if (!path) return "";
+	if (!*path || strchr(path, '/') ||
+	    (strcmp(path, ".") == 0) || (strcmp(path, "..") == 0)) return path + strlen(path);
+
+	return path;
+}
+
+/*
+ * The one byte set legal in a confined CGI hostname or column name: ASCII
+ * letters and digits plus the punctuation real xymon names use -- ':'
+ * (IPv6), ',' (the URL spelling of '.' in IP hosts, and literal-comma
+ * names), '.' (FQDNs and the host.service separator), and '_' '-'. Both
+ * path separators are excluded: '/' (POSIX) and '\\' (Windows/SMB) -- the
+ * confinement below only special-cases '/', so a '\\'-bearing value must
+ * not survive on a backend where '\\' separates directories. One set, one
+ * rule, every parameter; widening it (e.g. to accept UTF-8) is a
+ * documented policy change for another day (see hosts.cfg(5) discussion).
+ */
+#define CGI_NAMECHARS "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ:,._-"
+
+/*
+ * Confine a CGI value to a single legal path component -- the one policy
+ * behind every host/service parameter. The value must be a single
+ * component of CGI_NAMECHARS or it is refused as a whole (NULL): never
+ * truncated, normalized, or partially served, so a stray byte (space,
+ * control char, '/', '(' ...), ".", ".." and "" all reject rather than
+ * yield a servable prefix. If decode_commas, the IP URL spelling
+ * (192,168,1,1 -> 192.168.1.1, commafy() in lib/cgiurls.c) is decoded
+ * first; only the parameters generated that way pass 1 (HOST is emitted
+ * verbatim, so a literal-comma name stays reachable). The single-component
+ * check runs after decoding, so "," / ",," cannot slip through as
+ * "." / "..". Returns a newly allocated copy, or NULL when refused.
+ */
+char *cgi_pathcomponent(const char *value, int decode_commas)
+{
+	char *raw;
+
+	if (!value || value[strspn(value, CGI_NAMECHARS)]) return NULL;
+
+	raw = strdup(value);
+	if (decode_commas) uncommafy(raw);
+	if (!*safe_basename(raw)) { xfree(raw); return NULL; }
+
+	return raw;
+}
+
+/*
+ * True if the value carries a control byte (< 0x20 or DEL). Such a byte in
+ * a host/service/section value would inject a second line into a xymond
+ * protocol request (test=%s, section=%s), so callers refuse the whole
+ * value. The single definition of "dangerous byte" for every confinement
+ * helper and call site -- keep it here, not open-coded.
+ */
+int cgi_hasctrl(const char *value)
+{
+	const unsigned char *u;
+
+	for (u = (const unsigned char *)value; *u; u++)
+		if ((*u < 0x20) || (*u == 0x7f)) return 1;
+	return 0;
+}
+
+/*
+ * Confine a free-form service component -- a column name, a client section
+ * leaf, or a PCRE testname pattern (svcstatus's aggregate view compiles
+ * SERVICE as a regex, so 'cpu|disk', '^(a|b)$' must pass). Unlike a
+ * hostname it is not held to CGI_NAMECHARS: metacharacters are allowed.
+ * It is refused (NULL) only when it carries a control byte -- which would
+ * inject a second xymond protocol line where SERVICE becomes "test=%s" --
+ * or is not a single path component (safe_basename(): '/', '.', '..', "").
+ * Where it later becomes a filename the caller's path build stays confined
+ * because '/' and traversal are already excluded. Returns a newly
+ * allocated copy, or NULL.
+ */
+char *cgi_component(const char *value)
+{
+	char *raw;
+
+	if (!value || cgi_hasctrl(value)) return NULL;
+
+	raw = strdup(value);
+	if (!*safe_basename(raw)) { xfree(raw); return NULL; }
+
+	return raw;
+}
+
+/*
+ * Split a "host.service" parameter (history HISTFILE, reportlog HOSTSVC)
+ * at the last '.'. Both halves take the STRICT name confinement
+ * (cgi_pathcomponent): here the service is a plain column name that becomes
+ * a filename -- history.cgi even passes it to popen("tail ... <file>"), so
+ * it must stay clear of shell metacharacters, unlike svcstatus's free-form
+ * SERVICE (a regex, never shelled). The host half is comma-decoded. Both
+ * outputs are always written: NULL for a rejected, absent, or (for service)
+ * no-'.' component, otherwise a newly allocated copy the caller frees.
+ * value is modified in place (the split point).
+ */
+void cgi_split_hostsvc(char *value, char **hostname, char **service)
+{
+	char *p;
+
+	*hostname = *service = NULL;
+	if (!value) return;
+
+	p = strrchr(value, '.');
+	if (p) { *p = '\0'; *service = cgi_pathcomponent(p+1, 0); }
+	*hostname = cgi_pathcomponent(value, 1);
+}
+
 enum cgi_method_t cgi_method = CGI_OTHER;
 
 static char *cgi_error_text = NULL;

--- a/lib/cgi.h
+++ b/lib/cgi.h
@@ -27,6 +27,7 @@ extern cgidata_t *cgi_request(void);
 extern char *csp_header(const char *pagename); 
 extern int cgi_refererok(char *expected); 
 extern char *get_cookie(char *cookiename);
+extern char *safe_basename(char *path);
 
 #endif
 

--- a/lib/cgi.h
+++ b/lib/cgi.h
@@ -27,6 +27,11 @@ extern cgidata_t *cgi_request(void);
 extern char *csp_header(const char *pagename); 
 extern int cgi_refererok(char *expected); 
 extern char *get_cookie(char *cookiename);
+extern char *safe_basename(char *path);
+extern int cgi_hasctrl(const char *value);
+extern char *cgi_pathcomponent(const char *value, int decode_commas);
+extern char *cgi_component(const char *value);
+extern void cgi_split_hostsvc(char *value, char **hostname, char **service);
 
 #endif
 

--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -133,6 +133,35 @@ mktempdir() {
 	printf '%s' "$d"
 }
 
+# ---- C harness scaffolding ---------------------------------------------------
+
+# require_cc -- skip unless a C compiler is present. Sets/keeps CC (default
+# cc). For tests that compile a standalone harness with no in-tree libraries.
+require_cc() {
+	CC=${CC:-cc}
+	command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+}
+
+# require_c_buildenv ROOT -- skip unless a C compiler, make, and a configured
+# tree (include/config.h) are present. The shared baseline for every test
+# that compiles a harness against the in-tree libraries, so a new shared
+# skip condition lands in one place; a test may still add stricter
+# conditions of its own (e.g. "tree already built") next to its call.
+require_c_buildenv() {
+	require_cc
+	command -v make >/dev/null 2>&1 || skip "make not available"
+	[ -f "$1/include/config.h" ] || skip "tree not configured (no include/config.h)"
+}
+
+# build_xymon_libs ROOT LOGFILE ARCHIVE... -- build the named archives in
+# ROOT/lib, dumping the build log on stderr and failing if the build breaks.
+build_xymon_libs() {
+	local root=$1 log=$2
+	shift 2
+	make -C "$root/lib" "$@" >"$log" 2>&1 \
+		|| { cat "$log" >&2; fail "cannot build $*"; }
+}
+
 # ---- repo location -----------------------------------------------------------
 
 # find_root -- print the absolute path of the repo root, derived from the

--- a/tests/lib/fake-xymond.c
+++ b/tests/lib/fake-xymond.c
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later                                  */
+/*
+ * tests/lib/fake-xymond.c
+ *
+ * Minimal stand-in for xymond in the CGI tests: listen on an ephemeral
+ * 127.0.0.1 port (printed on stdout so the test can point XYMONDPORT at
+ * it), and answer every connection with the contents of the reply file
+ * given as argv[1], after draining the request (the xymon client sends its
+ * message, half-closes, then reads until EOF -- lib/sendmsg.c).
+ *
+ * One connection at a time is fine: the CGIs under test run sequentially.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int main(int argc, char *argv[])
+{
+	int lsock, csock;
+	struct sockaddr_in addr;
+	socklen_t alen = sizeof(addr);
+	char buf[4096];
+	char *reply;
+	long replylen;
+	FILE *fd;
+
+	if (argc != 2) { fprintf(stderr, "usage: %s replyfile\n", argv[0]); return 1; }
+
+	fd = fopen(argv[1], "r");
+	if (!fd) { perror(argv[1]); return 1; }
+	if (fseek(fd, 0, SEEK_END) != 0 || (replylen = ftell(fd)) < 0) {
+		fprintf(stderr, "%s: not a seekable regular file\n", argv[1]); return 1;
+	}
+	rewind(fd);
+	reply = malloc(replylen + 1);
+	if (!reply) { perror("malloc"); return 1; }
+	if (fread(reply, 1, replylen, fd) != (size_t)replylen) { perror("fread"); return 1; }
+	fclose(fd);
+
+	lsock = socket(AF_INET, SOCK_STREAM, 0);
+	if (lsock < 0) { perror("socket"); return 1; }
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	addr.sin_port = 0;
+	if (bind(lsock, (struct sockaddr *)&addr, sizeof(addr)) < 0) { perror("bind"); return 1; }
+	if (listen(lsock, 5) < 0) { perror("listen"); return 1; }
+	if (getsockname(lsock, (struct sockaddr *)&addr, &alen) < 0) { perror("getsockname"); return 1; }
+
+	printf("%d\n", ntohs(addr.sin_port));
+	fflush(stdout);
+
+	for (;;) {
+		csock = accept(lsock, NULL, NULL);
+		if (csock < 0) continue;
+		while (read(csock, buf, sizeof(buf)) > 0) /* drain the request */ ;
+		if (write(csock, reply, replylen) != replylen) perror("write");
+		close(csock);
+	}
+}

--- a/tests/lib/svcstatus-cgi.sh
+++ b/tests/lib/svcstatus-cgi.sh
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/lib/svcstatus-cgi.sh -- shared scaffolding for the svcstatus.cgi
+# tests (tests/web/svcstatus-*.sh): build the real CGI from this tree and
+# stand up a minimal XYMONHOME with a configured host "realhost". Sourced
+# after tests/lib/assert.sh (needs $ROOT set and require_c_buildenv already
+# called); not executable, so the runner never discovers it as a test.
+#
+# svcstatus_setup [--no-daemon]
+#     sets $work, writes $work/etc/{xymonserver.cfg,hosts.cfg}, scrapes the
+#     link libraries. By default it probes for a connection-refusing local
+#     port and points XYMONDPORT at it, so a live request fails fast with
+#     connection-refused. --no-daemon skips that probe (the caller stands up
+#     its own responder and appends XYMONDPORT itself), avoiding both the
+#     wasted probe and a duplicate XYMONDPORT line.
+# svcstatus_build [cflags..]
+#     builds $work/svcstatus, reusing a tree+flags-keyed cached binary when
+#     the sources and archives are older than it (the four split tests would
+#     otherwise recompile the same 3-file CGI from scratch each run).
+#     Returns 1 on a compile/link failure ($work/cc.log kept) so a caller
+#     can fall back (e.g. from an ASAN build to a plain one).
+# render QS / render_live QS
+#     run the CGI (historical / live mode) with QUERY_STRING=QS; set OUT and
+#     RC, fail on a crash exit code. Extra svcstatus args go after QS; extra
+#     environment is passed via $RENDER_ENV (e.g. "REMOTE_USER=alice").
+
+svcstatus_setup() {
+	local with_daemon=1
+	[ "${1:-}" = "--no-daemon" ] && with_daemon=0
+
+	[ -f "$ROOT/Makefile" ] || skip "tree not configured (no Makefile)"
+
+	# svcstatus.cgi links against SSLLIBS + NETLIBS + LIBRTDEF + PCRELIBS;
+	# scrape all four from the Makefile (NETLIBS is "-lsocket -lnsl" on
+	# Solaris, LIBRTDEF "-lrt" on older glibc, PCRELIBS may carry a -L path
+	# from configure's --pcrelib). Omitting them fails the link on a tree
+	# that builds fine. Keep the pkg-config/-lpcre2-8 fallback for a
+	# Makefile without PCRELIBS.
+	ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+	netlibs=$(sed -n 's/^NETLIBS *= *//p' "$ROOT/Makefile")
+	librtdef=$(sed -n 's/^LIBRTDEF *= *//p' "$ROOT/Makefile")
+	pcre_libs=${PCRELIBS:-$(sed -n 's/^PCRELIBS *= *//p' "$ROOT/Makefile")}
+	if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+		pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+	fi
+	[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+	work=$(mktempdir)
+
+	build_xymon_libs "$ROOT" "$work/libbuild.log" libxymon.a libxymoncomm.a
+
+	mkdir -p "$work/etc"
+	cp "$ROOT/xymond/etcfiles/xymonserver.cfg.DIST" "$work/etc/xymonserver.cfg"
+
+	# Appended lines override the DIST defaults (loadenv() lets a later
+	# putenv() win). Override HOSTSCFG directly, not XYMONHOME -- HOSTSCFG
+	# is expanded earlier in the file. XYMONVAR/XYMONHISTLOGS must be
+	# overridden here too: loadenv() putenv()s over the real environment,
+	# so the values render()/render_live() pass as env vars would lose to
+	# the DIST placeholders ("@XYMONVAR@/histlogs").
+	{
+		echo "HOSTSCFG=\"$work/etc/hosts.cfg\""
+		echo 'XYMSERVERS=""'
+		echo 'XYMSRV="127.0.0.1"'
+		echo "XYMONVAR=\"$work/var\""
+		echo "XYMONHISTLOGS=\"$work/var/histlogs\""
+	} >>"$work/etc/xymonserver.cfg"
+
+	if [ "$with_daemon" = 1 ]; then
+		# The daemon address must point at a dead local port so a live
+		# CLIENT request fails with connection-refused instead of
+		# depending on whether a real xymond happens to be listening.
+		# Probe candidates and take the first that refuses a connect
+		# (hardcoding one port breaks on a machine where something
+		# listens there); the connect probe runs in a subshell so a
+		# successful connect is closed again immediately.
+		local deadport=
+		for cand in 59999 56313 51724 49517 47311; do
+			if ! (exec 3<>"/dev/tcp/127.0.0.1/$cand") 2>/dev/null; then deadport=$cand; break; fi
+		done
+		[ -n "$deadport" ] || skip "no connection-refusing localhost port found for the dead-xymond endpoint"
+		echo "XYMONDPORT=\"$deadport\"" >>"$work/etc/xymonserver.cfg"
+	fi
+
+	# A configured host, so loadhostdata() succeeds on the historical-status
+	# path (otherwise every request there is refused as "No such host" and
+	# the guard under test is never exercised).
+	printf '127.0.0.1 realhost # \n' >"$work/etc/hosts.cfg"
+}
+
+# svcstatus.cgi is svcstatus.o + svcstatus-info.o + svcstatus-trends.o
+# (web/Makefile SVCSTATUSOBJS); build them here so the test does not depend
+# on the tree having been built already.
+# The archives are listed twice rather than wrapped in --start-group:
+# --start-group is GNU ld only, and the Darwin linker rejects it.
+#
+# The link is cached in a tree+flags-keyed location and reused when none of
+# the inputs is newer than it: the four split svcstatus tests build the
+# identical binary, so the first pays the compile and the rest copy it. The
+# freshness set covers the three .c files, the headers svcstatus.c includes
+# (svcstatus-info.h, svcstatus-trends.h, version.h), and the two lib archives
+# -- build_xymon_libs relinks an archive when a lib source or header (cgi.c,
+# libxymon.h, ...) changes, bumping its mtime. So any code change in the tree
+# is newer than the cache and forces a rebuild; the cache never hides one.
+svcstatus_build() {
+	local flagkey bin
+	flagkey=$(printf '%s' "$*" | tr -c 'A-Za-z0-9' '_')
+	bin="${TMPDIR:-/tmp}/xymon-svcstatus-cache.$(id -u)/$(printf '%s' "$ROOT" | tr -c 'A-Za-z0-9' '_').${flagkey:-plain}"
+	mkdir -p "$(dirname "$bin")"
+
+	if [ -x "$bin" ] && [ -z "$(find \
+			"$ROOT/web/svcstatus.c" "$ROOT/web/svcstatus-info.c" "$ROOT/web/svcstatus-trends.c" \
+			"$ROOT/web/svcstatus-info.h" "$ROOT/web/svcstatus-trends.h" "$ROOT/include/version.h" \
+			"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" -newer "$bin" 2>/dev/null)" ]; then
+		cp "$bin" "$work/svcstatus"
+		return 0
+	fi
+
+	"$CC" "$@" -I"$ROOT/include" -I"$ROOT/lib" -I"$ROOT/web" -o "$work/svcstatus" \
+		"$ROOT/web/svcstatus.c" "$ROOT/web/svcstatus-info.c" "$ROOT/web/svcstatus-trends.c" \
+		"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
+		$pcre_libs $ssllibs $netlibs $librtdef 2>"$work/cc.log" || return 1
+	cp "$work/svcstatus" "$bin"
+}
+
+# svcstatus_run MODE QS [extra svcstatus args...] -- run the CGI with
+# QUERY_STRING=QS; set OUT and RC. MODE is "--historical" or "" (live).
+# $RENDER_ENV supplies extra environment tokens (e.g. "REMOTE_USER=alice").
+svcstatus_run() {
+	local mode=$1 qs=$2
+	shift 2
+	set +e
+	OUT=$(env REQUEST_METHOD=GET QUERY_STRING="$qs" \
+	      XYMONHOME="$work" XYMONVAR="$work/var" CLIENTLOGS="$work/var/hostdata" \
+	      XYMONHISTLOGS="$work/var/histlogs" \
+	      ASAN_OPTIONS="detect_leaks=0${ASAN_OPTIONS:+:$ASAN_OPTIONS}" \
+	      ${RENDER_ENV:-} \
+		"$work/svcstatus" $mode --env="$work/etc/xymonserver.cfg" "$@" 2>/dev/null)
+	RC=$?
+	set -e
+	# 0 = page served, 1 = errormsg() refusal. Anything else (137, 139, ...)
+	# is a crash, which would otherwise look exactly like "no canary found".
+	[ "$RC" -le 1 ] || fail "svcstatus exited $RC (crash?) on QUERY_STRING=$qs"
+}
+
+render()      { svcstatus_run --historical "$@"; }
+render_live() { svcstatus_run "" "$@"; }

--- a/tests/rrd/ntp-offset-parse.sh
+++ b/tests/rrd/ntp-offset-parse.sh
@@ -18,10 +18,10 @@ if [ -r "$here/../lib/assert.sh" ]; then
 else
 	fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 	skip() { printf 'SKIP: %s\n' "$*" >&2; exit 77; }
+	require_cc() { CC=${CC:-cc}; command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"; }
 fi
 
-CC=${CC:-cc}
-command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+require_cc
 
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT

--- a/tests/server/xmh-item-names.sh
+++ b/tests/server/xmh-item-names.sh
@@ -46,10 +46,8 @@ the registered string is the public field name (xymon-xmh(5), xymondboard/hostin
 templates) and also what xmh_item_isflag[] is derived from:
 $mismatched"
 
-CC=${CC:-cc}
-command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
-
-[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+require_c_buildenv "$ROOT"
+[ -f "$ROOT/lib/libxymoncomm.a" ] \
 	|| skip "tree not built (run make first; the post-build CI suite covers this)"
 
 ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
@@ -57,8 +55,7 @@ ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-xmh-item-names.XXXXXX")
 trap 'rm -rf "$work"' EXIT HUP INT TERM
 
-make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
-	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+build_xymon_libs "$ROOT" "$work/libbuild.log" libxymoncomm.a
 
 cat > "$work/hosts.cfg" <<'EOF'
 127.0.0.1 taghost.example.com # conn dialup MULTIHOMED

--- a/tests/web/cgi-split-hostsvc-harness.c
+++ b/tests/web/cgi-split-hostsvc-harness.c
@@ -1,0 +1,192 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later                                  */
+/*
+ * tests/web/cgi-split-hostsvc-harness.c
+ *
+ * Drives the REAL CGI-value confinement helpers from lib/cgi.c (#147).
+ *
+ * Two confinements, by category:
+ *   - cgi_pathcomponent() -- STRICT, for values that are looked-up names or
+ *     become filenames: HOST/CLIENT/TIMEBUF and BOTH halves of the
+ *     HOSTSVC/HISTFILE split (the split service is a column name that
+ *     history.cgi shells out to `tail`, so it must be shell-safe). A single
+ *     component of the strict name charset (ASCII letters/digits + ":,._-")
+ *     or refused as a WHOLE (NULL), never truncated or normalized. A stray
+ *     byte (space, '/', '(', '\', ';', a control char, a UTF-8 byte)
+ *     rejects the whole value; ".", ".." and "" are refused; and the
+ *     comma-decoded spelling ("," -> ".") cannot slip a traversal through.
+ *     comma-decoding is per-parameter (HOST verbatim, CLIENT/HISTFILE/HOSTSVC
+ *     decode the 192,168,1,1 spelling). Non-ASCII names are refused for now
+ *     -- widening this charset is a separate policy change.
+ *   - cgi_component() -- FREE-FORM, only for svcstatus's direct SERVICE (a
+ *     column name or a PCRE testname pattern for the aggregate view) and
+ *     section leaves: metacharacters allowed, refused only on a control
+ *     byte (protocol injection) or traversal. It reaches a regex/query or a
+ *     re-confined histlog path, never a shell.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern char *cgi_pathcomponent(const char *value, int decode_commas);
+extern char *cgi_component(const char *value);
+extern void cgi_split_hostsvc(char *value, char **hostname, char **service);
+
+static int failures = 0;
+
+static const char *show(const char *s)
+{
+	return s ? s : "NULL";
+}
+
+static int same(const char *got, const char *expected)
+{
+	if (!expected || !got) return (expected == got);
+	return (strcmp(got, expected) == 0);
+}
+
+static void checkpc(const char *input, int decode_commas, const char *expected)
+{
+	char *got = cgi_pathcomponent(input, decode_commas);
+
+	if (!same(got, expected)) {
+		printf("FAIL pathcomponent('%s', %d) -> '%s' (expected '%s')\n",
+		       show(input), decode_commas, show(got), show(expected));
+		failures++;
+	}
+	free(got);
+}
+
+static void checkcomp(const char *input, const char *expected)
+{
+	char *got = cgi_component(input);
+
+	if (!same(got, expected)) {
+		printf("FAIL component('%s') -> '%s' (expected '%s')\n",
+		       show(input), show(got), show(expected));
+		failures++;
+	}
+	free(got);
+}
+
+static void check(const char *input, const char *exphost, const char *expsvc)
+{
+	char *buf = input ? strdup(input) : NULL;
+	char *host = NULL, *svc = NULL;
+
+	cgi_split_hostsvc(buf, &host, &svc);
+	if (!same(host, exphost) || !same(svc, expsvc)) {
+		printf("FAIL split('%s') -> host='%s' svc='%s' (expected '%s' / '%s')\n",
+		       show(input), show(host), show(svc), show(exphost), show(expsvc));
+		failures++;
+	}
+	free(buf);
+	free(host);
+	free(svc);
+}
+
+int main(void)
+{
+	/* ---- cgi_pathcomponent(): traversal-shaped values are refused whole
+	 * (NULL), never normalized into something servable ("../realhost"
+	 * must not become "realhost"). */
+	checkpc(NULL, 0, NULL);
+	checkpc("", 0, NULL);
+	checkpc(".", 0, NULL);
+	checkpc("..", 0, NULL);
+	checkpc("a/b", 0, NULL);
+	checkpc("../realhost", 0, NULL);
+	checkpc("realhost/", 0, NULL);
+	checkpc("cpu/..", 0, NULL);
+
+	/* Legal single components pass through unchanged: FQDN dots, IPv6
+	 * colons, hyphens/underscores. */
+	checkpc("web.grp", 0, "web.grp");
+	checkpc("fe80::1", 0, "fe80::1");
+	checkpc("web-front_01", 0, "web-front_01");
+
+	/* A byte outside the legal set refuses the WHOLE value -- not
+	 * truncated to a servable prefix. This is one rule for every
+	 * parameter: a space, a control byte (a newline would otherwise
+	 * inject a second xymond protocol line), a '(' or a UTF-8 byte all
+	 * reject. '\' is excluded too -- safe_basename() only special-cases
+	 * '/', so a backslash must not survive onto a Windows/SMB backend
+	 * where it separates directories. */
+	checkpc("web bar", 0, NULL);
+	checkpc("lab(test)", 0, NULL);
+	checkpc("DOM\\server", 0, NULL);
+	checkpc("..\\..\\etc", 0, NULL);
+	checkpc("cpu\nconfig", 0, NULL);
+	checkpc("cpu\rconfig", 0, NULL);
+	checkpc("cpu\tx", 0, NULL);
+	checkpc("cpu\177x", 0, NULL);
+	checkpc("\033[0m", 0, NULL);
+	checkpc("h\303\264te", 0, NULL);	/* UTF-8: deferred to the charset policy issue */
+
+	/* comma-decoding is per-parameter: HOST arrives verbatim (a literal
+	 * ',' stays reachable), CLIENT/HOSTSVC decode the 192,168,1,1
+	 * spelling -- and "," / ",," must not slip through as "." / ".." once
+	 * decoded. */
+	checkpc("a,b", 0, "a,b");
+	checkpc("a,b", 1, "a.b");
+	checkpc("192,168,1,1", 1, "192.168.1.1");
+	checkpc(",", 1, NULL);
+	checkpc(",,", 1, NULL);
+
+	/* ---- cgi_component(): the free-form service policy. A column name,
+	 * a client section leaf, or a PCRE testname pattern -- metacharacters
+	 * are ALLOWED (svcstatus compiles SERVICE as a regex for the aggregate
+	 * view), so only control bytes and traversal reject. */
+	checkcomp("cpu", "cpu");
+	checkcomp("cpu|disk", "cpu|disk");	/* aggregate/regex SERVICE */
+	checkcomp("^(a|b)$", "^(a|b)$");
+	checkcomp("disk.*", "disk.*");
+	checkcomp("cpu[0-9]", "cpu[0-9]");
+	checkcomp("Disk Usage", "Disk Usage");	/* free-form section leaf */
+	checkcomp("h\303\264te", "h\303\264te");	/* non-ASCII ok: not a looked-up name */
+	checkcomp("cpu\ndisk", NULL);	/* control byte -> would inject a protocol line */
+	checkcomp("cpu\r", NULL);
+	checkcomp("a/b", NULL);		/* traversal */
+	checkcomp(".", NULL);
+	checkcomp("..", NULL);
+	checkcomp("", NULL);
+	checkcomp(NULL, NULL);
+
+	/* ---- cgi_split_hostsvc(): legitimate values, including the
+	 * comma-spelled IP form. A '\'-bearing host half is refused (NULL),
+	 * so the callers reject the request. */
+	check("realhost.cpu", "realhost", "cpu");
+	check("192,168,1,1.conn", "192.168.1.1", "conn");
+	check("DOM\\server.cpu", NULL, "cpu");
+
+	/* Both halves take the STRICT confinement: the split service becomes a
+	 * filename that history.cgi shells out to tail, so a space (or any
+	 * out-of-charset byte) in the service half refuses it whole -- it is not
+	 * trimmed to "cpu" and served, and cannot carry a shell metacharacter. */
+	check("realhost.cpu ", "realhost", NULL);
+	check("realhost.conn;id", "realhost", NULL);
+	check("www,example,com.conn\r", "www.example.com", NULL);
+
+	/* A '/'-bearing value is refused whole, never normalized into a
+	 * servable prefix. */
+	check("realhost.cpu/..", NULL, NULL);
+	check("realhost.cpu/../../etc/passwd", NULL, NULL);
+
+	/* A backslash anywhere refuses the host half (it is a separator on
+	 * Windows/SMB backends), so both components come back refused. */
+	check("realhost.cpu\\..", NULL, NULL);
+
+	/* Traversal-shaped components come back NULL, and "," / ",," must not
+	 * slip through as "." / ".." via the comma decode. */
+	check("..", NULL, NULL);
+	check("...", NULL, NULL);
+	check(",,.conn", NULL, "conn");
+	check("realhost.", "realhost", NULL);
+	check("", NULL, NULL);
+
+	/* A NULL value (cgi_request() yields value==NULL on a bodyless
+	 * multipart part) must be refused, not dereferenced. */
+	check(NULL, NULL, NULL);
+
+	return failures ? 1 : 0;
+}

--- a/tests/web/cgi-split-hostsvc.sh
+++ b/tests/web/cgi-split-hostsvc.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/cgi-split-hostsvc.sh
+#
+# Compiles and runs cgi-split-hostsvc-harness.c against the real lib/cgi.c
+# (via libxymon.a). Pins the confinement contract of cgi_pathcomponent()
+# and cgi_split_hostsvc() -- history.cgi HISTFILE, reportlog.cgi HOSTSVC:
+# traversal-shaped values are refused whole (#147 review: "realhost.cpu/.."
+# must be refused, not served as "realhost.cpu"), while the legacy
+# tolerances (trailing-junk truncation, charset-free names, per-parameter
+# comma decoding) keep working.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+require_c_buildenv "$ROOT"
+
+work=$(mktempdir)
+
+build_xymon_libs "$ROOT" "$work/libbuild.log" libxymon.a
+
+"$CC" -I"$ROOT/include" -o "$work/harness" \
+	"$(dirname "$0")/cgi-split-hostsvc-harness.c" "$ROOT/lib/libxymon.a" \
+	2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+"$work/harness" >"$work/run.log" 2>&1 \
+	|| { cat "$work/run.log" >&2; fail "cgi_split_hostsvc() parse/reject behavior is broken"; }
+
+echo "OK $(basename "$0")"

--- a/tests/web/history-reportlog-reject.sh
+++ b/tests/web/history-reportlog-reject.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/history-reportlog-reject.sh
+#
+# history.cgi and reportlog.cgi share cgi_split_hostsvc()/cgi_pathcomponent()
+# for their HISTFILE/HOSTSVC/HOST/SERVICE parameters (#147). Pins that a
+# rejected or absent component is refused with the "Invalid request" page and
+# never crashes -- the NULL-based rejection introduced two ways to die:
+#   - history.c did displayname = strdup(hostname) with hostname==NULL for a
+#     rejected HISTFILE (strdup(NULL) segfault), and
+#   - its guard checked only !hostname/!service while the globals start as ""
+#     so an absent or dotless HISTFILE sailed past into a bogus empty page.
+# reportlog HOST also must refuse a path-shaped value ('realhost/..') whole,
+# not truncate it to the servable 'realhost'.
+#
+# The CGIs are built under ASAN where available so a NULL deref is a crash
+# (exit >= 2), not a silent read.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+require_c_buildenv "$ROOT"
+# shellcheck source=tests/lib/svcstatus-cgi.sh
+. "$(dirname "$0")/../lib/svcstatus-cgi.sh"
+
+# svcstatus_setup gives us $work, the scraped link libraries, and a minimal
+# xymonserver.cfg with a configured "realhost"; the CGIs here only exercise
+# the pre-daemon rejection path, so the dead-port endpoint is unused.
+svcstatus_setup
+
+cflags="-g -O1 -fsanitize=address,undefined"
+export ASAN_OPTIONS="exitcode=99${ASAN_OPTIONS:+:$ASAN_OPTIONS}"
+for cgi in history reportlog; do
+	"$CC" $cflags -I"$ROOT/include" -I"$ROOT/lib" -I"$ROOT/web" -o "$work/$cgi" \
+		"$ROOT/web/$cgi.c" \
+		"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
+		$pcre_libs $ssllibs $netlibs $librtdef 2>"$work/cc-$cgi.log" \
+	|| { "$CC" -I"$ROOT/include" -I"$ROOT/lib" -I"$ROOT/web" -o "$work/$cgi" \
+			"$ROOT/web/$cgi.c" \
+			"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
+			$pcre_libs $ssllibs $netlibs $librtdef 2>"$work/cc-$cgi.log" \
+		|| { cat "$work/cc-$cgi.log" >&2; fail "$cgi.cgi does not build"; }; }
+done
+
+# run_cgi <cgi> <query-string> -- sets OUT and RC; a clean errormsg() refusal
+# is exit 1, so anything >= 2 (134 SIGABRT, 139 SIGSEGV, 99 ASAN) is a crash.
+run_cgi() {
+	set +e
+	OUT=$(REQUEST_METHOD=GET QUERY_STRING="$2" \
+	      XYMONHOME="$work" XYMONVAR="$work/var" \
+	      ASAN_OPTIONS="detect_leaks=0:exitcode=99${ASAN_OPTIONS:+:$ASAN_OPTIONS}" \
+		"$work/$1" --env="$work/etc/xymonserver.cfg" 2>/dev/null)
+	RC=$?
+	set -e
+	[ "$RC" -le 1 ] || fail "$1.cgi exited $RC (crash?) on QUERY_STRING='$2'"
+}
+
+# assert_reject <cgi> <query-string> <what>
+assert_reject() {
+	run_cgi "$1" "$2"
+	[ "$RC" -eq 1 ] || fail "$3: $1.cgi QUERY_STRING='$2' was not refused (exit $RC)"
+	assert_contains "Invalid request" "$OUT" \
+		"$3: $1.cgi QUERY_STRING='$2' refused without the expected page"
+}
+
+# history HISTFILE: traversal-shaped, dotless, and absent values all refuse
+# without crashing (strdup(NULL) / empty-global guard bypass).
+assert_reject history "HISTFILE=.."          "traversal HISTFILE"
+assert_reject history "HISTFILE=."            "dot HISTFILE"
+assert_reject history "HISTFILE=a/b.cpu"      "slash-bearing HISTFILE"
+assert_reject history "HISTFILE=realhost"     "dotless HISTFILE (empty service)"
+assert_reject history ""                      "absent HISTFILE (empty globals)"
+# NOTE: the shell-metacharacter service half (HISTFILE=host.conn;id -> popen
+# "tail ... %s" injection) is pinned at the unit level in
+# cgi-split-hostsvc-harness.c (check("realhost.conn;id", "realhost", NULL)):
+# here, against the dead xymond, a passed-guard request fails downstream with
+# the same "Invalid request" page, so a CGI-level assert could not tell a
+# parse-time refusal from a later failure.
+
+# reportlog HOSTSVC/HOST/SERVICE: same rejection contract.
+assert_reject reportlog "HOSTSVC=.."          "traversal HOSTSVC"
+assert_reject reportlog ""                    "absent HOSTSVC"
+assert_reject reportlog "HOST=realhost/..&SERVICE=cpu" "path-shaped HOST (must refuse whole, not truncate)"
+assert_reject reportlog "HOST=realhost&SERVICE=cpu/.." "path-shaped SERVICE"
+# An out-of-charset byte refuses the whole value; the old code truncated
+# "cpu bar" to "cpu" and served that report (#147 review round 3).
+assert_reject reportlog "HOST=realhost&SERVICE=cpu%20bar" "space-bearing SERVICE (refuse whole, not the 'cpu' report)"
+
+echo "OK $(basename "$0")"

--- a/tests/web/html-log-custom-graphs.sh
+++ b/tests/web/html-log-custom-graphs.sh
@@ -15,9 +15,7 @@ set -euo pipefail
 ROOT=$(find_root)
 here=$(dirname "$0")
 
-CC=${CC:-cc}
-command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
-command -v make >/dev/null 2>&1 || skip "make not available"
+require_c_buildenv "$ROOT"
 
 pcre_libs=${PCRELIBS:-}
 if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
@@ -29,15 +27,13 @@ work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-htmllog-graphs.XXXXXX")
 trap 'rm -rf "$work"' EXIT HUP INT TERM
 
 # The harness links libxymoncomm. Like the require_bin tests, a tree that
-# was never configured/built skips (tests.yml runs on a bare tree; the
-# post-build suite in build.yml then exercises it for real) - the test
-# must not write config.h or other build artifacts into a bare tree. On
-# a built tree, refresh the archive incrementally so the harness tests
-# this tree's code, not a stale archive.
-[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+# was never built skips (tests.yml runs on a bare tree; the post-build
+# suite in build.yml then exercises it for real). On a built tree, refresh
+# the archive incrementally so the harness tests this tree's code, not a
+# stale archive.
+[ -f "$ROOT/lib/libxymoncomm.a" ] \
 	|| skip "tree not built (run make first; the post-build CI suite covers this)"
-make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
-	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+build_xymon_libs "$ROOT" "$work/libbuild.log" libxymoncomm.a
 
 "$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
 	"$here/html-log-custom-graphs-harness.c" "$ROOT/lib/libxymoncomm.a" \

--- a/tests/web/svcstatus-client-traversal.sh
+++ b/tests/web/svcstatus-client-traversal.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/svcstatus-client-traversal.sh
+#
+# Regression guard for the CGI path-traversal series #145 / #146 / #147:
+# the CLIENT/TIMEBUF client-data path ("$CLIENTLOGS/<host>/<tstamp>").
+#
+# svcstatus.cgi builds filesystem paths from request-supplied components.
+# This drives the real CGI against canary files and asserts that every
+# non-component value is refused outright (exit 1, "Invalid request") --
+# not merely that no canary leaks. "Refused" matters: a value like
+# "../realhost" must NOT be silently served as "realhost".
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+require_c_buildenv "$ROOT"
+# shellcheck source=tests/lib/svcstatus-cgi.sh
+. "$(dirname "$0")/../lib/svcstatus-cgi.sh"
+
+svcstatus_setup
+svcstatus_build || { cat "$work/cc.log" >&2; fail "svcstatus does not build -- cannot verify the traversal guards"; }
+
+# Canaries above and inside CLIENTLOGS, plus a legitimate client-data file.
+mkdir -p "$work/var/hostdata/realhost"
+printf 'CANARY-ABOVE-ROOT\n'  >"$work/var/CANARY_ABOVE"
+printf 'CANARY-IN-ROOT\n'     >"$work/var/hostdata/CANARY_IN"
+printf 'legitimate client data\n' >"$work/var/hostdata/realhost/20260101"
+
+# assert_refused <query-string> <what> -- the request must hit the
+# errormsg() refusal, not be served (exit 0) after silent normalization.
+assert_refused() {
+	render "$1"
+	[ "$RC" -eq 1 ] || fail "$2: QUERY_STRING='$1' was served (exit $RC), not refused"
+	assert_contains "Invalid request" "$OUT" \
+		"$2: QUERY_STRING='$1' refused without the expected error text"
+}
+
+# None of these name a real host: "." / "/" collapse onto the root, ".."
+# escapes upward, and "," / ",," become "." / ".." after the CLIENT rewrite.
+# Each must be refused outright, with no canary returned.
+for host in ".." "." "/" "//" "../" "/.." "," ",," ",,/" "./" ",."; do
+	for target in CANARY_ABOVE CANARY_IN; do
+		render "CLIENT=$host&TIMEBUF=$target"
+		case "$OUT" in
+			*CANARY-ABOVE-ROOT*|*CANARY-IN-ROOT*)
+				fail "path traversal: CLIENT='$host' disclosed $target (#145/#146/#147)"
+				;;
+		esac
+		[ "$RC" -eq 1 ] || fail "CLIENT='$host' was served (exit $RC), not refused"
+	done
+done
+
+# Slash-bearing values must be refused, not normalized: basename() would
+# reduce "../realhost" to "realhost", which a canary check alone cannot catch
+# (it returned real data with exit 0 under that broken variant).
+for host in "../realhost" "/realhost" ",,/realhost" "realhost/"; do
+	assert_refused "CLIENT=$host&TIMEBUF=20260101" "normalized host served"
+done
+assert_refused "CLIENT=realhost&TIMEBUF=dir/20260101" "normalized TIMEBUF served"
+
+# A legitimate request must still be served -- the guards must not have
+# turned into a blanket refusal.
+render "CLIENT=realhost&TIMEBUF=20260101"
+assert_contains "legitimate client data" "$OUT" \
+	"legitimate client-data request no longer served"
+
+# Hosts named by IP take a different parse path (CLIENT rewrites ',' to '.'),
+# so cover both spellings.
+mkdir -p "$work/var/hostdata/192.168.1.1"
+printf 'ipv4 client data\n' >"$work/var/hostdata/192.168.1.1/20260101"
+for spelling in "192,168,1,1" "192.168.1.1"; do
+	render "CLIENT=$spelling&TIMEBUF=20260101"
+	assert_contains "ipv4 client data" "$OUT" \
+		"IP-named host ($spelling) no longer served"
+done
+
+echo "OK $(basename "$0")"

--- a/tests/web/svcstatus-histlog-serving.sh
+++ b/tests/web/svcstatus-histlog-serving.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/svcstatus-histlog-serving.sh
+#
+# The serving side of the historical-log path: the traversal guards
+# (svcstatus-*-traversal.sh) must not refuse a legitimate legal-charset
+# name. Pins:
+#   - a dotted column name ("web.grp") stays reachable,
+#   - a hostname with a literal ',' is looked up verbatim (HOST is not
+#     comma-decoded; only CLIENT/HOSTSVC carry the 192,168,1,1 spelling),
+#   - a histlog whose "Status unchanged in " line is longer than the
+#     100-byte parse buffer renders instead of smashing the stack (the
+#     off-by-one clamp; caught by the ASAN build when available).
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+require_c_buildenv "$ROOT"
+# shellcheck source=tests/lib/svcstatus-cgi.sh
+. "$(dirname "$0")/../lib/svcstatus-cgi.sh"
+
+# --no-daemon: this test stands up its own fake xymond below and points
+# XYMONDPORT at it, so skip setup's dead-port probe and its XYMONDPORT line.
+svcstatus_setup --no-daemon
+
+# Prefer an ASAN build so the long-line case below detects a stack write
+# past the parse buffer as a crash instead of silent corruption. An ASAN
+# error must not exit 1 (render treats 1 as an ordinary refusal), so make
+# it exit 99. Fall back to a plain build where ASAN is unavailable.
+export ASAN_OPTIONS="exitcode=99${ASAN_OPTIONS:+:$ASAN_OPTIONS}"
+svcstatus_build -g -O1 -fsanitize=address,undefined \
+	|| svcstatus_build \
+	|| { cat "$work/cc.log" >&2; fail "svcstatus does not build -- cannot verify histlog serving"; }
+
+# The served page is rendered through the histlog templates.
+mkdir -p "$work/web"
+cp "$ROOT/xymond/webfiles/histlog_header" "$ROOT/xymond/webfiles/histlog_footer" "$work/web/"
+
+# Serving a histlog needs a xymond answering "hostinfo clone=<host>"
+# (lib/loadhosts_net.c): stand up the fake responder from tests/lib on an
+# ephemeral port and point the CGI's XYMONDPORT at it. The reply is
+# host-independent: the client keys the result on its own request, and
+# DISPLAYNAME falls back to the requested hostname.
+printf 'XMH_IP:127.0.0.1\n' >"$work/hostinfo.reply"
+"$CC" -o "$work/fake-xymond" "$ROOT/tests/lib/fake-xymond.c" 2>"$work/cc-fake.log" \
+	|| { cat "$work/cc-fake.log" >&2; fail "fake-xymond responder does not compile"; }
+"$work/fake-xymond" "$work/hostinfo.reply" >"$work/fake-xymond.port" &
+fakepid=$!
+register_cleanup "kill $fakepid 2>/dev/null || true"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+	[ -s "$work/fake-xymond.port" ] && break
+	sleep 0.2
+done
+[ -s "$work/fake-xymond.port" ] || fail "fake-xymond did not report its port"
+echo "XYMONDPORT=\"$(cat "$work/fake-xymond.port")\"" >>"$work/etc/xymonserver.cfg"
+
+echo '127.0.0.1 a,b #' >>"$work/etc/hosts.cfg"
+
+# Histlog files live in "$XYMONHISTLOGS/<host with . and , as _>/<svc>/<tstamp>".
+mkdir -p "$work/var/histlogs/realhost/cpu" \
+	"$work/var/histlogs/realhost/web.grp" \
+	"$work/var/histlogs/a_b/cpu"
+printf 'green Fri Aug 7 12:00:00 2026 MARKER-DOTTED-SVC\nAll fine\n' \
+	>"$work/var/histlogs/realhost/web.grp/20260101"
+printf 'green Fri Aug 7 12:00:00 2026 MARKER-COMMA-HOST\nAll fine\n' \
+	>"$work/var/histlogs/a_b/cpu/20260101"
+
+assert_served() {  # <query-string> <marker> <what>
+	render "$1"
+	[ "$RC" -eq 0 ] || fail "$3: QUERY_STRING='$1' was refused (exit $RC), not served"
+	assert_contains "$2" "$OUT" "$3: QUERY_STRING='$1' served without its log content"
+}
+
+assert_served "HOST=realhost&SERVICE=web.grp&TIMEBUF=20260101" \
+	"MARKER-DOTTED-SVC" "dotted column name"
+assert_served "HOST=a,b&SERVICE=cpu&TIMEBUF=20260101" \
+	"MARKER-COMMA-HOST" "verbatim comma hostname"
+
+# "Status unchanged in " parsing copies up to 100 bytes into a 100-byte
+# stack buffer; a line of 150 chars ending at EOF (no trailing newline)
+# exercised the off-by-one NUL write. render() flags any exit above 1 as a
+# crash, which is what the ASAN build turns the overflow into.
+{
+	printf 'green Fri Aug 7 12:00:00 2026 MARKER-LONG-LINE\n'
+	printf 'Status unchanged in '
+	printf 'X%.0s' $(seq 1 150)
+} >"$work/var/histlogs/realhost/cpu/20260101"
+assert_served "HOST=realhost&SERVICE=cpu&TIMEBUF=20260101" \
+	"MARKER-LONG-LINE" "oversized Status-unchanged line"
+
+# A histlog file with no newline at all (e.g. truncated by a full disk) sets
+# restofmsg to an empty string; the strstr() scans that follow must not
+# dereference it. Must be >= 10 bytes (the stat size gate) and single-line.
+mkdir -p "$work/var/histlogs/realhost/nonl"
+printf 'green MARKER-NO-NEWLINE-nonewline-here' >"$work/var/histlogs/realhost/nonl/20260101"
+assert_served "HOST=realhost&SERVICE=nonl&TIMEBUF=20260101" \
+	"MARKER-NO-NEWLINE" "newline-less histlog file"
+
+echo "OK $(basename "$0")"

--- a/tests/web/svcstatus-histlog-traversal.sh
+++ b/tests/web/svcstatus-histlog-traversal.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/svcstatus-histlog-traversal.sh
+#
+# Regression guard for the CGI path-traversal series #145 / #146 / #147:
+# the historical-log path ("$XYMONHISTLOGS/<host>/<service>/<tstamp>").
+#
+# A collapsing "service" (from SERVICE, HOSTSVC or SECTION) must be refused
+# before the path is built.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+require_c_buildenv "$ROOT"
+# shellcheck source=tests/lib/svcstatus-cgi.sh
+. "$(dirname "$0")/../lib/svcstatus-cgi.sh"
+
+svcstatus_setup
+svcstatus_build || { cat "$work/cc.log" >&2; fail "svcstatus does not build -- cannot verify the traversal guards"; }
+
+# Historical-log canaries: a stray file in the host dir (reachable via
+# SERVICE=".") and one above it (SERVICE=".."), in $XYMONHISTLOGS/<host>/...
+mkdir -p "$work/var/histlogs/realhost/cpu"
+printf 'CANARY-HISTLOG-HOSTDIR\n' >"$work/var/histlogs/realhost/CANARY_HISTDIR"
+printf 'CANARY-HISTLOG-ABOVE\n'   >"$work/var/histlogs/CANARY_HISTUP"
+
+# The guard fires before the host lookup, so a refusal returns its own
+# "Status: 403"; a leak would instead reach loadhostdata() ("Status: 500",
+# no xymond here) or disclose the canary. Assert both, so the check has
+# teeth against either failure.
+assert_histlog_refused() {  # <query-string> <what>
+	render "$1"
+	case "$OUT" in
+		*CANARY-HISTLOG-HOSTDIR*|*CANARY-HISTLOG-ABOVE*)
+			fail "$2: '$1' disclosed a histlog canary (#147 review)" ;;
+	esac
+	assert_contains "Status: 403" "$OUT" \
+		"$2: '$1' was not refused at the traversal guard (reached host load or was served)"
+}
+
+for svc in "." ".." "a/b" "../.." "cpu/.."; do
+	for target in CANARY_HISTDIR CANARY_HISTUP; do
+		assert_histlog_refused "HOST=realhost&SERVICE=$svc&TIMEBUF=$target" \
+			"histlog SERVICE traversal"
+	done
+done
+
+# A control byte in SERVICE (charset-free on this path) would otherwise
+# survive into the "test=<svc>" xymond request as a second protocol line, so
+# it must be refused at the confinement guard (Status: 403), not
+# confined-and-served (which would reach the host load / 404 instead).
+for bad in "cpu%0Aget config" "cpu%09x" "cpu%7f"; do
+	render "HOST=realhost&SERVICE=$bad&TIMEBUF=20260101"
+	assert_contains "Status: 403" "$OUT" \
+		"SERVICE control byte '$bad' was not refused -- protocol injection (#147 review follow-up)"
+done
+
+# SECTION reaches the same "service" variable, so a collapsing SECTION must be
+# refused on the historical path too.
+for sec in "." ".."; do
+	assert_histlog_refused "HOST=realhost&SECTION=$sec&TIMEBUF=CANARY_HISTUP" \
+		"histlog SECTION traversal"
+done
+
+# A SECTION with a traversal-shaped prefix: the service copy is the section's
+# final path component (as basename() historically produced, so access-control
+# groups keyed on it keep working), so the prefix cannot escape -- the lookup
+# stays confined under the host's own directory and must disclose nothing.
+render "HOST=realhost&SECTION=../CANARY_HISTUP&TIMEBUF=CANARY_HISTUP"
+case "$OUT" in
+	*CANARY-HISTLOG-HOSTDIR*|*CANARY-HISTLOG-ABOVE*)
+		fail "histlog SECTION traversal: '../CANARY_HISTUP' disclosed a histlog canary (#147 review)" ;;
+esac
+[ "$RC" -eq 1 ] || fail "histlog SECTION '../CANARY_HISTUP' was served (exit $RC), not refused"
+
+echo "OK $(basename "$0")"

--- a/tests/web/svcstatus-section-filter.sh
+++ b/tests/web/svcstatus-section-filter.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/svcstatus-section-filter.sh
+#
+# Regression guard for #147 review: SECTION as a live client-log filter.
+#
+# On a live CLIENT request, SECTION is a filter forwarded to xymond as
+# "clientlog <host> section=<value>"; section names legitimately contain '/'
+# (e.g. "msgs:/var/log/messages"). Emptying it would drop the filter and dump
+# the whole client data. With no xymond here, svcstatus echoes the request it
+# built -- which must still carry the full section filter.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+require_c_buildenv "$ROOT"
+# shellcheck source=tests/lib/svcstatus-cgi.sh
+. "$(dirname "$0")/../lib/svcstatus-cgi.sh"
+
+svcstatus_setup
+svcstatus_build || { cat "$work/cc.log" >&2; fail "svcstatus does not build -- cannot verify the SECTION handling"; }
+
+# SERVICE is compiled as a PCRE testname pattern for the aggregate/multi-test
+# view, so a pattern with regex metacharacters must pass the confinement guard
+# and reach do_request. The parse guard refuses with "Status: 403"; a value
+# that passes it instead reaches loadhostdata(), which here fails against the
+# dead xymond with "Status: 500 / Cannot load host configuration". (Both error
+# pages share the title "Invalid request", so key on the status, not the body.)
+render_live "HOST=realhost&SERVICE=cpu|disk"
+assert_not_contains "Status: 403" "$OUT" \
+	"aggregate SERVICE 'cpu|disk' was refused at the confinement guard -- regex view unreachable (#147 review round 5)"
+assert_contains "Cannot load host configuration" "$OUT" \
+	"aggregate SERVICE 'cpu|disk' did not reach do_request/loadhostdata past the guard (#147 review round 5)"
+
+render_live "CLIENT=realhost&SECTION=msgs:/var/log/messages"
+assert_contains "section=msgs:/var/log/messages" "$OUT" \
+	"SECTION with '/' was dropped -- would disclose the full client dump (#147 review)"
+
+# A SECTION ending in '/' (a directory-monitoring section) has an empty final
+# path component; basename() historically served it, so the request must not
+# 403 at the confinement guard. It reaches the clientlog request (which then
+# fails only because no xymond is listening), still carrying the full filter --
+# had it been refused, the request would never be built and no "section=" would
+# appear.
+render_live "CLIENT=realhost&SECTION=dir:/var/log/"
+assert_contains "section=dir:/var/log/" "$OUT" \
+	"SECTION ending in '/' was refused at the guard -- basename served it before (#147 review follow-up)"
+
+# A client section leaf is free-form (client section names carry spaces,
+# brackets, etc.), so it is confined against traversal but NOT to CGI_NAMECHARS
+# -- a space in the leaf must still forward the filter, not 403 the request.
+# (the echoed request htmlquotes the space as &nbsp;; a 403 would carry no
+# "section=" at all.)
+render_live "CLIENT=realhost&SECTION=Disk Usage"
+assert_contains "section=Disk&nbsp;Usage" "$OUT" \
+	"space-bearing SECTION leaf was refused -- client sections must stay viewable (#147 review round 4)"
+
+# A SECTION whose leaf merely happens to equal CLIENTCOLUMN ("clientlog") is a
+# request for that one section, not the whole client log: the filter must
+# survive, not be dropped by the CLIENTCOLUMN shortcut.
+render_live "CLIENT=realhost&SECTION=msgs:/var/log/clientlog"
+assert_contains "section=msgs:/var/log/clientlog" "$OUT" \
+	"SECTION leaf 'clientlog' dropped the filter and dumped the whole log (#147 review round 4)"
+
+# A control byte in SECTION reaches both the "section=" filter and the request
+# built from it, so it must be refused at the guard (Status: 403), not
+# forwarded as an injected protocol line. Test BOTH parameter orders: SECTION
+# is resolved after the whole query is parsed, so an invalid SECTION must
+# refuse whether CLIENT (which also writes "service") comes before or after it
+# -- otherwise a trailing CLIENT would overwrite the refusal and dump the log.
+render_live "CLIENT=realhost&SECTION=msgs%0Aget hostinfo"
+assert_contains "Status: 403" "$OUT" \
+	"SECTION with an embedded newline was not refused -- protocol injection (#147 review follow-up)"
+assert_not_contains "section=msgs" "$OUT" \
+	"SECTION with an embedded newline still built a filter"
+
+render_live "SECTION=%01&CLIENT=realhost"
+assert_contains "Status: 403" "$OUT" \
+	"invalid SECTION before CLIENT was not refused -- trailing CLIENT overwrote the refusal (#147 review follow-up)"
+assert_not_contains "Req=clientlog" "$OUT" \
+	"invalid SECTION before CLIENT still built a clientlog request"
+
+# web_access_allowed() can grant view access via a group named by the service;
+# for SECTION that service is the section's final path component ("messages"
+# for "msgs:/var/log/messages", as basename() historically produced). An empty
+# service there would make that grant impossible and 403 every path-bearing
+# SECTION on an access-controlled site (#147 review).
+printf 'messages: alice\n' >"$work/etc/access.cfg"
+RENDER_ENV="REMOTE_USER=alice" \
+	render_live "CLIENT=realhost&SECTION=msgs:/var/log/messages" --access="$work/etc/access.cfg"
+assert_not_contains "restricted" "$OUT" \
+	"section-derived service no longer reaches the access check -- grant by section basename broken (#147 review)"
+assert_contains "section=msgs:/var/log/messages" "$OUT" \
+	"access-granted SECTION request did not carry its filter"
+
+# SECTION equal to CLIENTCOLUMN ("clientlog") is the old spelling for "the
+# whole client log": the single-variable code dropped the filter there, so the
+# request must go out with no section= filter (a literal section=clientlog
+# filter matches nothing and turns the page into "<No data>").
+render_live "CLIENT=realhost&SECTION=clientlog"
+assert_contains "Req=clientlog&nbsp;realhost," "$OUT" \
+	"SECTION=clientlog: expected the plain clientlog request echo (htmlquoted)"
+assert_not_contains "section=" "$OUT" \
+	"SECTION=clientlog was forwarded as a filter instead of dropped (#147 review)"
+
+echo "OK $(basename "$0")"

--- a/web/history.c
+++ b/web/history.c
@@ -17,7 +17,6 @@ static char rcsid[] = "$Id$";
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <libgen.h>
 
 #include "libxymon.h"
 
@@ -609,8 +608,8 @@ static void parse_query(void)
 			*p = '\0';
 
 			p = strrchr(cwalk->value, '.');
-			if (p) { *p = '\0'; service = strdup(p+1); }
-			hostname = strdup(basename(cwalk->value));
+			if (p) { *p = '\0'; service = strdup(safe_basename(p+1)); }
+			hostname = strdup(safe_basename(cwalk->value));
 			while ((p = strchr(hostname, ','))) *p = '.';
 		}
 		else if (strcasecmp(cwalk->name, "IP") == 0) {

--- a/web/history.c
+++ b/web/history.c
@@ -17,7 +17,6 @@ static char rcsid[] = "$Id$";
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <libgen.h>
 
 #include "libxymon.h"
 
@@ -605,13 +604,7 @@ static void parse_query(void)
 		 */
 
 		if (strcasecmp(cwalk->name, "HISTFILE") == 0) {
-			char *p = cwalk->value + strspn(cwalk->value, "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ:,.\\/_-");
-			*p = '\0';
-
-			p = strrchr(cwalk->value, '.');
-			if (p) { *p = '\0'; service = strdup(p+1); }
-			hostname = strdup(basename(cwalk->value));
-			while ((p = strchr(hostname, ','))) *p = '.';
+			cgi_split_hostsvc(cwalk->value, &hostname, &service);
 		}
 		else if (strcasecmp(cwalk->name, "IP") == 0) {
 			ip = strdup(cwalk->value);
@@ -639,7 +632,9 @@ static void parse_query(void)
 		cwalk = cwalk->next;
 	}
 
-	if (!displayname) displayname = strdup(hostname);
+	/* hostname is NULL when HISTFILE was rejected; main() refuses the
+	 * request just below, but this runs first -- don't strdup(NULL). */
+	if (!displayname) displayname = strdup(hostname ? hostname : "");
 }
 
 
@@ -673,6 +668,14 @@ int main(int argc, char *argv[])
 	envcheck(reqenv);
 	cgidata = cgi_request();
 	parse_query();
+
+	/*
+	 * Refuse an absent, empty or rejected component. hostname/service
+	 * start as "" (the globals above), and cgi_split_hostsvc() leaves
+	 * service untouched for a dotless HISTFILE, so check emptiness too,
+	 * not just NULL -- both spellings must reach the refusal.
+	 */
+	if (!hostname || !*hostname || !service || !*service) errormsg("Invalid request");
 
 	SBUF_MALLOC(selfurl, 4096);
 
@@ -758,7 +761,13 @@ int main(int argc, char *argv[])
 	else {
 		SBUF_DEFINE(tailcmd);
 
-		/* Last 50 entries - we cheat and use "tail" in a pipe to pick the entries */
+		/* Last 50 entries - we cheat and use "tail" in a pipe to pick the entries.
+		 * histlogfn is passed unquoted to the shell here, so it MUST stay free of
+		 * shell metacharacters: hostname and service both come from the strict
+		 * cgi_split_hostsvc()/cgi_pathcomponent() confinement (CGI_NAMECHARS has
+		 * no ';','|','`','$',space,...) and XYMONHISTDIR is admin config. Do not
+		 * loosen the service confinement to a free-form set without also fixing
+		 * this call (it would reopen shell injection). */
 		fclose(fd);
 		SBUF_MALLOC(tailcmd, 1024 + strlen(histlogfn));
 

--- a/web/reportlog.c
+++ b/web/reportlog.c
@@ -18,7 +18,6 @@ static char rcsid[] = "$Id$";
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <libgen.h>
 
 #include "libxymon.h"
 
@@ -59,19 +58,19 @@ static void parse_query(void)
 			*p = '\0';
 
 			p = strrchr(cwalk->value, '.');
-			if (p) { *p = '\0'; service = strdup(p+1); }
-			hostname = strdup(basename(cwalk->value));
+			if (p) { *p = '\0'; service = strdup(safe_basename(p+1)); }
+			hostname = strdup(safe_basename(cwalk->value));
 			while ((p = strchr(hostname, ','))) *p = '.';
 		}
 		else if (strcasecmp(cwalk->name, "HOST") == 0) {
 			char *p = cwalk->value + strspn(cwalk->value, "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ:,._-");
 			*p = '\0';
-			hostname = strdup(basename(cwalk->value));
+			hostname = strdup(safe_basename(cwalk->value));
 		}
 		else if (strcasecmp(cwalk->name, "SERVICE") == 0) {
 			char *p = cwalk->value + strspn(cwalk->value, "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ:\\/_-");
 			*p = '\0';
-			service = strdup(basename(cwalk->value));
+			service = strdup(safe_basename(cwalk->value));
 		}
 		else if (strcasecmp(cwalk->name, "REPORTTIME") == 0) {
 			SBUF_MALLOC(reporttime, strlen(cwalk->value)+strlen("REPORTTIME=")+1);

--- a/web/reportlog.c
+++ b/web/reportlog.c
@@ -18,7 +18,6 @@ static char rcsid[] = "$Id$";
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <libgen.h>
 
 #include "libxymon.h"
 
@@ -55,23 +54,18 @@ static void parse_query(void)
 		 */
 
 		if (strcasecmp(cwalk->name, "HOSTSVC") == 0) {
-			char *p = cwalk->value + strspn(cwalk->value, "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ:,.\\/_-");
-			*p = '\0';
-
-			p = strrchr(cwalk->value, '.');
-			if (p) { *p = '\0'; service = strdup(p+1); }
-			hostname = strdup(basename(cwalk->value));
-			while ((p = strchr(hostname, ','))) *p = '.';
+			cgi_split_hostsvc(cwalk->value, &hostname, &service);
 		}
 		else if (strcasecmp(cwalk->name, "HOST") == 0) {
-			char *p = cwalk->value + strspn(cwalk->value, "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ:,._-");
-			*p = '\0';
-			hostname = strdup(basename(cwalk->value));
+			/* Verbatim spelling (replogurl() emits the raw name, no
+			 * comma-encoding). Reject the whole value on anything but
+			 * a single legal component, like svcstatus -- do not
+			 * truncate and serve a prefix ("web bar" must not become
+			 * the "web" report). */
+			hostname = cgi_pathcomponent(cwalk->value, 0);
 		}
 		else if (strcasecmp(cwalk->name, "SERVICE") == 0) {
-			char *p = cwalk->value + strspn(cwalk->value, "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ:\\/_-");
-			*p = '\0';
-			service = strdup(basename(cwalk->value));
+			service = cgi_pathcomponent(cwalk->value, 0);
 		}
 		else if (strcasecmp(cwalk->name, "REPORTTIME") == 0) {
 			SBUF_MALLOC(reporttime, strlen(cwalk->value)+strlen("REPORTTIME=")+1);
@@ -138,6 +132,10 @@ int main(int argc, char *argv[])
 
 	cgidata = cgi_request();
 	parse_query();
+
+	/* NULL = absent or rejected (not a single path component). */
+	if (!hostname || !service) errormsg("Invalid request");
+
 	load_hostinfo(hostname);
         if ((hinfo = hostinfo(hostname)) == NULL) {
 		errormsg("No such host");

--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -78,7 +78,7 @@ static int parse_query(void)
 			if (p) {
 				*p = '\0';
 				hostname = strdup(basename(cwalk->value));
-				service = strdup(p+1);
+				service = strdup(basename(p+1));
 				for (p=strchr(hostname, ','); (p); p = strchr(p, ',')) *p = '.';
 			}
 		}
@@ -95,7 +95,7 @@ static int parse_query(void)
 			outform = FRM_CLIENT;
 		}
 		else if (strcasecmp(cwalk->name, "SECTION") == 0) {
-			service = strdup(cwalk->value);
+			service = strdup(basename(cwalk->value));
 		}
 		else if (strcasecmp(cwalk->name, "NKPRIO") == 0) {
 			nkprio = strdup(cwalk->value);

--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -21,7 +21,6 @@ static char rcsid[] = "$Id$";
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <libgen.h>
 
 #include "libxymon.h"
 #include "version.h"
@@ -67,35 +66,35 @@ static int parse_query(void)
 	cwalk = cgidata;
 	while (cwalk) {
 		if (strcasecmp(cwalk->name, "HOST") == 0) {
-			hostname = strdup(basename(cwalk->value));
+			hostname = strdup(safe_basename(cwalk->value));
 		}
 		else if (strcasecmp(cwalk->name, "SERVICE") == 0) {
-			service = strdup(basename(cwalk->value));
+			service = strdup(safe_basename(cwalk->value));
 		}
 		else if (strcasecmp(cwalk->name, "HOSTSVC") == 0) {
 			/* For backwards compatibility */
 			char *p = strrchr(cwalk->value, '.');
 			if (p) {
 				*p = '\0';
-				hostname = strdup(basename(cwalk->value));
-				service = strdup(basename(p+1));
+				hostname = strdup(safe_basename(cwalk->value));
+				service = strdup(safe_basename(p+1));
 				for (p=strchr(hostname, ','); (p); p = strchr(p, ',')) *p = '.';
 			}
 		}
 		else if (strcasecmp(cwalk->name, "TIMEBUF") == 0) {
 			/* Only for the historical logs */
-			tstamp = strdup(basename(cwalk->value));
+			tstamp = strdup(safe_basename(cwalk->value));
 		}
 		else if (strcasecmp(cwalk->name, "CLIENT") == 0) {
 			char *p;
 
-			hostname = strdup(basename(cwalk->value));
+			hostname = strdup(safe_basename(cwalk->value));
 			p = hostname; while ((p = strchr(p, ',')) != NULL) *p = '.';
 			service = strdup("");
 			outform = FRM_CLIENT;
 		}
 		else if (strcasecmp(cwalk->name, "SECTION") == 0) {
-			service = strdup(basename(cwalk->value));
+			service = strdup(safe_basename(cwalk->value));
 		}
 		else if (strcasecmp(cwalk->name, "NKPRIO") == 0) {
 			nkprio = strdup(cwalk->value);
@@ -140,7 +139,7 @@ static int parse_query(void)
 
 	if (strcmp(service, xgetenv("CLIENTCOLUMN")) == 0) {
 		/* Make this a client request */
-		char *p = strdup(basename(hostname));
+		char *p = strdup(safe_basename(hostname));
 		xfree(hostname); hostname = p;	/* no need to convert to dots, since we'll already have them */
 		xfree(service);			/* service does double-duty as the 'section' param */
 		outform = FRM_CLIENT;

--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -21,7 +21,6 @@ static char rcsid[] = "$Id$";
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <libgen.h>
 
 #include "libxymon.h"
 #include "version.h"
@@ -39,6 +38,7 @@ static char *accessfn = NULL;
 /* CGI params */
 static char *hostname = NULL;
 static char *service = NULL;
+static char *sectionfilter = NULL;
 static char *tstamp = NULL;
 static char *nkprio = NULL, *nkttgroup = NULL, *nkttextra = NULL;
 static enum { FRM_STATUS, FRM_CLIENT } outform = FRM_STATUS;
@@ -63,48 +63,59 @@ static int parse_query(void)
 {
 	cgidata_t *cgidata = cgi_request();
 	cgidata_t *cwalk;
+	char *rawsection = NULL;
+	int sectionseen = 0;
 
 	cwalk = cgidata;
 	while (cwalk) {
 		if (strcasecmp(cwalk->name, "HOST") == 0) {
-			hostname = strdup(basename(cwalk->value));
+			/* Verbatim spelling: hostsvcurl() emits the raw name
+			 * (no comma-encoding). */
+			hostname = cgi_pathcomponent(cwalk->value, 0);
 		}
 		else if (strcasecmp(cwalk->name, "SERVICE") == 0) {
-			service = strdup(basename(cwalk->value));
+			/* Free-form: SERVICE is compiled as a PCRE testname
+			 * pattern for the aggregate view (do_request), so
+			 * metacharacters must survive; confined against control
+			 * bytes and traversal only. */
+			service = cgi_component(cwalk->value);
 		}
 		else if (strcasecmp(cwalk->name, "HOSTSVC") == 0) {
 			/* For backwards compatibility */
-			char *p = strrchr(cwalk->value, '.');
-			if (p) {
-				*p = '\0';
-				hostname = strdup(basename(cwalk->value));
-				service = strdup(basename(p+1));
-				for (p=strchr(hostname, ','); (p); p = strchr(p, ',')) *p = '.';
-			}
+			cgi_split_hostsvc(cwalk->value, &hostname, &service);
 		}
 		else if (strcasecmp(cwalk->name, "TIMEBUF") == 0) {
-			/* Only for the historical logs */
-			tstamp = strdup(basename(cwalk->value));
+			/* Only for the historical logs. NULL on rejection, like
+			 * the other parameters -- one convention in this function. */
+			tstamp = cgi_pathcomponent(cwalk->value, 0);
 		}
 		else if (strcasecmp(cwalk->name, "CLIENT") == 0) {
-			char *p;
-
-			hostname = strdup(basename(cwalk->value));
-			p = hostname; while ((p = strchr(p, ',')) != NULL) *p = '.';
+			/* CLIENT arrives comma-encoded (192,168,1,1). */
+			hostname = cgi_pathcomponent(cwalk->value, 1);
 			service = strdup("");
 			outform = FRM_CLIENT;
 		}
 		else if (strcasecmp(cwalk->name, "SECTION") == 0) {
-			service = strdup(basename(cwalk->value));
+			/*
+			 * Only capture the raw value here; it is resolved after
+			 * the loop. SECTION and CLIENT both write "service", and
+			 * an invalid SECTION must refuse the request rather than
+			 * fall back to CLIENT's "whole client log" -- deferring
+			 * makes that hold whatever order the two arrive in, and
+			 * NULL-guards a value cgi_request() never finalized.
+			 */
+			sectionseen = 1;
+			if (rawsection) xfree(rawsection);
+			rawsection = cwalk->value ? strdup(cwalk->value) : NULL;
 		}
 		else if (strcasecmp(cwalk->name, "NKPRIO") == 0) {
-			nkprio = strdup(cwalk->value);
+			nkprio = strdup(cwalk->value ? cwalk->value : "");
 		}
 		else if (strcasecmp(cwalk->name, "NKTTGROUP") == 0) {
-			nkttgroup = strdup(cwalk->value);
+			nkttgroup = strdup(cwalk->value ? cwalk->value : "");
 		}
 		else if (strcasecmp(cwalk->name, "NKTTEXTRA") == 0) {
-			nkttextra = strdup(cwalk->value);
+			nkttextra = strdup(cwalk->value ? cwalk->value : "");
 		}
 		else if ((strcmp(cwalk->name, "backsecs") == 0)   && cwalk->value && strlen(cwalk->value)) {
 			backsecs += atoi(cwalk->value);
@@ -133,16 +144,69 @@ static int parse_query(void)
 		else backsecs = 48*60*60;
 	}
 
+	/*
+	 * Resolve SECTION now that every parameter has been seen, so the
+	 * result does not depend on whether CLIENT came before or after it.
+	 * The raw value is the xymond "section=" filter -- section names
+	 * legitimately contain '/' (e.g. "msgs:/var/log/messages"), so it is
+	 * not confined to a path component or the filter would be dropped and
+	 * the whole client dump served. The "service" copy is the section's
+	 * final path component, free-form as basename() historically produced
+	 * (client section names legitimately carry spaces, brackets, etc., so
+	 * it is NOT held to CGI_NAMECHARS) -- it only feeds the access-control
+	 * check and, on the historical path, a filename that safe_basename()
+	 * re-confines, so it is confined here against traversal alone. A
+	 * control byte anywhere in the section would reach a xymond protocol
+	 * line, so it rejects the whole value: service=NULL, which the guard
+	 * below refuses, overriding any "" a CLIENT parameter set.
+	 */
+	if (sectionseen) {
+		if (service) { xfree(service); service = NULL; }
+		if (sectionfilter) { xfree(sectionfilter); sectionfilter = NULL; }
+
+		if (rawsection && !cgi_hasctrl(rawsection)) {
+			char *p, *leaf, *sb;
+			size_t n = strlen(rawsection);
+
+			sectionfilter = strdup(rawsection);
+			while ((n > 0) && (rawsection[n-1] == '/')) rawsection[--n] = '\0';
+			p = strrchr(rawsection, '/');
+			leaf = p ? p+1 : rawsection;
+			sb = safe_basename(leaf);	/* free-form; only "/", ".", ".." and "" reject */
+			service = *sb ? strdup(sb) : NULL;
+		}
+	}
+	if (rawsection) xfree(rawsection);
+
+	/*
+	 * NULL means absent or rejected: cgi_pathcomponent() returns NULL
+	 * for any value that is not a single path component, so a refused
+	 * parameter cannot arrive here as a partial or empty spelling.
+	 * service is "" only where a handler set it deliberately (CLIENT
+	 * means "the whole client log"); it is confined again where it
+	 * becomes a path component, at the historical-log path below.
+	 */
 	if (!hostname || !service || ((source == SRC_HISTLOGS) && !tstamp) ) {
 		errormsg(403, "Invalid request");
 		return 1;
 	}
 
-	if (strcmp(service, xgetenv("CLIENTCOLUMN")) == 0) {
-		/* Make this a client request */
-		char *p = strdup(basename(hostname));
-		xfree(hostname); hostname = p;	/* no need to convert to dots, since we'll already have them */
-		xfree(service);			/* service does double-duty as the 'section' param */
+	if (strcmp(service, xgetenv("CLIENTCOLUMN")) == 0 &&
+	    (!sectionfilter || strcmp(sectionfilter, service) == 0)) {
+		/*
+		 * The client column ("clientlog") as a whole value means "the
+		 * whole client log": make it a client request (hostname is
+		 * already validated) and drop service, which doubled as the
+		 * section param in the old single-variable code. This fires for
+		 * a bare SERVICE/HOSTSVC=clientlog (no filter) and for
+		 * SECTION=clientlog (filter == the column name). It must NOT
+		 * fire when only the section's LEAF is "clientlog"
+		 * (e.g. SECTION="msgs:/var/log/clientlog") -- that is a request
+		 * for one section, so keep its filter rather than dumping the
+		 * whole log.
+		 */
+		xfree(service);
+		if (sectionfilter) xfree(sectionfilter);
 		outform = FRM_CLIENT;
 	}
 
@@ -250,9 +314,9 @@ int do_request(void)
 			int xymondresult;
 			sendreturn_t *sres = newsendreturnbuf(1, NULL);
 
-			SBUF_MALLOC(xymondreq, 1024 + strlen(hostname) + (service ? strlen(service) : 0));
+			SBUF_MALLOC(xymondreq, 1024 + strlen(hostname) + (sectionfilter ? strlen(sectionfilter) : 0));
 			snprintf(xymondreq, xymondreq_buflen, "clientlog %s", hostname);
-			if (service && *service) snprintf(xymondreq + strlen(xymondreq), (xymondreq_buflen - strlen(xymondreq)), " section=%s", service);
+			if (sectionfilter && *sectionfilter) snprintf(xymondreq + strlen(xymondreq), (xymondreq_buflen - strlen(xymondreq)), " section=%s", sectionfilter);
 
 			xymondresult = sendmessage(xymondreq, NULL, XYMON_TIMEOUT, sres);
 			if (xymondresult != XYMONSEND_OK) {
@@ -276,13 +340,11 @@ int do_request(void)
 			fd = fopen(logfn, "r");
 			if (fd) {
 				struct stat st;
-				int n;
 
 				fstat(fileno(fd), &st);
 				if (S_ISREG(st.st_mode)) {
 					log = (char *)malloc(st.st_size + 1);
-					n = fread(log, 1, st.st_size, fd);
-					if (n >= 0) *(log+n) = '\0'; else *log = '\0';
+					if (log) { size_t nread = fread(log, 1, st.st_size, fd); log[nread] = '\0'; }
 				}
 				fclose(fd);
 			}
@@ -554,16 +616,25 @@ int do_request(void)
 		char *statusunchangedtext = "Status unchanged in ";
 		char *receivedfromtext = "Message received from ";
 		char *clientidtext = "Client data ID ";
-		char *p, *unchangedstr, *receivedfromstr, *clientidstr, *hostnamedash;
+		char *p, *unchangedstr, *receivedfromstr, *clientidstr, *hostnamedash, *safesvc;
 		int n;
 
 		if (!tstamp) { errormsg(500, "Invalid request"); return 1; }
+
+		/* service becomes a path component here. Every site that assigns
+		 * it already excludes '/', '.', '..' and "" (cgi_component /
+		 * cgi_pathcomponent / the SECTION leaf), so this re-confinement is
+		 * defense-in-depth at the path-construction sink, not a live check
+		 * -- kept deliberately: this series has more than once seen an
+		 * upstream confinement slip, and the cost here is one comparison. */
+		safesvc = safe_basename(service);
+		if (!*safesvc) { errormsg(403, "Invalid request"); return 1; }
 
 		if (loadhostdata(hostname, &ip, &displayname, &compacts, 0) != 0) return 1;
 		hostnamedash = strdup(hostname);
 		p = hostnamedash; while ((p = strchr(p, '.')) != NULL) *p = '_';
 		p = hostnamedash; while ((p = strchr(p, ',')) != NULL) *p = '_';
-		snprintf(logfn, sizeof(logfn), "%s/%s/%s/%s", xgetenv("XYMONHISTLOGS"), hostnamedash, service, tstamp);
+		snprintf(logfn, sizeof(logfn), "%s/%s/%s/%s", xgetenv("XYMONHISTLOGS"), hostnamedash, safesvc, tstamp);
 		xfree(hostnamedash);
 		p = tstamp; while ((p = strchr(p, '_')) != NULL) *p = ' ';
 		sethostenv_histlog(tstamp);
@@ -579,14 +650,14 @@ int do_request(void)
 			return 1;
 		}
 		log = (char *)malloc(st.st_size+1);
-		n = fread(log, 1, st.st_size, fd);
-		if (n >= 0) *(log+n) = '\0'; else *log = '\0';
+		if (!log) { errormsg(500, "Cannot read historical logfile\n"); fclose(fd); return 1; }
+		{ size_t nread = fread(log, 1, st.st_size, fd); log[nread] = '\0'; }
 		fclose(fd);
 
-		p = strchr(log, '\n'); 
+		p = strchr(log, '\n');
 		if (!p) {
 			firstline = strdup(log);
-			restofmsg = NULL;
+			restofmsg = log + strlen(log);	/* empty, not NULL: the strstr()s below must not deref it */
 		}
 		else { 
 			*p = '\0'; 
@@ -621,7 +692,10 @@ int do_request(void)
 		p = unchangedstr = strstr(restofmsg, statusunchangedtext);
 		if (p) {
 			p += strlen(statusunchangedtext);
-			n = strcspn(p, "\n"); if (n >= sizeof(timesincechange)) n = sizeof(timesincechange);
+			/* Clamp to sizeof-1: timesincechange[n]='\0' below must
+			 * land inside the buffer, so n may reach the last index
+			 * at most, not sizeof itself. */
+			n = strcspn(p, "\n"); if (n >= sizeof(timesincechange)) n = sizeof(timesincechange) - 1;
 			strncpy(timesincechange, p, n);
 			timesincechange[n] = '\0';
 		}
@@ -702,6 +776,7 @@ int do_request(void)
 	/* Cleanup CGI params */
 	if (hostname) xfree(hostname);
 	if (service) xfree(service);
+	if (sectionfilter) xfree(sectionfilter);
 	if (tstamp) xfree(tstamp);
 
 	/* Cleanup main vars */
@@ -786,7 +861,7 @@ int main(int argc, char *argv[])
 	redirect_cgilog("svcstatus");
 
 	*errortxt = '\0';
-	hostname = service = tstamp = NULL;
+	hostname = service = sectionfilter = tstamp = NULL;
 	if (do_request() != 0) {
 		fprintf(stdout, "%s", errortxt);
 		return 1;


### PR DESCRIPTION
Closes an unauthenticated path traversal in the CGI `basename()` handling that #145/#146 left open, and hardens every request-derived path/protocol/shell value in `svcstatus`, `history` and `reportlog`. Refs #145, #146.

## The bug
`basename()` normalizes instead of validating (`../realhost` → `realhost`), so `svcstatus.cgi --historical` with `CLIENT=..` built a path above the client-log directory and disclosed a file — unauthenticated in a default install.

## The fix
Confinement helpers in `lib/cgi.c`, applied per parameter:
- **`safe_basename()`** — validates, never normalizes: `/`, `.`, `..`, `""` all reject.
- **`cgi_pathcomponent()`** — STRICT (`HOST`/`CLIENT`/`TIMEBUF`, both halves of `HOSTSVC`/`HISTFILE`): a single `CGI_NAMECHARS` (`[A-Za-z0-9:,._-]`) component or refused **whole**, never truncated. Both `/` and `\` excluded; the split service stays strict because `history.cgi` shells it to `tail`.
- **`cgi_component()`** — FREE-FORM for svcstatus `SERVICE` (a PCRE pattern) and section leaves: refused only on a control byte or traversal.
- **`cgi_hasctrl()`** — one definition of the injection-dangerous byte, shared by the helpers and the `SECTION` resolver.

This also closes a control-byte protocol-injection gap and a `tail` shell-injection, and **refuses rather than truncates** malformed input. Non-ASCII canonical hostnames are refused for now; the matching `hosts.cfg` parser enforcement + docs are tracked in #309.

## Tests
A C harness pins the confinement helpers directly; the svcstatus/history/reportlog tests drive the real CGIs against canary files and a fake xymond, asserting traversal / protocol+shell injection / malformed inputs are refused *by refusal status* (not just canary absence) while legitimate spellings (dotted columns, comma-IP hosts, section filters, aggregate `SERVICE` regexes) still serve.
