### PR TITLE
do_rrd: remember an RRD exists instead of stat()ing it every update (TBT 214, devel f106d8840)

### DIFF
--- a/tests/rrd/rrd-recreate-after-drop.sh
+++ b/tests/rrd/rrd-recreate-after-drop.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/rrd/rrd-recreate-after-drop.sh
+#
+# Guard for the file-exists cache in do_rrd.c (TBT 214): remembering that an
+# RRD is present must not outlive the file.
+#
+# create_and_update_rrd() stat()s the RRD before every update to decide whether
+# to create it. Caching that answer per update-cache item removes a syscall per
+# value, but the flag then has to be cleared whenever the file can have gone --
+# and the paths that make it go are exactly the ones that flush without going
+# through the ordinary update: a drophost deletes the host's tree, a renamehost
+# moves it, and rrdcacheflush{all,host} commit an item at an arbitrary time.
+#
+# Left set, the next update skips the create, rrd_update fails on a file that
+# is not there, and flush_cached_updates() has already discarded the cached
+# readings -- so the data is lost rather than merely late. That is worse than
+# the stat it saves, which is why this is asserted rather than reasoned about.
+#
+# The scenario is the cheapest one that reaches it: report, drop, report again.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMOND_RRD "xymond/xymond_rrd"
+
+work=$(mktempdir)
+ts=$(date +%s)
+mkdir -p "$work/tmp" "$work/rrd" "$work/home/etc"
+: > "$work/home/etc/analysis.cfg"
+: > "$work/hosts.cfg"
+
+status_msg() {  # status_msg <msg-timestamp>
+	printf '@@status|%s|127.0.0.1|origin|testhost|disk|%s|green||green|%s|0||0||%s|0|linux|/\n' \
+		"$1" "$(($1+1800))" "$ts" "$ts"
+	printf 'disk report\n'
+	printf '/dev/sda1 1000000 400000 600000 40%% /\n'
+	printf '@@\n'
+}
+
+# HOSTSCFG and an analysis.cfg of our own: without them the worker connects
+# out to a live xymond on 127.0.0.1:1984 for every message and, failing that,
+# reads the machine's real configuration instead of this fixture.
+run_worker() {  # run_worker <rrddir>
+	env XYMONHOME="$work/home" XYMONTMP="$work/tmp" HOSTSCFG="$work/hosts.cfg" \
+		"$XYMOND_RRD" --rrddir="$1"
+}
+
+rrd="$work/rrd/testhost/disk,root.rrd"
+
+# ---- a report creates the RRD ----------------------------------------------
+
+status_msg "$ts" | run_worker "$work/rrd" >"$work/w1.log" 2>&1 \
+	|| { cat "$work/w1.log" >&2; fail "the worker rejected the first report"; }
+# fail, not skip: require_bin above already covers "no worker", and this
+# branch means the creation path itself is broken - which is the wiring under
+# test (tests/README.md: never skip for missing project code).
+[ -f "$rrd" ] || { ls -R "$work/rrd" >&2; fail "the first report did not create the RRD"; }
+
+# ---- the file goes away underneath the cache -------------------------------
+#
+# A drop is the honest way to reach it: it is what deletes a host's RRDs, and
+# it flushes the update cache on the way out without any update following.
+# Doing it in one worker run is what matters -- the cache lives in the process,
+# so a fresh process would start with an empty one and prove nothing. The
+# update cache is deliberately left on (no --no-cache): with it off every
+# update flushes on its own, the drop finds nothing pending, and the path this
+# guards is never taken.
+
+{
+	status_msg "$ts"
+	printf '@@drophost|%s|127.0.0.1|testhost\n@@\n' $((ts+10))
+	status_msg $((ts+20))
+} | run_worker "$work/rrd" >"$work/w2.log" 2>&1 \
+	|| { cat "$work/w2.log" >&2; fail "the worker exited non-zero over drop-then-report"; }
+
+# ---- the report after the drop must recreate it -----------------------------
+
+assert_file_exists "$rrd" \
+	"the report after a drophost did not recreate the RRD -- the cached file-exists flag outlived the file"
+
+# ---- and a deletion nothing told us about ----------------------------------
+#
+# The case the cached flag really risks: an admin removing one RRD by hand
+# after a droptest, as xymond_rrd.c documents, or moverrd.sh/rrdreconcile/a
+# restore. Nothing announces it, so the miss can only be noticed when the
+# write fails - and the readings must survive that.
+
+before=$(($(wc -c < "$rrd")))		# wc -c, not stat: no per-OS spelling
+
+# Through a fifo, so ONE worker sees the file disappear underneath it. Feeding
+# a fresh worker after the deletion tests nothing: it starts with an empty
+# flag and takes the ordinary stat-and-create path, which is exactly the path
+# that was never broken.
+fifo="$work/feed"
+mkfifo "$fifo"
+run_worker "$work/rrd" <"$fifo" >"$work/w3.log" 2>&1 &
+worker=$!
+exec 9>"$fifo"
+
+status_msg $((ts+20)) >&9
+wait_for() {  # wait_for SECONDS TEST...
+	local deadline=$((SECONDS + $1)); shift
+	while [ "$SECONDS" -lt "$deadline" ]; do eval "$@" && return 0; sleep 0.2; done
+	return 1
+}
+wait_for 20 '[ -f "$rrd" ]' || { cat "$work/w3.log" >&2; fail "the first reading did not reach the RRD"; }
+
+rm -f "$rrd"
+status_msg $((ts+40)) >&9
+status_msg $((ts+60)) >&9
+printf '@@shutdown|1|x\n@@\n' >&9
+exec 9>&-
+wait "$worker" || { cat "$work/w3.log" >&2; fail "the worker exited non-zero after an external deletion"; }
+
+assert_file_exists "$rrd" \
+	"an RRD deleted outside xymond was never recreated -- the cached file-exists flag outlived the file"
+
+after=$(($(wc -c < "$rrd")))
+[ "$after" = "$before" ] \
+	|| fail "the recreated RRD is not the shape the first one had ($after vs $before bytes)"
+
+# The file coming back is not the point - the readings surviving is. A build
+# that recreates an empty RRD and drops every value would satisfy everything
+# above, so read the data back. Needs the rrdtool CLI, which librrd-linked
+# builds do not imply, hence the guarded skip of this assertion only.
+if command -v rrdtool >/dev/null 2>&1; then
+	samples=$(rrdtool fetch "$rrd" AVERAGE -s "$((ts-60))" -e "$((ts+120))" 2>/dev/null \
+		| awk 'NF > 1 && $2 != "-nan" && $2 != "nan" && $2 != "-" { n++ } END { print n+0 }')
+	[ "${samples:-0}" -gt 0 ] \
+		|| fail "the recreated RRD holds no reading: the values buffered when the write failed were discarded"
+else
+	printf "note: rrdtool CLI absent, RRD contents unverified\\n" >&2
+fi

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -66,6 +66,7 @@ static void * updcache;
 typedef struct updcacheitem_t {
 	char *key;
 	rrdtpldata_t *tpl;
+	int fileok;		/* Cache the RRD-file-exists check to skip a stat() per update */
 	int valcount;
 	char *vals[CACHESZ];
 	int updseq[CACHESZ];
@@ -330,8 +331,13 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		if (!template) template = cacheitem->tpl;
 	}
 
