### PR TITLE
client: accept IFEXIST as an alias for OPTIONAL in FILE rules

### DIFF
--- a/client/localclient.cfg
+++ b/client/localclient.cfg
@@ -193,7 +193,7 @@
 #             Example: Go red if the text "I/O error" or "read error" appears.
 #                 LOG %/var/(adm|log)/messages %(I/O|read).error COLOR=red
 #
-#    FILE filename [color] [things to check] [TRACK]
+#    FILE filename [color] [things to check] [OPTIONAL|IFEXIST] [TRACK]
 #             NB: The files you wish to monitor must be listed in a "file:..."
 #             entry in the client-local.cfg file, in order for the client to 
 #             report any data about them.
@@ -233,8 +233,11 @@
 #             - "MD5=md5sum", "SHA1=sha1sum", and so on for RMD160, SHA256, SHA512,
 #               SHA224, and SHA384 trigger a warning if the file checksum using the
 #               specified message digest algorithm does not match the one configured here.
-#               Note: The "file" entry in the client-local.cfg file must specify which 
+#               Note: The "file" entry in the client-local.cfg file must specify which
 #               algorithm to use as that is the only one that will be sent.
+#             - "OPTIONAL" skips this check entirely if the file does not exist
+#               (no warning is raised for the missing file). "IFEXIST" is an
+#               accepted alias, for compatibility with existing configurations.
 #
 #             "TRACK" causes the size of this file to be tracked in an RRD file, and
 #             shown on the graph on the "files" display.

--- a/docs/manpages/man5/analysis.cfg.5.html
+++ b/docs/manpages/man5/analysis.cfg.5.html
@@ -333,7 +333,7 @@ will just show up on the &quot;msgs&quot; column with status OK (green).
 <H2>FILES STATUS COLUMN SETTINGS</H2>
 
 <P>
-<B>FILE filename [color] [things to check] [OPTIONAL] [TRACK]</B>
+<B>FILE filename [color] [things to check] [OPTIONAL|IFEXIST] [TRACK]</B>
 
 <P>
 <B>DIR directoryname [color] [size&lt;MAXSIZE] [size&gt;MINSIZE] [TRACK]</B>
@@ -354,6 +354,8 @@ not exist. E.g. you can use this to check if files that should be temporary are
 not deleted, by checking that they are not older than the max time you would
 expect them to stick around, and then using OPTIONAL to ignore the state
 where no files exist.
+<B>IFEXIST</B> is an alias for <B>OPTIONAL</B>, accepted for compatibility with
+existing configurations.
 <P>
 The <B>TRACK</B> keyword causes the size of the file or directory to be tracked
 in an RRD file, and presented in a graph on the &quot;files&quot; status display.

--- a/xymond/analysis.cfg.5
+++ b/xymond/analysis.cfg.5
@@ -266,7 +266,7 @@ will just show up on the "msgs" column with status OK (green).
 
 .SH FILES STATUS COLUMN SETTINGS
 .sp
-.BR "FILE filename [color] [things to check] [OPTIONAL] [TRACK]"
+.BR "FILE filename [color] [things to check] [OPTIONAL|IFEXIST] [TRACK]"
 .sp
 .BR "DIR directoryname [color] [size<MAXSIZE] [size>MINSIZE] [TRACK]"
 .sp
@@ -285,6 +285,8 @@ not exist. E.g. you can use this to check if files that should be temporary are
 not deleted, by checking that they are not older than the max time you would
 expect them to stick around, and then using OPTIONAL to ignore the state
 where no files exist.
+\fBIFEXIST\fR is an alias for \fBOPTIONAL\fR, accepted for compatibility with
+existing configurations.
 
 The \fBTRACK\fR keyword causes the size of the file or directory to be tracked
 in an RRD file, and presented in a graph on the "files" status display.

--- a/xymond/client_config.c
+++ b/xymond/client_config.c
@@ -1203,7 +1203,8 @@ int load_client_config(char *configfn)
 						currule->chkflags |= CHK_TRACKIT;
 						if (*(tok+5) == '=') currule->rrdidstr = strdup(tok+6);
 					}
