### PR TITLE
client/darwin: fix APFS filesystem filter (false disk/inode PANIC) (closes #156)

### DIFF
--- a/client/xymonclient-darwin.sh
+++ b/client/xymonclient-darwin.sh
@@ -26,10 +26,26 @@ uptime
 echo "[who]"
 who
 
-FILESYSTEMS=`mount | sed -E '/[\( ](nobrowse|afs|read-only)[ ,\)]/d;s/^.* on (.*) \(.*$/\1/'`
+# macOS `df` has no filesystem-type filter, and modern APFS mounts the system
+# root read-only and the data volume nobrowse - so the old "skip nobrowse/
+# read-only" heuristic dropped the REAL volumes too, leaving an empty list, so
+# df then listed everything including devfs (/dev) at 100% -> false disk/inode
+# PANIC. Select by filesystem TYPE instead (real local disks) and drop
+# everything under /System/Volumes/ except the Data volume - nested internals
+# like /System/Volumes/Update/SFR/mnt1 and the Preboot cryptexes are apfs too.
+# Overridable via XYMONCLIENT_FS_INCLUDE_TYPES/EXCLUDE_TYPES in xymonclient.cfg.
+typepat=""
+for t in apfs hfs exfat msdos $XYMONCLIENT_FS_INCLUDE_TYPES; do
+	for x in $XYMONCLIENT_FS_EXCLUDE_TYPES; do [ "$t" = "$x" ] && t=""; done
+	[ -n "$t" ] && typepat="$typepat${typepat:+|}$t"
+done
+FILESYSTEMS=`mount | sed -nE "s#^.+ on (/.*) \\((${typepat})[,)].*#\\1#p" | awk '!/^\/System\/Volumes\// || /^\/System\/Volumes\/Data$/'`
+# Never fall back to the unfiltered df listing if the filter itself failed -
+# but honor an explicit exclusion that legitimately empties the list.
+[ -z "$FILESYSTEMS" ] && [ -z "$XYMONCLIENT_FS_EXCLUDE_TYPES" ] && FILESYSTEMS=/
 
 echo "[df]"
-(IFS=$'\n'
+[ -n "$FILESYSTEMS" ] && (IFS=$'\n'
  set $FILESYSTEMS
  df -P -H $1; shift
  while test $# -gt 0
@@ -39,12 +55,12 @@ echo "[df]"
  done) | column -t -s " " | sed -e 's!Mounted *on!Mounted on!'
 
 echo "[inode]"
-(IFS=$'\n'
+[ -n "$FILESYSTEMS" ] && (IFS=$'\n'
  set $FILESYSTEMS
  df -P -i $1; shift
  while test $# -gt 0
  do
-   df -P -H $1 | tail -1 | sed 's/\([^0123456789% ]\) \([^ ]\)/\1_\2/g'
+   df -P -i $1 | tail -1 | sed 's/\([^0123456789% ]\) \([^ ]\)/\1_\2/g'
    shift
  done) | awk '
 NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9} 

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -17,6 +17,13 @@ XYMONCLIENTLOGS="$XYMONHOME/logs"     # Where we store the client logfiles
 # Options to logfetch, the xymon binary which examines log files for recent changes.
 LOGFETCHOPTS=""
 
+# Filesystem types reported in the "disk" and "inode" status columns.
+# INCLUDE adds types to the platform defaults, EXCLUDE removes from them.
+# Currently honored by the Darwin (macOS) client, where the defaults are
+# apfs, hfs, exfat and msdos.
+#XYMONCLIENT_FS_INCLUDE_TYPES=""
+#XYMONCLIENT_FS_EXCLUDE_TYPES=""
+
 
 # Local Mode (Only) Options
 #


### PR DESCRIPTION
## Summary

Fixes the macOS (Darwin) client reporting **all** filesystems — including `devfs`
(`/dev`) and `auto_home`, which are always 100% used — so `disk` and `inode` go to
a false **PANIC**. Closes #156.

## Root cause

`client/xymonclient-darwin.sh` filtered the `df`/`inode` list by dropping
`nobrowse`/`read-only` volumes, assuming those are synthetic. On modern macOS
(APFS, Catalina+) the **real** volumes carry exactly those flags:

```
/dev/disk3s1s1 on /                   (apfs, sealed, local, read-only, journaled)   <- read-only
/dev/disk3s5  on /System/Volumes/Data (apfs, local, journaled, nobrowse, ...)        <- nobrowse  (real data vol)
devfs         on /dev                 (devfs, local, nobrowse)
... every /System/Volumes/* is nobrowse ...
```

Every line matched, so the list came out **empty** → `df -P -H`/`df -P -i` (no args)
listed everything → `devfs` (100%) and `map auto_home` (100%) PANIC.

## Fix

- Select by filesystem **type** (`apfs hfs exfat msdos`) — the approach the BSD
  clients already use — and drop the synthetic `/System/Volumes/*` internals,
  keeping `/` and `/System/Volumes/Data`.
- Overridable via the same `XYMONCLIENT_FS_INCLUDE_TYPES` / `XYMONCLIENT_FS_EXCLUDE_TYPES`
  env vars #96 introduces for the Linux client (shared contract; default = correct).
- Fall back to `/` rather than the unfiltered listing if nothing matches.
- Fix a latent bug: the `[inode]` loop fetched later filesystems with `df -P -H`
  (blocks) instead of `df -P -i` (inodes) — masked only because the list was empty.

## Validation

Tested against a real macOS Tahoe `mount`/`df` layout (the reporter's Mac mini):
the filter now yields exactly `/` and `/System/Volumes/Data`; `devfs`/`auto_home`
and the redundant synthetic volumes are gone, so `disk`/`inode` report the real
data volume (61%) and clear. `sh -n` clean. Scope is Darwin-only — the other 7
clients exclude pseudo-FS natively and are untouched.

Related: #49, #96.