-	/* If the RRD file doesn't exist, create it immediately */
-	if (stat(filedir, &st) == -1) {
+	/*
+	 * If the RRD file doesn't exist, create it immediately. Once we have seen
+	 * the file (here or right after creating it), remember that in the cache
+	 * item so we don't stat() it on every single update; re-check after each
+	 * flush (below) so a deleted file still gets recreated.
+	 */
+	if (!cacheitem->fileok && !((stat(filedir, &st) != -1) && ++cacheitem->fileok)) {
 		xymon_rrd_argv_item_t *rrdcreate_params;
 		char **rrddefinitions;
 		int rrddefcount, i;
@@ -391,6 +397,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 			MEMUNDEFINE(rrdvalues);
 			return 1;
 		}
+		else cacheitem->fileok++;	/* Just created it - it's there now */
 	}
 
 	updtime = atoi(rrdvalues);
@@ -507,6 +514,10 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		MEMUNDEFINE(rrdvalues);
 		return 2;
 	}
+
+	/* We just flushed to disk; re-stat the file on the next update so a
+	   deleted/rotated RRD gets recreated. */
+	cacheitem->fileok = 0;
 
 	MEMUNDEFINE(filedir);
 	MEMUNDEFINE(rrdvalues);

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -498,15 +498,24 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 
 	/* At this point, we will commit the update to disk */
 	result = flush_cached_updates(cacheitem, rrdvalues);
