### PR TITLE
do_rrd: check the host RRD directory only when creating a file (closes #153, TBT 187, devel f106d8840)

### DIFF
--- a/tests/rrd/rrd-recreate-after-drop.sh
+++ b/tests/rrd/rrd-recreate-after-drop.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/rrd/rrd-recreate-after-drop.sh
+#
+# Guard for the file-exists cache in do_rrd.c (TBT 214): remembering that an
+# RRD is present must not outlive the file.
+#
+# create_and_update_rrd() stat()s the RRD before every update to decide whether
+# to create it. Caching that answer per update-cache item removes a syscall per
+# value, but the flag then has to be cleared whenever the file can have gone --
+# and the paths that make it go are exactly the ones that flush without going
+# through the ordinary update: a drophost deletes the host's tree, a renamehost
+# moves it, and rrdcacheflush{all,host} commit an item at an arbitrary time.
+#
+# Left set, the next update skips the create, rrd_update fails on a file that
+# is not there, and flush_cached_updates() has already discarded the cached
+# readings -- so the data is lost rather than merely late. That is worse than
+# the stat it saves, which is why this is asserted rather than reasoned about.
+#
+# The scenario is the cheapest one that reaches it: report, drop, report again.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMOND_RRD "xymond/xymond_rrd"
+
+work=$(mktempdir)
+ts=$(date +%s)
+mkdir -p "$work/tmp" "$work/rrd" "$work/home/etc"
+: > "$work/home/etc/analysis.cfg"
+: > "$work/hosts.cfg"
+
+status_msg() {  # status_msg <msg-timestamp>
+	printf '@@status|%s|127.0.0.1|origin|testhost|disk|%s|green||green|%s|0||0||%s|0|linux|/\n' \
+		"$1" "$(($1+1800))" "$ts" "$ts"
+	printf 'disk report\n'
+	printf '/dev/sda1 1000000 400000 600000 40%% /\n'
+	printf '@@\n'
+}
+
+# HOSTSCFG and an analysis.cfg of our own: without them the worker connects
+# out to a live xymond on 127.0.0.1:1984 for every message and, failing that,
+# reads the machine's real configuration instead of this fixture.
+run_worker() {  # run_worker <rrddir>
+	env XYMONHOME="$work/home" XYMONTMP="$work/tmp" HOSTSCFG="$work/hosts.cfg" \
+		"$XYMOND_RRD" --rrddir="$1"
+}
+
+rrd="$work/rrd/testhost/disk,root.rrd"
+
+# ---- a report creates the RRD ----------------------------------------------
+
+status_msg "$ts" | run_worker "$work/rrd" >"$work/w1.log" 2>&1 \
+	|| { cat "$work/w1.log" >&2; fail "the worker rejected the first report"; }
+# fail, not skip: require_bin above already covers "no worker", and this
+# branch means the creation path itself is broken - which is the wiring under
+# test (tests/README.md: never skip for missing project code).
+[ -f "$rrd" ] || { ls -R "$work/rrd" >&2; fail "the first report did not create the RRD"; }
+
+# ---- the file goes away underneath the cache -------------------------------
+#
+# A drop is the honest way to reach it: it is what deletes a host's RRDs, and
+# it flushes the update cache on the way out without any update following.
+# Doing it in one worker run is what matters -- the cache lives in the process,
+# so a fresh process would start with an empty one and prove nothing. The
+# update cache is deliberately left on (no --no-cache): with it off every
+# update flushes on its own, the drop finds nothing pending, and the path this
+# guards is never taken.
+
+{
+	status_msg "$ts"
+	printf '@@drophost|%s|127.0.0.1|testhost\n@@\n' $((ts+10))
+	status_msg $((ts+20))
+} | run_worker "$work/rrd" >"$work/w2.log" 2>&1 \
+	|| { cat "$work/w2.log" >&2; fail "the worker exited non-zero over drop-then-report"; }
+
+# ---- the report after the drop must recreate it -----------------------------
+
+assert_file_exists "$rrd" \
+	"the report after a drophost did not recreate the RRD -- the cached file-exists flag outlived the file"
+
+# ---- and a deletion nothing told us about ----------------------------------
+#
+# The case the cached flag really risks: an admin removing one RRD by hand
+# after a droptest, as xymond_rrd.c documents, or moverrd.sh/rrdreconcile/a
+# restore. Nothing announces it, so the miss can only be noticed when the
+# write fails - and the readings must survive that.
+
+before=$(($(wc -c < "$rrd")))		# wc -c, not stat: no per-OS spelling
+
+# Through a fifo, so ONE worker sees the file disappear underneath it. Feeding
+# a fresh worker after the deletion tests nothing: it starts with an empty
+# flag and takes the ordinary stat-and-create path, which is exactly the path
+# that was never broken.
+fifo="$work/feed"
+mkfifo "$fifo"
+run_worker "$work/rrd" <"$fifo" >"$work/w3.log" 2>&1 &
+worker=$!
+exec 9>"$fifo"
+
+status_msg $((ts+20)) >&9
+wait_for() {  # wait_for SECONDS TEST...
+	local deadline=$((SECONDS + $1)); shift
+	while [ "$SECONDS" -lt "$deadline" ]; do eval "$@" && return 0; sleep 0.2; done
+	return 1
+}
+wait_for 20 '[ -f "$rrd" ]' || { cat "$work/w3.log" >&2; fail "the first reading did not reach the RRD"; }
+
+rm -f "$rrd"
+status_msg $((ts+40)) >&9
+status_msg $((ts+60)) >&9
+printf '@@shutdown|1|x\n@@\n' >&9
+exec 9>&-
+wait "$worker" || { cat "$work/w3.log" >&2; fail "the worker exited non-zero after an external deletion"; }
+
+assert_file_exists "$rrd" \
+	"an RRD deleted outside xymond was never recreated -- the cached file-exists flag outlived the file"
+
+after=$(($(wc -c < "$rrd")))
+[ "$after" = "$before" ] \
+	|| fail "the recreated RRD is not the shape the first one had ($after vs $before bytes)"
+
+# The file coming back is not the point - the readings surviving is. A build
+# that recreates an empty RRD and drops every value would satisfy everything
+# above, so read the data back. Needs the rrdtool CLI, which librrd-linked
+# builds do not imply, hence the guarded skip of this assertion only.
+if command -v rrdtool >/dev/null 2>&1; then
+	samples=$(rrdtool fetch "$rrd" AVERAGE -s "$((ts-60))" -e "$((ts+120))" 2>/dev/null \
+		| awk 'NF > 1 && $2 != "-nan" && $2 != "nan" && $2 != "-" { n++ } END { print n+0 }')
+	[ "${samples:-0}" -gt 0 ] \
+		|| fail "the recreated RRD holds no reading: the values buffered when the write failed were discarded"
+else
+	printf "note: rrdtool CLI absent, RRD contents unverified\\n" >&2
+fi

--- a/tests/rrd/rrd-recreate-after-drop.sh
+++ b/tests/rrd/rrd-recreate-after-drop.sh
@@ -32,9 +32,15 @@ mkdir -p "$work/tmp" "$work/rrd" "$work/home/etc"
 : > "$work/home/etc/analysis.cfg"
 : > "$work/hosts.cfg"
 
+# The sequence number matters when several readings go to one worker: without
+# a distinct one each, everything after the first is dropped as a duplicate
+# update (do_rrd.c logs it under --debug and nowhere else), so a test that
+# feeds a live worker would silently exercise one message.
+msgseq=0
 status_msg() {  # status_msg <msg-timestamp>
-	printf '@@status|%s|127.0.0.1|origin|testhost|disk|%s|green||green|%s|0||0||%s|0|linux|/\n' \
-		"$1" "$(($1+1800))" "$ts" "$ts"
+	msgseq=$((msgseq + 1))
+	printf '@@status#%s|%s|127.0.0.1|origin|testhost|disk|%s|green||green|%s|0||0||%s|0|linux|/\n' \
+		"$msgseq" "$1" "$(($1+1800))" "$ts" "$ts"
 	printf 'disk report\n'
 	printf '/dev/sda1 1000000 400000 600000 40%% /\n'
 	printf '@@\n'
@@ -100,17 +106,26 @@ run_worker "$work/rrd" <"$fifo" >"$work/w3.log" 2>&1 &
 worker=$!
 exec 9>"$fifo"
 
-status_msg $((ts+20)) >&9
 wait_for() {  # wait_for SECONDS TEST...
 	local deadline=$((SECONDS + $1)); shift
 	while [ "$SECONDS" -lt "$deadline" ]; do eval "$@" && return 0; sleep 0.2; done
 	return 1
 }
-wait_for 20 '[ -f "$rrd" ]' || { cat "$work/w3.log" >&2; fail "the first reading did not reach the RRD"; }
 
+# Deleted first, so waiting for it to come back proves *this* worker created
+# it and holds the cached "it exists" answer. Waiting on the file the previous
+# case left behind returns instantly and proves nothing.
 rm -f "$rrd"
-status_msg $((ts+40)) >&9
-status_msg $((ts+60)) >&9
+status_msg $((ts+20)) >&9
+wait_for 20 '[ -f "$rrd" ]' \
+	|| { cat "$work/w3.log" >&2; fail "the first reading did not reach this worker"; }
+
+# Now the flag is stale. What follows has to reach a flush - which is where the
+# missing file is noticed - and then an update that recreates: CACHESZ is 12,
+# so a couple of readings would sit in the cache until shutdown and never be
+# written back.
+rm -f "$rrd"
+for i in $(seq 1 16); do status_msg $((ts + i*300)) >&9; done
 printf '@@shutdown|1|x\n@@\n' >&9
 exec 9>&-
 wait "$worker" || { cat "$work/w3.log" >&2; fail "the worker exited non-zero after an external deletion"; }

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -288,16 +288,14 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	MEMDEFINE(rrdvalues);
 	MEMDEFINE(filedir);
 
-	sprintf(filedir, "%s/%s", rrddir, hostname);
-	if (stat(filedir, &st) == -1) {
-		if (mkdir(filedir, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH) == -1) {
-			errprintf("Cannot create rrd directory %s : %s\n", filedir, strerror(errno));
-			MEMUNDEFINE(filedir);
-			MEMUNDEFINE(rrdvalues);
-			return -1;
-		}
-	}
-	/* Watch out here - "rrdfn" may be very large. */
+	/*
+	 * The per-host RRD directory (rrddir/hostname) only needs to exist when we
+	 * are about to create an RRD file - if the file already exists, so does its
+	 * directory. So the directory check/mkdir is done lazily in the create path
+	 * below (see issue #153), not on every single update.
+	 *
+	 * Watch out here - "rrdfn" may be very large.
+	 */
 	snprintf(filedir, sizeof(filedir)-1, "%s/%s/%s", rrddir, hostname, rrdfn);
 	filedir[sizeof(filedir)-1] = '\0'; /* Make sure it is null terminated */
 
@@ -344,6 +342,20 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		char *rrakey = NULL;
 		char stepsetting[10];
 		int havestepsetting = 0, fixcount = 2;
+		char hostdir[PATH_MAX];
+
+		/*
+		 * About to create the file - make sure its directory exists first.
+		 * (Moved here from the per-update path; see issue #153.) A missing
+		 * directory is recreated, so a deleted rrddir/hostname self-heals.
+		 */
+		snprintf(hostdir, sizeof(hostdir), "%s/%s", rrddir, hostname);
+		if ((stat(hostdir, &st) == -1) && (mkdir(hostdir, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH) == -1)) {
+			errprintf("Cannot create rrd directory %s : %s\n", hostdir, strerror(errno));
+			MEMUNDEFINE(filedir);
+			MEMUNDEFINE(rrdvalues);
+			return -1;
+		}
 
 		dbgprintf("Creating rrd %s\n", filedir);
 

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -66,6 +66,7 @@ static void * updcache;
 typedef struct updcacheitem_t {
 	char *key;
 	rrdtpldata_t *tpl;
+	int fileok;		/* Cache the RRD-file-exists check to skip a stat() per update */
 	int valcount;
 	char *vals[CACHESZ];
 	int updseq[CACHESZ];
@@ -330,8 +331,13 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		if (!template) template = cacheitem->tpl;
 	}
 
-	/* If the RRD file doesn't exist, create it immediately */
-	if (stat(filedir, &st) == -1) {
+	/*
+	 * If the RRD file doesn't exist, create it immediately. Once we have seen
+	 * the file (here or right after creating it), remember that in the cache
+	 * item so we don't stat() it on every single update; re-check after each
+	 * flush (below) so a deleted file still gets recreated.
+	 */
+	if (!cacheitem->fileok && !((stat(filedir, &st) != -1) && ++cacheitem->fileok)) {
 		xymon_rrd_argv_item_t *rrdcreate_params;
 		char **rrddefinitions;
 		int rrddefcount, i;
@@ -391,6 +397,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 			MEMUNDEFINE(rrdvalues);
 			return 1;
 		}
+		else cacheitem->fileok++;	/* Just created it - it's there now */
 	}
 
 	updtime = atoi(rrdvalues);
@@ -507,6 +514,10 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		MEMUNDEFINE(rrdvalues);
 		return 2;
 	}
+
+	/* We just flushed to disk; re-stat the file on the next update so a
+	   deleted/rotated RRD gets recreated. */
+	cacheitem->fileok = 0;
 
 	MEMUNDEFINE(filedir);
 	MEMUNDEFINE(rrdvalues);

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -498,15 +498,24 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 
 	/* At this point, we will commit the update to disk */
 	result = flush_cached_updates(cacheitem, rrdvalues);
+
+	/*
+	 * Re-stat the file on the next update, whatever the flush result: if the
+	 * flush failed because the RRD was removed/rotated, the next update must
+	 * recreate it rather than keep failing forever. Resetting before the error
+	 * return below preserves the original per-update self-healing behaviour.
+	 */
+	cacheitem->fileok = 0;
+
 	if (result != 0) {
 		char *msg = rrd_get_error();
 
 		if (strstr(msg, "(minimum one second step)") != NULL) {
-			dbgprintf("RRD error updating %s from %s: %s\n", 
+			dbgprintf("RRD error updating %s from %s: %s\n",
 				  filedir, (senderip ? senderip : "unknown"), msg);
 		}
 		else {
-			errprintf("RRD error updating %s from %s: %s\n", 
+			errprintf("RRD error updating %s from %s: %s\n",
 				  filedir, (senderip ? senderip : "unknown"), msg);
 		}
 
@@ -514,10 +523,6 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		MEMUNDEFINE(rrdvalues);
 		return 2;
 	}
-
-	/* We just flushed to disk; re-stat the file on the next update so a
-	   deleted/rotated RRD gets recreated. */
-	cacheitem->fileok = 0;
 
 	MEMUNDEFINE(filedir);
 	MEMUNDEFINE(rrdvalues);

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -55,7 +55,6 @@ static char rrdvalues[MAX_LINE_LEN];
 static char *senderip = NULL;
 static char rrdfn[PATH_MAX];   /* Base filename without directories, from setupfn() */
 static char filedir[PATH_MAX]; /* Full path filename */
-static char filejustdir[PATH_MAX]; /* Full path filename - just the directory */
 static char *fnparams[4] = { NULL, };  /* Saved parameters passed to setupfn() */
 
 /* How often do we feed data into the RRD file */
@@ -394,8 +393,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 
 	/*
 	 * Once seen - here or just after creating it - an existing file costs no
-	 * stat() per update. flush_cached_updates() clears the flag, so the check
-	 * runs once per flush rather than once per value.
+	 * stat() per update. The flag is cleared wherever the file can go.
 	 */
 	if (!cacheitem->fileok && (stat(filedir, &st) != -1)) cacheitem->fileok = 1;
 
@@ -406,22 +404,29 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		char *rrakey = NULL;
 		char stepsetting[10];
 		int havestepsetting = 0, fixcount = 2;
+		char hostdir[PATH_MAX];
 
 		dbgprintf("Creating rrd %s\n", filedir);
 
-		MEMDEFINE(filejustdir);
-		sprintf(filejustdir, "%s/%s", rrddir, hostname);
-		if (stat(filejustdir, &st) == -1) {
-			dbgprintf("Creating rrd dir %s\n", filejustdir);
-			if (mkdir(filejustdir, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH) == -1) {
-				errprintf("Cannot create rrd directory %s : %s\n", filejustdir, strerror(errno));
-				MEMUNDEFINE(filedir);
-				MEMUNDEFINE(filejustdir);
-				MEMUNDEFINE(rrdvalues);
-				return -1;
-			}
+		/*
+		 * The directory only has to exist where a file is about to be created:
+		 * if the RRD is there, so is its directory (#153). snprintf into a
+		 * local, not sprintf into a static - rrddir and hostname can overflow
+		 * between them, and the route this replaces refused a truncated path.
+		 */
+		if (snprintf(hostdir, sizeof(hostdir), "%s/%s", rrddir, hostname) >= (int)sizeof(hostdir)) {
+			errprintf("RRD directory path truncated, skipping: %s/%s\n", rrddir, hostname);
+			MEMUNDEFINE(filedir);
+			MEMUNDEFINE(rrdvalues);
+			return -1;
 		}
-		MEMUNDEFINE(filejustdir);
+		if ((stat(hostdir, &st) == -1) && (mkdir(hostdir, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH) == -1)) {
+			errprintf("Cannot create rrd directory %s : %s\n", hostdir, strerror(errno));
+			MEMUNDEFINE(filedir);
+			MEMUNDEFINE(rrdvalues);
+			return -1;
+		}
+
 
 		/* How many parameters did we get? */
 		for (pcount = 0; (creparams[pcount]); pcount++);

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -239,6 +239,7 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 	/* Flush any updates we've cached */
 	xymon_rrd_argv_item_t updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
 	int i, pcount, result;
+	struct stat st;
 
 	dbgprintf("Flushing '%s' with %d updates pending, template '%s'\n", 
 		  cacheitem->key, (newdata ? 1 : 0) + cacheitem->valcount, cacheitem->tpl->template);
@@ -271,13 +272,50 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 	utimes(filedir, NULL);
 #endif
 
-	/* Clear the cached data */
-	for (i=0; (i < cacheitem->valcount); i++) {
-		cacheitem->updseq[i] = 0;
-		cacheitem->updtime[i] = 0;
-		if (cacheitem->vals[i]) xfree(cacheitem->vals[i]);
+	/*
+	 * A failed write keeps its readings only when the file is gone - deleted
+	 * by hand, moverrd.sh, a restore. The next update re-stats, recreates and
+	 * writes them. Kept for any other error, a reading RRDtool will never
+	 * accept sits at the front and fails every flush behind it. The new one
+	 * joins them: the caller frees it on return.
+	 */
+	if ((result != 0) && (stat(filedir, &st) != 0)) {
+		if (newdata && (cacheitem->valcount < CACHESZ)) {
+			cacheitem->updseq[cacheitem->valcount] = seq;
+			cacheitem->updtime[cacheitem->valcount] = getcurrenttime(NULL);
+			cacheitem->vals[cacheitem->valcount] = strdup(newdata);
+			cacheitem->valcount += 1;
+		}
 	}
-	cacheitem->valcount = 0;
+	else if (result != 0) {
+		/* Nothing here will ever be accepted: drop it rather than wedge. */
+		for (i=0; (i < cacheitem->valcount); i++) {
+			cacheitem->updseq[i] = 0;
+			cacheitem->updtime[i] = 0;
+			if (cacheitem->vals[i]) xfree(cacheitem->vals[i]);
+		}
+		cacheitem->valcount = 0;
+	}
+
+	if (result == 0) {
+		for (i=0; (i < cacheitem->valcount); i++) {
+			cacheitem->updseq[i] = 0;
+			cacheitem->updtime[i] = 0;
+			if (cacheitem->vals[i]) xfree(cacheitem->vals[i]);
+		}
+		cacheitem->valcount = 0;
+	}
+
+	/*
+	 * Re-check the file on the next update, whatever the result. This lives
+	 * here rather than at the call site because the callers that commit are
+	 * not the only ones that matter: a renamehost flushes through
+	 * updcache_host_op() just before rename() moves the files, and the two
+	 * rrdcacheflush* entry points commit an item at an arbitrary later time.
+	 * A drophost does not reach here at all - it discards - which is why
+	 * updcache_host_op() clears the flag for every item it touches.
+	 */
+	cacheitem->fileok = 0;
 
 	return result;
 }
@@ -367,9 +405,14 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		if (!template) template = cacheitem->tpl;
 	}
 
-	/* If the RRD file doesn't exist, create it immediately */
-	/* otherwise, mark that it's present so we don't burn a syscall again */
-	if (!no_rrd && !cacheitem->fileok && !( (stat(filedir, &st) != -1) && ++cacheitem->fileok ) ) {
+	/*
+	 * Once seen - here or just after creating it - an existing file costs no
+	 * stat() per update. flush_cached_updates() clears the flag, so the check
+	 * runs once per flush rather than once per value.
+	 */
+	if (!cacheitem->fileok && (stat(filedir, &st) != -1)) cacheitem->fileok = 1;
+
+	if (!cacheitem->fileok) {
 		xymon_rrd_argv_item_t *rrdcreate_params;
 		char **rrddefinitions;
 		int rrddefcount, i;
@@ -429,7 +472,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 			MEMUNDEFINE(rrdvalues);
 			return 1;
 		}
-		else cacheitem->fileok++;
+		else cacheitem->fileok = 1;	/* Just created it - it's there now */
 	}
 
 	updtime = atoi(rrdvalues);
@@ -546,9 +589,6 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 				  filedir, (senderip ? senderip : "unknown"), msg);
 		}
 
-		/* check the file next time around */
-		cacheitem->fileok = 0;
-
 		MEMUNDEFINE(filedir);
 		MEMUNDEFINE(rrdvalues);
 		return 2;
@@ -596,6 +636,15 @@ static void updcache_host_op(char *hostname, int flushfirst, char *flushas)
 		updcacheitem_t *cacheitem = (updcacheitem_t *)xtreeData(updcache, handle);
 
 		if (strncasecmp(cacheitem->key, prefix, plen) != 0) continue;
+
+		/*
+		 * Cleared here, before the valcount test below skips the idle items
+		 * and before the discard branch, which never reaches
+		 * flush_cached_updates(). Left set, a re-added host skips the create
+		 * and loses a cache cycle against a file that is not there.
+		 */
+		cacheitem->fileok = 0;
+
 		if (cacheitem->valcount == 0) continue;
 		nhit++;
 

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -67,6 +67,7 @@ static void * updcache;
 typedef struct updcacheitem_t {
 	char *key;
 	rrdtpldata_t *tpl;
+	int fileok;
 	int valcount;
 	char *vals[CACHESZ];
 	int updseq[CACHESZ];
@@ -367,7 +368,8 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	}
 
 	/* If the RRD file doesn't exist, create it immediately */
-	if (stat(filedir, &st) == -1) {
+	/* otherwise, mark that it's present so we don't burn a syscall again */
+	if (!no_rrd && !cacheitem->fileok && !( (stat(filedir, &st) != -1) && ++cacheitem->fileok ) ) {
 		xymon_rrd_argv_item_t *rrdcreate_params;
 		char **rrddefinitions;
 		int rrddefcount, i;
@@ -427,6 +429,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 			MEMUNDEFINE(rrdvalues);
 			return 1;
 		}
+		else cacheitem->fileok++;
 	}
 
 	updtime = atoi(rrdvalues);
@@ -500,7 +503,11 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	}
 
 	/* Are we actually handling the writing of RRD files? */
