### PR TITLE
lib/netservices: free the per-service record struct on reload (fixes #148) (TBT 518)

### DIFF
--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -293,11 +293,12 @@ char *init_tcp_services(void)
 	/* Free the temp. svclist list */
 	while (head) {
 		/*
-		 * Note: Don't free the strings inside the records, 
-		 * as they are now owned by the svcinfo records.
+		 * Note: free the record struct itself, but NOT the strings
+		 * inside it - those are now owned by the svcinfo records.
 		 */
 		walk = head;
 		head = head->next;
+		xfree(walk->rec);
 		xfree(walk);
 	}
 


### PR DESCRIPTION
## Summary

Fix a small, deterministic memory leak in `init_tcp_services()`
(`lib/netservices.c`): each (re)load of the network-service table leaks one
`svcinfo_t` struct per configured service.

## Root cause

Each temporary list node gets its own record via
`newitem->rec = calloc(1, sizeof(svcinfo_t))`. The record's **string members**
are shallow-copied into the `svcinfo[]` array and are intentionally not freed in
the teardown loop — but the loop frees only the **node** (`xfree(walk)`), never
the record struct itself, so each `svcinfo_t` allocation leaks.

## Fix

```c
xfree(walk->rec);   /* the record struct; its strings stay owned by svcinfo[] */
xfree(walk);
```

Frees only the otherwise-unreferenced container struct — no double-free, no
use-after-free (the string members remain owned by `svcinfo[]`).

## Validation

- `lib/netservices.c` compiles clean (incl. `-Werror=implicit-function-declaration`).
- The ownership was traced in `main`: `rec` is per-node (`calloc` at `:200`); its
  members are copied into `svcinfo[]` at `:275`+; the teardown comment already
  states the strings must not be freed — this change frees only the struct.

Origin: surfaced during the Terabithia downstream audit (#29). Closes #148.