+
+	/*
+	 * Re-stat the file on the next update, whatever the flush result: if the
+	 * flush failed because the RRD was removed/rotated, the next update must
+	 * recreate it rather than keep failing forever. Resetting before the error
+	 * return below preserves the original per-update self-healing behaviour.
+	 */
+	cacheitem->fileok = 0;
+
 	if (result != 0) {
 		char *msg = rrd_get_error();
 
 		if (strstr(msg, "(minimum one second step)") != NULL) {
-			dbgprintf("RRD error updating %s from %s: %s\n", 
+			dbgprintf("RRD error updating %s from %s: %s\n",
 				  filedir, (senderip ? senderip : "unknown"), msg);
 		}
 		else {
-			errprintf("RRD error updating %s from %s: %s\n", 
+			errprintf("RRD error updating %s from %s: %s\n",
 				  filedir, (senderip ? senderip : "unknown"), msg);
 		}
 
@@ -514,10 +523,6 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		MEMUNDEFINE(rrdvalues);
 		return 2;
 	}
-
-	/* We just flushed to disk; re-stat the file on the next update so a
-	   deleted/rotated RRD gets recreated. */
-	cacheitem->fileok = 0;
 
 	MEMUNDEFINE(filedir);
 	MEMUNDEFINE(rrdvalues);

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -239,6 +239,7 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 	/* Flush any updates we've cached */
 	xymon_rrd_argv_item_t updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
 	int i, pcount, result;
+	struct stat st;
 
 	dbgprintf("Flushing '%s' with %d updates pending, template '%s'\n", 
 		  cacheitem->key, (newdata ? 1 : 0) + cacheitem->valcount, cacheitem->tpl->template);
@@ -271,13 +272,50 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 	utimes(filedir, NULL);
 #endif
 
-	/* Clear the cached data */
-	for (i=0; (i < cacheitem->valcount); i++) {
-		cacheitem->updseq[i] = 0;
-		cacheitem->updtime[i] = 0;
-		if (cacheitem->vals[i]) xfree(cacheitem->vals[i]);
+	/*
+	 * A failed write keeps its readings only when the file is gone - deleted
+	 * by hand, moverrd.sh, a restore. The next update re-stats, recreates and
+	 * writes them. Kept for any other error, a reading RRDtool will never
+	 * accept sits at the front and fails every flush behind it. The new one
+	 * joins them: the caller frees it on return.
+	 */
+	if ((result != 0) && (stat(filedir, &st) != 0)) {
+		if (newdata && (cacheitem->valcount < CACHESZ)) {
+			cacheitem->updseq[cacheitem->valcount] = seq;
+			cacheitem->updtime[cacheitem->valcount] = getcurrenttime(NULL);
+			cacheitem->vals[cacheitem->valcount] = strdup(newdata);
+			cacheitem->valcount += 1;
+		}
 	}
-	cacheitem->valcount = 0;
+	else if (result != 0) {
+		/* Nothing here will ever be accepted: drop it rather than wedge. */
+		for (i=0; (i < cacheitem->valcount); i++) {
+			cacheitem->updseq[i] = 0;
+			cacheitem->updtime[i] = 0;
+			if (cacheitem->vals[i]) xfree(cacheitem->vals[i]);
+		}
+		cacheitem->valcount = 0;
+	}
+
+	if (result == 0) {
+		for (i=0; (i < cacheitem->valcount); i++) {
+			cacheitem->updseq[i] = 0;
+			cacheitem->updtime[i] = 0;
+			if (cacheitem->vals[i]) xfree(cacheitem->vals[i]);
+		}
+		cacheitem->valcount = 0;
+	}
+
+	/*
+	 * Re-check the file on the next update, whatever the result. This lives
+	 * here rather than at the call site because the callers that commit are
+	 * not the only ones that matter: a renamehost flushes through
+	 * updcache_host_op() just before rename() moves the files, and the two
+	 * rrdcacheflush* entry points commit an item at an arbitrary later time.
+	 * A drophost does not reach here at all - it discards - which is why
+	 * updcache_host_op() clears the flag for every item it touches.
+	 */
+	cacheitem->fileok = 0;
 
 	return result;
 }
@@ -367,9 +405,14 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		if (!template) template = cacheitem->tpl;
 	}
 
-	/* If the RRD file doesn't exist, create it immediately */
-	/* otherwise, mark that it's present so we don't burn a syscall again */
-	if (!no_rrd && !cacheitem->fileok && !( (stat(filedir, &st) != -1) && ++cacheitem->fileok ) ) {
+	/*
+	 * Once seen - here or just after creating it - an existing file costs no
+	 * stat() per update. flush_cached_updates() clears the flag, so the check
+	 * runs once per flush rather than once per value.
+	 */
+	if (!cacheitem->fileok && (stat(filedir, &st) != -1)) cacheitem->fileok = 1;
+
+	if (!cacheitem->fileok) {
 		xymon_rrd_argv_item_t *rrdcreate_params;
 		char **rrddefinitions;
 		int rrddefcount, i;
@@ -429,7 +472,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 			MEMUNDEFINE(rrdvalues);
 			return 1;
 		}
-		else cacheitem->fileok++;
+		else cacheitem->fileok = 1;	/* Just created it - it's there now */
 	}
 
 	updtime = atoi(rrdvalues);
@@ -546,9 +589,6 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 				  filedir, (senderip ? senderip : "unknown"), msg);
 		}
 
