### PR TITLE
snmpcollect: don't fail over to the next IP on NOSUCHNAME (fixes #137)

### DIFF
--- a/xymonnet/xymon-snmpcollect.c
+++ b/xymonnet/xymon-snmpcollect.c
@@ -278,11 +278,14 @@ int asynch_response(int operation, struct snmp_session *sp, int reqid, struct sn
 			break;
 
 		  case SNMP_ERR_NOSUCHNAME:
+			/*
+			 * NOSUCHNAME means the agent answered but does not implement this
+			 * OID - a host-wide fact, not IP-specific. Failing over to another
+			 * IP of the same host cannot change the result; it only wastes a
+			 * poll cycle and muddles multi-homed handling. Just log it.
+			 * (See issue #137; was: advance to the next host IP and re-poll.)
+			 */
 			dbgprintf("Host %s item %s: No such name\n", req->hostname, req->curr_oid->devname);
-			if (req->hostip[req->hostipidx+1]) {
-				req->hostipidx++;
-				startonehost(req, 1);
-			}
 			break;
 
 		  case SNMP_ERR_TOOBIG:


### PR DESCRIPTION
## Summary

In `xymonnet/xymon-snmpcollect.c` (`asynch_response`), the
`SNMP_ERR_NOSUCHNAME` case advanced to the next host IP and re-polled:

```c
case SNMP_ERR_NOSUCHNAME:
    dbgprintf("Host %s item %s: No such name\n", req->hostname, req->curr_oid->devname);
    if (req->hostip[req->hostipidx+1]) { req->hostipidx++; startonehost(req, 1); }
    break;
```

`NOSUCHNAME` means the agent **answered** and simply doesn't implement that OID —
a host-wide fact, not IP-specific. Failing over to another IP of the same host
cannot change the result; it only wastes a poll cycle and muddles multi-homed
handling.

## Fix

Drop the failover for `NOSUCHNAME` (keep the `dbgprintf`).

## Validation

- `xymonnet/xymon-snmpcollect.c` compiles clean against net-snmp 5.9.1.
- Pure removal of the dead failover branch; no other behaviour changes.

Closes #137. Spun off from #23.