-	if (no_rrd) return 0;
+	if (no_rrd) {
+		MEMUNDEFINE(filedir);
+		MEMUNDEFINE(rrdvalues);
+		return 0;
+	}
 
 	/* 
 	 * We cannot just cache data every time because then after CACHESZ updates
@@ -538,6 +545,9 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 			errprintf("RRD error updating %s from %s: %s\n", 
 				  filedir, (senderip ? senderip : "unknown"), msg);
 		}
+
+		/* check the file next time around */
+		cacheitem->fileok = 0;
 
 		MEMUNDEFINE(filedir);
 		MEMUNDEFINE(rrdvalues);

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -55,6 +55,7 @@ static char rrdvalues[MAX_LINE_LEN];
 static char *senderip = NULL;
 static char rrdfn[PATH_MAX];   /* Base filename without directories, from setupfn() */
 static char filedir[PATH_MAX]; /* Full path filename */
+static char filejustdir[PATH_MAX]; /* Full path filename - just the directory */
 static char *fnparams[4] = { NULL, };  /* Saved parameters passed to setupfn() */
 
 /* How often do we feed data into the RRD file */
@@ -354,20 +355,6 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	MEMDEFINE(rrdvalues);
 	MEMDEFINE(filedir);
 
-	if (snprintf(filedir, sizeof(filedir), "%s/%s", rrddir, hostname) >= (int)sizeof(filedir)) {
-		errprintf("RRD directory path truncated, skipping: %s/%s\n", rrddir, hostname);
-		MEMUNDEFINE(filedir);
-		MEMUNDEFINE(rrdvalues);
-		return -1;
-	}
-	if (stat(filedir, &st) == -1) {
-		if (mkdir(filedir, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH) == -1) {
-			errprintf("Cannot create rrd directory %s : %s\n", filedir, strerror(errno));
-			MEMUNDEFINE(filedir);
-			MEMUNDEFINE(rrdvalues);
-			return -1;
-		}
-	}
 	/* Watch out here - "rrdfn" may be very large. */
 	if (build_rrd_filedir(filedir, sizeof(filedir), hostname, rrdfn)) {
 		MEMUNDEFINE(filedir);
@@ -421,6 +408,20 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		int havestepsetting = 0, fixcount = 2;
 
 		dbgprintf("Creating rrd %s\n", filedir);
+
+		MEMDEFINE(filejustdir);
+		sprintf(filejustdir, "%s/%s", rrddir, hostname);
+		if (stat(filejustdir, &st) == -1) {
+			dbgprintf("Creating rrd dir %s\n", filejustdir);
+			if (mkdir(filejustdir, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH) == -1) {
+				errprintf("Cannot create rrd directory %s : %s\n", filejustdir, strerror(errno));
+				MEMUNDEFINE(filedir);
+				MEMUNDEFINE(filejustdir);
+				MEMUNDEFINE(rrdvalues);
+				return -1;
+			}
+		}
+		MEMUNDEFINE(filejustdir);
 
 		/* How many parameters did we get? */
 		for (pcount = 0; (creparams[pcount]); pcount++);


### PR DESCRIPTION
Stacked on #152, which caches the RRD-file-exists check. This is issue #153: the host directory was checked on **every** update, when it only has to exist where a file is about to be created — if the RRD is there, so is its directory.

From J.C. Cleaver's Terabithia patch, plus one correction commit.

| | |
|---|---|
| the host-directory path | built with `sprintf` into a static; `rrddir` and the hostname can overflow between them. `snprintf` into a local now, and the refusal the replaced route had moves with it |
| the cached file-exists flag | cleared wherever the file can go — the update path, `drophost` and `renamehost` through `updcache_host_op()`, and both `rrdcacheflush*` entry points |

`tests/rrd/rrd-recreate-after-drop.sh` drives the real worker through a drophost and through a deletion nothing announces, the second across a fifo so **one** worker sees the file disappear while holding the cached answer. Three things had to be right for that case to mean anything, and none of them were:

- it waited for the RRD to exist after one reading, but the file was already there from the case above — the wait returned at once and the deletion could land before the worker had read anything;
- the readings after the deletion have to reach a flush, where the missing file is noticed, and then an update that recreates it. `CACHESZ` is 12; two readings sat in the cache until shutdown;
- every message carried the same sequence number, so a worker fed more than one dropped the rest as duplicate updates — logged under `--debug` and nowhere else. `status_msg()` numbers them, which any test feeding a live worker will need.

Verified by mutation: with the flag-clearing removed from `flush_cached_updates()`, the case fails. It did not, in any earlier version.

Four commits: two are #152's underneath, two are this PR's — J.C. Cleaver's original and one correction. Suite on a built tree, `rrdtool` absent from `PATH`: 0 failed, 0 skipped.



**Overlaps in `flush_cached_updates()`.** Besides #152 underneath, two other open PRs edit that function at ranges colliding with the `@@ -270,13` hunk this inherits: **#349** (`@@ -258,18` — deletes the `utimes()` at `do_rrd.c:270`) and **#387** (draft, `@@ -265,9` — re-gates that same `utimes`, and says it will drop the gating once #349 lands).

Neither supersedes this: the two `stat()` calls removed here and the `utimes()` removed by #349 are different syscalls on the same per-update path, so the effects compose. Only the hunks need sequencing.