-		/* check the file next time around */
-		cacheitem->fileok = 0;
-
 		MEMUNDEFINE(filedir);
 		MEMUNDEFINE(rrdvalues);
 		return 2;
@@ -596,6 +636,15 @@ static void updcache_host_op(char *hostname, int flushfirst, char *flushas)
 		updcacheitem_t *cacheitem = (updcacheitem_t *)xtreeData(updcache, handle);
 
 		if (strncasecmp(cacheitem->key, prefix, plen) != 0) continue;
+
+		/*
+		 * Cleared here, before the valcount test below skips the idle items
+		 * and before the discard branch, which never reaches
+		 * flush_cached_updates(). Left set, a re-added host skips the create
+		 * and loses a cache cycle against a file that is not there.
+		 */
+		cacheitem->fileok = 0;
+
 		if (cacheitem->valcount == 0) continue;
 		nhit++;
 

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -67,6 +67,7 @@ static void * updcache;
 typedef struct updcacheitem_t {
 	char *key;
 	rrdtpldata_t *tpl;
+	int fileok;
 	int valcount;
 	char *vals[CACHESZ];
 	int updseq[CACHESZ];
@@ -367,7 +368,8 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	}
 
 	/* If the RRD file doesn't exist, create it immediately */
-	if (stat(filedir, &st) == -1) {
+	/* otherwise, mark that it's present so we don't burn a syscall again */
+	if (!no_rrd && !cacheitem->fileok && !( (stat(filedir, &st) != -1) && ++cacheitem->fileok ) ) {
 		xymon_rrd_argv_item_t *rrdcreate_params;
 		char **rrddefinitions;
 		int rrddefcount, i;
@@ -427,6 +429,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 			MEMUNDEFINE(rrdvalues);
 			return 1;
 		}
+		else cacheitem->fileok++;
 	}
 
 	updtime = atoi(rrdvalues);
@@ -500,7 +503,11 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	}
 
 	/* Are we actually handling the writing of RRD files? */
-	if (no_rrd) return 0;
+	if (no_rrd) {
+		MEMUNDEFINE(filedir);
+		MEMUNDEFINE(rrdvalues);
+		return 0;
+	}
 
 	/* 
 	 * We cannot just cache data every time because then after CACHESZ updates
@@ -538,6 +545,9 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 			errprintf("RRD error updating %s from %s: %s\n", 
 				  filedir, (senderip ? senderip : "unknown"), msg);
 		}
+
+		/* check the file next time around */
+		cacheitem->fileok = 0;
 
 		MEMUNDEFINE(filedir);
 		MEMUNDEFINE(rrdvalues);


### PR DESCRIPTION
`do_rrd.c` ran a `stat()` before every update to see whether the RRD existed. From J.C. Cleaver's Terabithia patch: remember the answer per cache item, so the check costs one syscall per flush rather than one per reading.

The flag has to be cleared wherever the file can go, and the correction commit is about the places it was not:

| | |
|---|---|
| `drophost` / `renamehost` | discard and rename never reach `flush_cached_updates()`, so `updcache_host_op()` clears the flag for every item it touches — otherwise a re-added host skips the create and writes into nothing |
| a deletion nothing announces | an admin removing one RRD after a droptest, `moverrd.sh`, `rrdreconcile`, a restore. Only the failed write can notice, so the readings are kept and the next update re-stats, recreates and writes them |
| that retention | applies **only** when the file is gone. Kept for every error, a reading RRDtool will never accept sits at the front of the list and fails every flush behind it |
| the reading that just arrived | joins the retained ones — it was handed to the update that failed, and the caller frees it on return |

`tests/rrd/rrd-recreate-after-drop.sh` drives the real worker through a drophost and through an external deletion, the second across a fifo so **one** worker sees the file disappear: a fresh worker starts with no cached flag and takes the ordinary stat-and-create path, which was never the one at risk.

**Not pinned, and worth saying:** the retention itself has no test. The window it protects is inside a single cache cycle — the flag is cleared at the end of every flush — and driving it from outside means timing the cache, which makes a race rather than a check. The narrowing above is by inspection.

Two commits: J.C. Cleaver's original, then one correction. Suite on a built tree, with `rrdtool` present so the gated halves run: 0 failed, 0 skipped.



**Overlaps in `flush_cached_updates()`.** Three other open PRs edit that one function at ranges colliding with this one's `@@ -270,13`: **#154** (stacked on this, so it rebases with it), **#349** (`@@ -258,18` — deletes the `utimes()` at `do_rrd.c:270`) and **#387** (draft, `@@ -265,9` — re-gates that same `utimes`, and says it will drop the gating once #349 lands).

Nothing here is superseded by any of them: each removes a *different* syscall from the per-update path — one `stat` here, two more in #154, one `utimes` in #349 — so the effects compose. Only the hunks need sequencing; whichever lands first, the rest rebase.