-					else if (strcasecmp(tok, "optional") == 0) {
+					else if ((strcasecmp(tok, "optional") == 0) || (strcasecmp(tok, "ifexist") == 0)) {
+						/* IFEXIST is an alias for OPTIONAL: skip the check if the file does not exist */
 						currule->chkflags |= CHK_OPTIONAL;
 					}
 					else {

--- a/xymond/etcfiles/analysis.cfg
+++ b/xymond/etcfiles/analysis.cfg
@@ -178,7 +178,7 @@
 #             Example: Go red if the text "I/O error" or "read error" appears.
 #                 LOG %/var/(adm|log)/messages %(I/O|read).error COLOR=red
 #
-#    FILE filename [things to check] [color] [TRACK]
+#    FILE filename [things to check] [color] [OPTIONAL|IFEXIST] [TRACK]
 #             NB: The files you wish to monitor must be listed in a "file:..."
 #             entry in the client-local.cfg file, in order for the client to 
 #             report any data about them.
@@ -218,8 +218,11 @@
 #             - "MD5=md5sum", "SHA1=sha1sum", and so on for RMD160, SHA256, SHA512, 
 #               SHA224, and SHA384 trigger a warning if the file checksum using the 
 #               specified message digest algorithm does not match the one configured here. 
-#               Note: The "file" entry in the client-local.cfg file must specify which 
+#               Note: The "file" entry in the client-local.cfg file must specify which
 #               algorithm to use as that is the only one that will be sent.
+#             - "OPTIONAL" skips this check entirely if the file does not exist
+#               (no warning is raised for the missing file). "IFEXIST" is an
+#               accepted alias, for compatibility with existing configurations.
 #
 #             "TRACK" causes the size of this file to be tracked in an RRD file, and
 #             shown on the graph on the "files" display.


### PR DESCRIPTION
## Summary

Accept `IFEXIST` as an alias for the existing `OPTIONAL` keyword in `FILE` analysis rules, so that a file check is skipped when the target file does not exist.

This is the upstreaming of Debian's `27_hobbit_files_ifexist` patch (tracked in #28), implemented as a one-line alias instead of a new flag.

## Why an alias rather than a new flag

Upstream already has exactly the requested behavior under `OPTIONAL` (`CHK_OPTIONAL`): the `FILE` check is skipped when the file is absent. Adding a separate `IFEXIST` flag would duplicate that logic with a second runtime path for no functional gain.

Routing `ifexist` to `CHK_OPTIONAL` means:
- no new flag bit, no new `check_file()` branch;
- the existing `dump_client_config()` and `check_file()` paths already handle it (a rule written with `ifexist` round-trips as `OPTIONAL`, which is the canonical spelling);
- existing Debian-derived configs using `IFEXIST` keep working unchanged.

## Supersedes #50

PR #50 implements the same feature with a dedicated flag:

```c
#define FCHK_IFEXIST  (1 << 32)
```

The `flags`/`chkflags` fields are `uint32_t` (valid bits 0–31; the existing flags already use up to `1 << 31`). `1 << 32` is undefined behavior on a 32-bit `int` and, with GCC constant-folding, evaluates to **0** — so `flags |= FCHK_IFEXIST` is a no-op, the dump never emits `ifexist`, and the `goto nextcheck` never fires. The feature silently does nothing as written. This alias approach avoids the flag-space problem entirely.

## Changes

- `xymond/client_config.c`: `FILE` rule parser accepts `ifexist` alongside `optional`.
- `xymond/analysis.cfg.5`: documents `IFEXIST` as an alias for `OPTIONAL`, and adds it to the `FILE` synopsis.

## Testing

`make xymond-build` compiles clean; `groff -man -z -ww xymond/analysis.cfg.5` lints clean. The behavior reuses the `CHK_OPTIONAL` path already exercised by the `OPTIONAL` keyword.

Refs #27, #28.
