### PR TITLE
svcstatus: stop the trends-page locator redirect loop with SKIPLOC (TBT 44)

### DIFF
--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -40,6 +40,7 @@ static char *accessfn = NULL;
 static char *hostname = NULL;
 static char *service = NULL;
 static char *tstamp = NULL;
+static char *skiploc = NULL;
 static char *nkprio = NULL, *nkttgroup = NULL, *nkttextra = NULL;
 static enum { FRM_STATUS, FRM_CLIENT } outform = FRM_STATUS;
 STATIC_SBUF_DEFINE(clienturi);
@@ -105,6 +106,9 @@ static int parse_query(void)
 		}
 		else if (strcasecmp(cwalk->name, "NKTTEXTRA") == 0) {
 			nkttextra = strdup(cwalk->value);
+		}
+		else if ((strcasecmp(cwalk->name, "SKIPLOC") == 0)   && cwalk->value && strlen(cwalk->value) && (strcmp(cwalk->value, "1") == 0)) {
+			skiploc = strdup(cwalk->value);
 		}
 		else if ((strcmp(cwalk->name, "backsecs") == 0)   && cwalk->value && strlen(cwalk->value)) {
 			backsecs += atoi(cwalk->value);
@@ -303,7 +307,7 @@ int do_request(void)
 		strncpy(timesincechange, "0 minutes", sizeof(timesincechange));
 
 		if (strcmp(service, xgetenv("TRENDSCOLUMN")) == 0) {
-			if (locatorbased) {
+			if (locatorbased && !skiploc) {
 				char *cgiurl, *qres;
 
 				qres = locator_query(hostname, ST_RRD, &cgiurl);
@@ -312,7 +316,7 @@ int do_request(void)
 				}
 				else {
 					/* Redirect browser to the real server */
-					fprintf(stdout, "Location: %s/svcstatus.sh?HOST=%s&SERVICE=%s\n\n",
+					fprintf(stdout, "Location: %s/svcstatus.sh?HOST=%s&SERVICE=%s&SKIPLOC=1\n\n",
 						cgiurl, hostname, service);
 					return 0;
 				}
@@ -703,6 +707,7 @@ int do_request(void)
 	if (hostname) xfree(hostname);
 	if (service) xfree(service);
 	if (tstamp) xfree(tstamp);
+	if (skiploc) xfree(skiploc);
 
 	/* Cleanup main vars */
 	if (clientid) xfree(clientid);
@@ -786,7 +791,7 @@ int main(int argc, char *argv[])
 	redirect_cgilog("svcstatus");
 
 	*errortxt = '\0';
-	hostname = service = tstamp = NULL;
+	hostname = service = tstamp = skiploc = NULL;
 	if (do_request() != 0) {
 		fprintf(stdout, "%s", errortxt);
 		return 1;

--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -40,6 +40,7 @@ static char *hostname = NULL;
 static char *service = NULL;
 static char *sectionfilter = NULL;
 static char *tstamp = NULL;
+static char *skiploc = NULL;
 static char *nkprio = NULL, *nkttgroup = NULL, *nkttextra = NULL;
 static enum { FRM_STATUS, FRM_CLIENT } outform = FRM_STATUS;
 STATIC_SBUF_DEFINE(clienturi);
@@ -116,6 +117,9 @@ static int parse_query(void)
 		}
 		else if (strcasecmp(cwalk->name, "NKTTEXTRA") == 0) {
 			nkttextra = strdup(cwalk->value ? cwalk->value : "");
+		}
+		else if ((strcasecmp(cwalk->name, "SKIPLOC") == 0)   && cwalk->value && strlen(cwalk->value) && (strcmp(cwalk->value, "1") == 0)) {
+			skiploc = strdup(cwalk->value);
 		}
 		else if ((strcmp(cwalk->name, "backsecs") == 0)   && cwalk->value && strlen(cwalk->value)) {
 			backsecs += atoi(cwalk->value);
@@ -365,7 +369,7 @@ int do_request(void)
 		strncpy(timesincechange, "0 minutes", sizeof(timesincechange));
 
 		if (strcmp(service, xgetenv("TRENDSCOLUMN")) == 0) {
-			if (locatorbased) {
+			if (locatorbased && !skiploc) {
 				char *cgiurl, *qres;
 
 				qres = locator_query(hostname, ST_RRD, &cgiurl);
@@ -374,7 +378,7 @@ int do_request(void)
 				}
 				else {
 					/* Redirect browser to the real server */
-					fprintf(stdout, "Location: %s/svcstatus.sh?HOST=%s&SERVICE=%s\n\n",
+					fprintf(stdout, "Location: %s/svcstatus.sh?HOST=%s&SERVICE=%s&SKIPLOC=1\n\n",
 						cgiurl, hostname, service);
 					return 0;
 				}
@@ -783,6 +787,7 @@ int do_request(void)
 	if (service) xfree(service);
 	if (sectionfilter) xfree(sectionfilter);
 	if (tstamp) xfree(tstamp);
+	if (skiploc) xfree(skiploc);
 
 	/* Cleanup main vars */
 	if (clientid) xfree(clientid);
@@ -866,7 +871,7 @@ int main(int argc, char *argv[])
 	redirect_cgilog("svcstatus");
 
 	*errortxt = '\0';
-	hostname = service = sectionfilter = tstamp = NULL;
+	hostname = service = sectionfilter = tstamp = skiploc = NULL;
 	if (do_request() != 0) {
 		fprintf(stdout, "%s", errortxt);
 		return 1;


### PR DESCRIPTION
Backport of J.C. Cleaver's fix for the trends-page redirect loop in
locator-based (distributed) setups.

**Problem**: when svcstatus renders the `trends` column for a host whose
RRDs live on another server, it queries xymond_locator and redirects the
browser there — but the receiving server runs the same locator logic and
redirects again, looping forever.

**Fix**: the redirect URL gains `&SKIPLOC=1`; the receiving CGI parses it
(strictly value `1`) and renders locally instead of consulting the
locator — a one-hop guard.

**Lineage**: 4.4 branch `a0822c27`, shipped downstream as Terabithia patch
`44` (`xymon.trendsloop.patch`, tracked in #29 bucket 5 / #106 Part A).
Cherry-picked onto current main; applies cleanly.

**History**: this PR originally carried two more 4.4 backports (unique
info/trends/clientlog icons, extra vmstat/iostatx trends graphs). Both are
patch-identical to commits already inside #46, so they were dropped here
to leave #46 as their single carrier — this PR now carries only the fix
that #46 does not contain.