### PR TITLE
tests: establish test infrastructure and initial coverage (RFC #97)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,19 +87,13 @@ jobs:
       # there. Run it here too, where the binaries this variant produced are on
       # disk, so those tests actually execute against the build.
       #
-      # SCAFFOLDING -- as of today NO test calls require_bin: every test reads
-      # committed source or compiles its own probe, so none consumes a build
-      # artefact. That makes this step currently REDUNDANT with tests.yml (same
-      # checks, same results, after an unnecessary rebuild). It is kept on
-      # purpose: the moment a behavioural test drives a compiled tool, this is
-      # the only job where that test runs instead of skipping. Drop this step
-      # together with require_bin if the binary-test direction is abandoned.
+      # First such test: tests/server/xymongrep-filter.sh, which drives the
+      # common/xymongrep this leg just built. This step is the only place in
+      # CI where it executes instead of skipping.
       #
-      # Gated to the server leg only: until a require_bin test exists, running
-      # the identical suite in all three matrix legs triples the redundancy for
-      # nothing. The server build produces the broadest binary set, so it stays
-      # the scaffolding leg; widen the gate (or drop it) when the first test
-      # needs a binary this leg doesn't build.
+      # Gated to the server leg only: it produces the broadest binary set
+      # (including common/xymongrep). Widen the gate when a test needs a
+      # binary this leg doesn't build.
       - name: Run regression tests against the build
         if: matrix.variant == 'server'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,19 @@ on:
   push:
   pull_request:
 
+# Both workflows check out and run pull-request code; the token needs
+# nothing beyond reading the repo. Same grant as tests.yml.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build (${{ matrix.name }})
     runs-on: ubuntu-latest
+    # A regression test that blocks (e.g. a configure probe growing an
+    # interactive prompt) would otherwise hang the job for the runner's
+    # 6-hour ceiling. Build + suite take ~1 minute; 15 is generous.
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -72,3 +81,39 @@ jobs:
         run: |
           echo "running make with $(nproc) parallel processes"
           make -j$(nproc)
+
+      # tests.yml runs the same suite without building, so any test that needs
+      # a compiled binary (require_bin in tests/lib/assert.sh) silently skips
+      # there. Run it here too, where the binaries this variant produced are on
+      # disk, so those tests actually execute against the build.
+      #
+      # SCAFFOLDING -- as of today NO test calls require_bin: every test reads
+      # committed source or compiles its own probe, so none consumes a build
+      # artefact. That makes this step currently REDUNDANT with tests.yml (same
+      # checks, same results, after an unnecessary rebuild). It is kept on
+      # purpose: the moment a behavioural test drives a compiled tool, this is
+      # the only job where that test runs instead of skipping. Drop this step
+      # together with require_bin if the binary-test direction is abandoned.
+      #
+      # Gated to the server leg only: until a require_bin test exists, running
+      # the identical suite in all three matrix legs triples the redundancy for
+      # nothing. The server build produces the broadest binary set, so it stays
+      # the scaffolding leg; widen the gate (or drop it) when the first test
+      # needs a binary this leg doesn't build.
+      - name: Run regression tests against the build
+        if: matrix.variant == 'server'
+        run: |
+          # Mirror tests.yml: this step checks out and builds full source, so
+          # every test finds the code it guards. The runner's all-skip exit 77
+          # ("nothing verified") can therefore only mean broken discovery, not a
+          # legitimate skip -- map it to a hard failure. Actions has no neutral
+          # state, so 77 would otherwise surface as a bare nonzero failure with
+          # no explanation. `|| rc=$?` exempts the runner from bash -e so the
+          # mapping is reachable.
+          rc=0
+          ./tests/testsuite || rc=$?
+          if [ "$rc" = 77 ]; then
+            echo "::error::testsuite skipped everything (rc=77) -- with full source built this means broken discovery, not a legitimate skip"
+            exit 1
+          fi
+          exit "$rc"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  shell:
+    name: shell regression tests
+    runs-on: ubuntu-latest
+    # A regression test that blocks (e.g. a configure probe growing an
+    # interactive prompt) would otherwise hang the job for the runner's
+    # 6-hour ceiling. The suite takes seconds; 10 is generous.
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # The runner lives in tests/testsuite so developers can run the exact
+      # same thing locally (./tests/testsuite or make test). It auto-detects
+      # GitHub Actions and emits log annotations here, plain output on a CLI.
+      #
+      # testsuite exits 77 ("everything skipped -- nothing verified"). Actions
+      # has no neutral state: any nonzero exit is a failure, so we must map 77
+      # explicitly rather than let it surface as a bare "exit code 77". This job
+      # checks out the full source, so every test finds the code it guards and
+      # runs -- an all-skip here is never the legitimate "tests shipped without
+      # source" case, it means discovery or the tree itself is broken. Treat it
+      # as a hard failure with a clear message.
+      - name: Run testsuite
+        run: |
+          # GitHub runs steps with `bash -e`, which would abort on testsuite's
+          # nonzero exit before we can read it. `|| rc=$?` exempts the command
+          # from -e so the 77 mapping below is actually reachable.
+          rc=0
+          ./tests/testsuite || rc=$?
+          if [ "$rc" = 77 ]; then
+            echo "::error::testsuite skipped everything (rc=77) -- with full source checked out this means broken discovery, not a legitimate skip"
+            exit 1
+          fi
+          exit "$rc"

--- a/build/Makefile.rules
+++ b/build/Makefile.rules
@@ -140,6 +140,14 @@ win32: include/config.h
 	CC="$(CC)" CFLAGS="$(CFLAGS) -DXYMONWINCLIENT -DCLIENTONLY" LDFLAGS="$(LDFLAGS)" RPATHOPT="$(RPATHOPT)" SSLFLAGS="$(SSLFLAGS)" SSLINCDIR="$(SSLINCDIR)" SSLLIBS="$(SSLLIBS)" NETLIBS="$(NETLIBS)" LIBRTDEF="$(LIBRTDEF)" XYMONHOME="$(XYMONHOME)" XYMONTOPDIR="$(XYMONTOPDIR)" XYMONLOGDIR="$(XYMONLOGDIR)" XYMONHOSTNAME="$(XYMONHOSTNAME)" XYMONHOSTIP="$(XYMONHOSTIP)" XYMONHOSTOS="$(XYMONHOSTOS)" $(MAKE) -C common xymon.exe
 
 #####################
+# Regression testsuite
+#####################
+# Runs every executable test under tests/ via the shared runner. The runner
+# resolves the repo root itself, so it works from any cwd. See tests/README.md.
+.PHONY: test
+test:
+	$(BUILDTOPDIR)/tests/testsuite
+
 # Cleanup targets
 #####################
 distclean: allclean

--- a/build/makedeb.sh
+++ b/build/makedeb.sh
@@ -11,7 +11,7 @@ cd $BASEDIR
 
 rm -rf debbuild
 mkdir -p $BASEDIR/debbuild/xymon-$REL
-for f in xymongen xymonnet bbpatches xymonproxy build common contrib docs xymond web include lib client demotool
+for f in xymongen xymonnet bbpatches xymonproxy build common contrib docs xymond web include lib client demotool tests
 do
         find $f/ | egrep -v "RCS|\.svn" | cpio -pdvmu $BASEDIR/debbuild/xymon-$REL/
 done

--- a/build/makerpm.sh
+++ b/build/makerpm.sh
@@ -32,7 +32,7 @@ cp rpm/xymon-client.init rpmbuild/SOURCES/
 cp rpm/xymon-client.default rpmbuild/SOURCES/
 
 mkdir -p rpmbuild/xymon-$REL
-for f in xymongen xymonnet bbpatches xymonproxy build common contrib docs xymond web include lib client demotool
+for f in xymongen xymonnet bbpatches xymonproxy build common contrib docs xymond web include lib client demotool tests
 do
         find $f/ | egrep -v "RCS|.svn" | cpio -pdvmu $BASEDIR/rpmbuild/xymon-$REL/
 done

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,154 @@
+# tests/ — regression scenarios
+
+A place to put runnable, reproducible regression scenarios for behaviour
+the project has consciously changed. The bar is intentionally low: when
+a PR changes user-visible behaviour, drop a test here so the next person
+can re-run the check without re-reading the PR.
+
+Designed as the implementation of RFC [#97](https://github.com/xymon-monitoring/xymon/issues/97).
+
+## Running the tests
+
+From a fresh checkout, no build required:
+
+    ./tests/testsuite
+
+It discovers every executable `tests/**/*.sh`, runs each, and prints a
+pass/skip/fail summary (exit `0` = pass, `77` = skip, anything else = fail).
+Output adapts on its own: plain text on a terminal, GitHub Actions annotations
+under CI — the workflow and a developer run the exact same runner.
+
+Once the tree is configured, `make test` runs the same thing. A single
+test also runs standalone — what reviewers do:
+
+    ./tests/client/fs-filter.sh
+
+`bash` is a hard prerequisite of the suite (every test uses it; see
+Conventions). The runner itself is POSIX sh, and on a host without bash it
+skips the whole suite with exit `77` rather than reporting interpreter
+failures as test failures.
+
+## What lives here, what doesn't
+
+- **Here:** shell-level integration scenarios that exercise binaries,
+  shipped config files, packaging artefacts, or documented invariants.
+- **Not here:** pure-C unit tests. Those stay where they are
+  (`xymonnet/test-evheap.c`, `lib/test-endianness.c`, etc.) and are
+  built/run by the existing per-directory Makefiles.
+
+## Directory layout
+
+Tests are organised by **domain area**, not by source path. Source
+paths shift over time (CMake migration is in flight); domains don't.
+Cross-cutting scenarios that don't map to a single source dir (e.g.
+shipped-file invariants) get their own area.
+
+| Area              | What lives here                                        |
+| ----------------- | ------------------------------------------------------ |
+| `tests/client/`   | xymon client tools and behaviours                      |
+| `tests/server/`   | xymond-side tools (xymongrep, xymoncgimsg, alert routing) |
+| `tests/network/`  | xymonnet probes (xymonping, network checks)            |
+| `tests/web/`      | CGIs, HTML rendering paths                             |
+| `tests/packaging/`| cross-cutting: shipped files, paths, generated configs |
+| `tests/buildsystem/` | parallel make, configure probes, CMake feature detection |
+| `tests/integration/` | end-to-end scenarios spanning multiple components   |
+| `tests/lib/`      | sourced helpers (`assert.sh`, future `net.sh` etc.)    |
+| `tests/fixtures/` | shared data files (config snippets, expected outputs)  |
+
+Add a new area by PR when an existing one doesn't fit. Don't bend a
+test to fit the wrong area just to avoid creating a new directory.
+
+### Runnable vs sourced/data files
+
+Only the **test entry point** has the executable bit set. Helpers
+under `lib/` are sourced; files under `fixtures/` are read. Neither
+is `+x`. The CI discovery rule (`find tests -type f -name '*.sh'
+-perm -u+x`) relies on this — the exec bit, not the path, decides what
+runs. The runner additionally excludes `lib/` and `fixtures/` as a
+backstop for checkouts where every file reads as executable (FAT/NTFS
+mounts, `core.fileMode=false` trees), so a sourced helper is never
+mistaken for a test there; new test directories need no exclude-list
+maintenance.
+
+## Conventions
+
+- **One file per scenario set.** Filename describes the area, not the
+  PR: `tests/client/fs-filter.sh`, `tests/packaging/fhs-paths.sh`.
+  Split when a file passes ~200 lines.
+- **Executable. Bash. Strict mode.** First line:
+  `#!/usr/bin/env bash`. Second line: `set -euo pipefail`.
+  POSIX-sh compatibility is a non-goal.
+- **Quiet on success, verbose on failure.** Don't print per-step
+  progress on the happy path; CI logs are noisy enough. On failure
+  the `fail` helper prints to stderr and exits, which is usually
+  enough context.
+- **Exit codes:**
+  - `0` — pass
+  - `77` — skip (matches the autotools / autopkgtest convention; CI
+    treats this as "not run", not as a failure)
+  - anything else — fail
+- **Skip only for a missing environment, never for missing project
+  code.** A test ships in the same tree as the behaviour it guards, so
+  the *feature being absent* is a regression to fail on, not a reason to
+  skip. Reserve `skip` for things the host can't provide: an absent host
+  tool (`awk`, `df`), an OS the test doesn't apply to, a binary that
+  wasn't built, or source files genuinely not present in this checkout.
+  "The wiring this test guards is gone" must `fail`. The one exception is
+  a test deliberately staged ahead of an unmerged feature — call that out
+  in the test and remove the staging skip the moment the feature lands.
+- **Deterministic.** Tests must produce the same result every run, on
+  any contributor's box and in CI. Flaky tests are removed, not
+  retried. If a test needs to wait for something, wait for the
+  condition, not for a wall-clock duration.
+- **No persistent side effects.** Use `mktemp -d` for scratch space and
+  register cleanup via `register_cleanup` (see `lib/assert.sh`).
+- **No git assumption.** Tests must run against an extracted release
+  tarball or a Debian source package, where `.git` is absent. Use
+  `find_root` (script-location-based, not `git rev-parse`). When you
+  need to isolate from the source tree before mutating files, copy the
+  paths you actually need with `cp -r` into a `mktempdir`; do not use
+  `git worktree`, `git stash`, or any other git invocation.
+- **Path discovery via env var with default.** When a test needs a
+  built binary, read it from an env var and default to the in-tree
+  build path:
+  ```bash
+  XYMONPING="${XYMONPING:-./xymonnet/xymonping}"
+  ```
+  This keeps tests usable in CMake out-of-source builds (the build
+  system passes the real path), in the in-tree Makefile build (default
+  matches), and in autopkgtest (which exports installed paths).
+- **License.** GPL-2.0+, matching the rest of the repo. A short
+  SPDX-style header at the top of each test is sufficient:
+  ```bash
+  # SPDX-License-Identifier: GPL-2.0-or-later
+  ```
+
+## How to add a regression scenario
+
+1. Pick the area: `tests/<area>/<scenario>.sh`. Create the subdirectory
+   if needed.
+2. Copy the SPDX header and the strict-mode preamble from any existing
+   test as a starting point.
+3. Source the helpers: `. "$(dirname "$0")/../lib/assert.sh"`.
+4. Drive the scenario: set up fixtures in a temp dir, invoke the
+   binary or script under test, assert on its output / exit code /
+   side effects.
+5. Run it standalone. If it passes locally and is deterministic, open
+   the PR. CI will run it on every push.
+
+## Why no framework
+
+Day-1 deliberate choice. Adopting bats/shunit2/pytest forces every
+contributor (and every distro packager downstream) to learn that
+framework before they can read a test. `set -euo pipefail` plus a tiny
+assertion helper covers the surface we have today. If the directory
+grows past ~30 tests and the lack of structure starts to bite, we
+revisit.
+
+## Downstream consumers
+
+Debian's [autopkgtest](https://wiki.debian.org/autopkgtest) is an
+intended consumer (see [#97](https://github.com/xymon-monitoring/xymon/issues/97)
+discussion). Tests should be portable to a minimal Debian chroot:
+declare any non-trivial host dependency at the top of the file with a
+`skip` if it's missing, rather than failing.

--- a/tests/README.md
+++ b/tests/README.md
@@ -109,14 +109,22 @@ maintenance.
   paths you actually need with `cp -r` into a `mktempdir`; do not use
   `git worktree`, `git stash`, or any other git invocation.
 - **Path discovery via env var with default.** When a test needs a
-  built binary, read it from an env var and default to the in-tree
-  build path:
+  built binary or an installed artefact, read it from an env var and
+  default to the in-tree path -- `require_bin` (lib/assert.sh) does this
+  for binaries:
   ```bash
-  XYMONPING="${XYMONPING:-./xymonnet/xymonping}"
+  require_bin XYMONGREP common/xymongrep          # binaries
+  SCRIPT="${XYMONCLIENT_LINUX:-$ROOT/client/xymonclient-linux.sh}"  # scripts
   ```
   This keeps tests usable in CMake out-of-source builds (the build
   system passes the real path), in the in-tree Makefile build (default
-  matches), and in autopkgtest (which exports installed paths).
+  matches), and in autopkgtest (the control file exports installed
+  paths). The override contract assumes test and artefact come from the
+  **same version**: pointing a newer test at an older installed artefact
+  will fail on features that artefact predates -- that is the
+  skip-only-for-environment policy above working as designed, not a bug.
+  (In Debian CI the contract holds automatically: tests and debs are
+  built from the same source package.)
 - **License.** GPL-2.0+, matching the rest of the repo. A short
   SPDX-style header at the top of each test is sufficient:
   ```bash
@@ -149,6 +157,29 @@ revisit.
 
 Debian's [autopkgtest](https://wiki.debian.org/autopkgtest) is an
 intended consumer (see [#97](https://github.com/xymon-monitoring/xymon/issues/97)
-discussion). Tests should be portable to a minimal Debian chroot:
-declare any non-trivial host dependency at the top of the file with a
-`skip` if it's missing, rather than failing.
+discussion). autopkgtest runs test commands from the root of the
+**unpacked, unbuilt source package** (read-only -- another reason for
+the copy-into-`mktempdir` convention) against the **installed binary
+packages**. The suite maps onto that as a single test entry, roughly:
+
+```
+Test-Command: XYMONGREP=/usr/lib/xymon/client/bin/xymongrep \
+              XYMONCLIENT_LINUX=/usr/lib/xymon/client/bin/xymonclient-linux.sh \
+              ./tests/testsuite
+Depends: xymon, xymon-client, gcc, make
+Restrictions: skippable
+```
+
+`Restrictions: skippable` maps the runner's all-skip exit `77` to SKIP
+instead of FAIL; `gcc`/`make` in `Depends` keep the compile-probe tests
+alive (autopkgtest does not provide build-dependencies by default). The
+env overrides point binary-driving tests (`require_bin`) and
+installed-artefact tests at the package's files -- those are the tests
+that give Debian's library-transition CI something that can break at
+runtime. Source-reading tests run against the unpacked (patched) source
+tree; for the installed-package use case they are *supplementary*
+signal, which is why new tests that can drive a built binary should.
+
+Tests should be portable to a minimal Debian chroot: declare any
+non-trivial host dependency at the top of the file with a `skip` if
+it's missing, rather than failing.

--- a/tests/README.md
+++ b/tests/README.md
@@ -124,7 +124,14 @@ maintenance.
   will fail on features that artefact predates -- that is the
   skip-only-for-environment policy above working as designed, not a bug.
   (In Debian CI the contract holds automatically: tests and debs are
-  built from the same source package.)
+  built from the same source package.) The override is also an
+  **existence assertion**: a test may `skip` when the in-tree default is
+  absent (binary not built in this configuration), but an explicitly
+  exported path that points at nothing must `fail` -- a broken build or
+  package layout is precisely what the exporting caller (CMake,
+  autopkgtest) runs the suite to catch, and skipping would green-light
+  it. `require_bin` implements both halves; installed-script tests
+  guard `$XYMONCLIENT_LINUX` the same way.
 - **License.** GPL-2.0+, matching the rest of the repo. A short
   SPDX-style header at the top of each test is sufficient:
   ```bash

--- a/tests/buildsystem/configure-no-rrd.sh
+++ b/tests/buildsystem/configure-no-rrd.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/buildsystem/configure-no-rrd.sh
+#
+# Regression guard for xymon-monitoring/xymon#84: './configure --server'
+# must exit non-zero when the RRDtool probe fails. Before #84 the
+# script would silently set ENABLERRD=n and proceed, producing a
+# server build that would then fail at runtime when something tried
+# to write an RRD.
+#
+# Approach: copy the files configure --server actually touches
+# (configure, configure.server, build/) into a throwaway temp dir,
+# replace build/rrd.sh with a stub that forces RRDOK=NO, run
+# ./configure --server with stdin closed, and assert rc != 0. The
+# copied tree means we never mutate the user's source tree even if
+# the test is killed mid-run.
+#
+# Deliberately copy-based, not git-worktree-based: tests must work
+# from an extracted release tarball or inside a Debian autopkgtest
+# chroot, where .git is absent. See tests/README.md.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+[ -f "$ROOT/configure" ]        || skip "configure missing (CMake-only tree?)"
+[ -f "$ROOT/configure.server" ] || skip "configure.server missing"
+[ -d "$ROOT/build" ]            || skip "build/ missing"
+
+TMP=$(mktempdir)
+SRC="$TMP/src"
+mkdir -p "$SRC"
+
+# Copy just what configure --server reads: the two configure scripts
+# and the build/ directory (build/{rrd,pcre,c-ares,ssl,ldap,...}.sh
+# probe scripts and the small Makefile.test-* helpers they invoke).
+# Skip everything else -- we don't want to drag in the whole source
+# tree or any build artefacts.
+cp -p "$ROOT/configure" "$ROOT/configure.server" "$SRC/"
+cp -rp "$ROOT/build" "$SRC/build"
+
+# configure.client is referenced by configure (dispatcher) for the
+# --help path; copy it if present, but don't require it.
+[ -f "$ROOT/configure.client" ] && cp -p "$ROOT/configure.client" "$SRC/"
+
+cat > "$SRC/build/rrd.sh" <<'EOF'
+# Stub for tests/buildsystem/configure-no-rrd.sh -- force RRDOK=NO so
+# we can assert that configure.server exits cleanly on a failed probe.
+echo "Checking for RRDtool ... (mocked: forcing RRDOK=NO)"
+RRDOK="NO"
+EOF
+
+cd "$SRC"
+
+# configure.server sources build/fping.sh before build/rrd.sh. On hosts
+# where fping is present-but-unusable (or USEXYMONPING=n with a failing
+# FPING), fping.sh enters an interactive prompt loop; with stdin closed
+# that loop spins forever, so the RRD assertion below is never reached.
+# Force the non-interactive xymonping path so this test is pinned to
+# the RRD probe regardless of host fping state.
+export USEXYMONPING=y
+
+LOG="$TMP/configure.log"
+set +e
+./configure --server </dev/null >"$LOG" 2>&1
+rc=$?
+set -e
+
+dump_log() {
+	echo "--- configure log ---" >&2
+	cat "$LOG" >&2
+	echo "--- end log ---" >&2
+}
+
+if [ "$rc" -eq 0 ]; then
+	dump_log
+	fail "configure --server exited 0 with RRDOK=NO; expected non-zero (regression of #84)"
+fi
+
+# A non-zero exit alone is not sufficient: on a clean runner the rest
+# of configure --server has plenty of unrelated ways to fail later
+# (missing xymon user, missing libs, ...), so rc != 0 could be
+# satisfied even if pre-#84 silent-continue behavior were reintroduced.
+# Pin the failure to the RRD abort code path in configure.server.
+if ! grep -q "RRDtool probe failed" "$LOG"; then
+	# configure.server checks a few prerequisites *before* it reaches the
+	# RRD stub: GNU make (it bails with "GNU make is required ...") and a
+	# usable PCRE (build/pcre.sh exits with "Missing PCRE include- or
+	# library-files ..."). If one of those is absent on this host the run
+	# aborts early and never exercises the RRD path -- that's a missing
+	# precondition, not a #84 regression, so skip rather than false-fail.
+	# (Matches the tarball/autopkgtest portability goal: declare the host
+	# dependency and skip when it's not met.)
+	if grep -q "GNU make is required" "$LOG"; then
+		skip "GNU make unavailable -- configure aborts before the RRD probe"
+	fi
+	if grep -q "Missing PCRE include- or library-files" "$LOG"; then
+		skip "usable PCRE unavailable -- configure aborts before the RRD probe"
+	fi
+	dump_log
+	fail "configure --server exited $rc but not via the RRD abort path (regression of #84)"
+fi

--- a/tests/buildsystem/docs-templating.sh
+++ b/tests/buildsystem/docs-templating.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/buildsystem/docs-templating.sh
+#
+# Behavioural guard for the doc templating added by
+# xymon-monitoring/xymon#90: install.html and xymon-apacheconf.txt are now
+# generated from *.DIST templates by docs/Makefile, substituting @VAR@
+# placeholders (install dirs, CGI dirs, ...) via sed.
+#
+# We copy the Makefile and the two .DIST templates into a temp dir and run the
+# real recipes with known values, then assert the outputs carry the substituted
+# values and -- the point of the fix -- carry no leftover @PLACEHOLDER@. Working
+# in a copy keeps the repo tree clean. Skips if make or the templates are absent.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+DOCS="$ROOT/docs"
+MAKE="${MAKE:-make}"
+
+command -v "$MAKE" >/dev/null 2>&1 || skip "no make"
+for f in Makefile install.html.DIST xymon-apacheconf.txt.DIST; do
+	[ -f "$DOCS/$f" ] || skip "docs/$f absent -- predates #90"
+done
+
+work=$(mktempdir)
+cp "$DOCS/Makefile" "$DOCS/install.html.DIST" \
+   "$DOCS/xymon-apacheconf.txt.DIST" "$work/"
+
+"$MAKE" -C "$work" install.html xymon-apacheconf.txt \
+	INSTALLETCDIR=/etc/xymon XYMONTOPDIR=/opt/xymon XYMONUSER=xymonuser \
+	INSTALLWWWDIR=/var/www/xymon CGIDIR=/cgi SECURECGIDIR=/secure-cgi \
+	>"$work/make.log" 2>&1 \
+	|| fail "docs templating recipe failed:
+$(cat "$work/make.log")"
+
+for out in install.html xymon-apacheconf.txt; do
+	assert_file_exists "$work/$out" "docs templating did not generate $out (#90)"
+	# the substituted values landed
+	# (no leftover @PLACEHOLDER@ tokens -- that was the symptom #90 fixed)
+	leftover=$(grep -oE '@[A-Z_]+@' "$work/$out" || true)
+	[ -z "$leftover" ] || fail "$out still has unsubstituted placeholders (#90): $leftover"
+done
+
+assert_contains "/opt/xymon" "$(cat "$work/install.html")" \
+	"install.html did not substitute XYMONTOPDIR (#90)"
+assert_contains "/var/www/xymon" "$(cat "$work/xymon-apacheconf.txt")" \
+	"xymon-apacheconf.txt did not substitute INSTALLWWWDIR (#90)"
+
+pass "docs templating substitutes @VARs@ with no leftover placeholders"

--- a/tests/buildsystem/parallel-make.sh
+++ b/tests/buildsystem/parallel-make.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/buildsystem/parallel-make.sh
+#
+# Regression guard for the legacy-Makefile parallel-build race fixed
+# by xymon-monitoring/xymon#76 (refs #3) and #92 (refs #91). Both PRs
+# added missing prerequisites in build/Makefile.rules and lib/Makefile
+# so that 'make -jN' does not race when fetching headers from lib/ or
+# when rebuilding the build/ helpers.
+#
+# This is a *static* check by design: actually exercising 'make -jN'
+# is already done by .github/workflows/build.yml (which uses -jN per
+# #76), and a separate behavioural run would cost minutes per CI cycle
+# while telling us nothing the build workflow doesn't already cover.
+# What we check here is that the dependency *declarations* survive
+# future Makefile edits; without them, parallel builds regress
+# silently and intermittently.
+#
+# When the in-progress CMake migration replaces these Makefiles, this
+# test skips cleanly via the [-f $RULES] / [-f $LIB] guards below and
+# can be retired alongside the legacy build system.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+RULES="$ROOT/build/Makefile.rules"
+LIB="$ROOT/lib/Makefile"
+
+[ -f "$RULES" ] || skip "build/Makefile.rules absent (CMake-only tree?)"
+[ -f "$LIB" ]   || skip "lib/Makefile absent"
+
+rules=$(cat "$RULES")
+lib=$(cat "$LIB")
+
+# --- #76 (refs #3) -----------------------------------------------------------
+
+# build-build must depend on either lib-build or lib-client, not stand
+# alone. Without this, the build/ helpers start compiling before lib/
+# has produced the headers they include.
+assert_match 'build-build:[[:space:]]+include/config\.h[[:space:]]+lib-(build|client)' \
+             "$rules" \
+             "build-build must depend on lib-build or lib-client (#3/#76)"
+
+# lib-client (the non-CLIENTONLY arm) must depend on lib-build so the
+# client variant doesn't compile against half-built shared headers.
+assert_contains "lib-client: include/config.h lib-build" \
+                "$rules" \
+                "lib-client must depend on lib-build in the non-CLIENTONLY arm (#3/#76)"
+
+# sha1.o, rmd160c.o and the standalone md5/sha1/rmd160 binaries each
+# shell out to ./test-endianness during their build line. They need
+# test-endianness as an explicit prereq so -jN can't try to compile
+# them before it exists. Match by exact target line so we don't confuse
+# the object-file rule (sha1.o:) with the standalone binary rule (sha1:).
+for line in \
+	"sha1.o: sha1.c test-endianness" \
+	"rmd160c.o: rmd160c.c test-endianness" \
+	"md5: md5.c test-endianness" \
+	"sha1: sha1.c test-endianness" \
+	"rmd160: rmd160c.c test-endianness"; do
+	assert_contains "$line" "$lib" \
+	                "lib/Makefile must contain '$line' (#3/#76)"
+done
+
+# --- #92 (refs #91) ----------------------------------------------------------
+
+# common-client (the non-CLIENTONLY arm) must depend on common-build
+# so the client variant doesn't race with the server variant on the
+# shared common/ output dir.
+assert_contains "common-client: lib-client common-build" \
+                "$rules" \
+                "common-client must depend on common-build in the non-CLIENTONLY arm (#91/#92)"

--- a/tests/buildsystem/rrd-api-compat.sh
+++ b/tests/buildsystem/rrd-api-compat.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/buildsystem/rrd-api-compat.sh
+#
+# Regression guard for lib/rrd_api_compat.h (PR #80).
+#
+# RRDtool changed the argv parameter of its public API from "char **" to
+# "const char **". lib/rrd_api_compat.h hides that behind xymon_rrd_argv_item_t
+# and the xymon_rrd_* wrappers, selected by RRD_CONST_ARGS (probed by
+# build/rrd.sh).
+#
+# We compile a small probe that includes the header and calls every wrapper,
+# against a mocked <rrd.h> in BOTH the legacy ("char **") and the modern
+# ("const char **") forms -- with the matching RRD_CONST_ARGS value. No real
+# librrd is needed, so it runs anywhere with a C compiler. Skips cleanly when
+# the compiler or the header is absent (e.g. a branch predating PR #80).
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+HEADER="$ROOT/lib/rrd_api_compat.h"
+CC="${CC:-cc}"
+
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler (CC=$CC)"
+[ -f "$HEADER" ] || skip "lib/rrd_api_compat.h absent (predates PR #80)"
+
+WORK=$(mktempdir)
+
+write_mock_rrd_h() {            # $1 = legacy | const
+	local argv="char **"
+	[ "$1" = "const" ] && argv="const char **"
+	cat >"$WORK/rrd.h" <<EOF
+#ifndef RRD_H
+#define RRD_H
+#include <time.h>
+typedef double rrd_value_t;
+int rrd_update(int, $argv);
+int rrd_create(int, $argv);
+int rrd_fetch(int, $argv, time_t *, time_t *, unsigned long *,
+              unsigned long *, char ***, rrd_value_t **);
+int rrd_graph(int, $argv, char ***, int *, int *, void *, double *, double *);
+#endif
+EOF
+}
+
+cat >"$WORK/probe.c" <<'EOF'
+#include "rrd_api_compat.h"
+
+int main(void)
+{
+	xymon_rrd_argv_item_t argv[2] = { "x", 0 };
+	char **calcpr = 0, **dsnames = 0;
+	rrd_value_t *data = 0;
+	int xsize = 0, ysize = 0;
+	double ymin = 0, ymax = 0;
+	time_t start = 0, end = 0;
+	unsigned long step = 0, dscount = 0;
+
+	(void)xymon_rrd_update(1, argv);
+	(void)xymon_rrd_create(1, argv);
+	(void)xymon_rrd_fetch(1, argv, &start, &end, &step, &dscount,
+			      &dsnames, &data);
+	(void)xymon_rrd_graph(1, argv, &calcpr, &xsize, &ysize, 0,
+			      &ymin, &ymax);
+	return 0;
+}
+EOF
+
+check() {                      # $1 = legacy|const   $2 = RRD_CONST_ARGS value
+	write_mock_rrd_h "$1"
+	printf '  %-7s API (RRD_CONST_ARGS=%s) ... ' "$1" "$2"
+	if ! "$CC" -std=c99 -Wall -Wextra -Werror "-DRRD_CONST_ARGS=$2" \
+		-I"$WORK" -I"$ROOT/lib" \
+		-c "$WORK/probe.c" -o "$WORK/probe.o" 2>"$WORK/err"; then
+		echo "FAILED"
+		fail "rrd_api_compat.h does not compile for the $1 argv API:
+$(cat "$WORK/err")"
+	fi
+	echo "ok"
+}
+
+echo "Checking lib/rrd_api_compat.h against both RRDtool argv APIs:"
+check legacy 0
+check const  1
+pass "rrd_api_compat.h compiles cleanly for both argv API forms"

--- a/tests/client/dpkg-report.sh
+++ b/tests/client/dpkg-report.sh
@@ -29,7 +29,13 @@ ROOT=$(find_root)
 # tests/README.md.
 SCRIPT="${XYMONCLIENT_LINUX:-$ROOT/client/xymonclient-linux.sh}"
 
-[ -f "$SCRIPT" ] || skip "$SCRIPT absent"
+# Same fail-on-explicit-override contract as require_bin (lib/assert.sh):
+# $XYMONCLIENT_LINUX set means the caller asserts the installed script exists
+# there, so a dangling path is a broken package layout and must not skip green.
+if [ ! -f "$SCRIPT" ]; then
+	[ -z "${XYMONCLIENT_LINUX:-}" ] || fail "XYMONCLIENT_LINUX explicitly set to '$SCRIPT' but no such file -- broken package layout, not a skip"
+	skip "$SCRIPT absent"
+fi
 command -v awk >/dev/null 2>&1 || skip "no awk"
 
 # The client script ships in the same tree as this test, so a missing dpkg

--- a/tests/client/dpkg-report.sh
+++ b/tests/client/dpkg-report.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/dpkg-report.sh
+#
+# Behavioural guard for the reformatted dpkg output added to
+# xymonclient-linux.sh by xymon-monitoring/xymon#48: the client sends a compact
+# three-column `dpkg -l` listing (status, name, version) under a `[dpkg]` tag,
+# instead of the full wide table.
+#
+# We run the script's actual reformat pipeline with a `dpkg` stub on PATH that
+# emits a canned `dpkg -l` table, and assert the output keeps status/name/
+# version and drops the architecture/description columns and the header. Like
+# fs-filter.sh, this extracts the pipeline from the script, so a restructuring
+# that breaks that line stops catching the logic -- a conscious trade. Skips
+# only when the environment is absent (no client script, or no awk); if a
+# present client script has lost the dpkg reformat pipeline, that is a
+# regression and the test fails rather than skipping green.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SCRIPT="$ROOT/client/xymonclient-linux.sh"
+
+[ -f "$SCRIPT" ] || skip "client/xymonclient-linux.sh absent"
+command -v awk >/dev/null 2>&1 || skip "no awk"
+
+# The client script ships in the same tree as this test, so a missing dpkg
+# reformat pipeline means the #48 behaviour was removed -- a regression, not a
+# pre-feature tree -- and must fail. (A genuinely absent environment -- no awk,
+# or no client script at all -- already skipped above.)
+pipeline=$(grep -E 'dpkg -l[[:space:]]*\|[[:space:]]*awk' "$SCRIPT" | head -1 || true)
+[ -n "$pipeline" ] || fail "xymonclient-linux.sh lost the dpkg reformat pipeline (#48)"
+
+# The reformatted listing is only useful under the [dpkg] section tag the
+# server parses. Extracting the pipeline alone never checks the tag, so a
+# rename (or a dropped header) would slip through as a false green. Assert the
+# [dpkg] tag is emitted and that it precedes the pipeline that fills it.
+# `|| true`: a no-match grep exits 1, which under `set -e -o pipefail` would
+# abort the script before the explicit fail() below could report the reason.
+tag_line=$( (grep -n '^[[:space:]]*echo "\[dpkg\]"' "$SCRIPT" || true) | head -1 | cut -d: -f1)
+pipe_line=$( (grep -nE 'dpkg -l[[:space:]]*\|[[:space:]]*awk' "$SCRIPT" || true) | head -1 | cut -d: -f1)
+[ -n "$tag_line" ] || fail "xymonclient-linux.sh no longer emits the [dpkg] section tag (#48)"
+[ "$tag_line" -lt "$pipe_line" ] \
+	|| fail "the [dpkg] section tag must precede the dpkg reformat pipeline (#48)"
+
+# Behavioural extraction below runs the pipeline in isolation, so the real
+# script's enclosing guard is never executed -- flipping it to `if false` would
+# emit no [dpkg] report yet leave this test green. Statically assert the guard
+# still gates the block on dpkg actually being present, so a falsified condition
+# (a constant, or a removed `command -v dpkg`) fails here.
+grep -Eq 'if[[:space:]]+command -v dpkg[[:space:]]' "$SCRIPT" \
+	|| fail "xymonclient-linux.sh no longer gates the [dpkg] report on dpkg presence (#48)"
+
+work=$(mktempdir)
+mkdir "$work/bin"
+cat >"$work/bin/dpkg" <<'EOF'
+#!/bin/sh
+[ "$1" = "-l" ] || exit 0
+cat <<'TBL'
+Desired=Unknown/Install/Remove/Purge/Hold
+| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+||/ Name           Version      Architecture Description
++++-==============-============-============-=================================
+ii  bash           5.1-6        amd64        GNU Bourne Again SHell
+ii  coreutils      8.32-4       amd64        GNU core utilities
+rc  oldpkg         1.0          amd64        removed, config remains
+TBL
+EOF
+chmod +x "$work/bin/dpkg"
+
+out=$(PATH="$work/bin:$PATH" bash -c "$pipeline")
+
+# reformatted three-column rows kept
+assert_contains "ii bash 5.1-6" "$out" "dpkg report lost the compact status/name/version row (#48)"
+assert_contains "ii coreutils 8.32-4" "$out" "dpkg report dropped an installed package (#48)"
+# non-installed rows (rc = removed, config remains) must survive too: keeping
+# the status column is the whole point of #48, so a pipeline that narrowed to
+# `ii` only -- dropping rc/hold/half-installed states -- is a regression.
+assert_contains "rc oldpkg 1.0" "$out" "dpkg report dropped the non-installed (rc) row -- the status column is the point of #48"
+# the wide-table noise dropped
+assert_not_contains "GNU Bourne Again SHell" "$out" "dpkg report still carries the description column (#48)"
+assert_not_contains "Architecture" "$out" "dpkg report still carries the table header (#48)"
+
+pass "xymonclient-linux.sh emits the compact #48 dpkg report (status/name/version only)"

--- a/tests/client/dpkg-report.sh
+++ b/tests/client/dpkg-report.sh
@@ -22,9 +22,14 @@ set -euo pipefail
 . "$(dirname "$0")/../lib/assert.sh"
 
 ROOT=$(find_root)
-SCRIPT="$ROOT/client/xymonclient-linux.sh"
+# Default: the in-tree script. $XYMONCLIENT_LINUX (autopkgtest) points at the
+# INSTALLED script -- /usr/lib/xymon/client/bin/xymonclient-linux.sh on Debian
+# -- so the test exercises what the package actually ships, distro patches
+# included. Same-version artifacts only; see "Path discovery" in
+# tests/README.md.
+SCRIPT="${XYMONCLIENT_LINUX:-$ROOT/client/xymonclient-linux.sh}"
 
-[ -f "$SCRIPT" ] || skip "client/xymonclient-linux.sh absent"
+[ -f "$SCRIPT" ] || skip "$SCRIPT absent"
 command -v awk >/dev/null 2>&1 || skip "no awk"
 
 # The client script ships in the same tree as this test, so a missing dpkg

--- a/tests/client/fs-filter.sh
+++ b/tests/client/fs-filter.sh
@@ -37,12 +37,18 @@ ROOT=$(find_root)
 # tests/README.md.
 SCRIPT="${XYMONCLIENT_LINUX:-$ROOT/client/xymonclient-linux.sh}"
 
+# Same fail-on-explicit-override contract as require_bin (lib/assert.sh):
+# $XYMONCLIENT_LINUX set means the caller asserts the installed script exists
+# there, so a dangling path is a broken package layout and must not skip green.
+if [ ! -f "$SCRIPT" ]; then
+	[ -z "${XYMONCLIENT_LINUX:-}" ] || fail "XYMONCLIENT_LINUX explicitly set to '$SCRIPT' but no such file -- broken package layout, not a skip"
+	skip "$SCRIPT missing"
+fi
 # The #49 env-var FS filter is a separate feature (PR #96) that is not yet
 # merged into this branch, so its absence here is "feature not landed", not a
 # regression of in-tree code -- this guard skips green until #49 arrives, then
 # starts exercising the env-var logic, including the [inode] block guarded
 # alongside the [df] block below.
-[ -f "$SCRIPT" ] || skip "$SCRIPT missing"
 grep -q XYMONCLIENT_FS_INCLUDE_TYPES "$SCRIPT" \
 	|| skip "xymonclient-linux.sh has no #49 env-var FS filter yet (PR #96 not in this branch)"
 

--- a/tests/client/fs-filter.sh
+++ b/tests/client/fs-filter.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-filter.sh
+#
+# Regression guard for xymon-monitoring/xymon#96 (refs #49):
+# xymonclient-linux.sh respects four environment variables that tune
+# which filesystems appear in the df/inode blocks of the client report:
+#
+#   XYMONCLIENT_FS_INCLUDE_TYPES   types to un-exclude (e.g. tmpfs)
+#   XYMONCLIENT_FS_EXCLUDE_TYPES   additional types to exclude
+#   XYMONCLIENT_FS_DF_LOCAL_ONLY   yes (default, df -l) vs no
+#   XYMONCLIENT_FS_DF_TIMEOUT      seconds (default 30) or "" to disable
+#
+# The script reads /proc/filesystems directly and shells out to df.
+# To test in isolation we extract the [df] section from the script,
+# rewrite the /proc/filesystems path to point at a fixture, and run it
+# with a df stub that records the command-line it was invoked with.
+#
+# The extraction (sed pattern below) is the brittle bit -- if anyone
+# restructures xymonclient-linux.sh in a way that breaks the
+# `echo "[df]"` ... `echo "[inode]"` block boundary, this test will
+# stop catching the actual filter logic. That trade is conscious:
+# wrapping every shell-out in the full script would need stubs for
+# uptime, who, vmstat, top, free, ifconfig, iostat, ps and several
+# others, which is more surface than the test buys back.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SCRIPT="$ROOT/client/xymonclient-linux.sh"
+
+# The #49 env-var FS filter is a separate feature (PR #96) that is not yet
+# merged into this branch, so its absence here is "feature not landed", not a
+# regression of in-tree code -- this guard skips green until #49 arrives, then
+# starts exercising the env-var logic, including the [inode] block guarded
+# alongside the [df] block below.
+[ -f "$SCRIPT" ] || skip "client/xymonclient-linux.sh missing"
+grep -q XYMONCLIENT_FS_INCLUDE_TYPES "$SCRIPT" \
+	|| skip "xymonclient-linux.sh has no #49 env-var FS filter yet (PR #96 not in this branch)"
+
+TMP=$(mktempdir)
+
+# --- fixtures ----------------------------------------------------------------
+
+# Representative /proc/filesystems: pseudo-FS that should default-exclude
+# (sysfs, tmpfs, proc, overlay, nfs, nfs4), one that must never be excluded
+# (rootfs), and two real disk FS that must not appear in the nodev list.
+cat > "$TMP/proc.filesystems" <<'EOF'
+nodev	sysfs
+nodev	tmpfs
+nodev	proc
+	ext4
+	xfs
+nodev	overlay
+nodev	nfs
+nodev	nfs4
+nodev	rootfs
+EOF
+
+# Extract just the [df] block from xymonclient-linux.sh and rewrite the
+# /proc/filesystems reference. Drop the trailing `echo "[inode]"` line with
+# `sed '$d'` (portable last-line delete; `head -n -1` is a GNU extension and
+# OpenBSD head(1) rejects a negative count) so we exit cleanly after one df
+# invocation per run.
+SNIPPET="$TMP/df-section.sh"
+sed -n '/^echo "\[df\]"/,/^echo "\[inode\]"/p' "$SCRIPT" \
+	| sed '$d' \
+	| sed "s!/proc/filesystems!$TMP/proc.filesystems!g" \
+	> "$SNIPPET"
+
+# Combined [df]+[inode] block (stops before [mount], drops that trailing echo).
+# The [inode] block reuses the EXCLUDES/ROOTFS computed at the top of the [df]
+# block, so the two must be extracted together to run the inode invocation in
+# isolation -- a lone [inode] snippet would see an empty EXCLUDES.
+COMBINED="$TMP/df-inode-section.sh"
+sed -n '/^echo "\[df\]"/,/^echo "\[mount\]"/p' "$SCRIPT" \
+	| sed '$d' \
+	| sed "s!/proc/filesystems!$TMP/proc.filesystems!g" \
+	> "$COMBINED"
+
+# --- stubs -------------------------------------------------------------------
+
+STUB="$TMP/bin"
+mkdir -p "$STUB"
+
+# df stub: append its full argv to a log file, emit a minimal valid table
+# so the downstream `sed` in the script has something to chew on. The [df] and
+# [inode] blocks both shell out to df; route the inode invocation (`df -Pil` /
+# `df -i`) to its own log so each block's flags can be asserted independently.
+DF_LOG="$TMP/df.args"
+INODE_LOG="$TMP/inode.args"
+cat > "$STUB/df" <<EOF
+#!/usr/bin/env bash
+if [[ " \$* " =~ -P[a-zA-Z]*i ]] || [[ " \$* " =~ " -i " ]]; then
+	echo "\$*" >> "$INODE_LOG"
+else
+	echo "\$*" >> "$DF_LOG"
+fi
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf '/dev/sda1 1000000 500000 500000 50%% /\n'
+EOF
+chmod +x "$STUB/df"
+
+# readlink stub: the script does `readlink -m /dev/root` early in the
+# block. Print a sentinel so the sed substitution in the script succeeds.
+cat > "$STUB/readlink" <<'EOF'
+#!/usr/bin/env bash
+echo "/dev/sda1"
+EOF
+chmod +x "$STUB/readlink"
+
+# timeout stub: #49 wraps df in `timeout <n>s df ...` (default 30s) so df
+# can't hang forever on a stale NFS/CIFS mount. timeout exec's df with the
+# same argv, so the df stub above cannot tell whether it was wrapped --
+# record here the duration timeout was handed, then exec the wrapped command
+# so every df assertion above still holds with the wrapper active.
+TIMEOUT_LOG="$TMP/timeout.args"
+cat > "$STUB/timeout" <<EOF
+#!/usr/bin/env bash
+echo "\$1" >> "$TIMEOUT_LOG"
+shift
+exec "\$@"
+EOF
+chmod +x "$STUB/timeout"
+
+export PATH="$STUB:$PATH"
+
+# --- runner ------------------------------------------------------------------
+
+# run_snippet: invoke the extracted block in a fresh subshell, return the
+# command-line df was called with. The default timeout wrapper is left in
+# place (the timeout stub records it and exec's df), so the exclude/include
+# assertions and the dedicated timeout assertions share one code path.
+# Per-case env vars are passed via an inline prefix on the caller's
+# `args=$(VAR=val run_snippet)`; see the leak warning below.
+run_snippet() {
+	: > "$DF_LOG"
+	: > "$INODE_LOG"
+	: > "$TIMEOUT_LOG"
+	/bin/sh "$SNIPPET" >/dev/null 2>&1
+	# Pad with spaces so substring assertions for " -x tmpfs " work even
+	# at the ends of the line.
+	printf ' %s ' "$(cat "$DF_LOG")"
+}
+
+# run_inode: run the combined [df]+[inode] block and return the argv the
+# *inode* df invocation was called with (the df stub routes it to INODE_LOG).
+# Per-case env vars are passed via an inline prefix, same as run_snippet.
+run_inode() {
+	: > "$DF_LOG"
+	: > "$INODE_LOG"
+	: > "$TIMEOUT_LOG"
+	/bin/sh "$COMBINED" >/dev/null 2>&1
+	printf ' %s ' "$(cat "$INODE_LOG")"
+}
+
+# Callers pass per-case env vars via the inline prefix on the
+# `args=$(VAR=val run_snippet)` invocation. Do NOT also set them on
+# the outer `args=$(...)` -- e.g. `VAR=val args=$(VAR=val run_snippet)`
+# is a *single* simple command with no command word, which makes both
+# assignments target the calling shell. The outer one then leaks VAR
+# into every subsequent case. Use a single inline prefix on the
+# command-substitution side only.
+
+# --- default behaviour: -P -l, every nodev (except rootfs) excluded ---------
+
+args=$(run_snippet)
+
+assert_contains " -P "        "$args" "default must pass -P to df"
+assert_contains " -l "        "$args" "default must pass -l to df (local only)"
+assert_contains " -x iso9660 " "$args" "default must exclude iso9660"
+assert_contains " -x sysfs "  "$args" "default must exclude sysfs (nodev)"
+assert_contains " -x tmpfs "  "$args" "default must exclude tmpfs (nodev)"
+assert_contains " -x overlay " "$args" "default must exclude overlay (nodev)"
+assert_contains " -x nfs "    "$args" "default must exclude nfs (nodev)"
+assert_not_contains " -x rootfs " "$args" "default must NOT exclude rootfs (special case)"
+assert_not_contains " -x ext4 " "$args" "default must NOT exclude ext4 (non-nodev)"
+
+# --- XYMONCLIENT_FS_INCLUDE_TYPES un-excludes one type ----------------------
+
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=tmpfs run_snippet)
+assert_not_contains " -x tmpfs " "$args" \
+	"XYMONCLIENT_FS_INCLUDE_TYPES=tmpfs must drop tmpfs from -x list"
+assert_contains " -x sysfs " "$args" \
+	"XYMONCLIENT_FS_INCLUDE_TYPES=tmpfs must not affect other excludes"
+
+# Multiple include types in one call.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES="tmpfs overlay" run_snippet)
+assert_not_contains " -x tmpfs "   "$args" "multi-include must drop tmpfs"
+assert_not_contains " -x overlay " "$args" "multi-include must drop overlay"
+assert_contains     " -x sysfs "   "$args" "multi-include must leave sysfs"
+
+# --- XYMONCLIENT_FS_EXCLUDE_TYPES adds extra exclusions ---------------------
+
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES=ext4 run_snippet)
+assert_contains " -x ext4 "  "$args" "XYMONCLIENT_FS_EXCLUDE_TYPES=ext4 must add ext4"
+assert_contains " -x sysfs " "$args" "extra exclude must not displace defaults"
+
+# Extra exclude that's already in the default list must not be duplicated.
+# `grep -o | wc -l` counts occurrences across one line (grep -c would cap at
+# 1 per line, hiding a duplicate); BSD/macOS wc pads its output with leading
+# spaces, so normalize through arithmetic before comparing.
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES=tmpfs run_snippet)
+tmpfs_count=$(printf '%s' "$args" | grep -o -- '-x tmpfs' | wc -l)
+tmpfs_count=$((tmpfs_count))
+assert_equal 1 "$tmpfs_count" \
+	"XYMONCLIENT_FS_EXCLUDE_TYPES=tmpfs must not duplicate an existing exclude"
+
+# --- XYMONCLIENT_FS_DF_LOCAL_ONLY=no drops the -l flag ----------------------
+
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=no run_snippet)
+assert_contains     " -P " "$args" "DF_LOCAL_ONLY=no must still pass -P"
+assert_not_contains " -l " "$args" "DF_LOCAL_ONLY=no must drop -l"
+
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=yes run_snippet)
+assert_contains " -l " "$args" "DF_LOCAL_ONLY=yes must still pass -l"
+
+# --- XYMONCLIENT_FS_DF_TIMEOUT wraps df in `timeout <n>s` --------------------
+#
+# df can hang on stale NFS/CIFS mounts, so #49 runs it under timeout(1).
+# TIMEOUT_LOG holds the duration the timeout stub was handed (empty if df
+# was invoked directly). Assertions read the log after each run rather than
+# the returned df args, since the wrapper is invisible at the df layer.
+
+# Default (variable unset): df is wrapped in `timeout 30s`.
+run_snippet >/dev/null
+assert_equal "30s" "$(cat "$TIMEOUT_LOG")" \
+	"default must wrap df in 'timeout 30s'"
+
+# A custom value is honoured verbatim.
+XYMONCLIENT_FS_DF_TIMEOUT=5 run_snippet >/dev/null
+assert_equal "5s" "$(cat "$TIMEOUT_LOG")" \
+	"XYMONCLIENT_FS_DF_TIMEOUT=5 must wrap df in 'timeout 5s'"
+
+# Empty string disables the wrapper: df is invoked directly, timeout untouched.
+XYMONCLIENT_FS_DF_TIMEOUT="" run_snippet >/dev/null
+assert_equal "" "$(cat "$TIMEOUT_LOG")" \
+	'XYMONCLIENT_FS_DF_TIMEOUT="" must invoke df without a timeout wrapper'
+
+# --- [inode] report must be filtered the same way as [df] -------------------
+#
+# The [inode] block runs `df -Pil -x iso9660 -x $EXCLUDES`, reusing the exact
+# exclude set the [df] block built. Extracting [df] alone (the SNIPPET above)
+# never exercises this second df invocation, so a regression that leaves the
+# inode report unfiltered would go unnoticed. run_inode runs both blocks and
+# returns the *inode* invocation's argv; assert the same nodev/rootfs/real-FS
+# rules hold there.
+
+iargs=$(run_inode)
+assert_contains     " -x sysfs "  "$iargs" "inode report must exclude sysfs (nodev), same as df"
+assert_contains     " -x tmpfs "  "$iargs" "inode report must exclude tmpfs (nodev), same as df"
+assert_contains     " -x overlay " "$iargs" "inode report must exclude overlay (nodev), same as df"
+assert_not_contains " -x ext4 "   "$iargs" "inode report must NOT exclude ext4 (non-nodev)"
+assert_not_contains " -x rootfs " "$iargs" "inode report must NOT exclude rootfs (special case)"
+
+# The include/exclude env vars must reach the inode block too, not just [df].
+iargs=$(XYMONCLIENT_FS_INCLUDE_TYPES=tmpfs run_inode)
+assert_not_contains " -x tmpfs " "$iargs" \
+	"XYMONCLIENT_FS_INCLUDE_TYPES=tmpfs must also drop tmpfs from the inode report"
+iargs=$(XYMONCLIENT_FS_EXCLUDE_TYPES=ext4 run_inode)
+assert_contains " -x ext4 " "$iargs" \
+	"XYMONCLIENT_FS_EXCLUDE_TYPES=ext4 must also add ext4 to the inode report"
+
+# --- /proc/filesystems missing: warn, no excludes (script must not crash) ---
+
+# Repoint the snippet at a non-existent path; the [-r ...] guard should
+# kick in, the warning go to stderr, and df be invoked without any nodev
+# -x flags (iso9660 is always passed).
+MISSING_SNIPPET="$TMP/df-section-missing.sh"
+sed "s!$TMP/proc.filesystems!$TMP/does-not-exist!g" "$SNIPPET" > "$MISSING_SNIPPET"
+
+: > "$DF_LOG"
+XYMONCLIENT_FS_DF_TIMEOUT="" /bin/sh "$MISSING_SNIPPET" >/dev/null 2>"$TMP/stderr"
+args=$(printf ' %s ' "$(cat "$DF_LOG")")
+
+# NB: our sed rewrite of /proc/filesystems also rewrites the warning text,
+# so we assert on the surviving "not readable, filesystem filter disabled"
+# tail rather than the path.
+assert_contains "not readable, filesystem filter disabled" "$(cat "$TMP/stderr")" \
+	"unreadable filesystem-list must produce a warning on stderr"
+assert_contains "xymonclient-linux:" "$(cat "$TMP/stderr")" \
+	"warning must be tagged so it's identifiable in client logs"
+assert_contains     " -x iso9660 " "$args" "iso9660 must still be excluded"
+assert_not_contains " -x sysfs "   "$args" "no nodev excludes when /proc/filesystems unreadable"

--- a/tests/client/fs-filter.sh
+++ b/tests/client/fs-filter.sh
@@ -30,14 +30,19 @@ set -euo pipefail
 . "$(dirname "$0")/../lib/assert.sh"
 
 ROOT=$(find_root)
-SCRIPT="$ROOT/client/xymonclient-linux.sh"
+# Default: the in-tree script. $XYMONCLIENT_LINUX (autopkgtest) points at the
+# INSTALLED script -- /usr/lib/xymon/client/bin/xymonclient-linux.sh on Debian
+# -- so the test exercises what the package actually ships, distro patches
+# included. Same-version artifacts only; see "Path discovery" in
+# tests/README.md.
+SCRIPT="${XYMONCLIENT_LINUX:-$ROOT/client/xymonclient-linux.sh}"
 
 # The #49 env-var FS filter is a separate feature (PR #96) that is not yet
 # merged into this branch, so its absence here is "feature not landed", not a
 # regression of in-tree code -- this guard skips green until #49 arrives, then
 # starts exercising the env-var logic, including the [inode] block guarded
 # alongside the [df] block below.
-[ -f "$SCRIPT" ] || skip "client/xymonclient-linux.sh missing"
+[ -f "$SCRIPT" ] || skip "$SCRIPT missing"
 grep -q XYMONCLIENT_FS_INCLUDE_TYPES "$SCRIPT" \
 	|| skip "xymonclient-linux.sh has no #49 env-var FS filter yet (PR #96 not in this branch)"
 

--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -153,17 +153,16 @@ find_root() {
 # don't fail when the binary just wasn't built in this configuration.
 #
 # Usage:
-#     require_bin XYMONPING ./xymonnet/xymonping
-#     "$XYMONPING" --help
+#     require_bin XYMONGREP common/xymongrep
+#     "$XYMONGREP" --hosts=...
 #
-# SCAFFOLDING -- no current test calls this. Every test today reads committed
-# source (or compiles its own probe), so none needs a built binary. It is kept
-# deliberately as the entry point for the first behavioural test that drives a
-# compiled tool: such a test reads its binary via require_bin, which is also
-# what makes the post-build run in .github/workflows/build.yml meaningful (see
-# the note there). Until that test lands, build.yml's suite run is redundant
-# with tests.yml. Remove this helper and that build.yml step together if the
-# binary-test direction is abandoned.
+# First consumer: tests/server/xymongrep-filter.sh. This helper is what lets
+# the same test run against an in-tree build (the DEFAULT path, resolved from
+# the repo root), a CMake out-of-source build, or an installed package under
+# Debian autopkgtest (both export an absolute $VAR). It is also what makes the
+# post-build suite run in .github/workflows/build.yml meaningful (see the note
+# there): under tests.yml nothing is built, so require_bin tests skip; after a
+# build they execute against the produced binary.
 require_bin() {
 	local var=$1 default=$2
 	local cur=${!var:-}

--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -149,8 +149,13 @@ find_root() {
 # ---- binary discovery --------------------------------------------------------
 
 # require_bin VAR DEFAULT -- ensure $VAR (or DEFAULT if unset) points to an
-# executable; export VAR with the resolved path. Skip if absent so tests
-# don't fail when the binary just wasn't built in this configuration.
+# executable; export VAR with the resolved path. Skip if the in-tree DEFAULT
+# is absent (the binary just wasn't built in this configuration), but FAIL if
+# an explicit $VAR override points at nothing: the override is the caller
+# asserting the binary exists there (CMake passes the build product's path,
+# autopkgtest the installed one), so a dangling path means a broken build or
+# package layout -- exactly what those callers run this suite to catch -- and
+# must not skip green.
 #
 # Usage:
 #     require_bin XYMONGREP common/xymongrep
@@ -166,6 +171,7 @@ find_root() {
 require_bin() {
 	local var=$1 default=$2
 	local cur=${!var:-}
+	local explicit=$cur
 	# No override: resolve the in-tree default against the repo root, not cwd.
 	# A relative default like ./xymonnet/xymonping is only valid from the repo
 	# top; a standalone test launched from elsewhere would otherwise probe the
@@ -178,6 +184,9 @@ require_bin() {
 		esac
 	fi
 	if [ ! -x "$cur" ]; then
+		if [ -n "$explicit" ]; then
+			fail "$var explicitly set to '$cur' but no executable is there -- broken build or package layout, not a skip"
+		fi
 		skip "$var ($cur) not built or not executable"
 	fi
 	# shellcheck disable=SC2163

--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# shellcheck shell=bash
+#
+# tests/lib/assert.sh -- minimal helpers for tests/ scenarios.
+#
+# Source from a test:
+#     . "$(dirname "$0")/../lib/assert.sh"
+#
+# Contract documented in tests/README.md. The intent here is to give
+# tests just enough vocabulary to read clearly, without growing into a
+# framework. Resist adding features until a concrete test needs one.
+
+# Guard against double-sourcing.
+[ -n "${__XYMON_TESTS_ASSERT_SOURCED:-}" ] && return 0
+__XYMON_TESTS_ASSERT_SOURCED=1
+
+# ---- result reporting --------------------------------------------------------
+
+# fail MSG -- print on stderr and exit non-zero (CI treats as failure).
+fail() {
+	printf 'FAIL: %s\n' "$*" >&2
+	exit 1
+}
+
+# skip REASON -- print on stderr and exit 77 (CI treats as skipped, not failed;
+# matches the autotools / autopkgtest convention). Use when a precondition for
+# the test is genuinely absent, not to paper over a real failure.
+skip() {
+	printf 'SKIP: %s\n' "$*" >&2
+	exit 77
+}
+
+# pass [MSG] -- cosmetic; tests that reach the end without failing already
+# pass. Useful only when a test wants to emit a one-line success summary.
+pass() {
+	printf 'PASS: %s\n' "${*:-ok}"
+	exit 0
+}
+
+# ---- assertions --------------------------------------------------------------
+
+# assert_equal WANT GOT [MSG]
+assert_equal() {
+	local want=$1 got=$2 msg=${3:-}
+	if [ "$want" != "$got" ]; then
+		fail "${msg:+$msg: }expected '$want', got '$got'"
+	fi
+}
+
+# assert_contains NEEDLE HAYSTACK [MSG]
+assert_contains() {
+	local needle=$1 haystack=$2 msg=${3:-}
+	case "$haystack" in
+		*"$needle"*) ;;
+		*) fail "${msg:+$msg: }'$haystack' does not contain '$needle'" ;;
+	esac
+}
+
+# assert_not_contains NEEDLE HAYSTACK [MSG]
+assert_not_contains() {
+	local needle=$1 haystack=$2 msg=${3:-}
+	case "$haystack" in
+		*"$needle"*) fail "${msg:+$msg: }'$haystack' unexpectedly contains '$needle'" ;;
+	esac
+}
+
+# assert_match REGEX STRING [MSG] -- bash =~ regex
+assert_match() {
+	local re=$1 s=$2 msg=${3:-}
+	if ! [[ $s =~ $re ]]; then
+		fail "${msg:+$msg: }'$s' does not match /$re/"
+	fi
+}
+
+# assert_file_exists PATH [MSG]
+assert_file_exists() {
+	local p=$1 msg=${2:-}
+	[ -e "$p" ] || fail "${msg:+$msg: }file does not exist: $p"
+}
+
+# ---- fixtures / cleanup ------------------------------------------------------
+
+# register_cleanup CMD... -- append a cleanup command that runs on EXIT.
+# Stackable: each call adds to the chain. Use for temp dirs, killed
+# processes, restored files. Tests that need cleanup should call this
+# rather than installing their own trap, so multiple registrations
+# compose.
+#
+# CONTRACT: the arguments are joined and stored as a single string that is
+# later eval'd (see __xymon_tests_run_cleanups). This is deliberate -- it
+# lets a registered command defer glob/expansion to teardown time (the
+# mktempdir cleanup below relies on it). The flip side is that any dynamic
+# path passed in must be shell-escaped by the caller; a bare
+#     register_cleanup rm -rf "$dir"
+# word-splits at eval if $dir holds whitespace or metacharacters. Escape it:
+#     register_cleanup "rm -rf -- $(printf '%q' "$dir")"
+__XYMON_TESTS_CLEANUP_CMDS=()
+__xymon_tests_run_cleanups() {
+	local rc=$? i
+	# Run in reverse registration order so teardown mirrors setup.
+	for (( i=${#__XYMON_TESTS_CLEANUP_CMDS[@]}-1; i>=0; i-- )); do
+		eval "${__XYMON_TESTS_CLEANUP_CMDS[i]}" || true
+	done
+	exit "$rc"
+}
+trap __xymon_tests_run_cleanups EXIT
+register_cleanup() {
+	__XYMON_TESTS_CLEANUP_CMDS+=("$*")
+}
+
+# mktempdir -- create a temp dir and arrange its removal on EXIT. Prints the
+# path. Callers almost always use TMP=$(mktempdir), and command substitution
+# runs in a subshell: anything mktempdir appended to the cleanup array there
+# would die with the subshell, leaking the dir (this is exactly what used to
+# happen -- /tmp filled with xymon-test.* dirs). So rather than register a
+# per-dir cleanup from inside the subshell, every dir is stamped with this
+# process's PID and a single glob removal is registered once, below, in the
+# parent shell at source time. `$$` is the script's PID even inside $(...),
+# so the stamp is stable across the subshell boundary.
+__XYMON_TESTS_TMPROOT=${TMPDIR:-/tmp}
+__XYMON_TESTS_TMPROOT=${__XYMON_TESTS_TMPROOT%/}
+# register_cleanup stores a string that is later eval'd, so a TMPDIR whose
+# path carries whitespace or shell metacharacters would word-split or
+# mis-parse at teardown -- the rm would target the wrong paths and leak the
+# real dir (or worse). Shell-escape the fixed prefix with printf %q and
+# append the literal glob unquoted, so the path survives eval intact while
+# the trailing * still expands.
+__xymon_tests_tmpglob=$(printf '%q' "${__XYMON_TESTS_TMPROOT}/xymon-test.$$.")
+register_cleanup "rm -rf -- ${__xymon_tests_tmpglob}*"
+mktempdir() {
+	local d
+	d=$(mktemp -d "${__XYMON_TESTS_TMPROOT}/xymon-test.$$.XXXXXX") || fail "mktemp -d failed"
+	printf '%s' "$d"
+}
+
+# ---- repo location -----------------------------------------------------------
+
+# find_root -- print the absolute path of the repo root, derived from the
+# calling test's own location (tests/<area>/<name>.sh -> repo root is two
+# dirs up). Independent of cwd, so the test produces the same result
+# whether invoked from the repo top, a sibling worktree, or anywhere
+# else. Prefer this over `git rev-parse --show-toplevel`, which honours
+# cwd and silently picks the wrong tree when a test is launched from
+# outside its own worktree.
+find_root() {
+	cd "$(dirname "${BASH_SOURCE[1]}")/../.." && pwd
+}
+
+# ---- binary discovery --------------------------------------------------------
+
+# require_bin VAR DEFAULT -- ensure $VAR (or DEFAULT if unset) points to an
+# executable; export VAR with the resolved path. Skip if absent so tests
+# don't fail when the binary just wasn't built in this configuration.
+#
+# Usage:
+#     require_bin XYMONPING ./xymonnet/xymonping
+#     "$XYMONPING" --help
+#
+# SCAFFOLDING -- no current test calls this. Every test today reads committed
+# source (or compiles its own probe), so none needs a built binary. It is kept
+# deliberately as the entry point for the first behavioural test that drives a
+# compiled tool: such a test reads its binary via require_bin, which is also
+# what makes the post-build run in .github/workflows/build.yml meaningful (see
+# the note there). Until that test lands, build.yml's suite run is redundant
+# with tests.yml. Remove this helper and that build.yml step together if the
+# binary-test direction is abandoned.
+require_bin() {
+	local var=$1 default=$2
+	local cur=${!var:-}
+	# No override: resolve the in-tree default against the repo root, not cwd.
+	# A relative default like ./xymonnet/xymonping is only valid from the repo
+	# top; a standalone test launched from elsewhere would otherwise probe the
+	# wrong path and skip with 77 even when the binary exists. An explicit env
+	# override (absolute path from CMake/autopkgtest) is used verbatim.
+	if [ -z "$cur" ]; then
+		case $default in
+			/*) cur=$default ;;
+			*)  cur=$(find_root)/$default ;;
+		esac
+	fi
+	if [ ! -x "$cur" ]; then
+		skip "$var ($cur) not built or not executable"
+	fi
+	# shellcheck disable=SC2163
+	export "$var"="$cur"
+}

--- a/tests/network/alpn-support.sh
+++ b/tests/network/alpn-support.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/network/alpn-support.sh
+#
+# Guard for the xymonnet ALPN support added by xymon-monitoring/xymon#37.
+#
+# #37 lets a protocols.cfg service negotiate an ALPN protocol during the TLS
+# handshake (e.g. `options ssl,alpn=imap`). The plumbing spans three layers:
+#   - lib/netservices.h : the TCP_ALPN flag + the `alpns` field,
+#   - lib/netservices.c : parsing the `alpn=` option into that field,
+#   - xymonnet/contest.c: handing the parsed list to OpenSSL via
+#     SSL_CTX_set_alpn_protos() during SSL setup.
+#
+# Exercising it for real needs xymonnet built plus a TLS server advertising
+# ALPN; the build CI already compiles these files, so this is a static guard
+# that the wiring across the three layers (and the manpage) survives future
+# edits -- e.g. the netservices/contest rework or the CMake migration. Skips
+# only when the source files are absent (e.g. an autopkgtest run against an
+# installed package with no source tree); if a present tree has lost the ALPN
+# wiring, that is a regression and the test fails rather than skipping green.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+HDR="$ROOT/lib/netservices.h"
+SRC="$ROOT/lib/netservices.c"
+SSL="$ROOT/xymonnet/contest.c"
+MAN="$ROOT/xymonnet/protocols.cfg.5"
+
+for f in "$HDR" "$SRC" "$SSL" "$MAN"; do
+	[ -f "$f" ] || skip "$(basename "$f") absent"
+done
+
+hdr=$(cat "$HDR")
+src=$(cat "$SRC")
+
+# These source files ship in the same tree as this test, so missing ALPN
+# wiring means someone removed it -- a regression (e.g. a partial removal
+# during the netservices/contest rework), not a pre-feature tree -- and must
+# fail, never skip green. The only legitimate skip is an absent *environment*
+# (the source files themselves not present, handled above), not absent
+# project code. Assert every layer unconditionally.
+
+# header: the flag and the field that carries the negotiated protocol list
+assert_contains "TCP_ALPN" "$hdr" "netservices.h lost the TCP_ALPN flag (#37)"
+assert_contains "char *alpns" "$hdr" "netservices.h lost the svcinfo alpns field (#37)"
+
+# parser: the alpn= option is read INTO the alpns field. A bare grep for
+# "alpns" is a false green -- the field declaration and the later copy-out to
+# svcinfo both mention it, so the parser store can be deleted while the word
+# survives. Pin the assertion to the assignment of the parsed value into the
+# alpns field, which is the line that actually wires parsing up.
+assert_contains '"alpn=", 5' "$src" "netservices.c no longer parses the alpn= option (#37)"
+# The stored value must be opt+5, not opt: "alpn=" is 5 chars, so dropping the
+# +5 stores the literal "alpn=imap" instead of "imap" -- a real parser bug.
+# Pin the offset so the strdup(opt+5) -> strdup(opt) mutation fails here; a
+# bare strdup(opt...) match would accept the broken form as a false green.
+grep -Eq 'alpns[[:space:]]*=[[:space:]]*strdup\(opt[[:space:]]*\+[[:space:]]*5[[:space:]]*\)' "$SRC" \
+	|| fail "netservices.c no longer stores the parsed alpn= value (opt+5) into the alpns field (#37)"
+
+# SSL setup: the parsed list must actually FLOW to OpenSSL, not merely have the
+# call present. A bare grep for SSL_CTX_set_alpn_protos is a false green -- the
+# call survives even if the source assignments are nulled (alpn_protocols left
+# NULL) or the call is fed a literal NULL, both of which silently disable ALPN
+# while the symbol stays. Pin both ends of the data flow: the parsed alpns is
+# read into the protocol list, and the packed buffer (not NULL) feeds the call.
+grep -Eq 'alpn_protocols[[:space:]]*=[[:space:]]*item->(svcinfo|ssloptions)->alpns' "$SSL" \
+	|| fail "contest.c no longer reads the parsed alpns into the ALPN protocol list (#37)"
+grep -Eq 'SSL_CTX_set_alpn_protos\(item->sslctx, *alpn_buffer,' "$SSL" \
+	|| fail "contest.c no longer hands the packed ALPN buffer to OpenSSL (#37)"
+
+# manpage documents the option. The page ships in this tree and its absence
+# already skipped the whole test above, so assert unconditionally -- a present
+# tree that lost the docs is a regression, not a legitimate skip.
+assert_contains "alpn=" "$(cat "$MAN")" \
+	"protocols.cfg.5 no longer documents the alpn= option (#37)"
+
+pass "xymonnet keeps the #37 ALPN wiring (flag, parser, SSL setup, manpage)"

--- a/tests/network/tls13-support.sh
+++ b/tests/network/tls13-support.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/network/tls13-support.sh
+#
+# Guard for the "TLSv1.3-only" xymonnet test option added by
+# xymon-monitoring/xymon#33 (the `httpsd://` scheme / SSLVERSION_TLS13).
+#
+# The wiring spans:
+#   - xymonnet/contest.h : the SSLVERSION_TLS13 selector,
+#   - xymonnet/contest.c : pinning the SSL context to TLS 1.3
+#                          (SSL_CTX_set_{min,max}_proto_version + TLS1_3_VERSION),
+#   - xymonnet/httptest.c: mapping the `httpsd://` scheme to it.
+#
+# Sibling of alpn-support.sh: a behavioural run needs a TLS 1.3 server, the
+# build CI already compiles these files, so this is a static guard that the
+# wiring survives future edits. Skips only when the source files are absent
+# (e.g. an autopkgtest run with no source tree); if a present tree has lost the
+# TLS 1.3 wiring, that is a regression and the test fails rather than skips.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+HDR="$ROOT/xymonnet/contest.h"
+SSL="$ROOT/xymonnet/contest.c"
+HTTP="$ROOT/xymonnet/httptest.c"
+
+for f in "$HDR" "$SSL" "$HTTP"; do
+	[ -f "$f" ] || skip "$(basename "$f") absent"
+done
+
+hdr=$(cat "$HDR")
+
+# These source files ship in the same tree as this test, so missing TLS 1.3
+# wiring means someone removed it -- a regression, not a pre-feature tree --
+# and must fail, never skip green. The only legitimate skip is an absent
+# *environment* (the source files themselves not present, handled above), not
+# absent project code. Assert every layer unconditionally.
+
+assert_contains "SSLVERSION_TLS13" "$hdr" \
+	"contest.h lost the SSLVERSION_TLS13 selector (#33)"
+
+# The proto-version pinning is only effective if it is REACHED from the
+# SSLVERSION_TLS13 case: deleting the case label strands the set_*_proto_version
+# lines as dead code, and an inserted `break` right after the label makes them
+# unreachable -- both leave the lines in the file, so whole-file greps stay a
+# false green. Extract just the case body (from the label up to and including
+# its first `break;`) and assert the pins live INSIDE it. A missing label gives
+# an empty body; a break-after-label gives a body with no pins; either fails.
+tls13_case=$(awk '/case SSLVERSION_TLS13:/{c=1} c{print} c&&/break;/{exit}' "$SSL")
+[ -n "$tls13_case" ] || fail \
+	"contest.c no longer has the SSLVERSION_TLS13 switch case -- TLS 1.3 setup unreachable (#33)"
+
+# Within that case body, "TLS 1.3-only" needs BOTH the minimum and the maximum
+# pinned to TLS1_3_VERSION: a minimum alone still lets OpenSSL negotiate a
+# higher version, defeating the intent. Pin to TLS1_3_VERSION specifically so
+# the 1.2/1.1/1.0 cases' calls cannot satisfy this, and scope to the case body
+# so removing or unreaching either line must fail here.
+grep -q 'set_min_proto_version(.*TLS1_3_VERSION)' <<<"$tls13_case" \
+	|| fail "contest.c no longer pins the SSL minimum to TLS 1.3 inside the TLS13 case (#33)"
+grep -q 'set_max_proto_version(.*TLS1_3_VERSION)' <<<"$tls13_case" \
+	|| fail "contest.c no longer caps the SSL maximum at TLS 1.3 inside the TLS13 case (#33)"
+
+# The scheme mapping is the line that actually binds the httpsd:// scheme to
+# TLS 1.3: httptest.c selects the version from the scheme option char, "d" ->
+# SSLVERSION_TLS13. A bare grep for the token is a false green -- the selector
+# survives any mutation of the option char ("d" -> "x") or of the assignment
+# target, leaving the scheme unmapped while the word stays. Pin the assertion
+# to the option char AND the version on the same mapping line.
+grep -Eq 'strstr\(.*schemeopts, *"d"\).*SSLVERSION_TLS13' "$HTTP" \
+	|| fail "httptest.c no longer maps the httpsd:// scheme char (\"d\") to TLS 1.3 (#33)"
+
+pass "xymonnet keeps the #33 TLSv1.3 wiring (selector, proto-version pin, scheme)"

--- a/tests/server/digest-md5hash.sh
+++ b/tests/server/digest-md5hash.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/digest-md5hash.sh
+#
+# Guard for the md5hash() buffer-size fix in lib/digest.c
+# (xymon-monitoring/xymon#8).
+#
+# The hex-formatting loop computed snprintf's size argument as
+#   sizeof(md_string) - (md_string - p)
+# but `p` advances past `md_string`, so `md_string - p` is negative and the
+# size argument (a size_t) wrapped to a value LARGER than the buffer --
+# defeating snprintf's bounds protection. The fix flips it to `(p - md_string)`,
+# the true bytes already written, so the remaining size is correct.
+#
+# md5hash() itself pulls in libxymon + the myMD5 backend, so we don't link it;
+# instead we (1) bind to the real file -- the fixed operand order must be there
+# and the buggy one gone -- and (2) compile+run a faithful copy of the loop:
+# it must fill exactly 32 hex chars without touching a trailing canary, and the
+# buggy size expression must be shown to exceed the buffer. Skips if the file is
+# absent; the compile+run step skips if no C compiler.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SRC="$ROOT/lib/digest.c"
+CC="${CC:-cc}"
+
+[ -f "$SRC" ] || skip "lib/digest.c absent"
+src=$(cat "$SRC")
+
+# (1) bind to the real code: fixed operand order present, buggy one gone.
+assert_contains "sizeof(md_string) - (p - md_string)" "$src" \
+	"digest.c md5hash() lost the corrected snprintf size operand order (#8)"
+assert_not_contains "sizeof(md_string) - (md_string - p)" "$src" \
+	"digest.c md5hash() regressed to the negative-offset size argument (#8)"
+
+# (2) behavioural demo of the property, if we can compile.
+if ! command -v "$CC" >/dev/null 2>&1; then
+	pass "digest.c keeps the #8 fix (static check; no C compiler for the run)"
+fi
+
+WORK=$(mktempdir)
+cat >"$WORK/t.c" <<'EOF'
+#include <stdio.h>
+#include <string.h>
+int main(void)
+{
+	unsigned char md_value[16];
+	struct { char md_string[2*16+1]; char canary; } s;
+	int i; char *p;
+	s.canary = '#';
+	for (i = 0; i < 16; i++) md_value[i] = (unsigned char)((i << 4) | i);
+
+	/* the real (fixed) loop from md5hash() */
+	for (i = 0, p = s.md_string; (i < (int)sizeof(md_value)); i++)
+		p += snprintf(p, (sizeof(s.md_string) - (p - s.md_string)), "%02x", md_value[i]);
+	*p = '\0';
+
+	if (strlen(s.md_string) != 32) { fprintf(stderr, "len=%zu\n", strlen(s.md_string)); return 1; }
+	if (s.canary != '#')          { fprintf(stderr, "canary clobbered\n");             return 1; }
+
+	/* prove the buggy operand order yields an out-of-bounds size argument */
+	{
+		char *q = s.md_string + 10;            /* mid-loop */
+		size_t fixed = sizeof(s.md_string) - (q - s.md_string);
+		size_t buggy = sizeof(s.md_string) - (s.md_string - q);
+		if (!(fixed <= sizeof(s.md_string) && buggy > sizeof(s.md_string))) {
+			fprintf(stderr, "fixed=%zu buggy=%zu\n", fixed, buggy);
+			return 1;
+		}
+	}
+	return 0;
+}
+EOF
+
+if ! "$CC" -std=c99 -Wall -Wextra -Werror -o "$WORK/t" "$WORK/t.c" 2>"$WORK/err"; then
+	fail "md5hash format probe did not compile:
+$(cat "$WORK/err")"
+fi
+"$WORK/t" || fail "md5hash format probe failed: the loop overran or the size property broke (#8)"
+
+pass "digest.c keeps the #8 fix (32 hex chars, canary intact, size argument bounded)"

--- a/tests/server/xymongrep-filter.sh
+++ b/tests/server/xymongrep-filter.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymongrep-filter.sh
+#
+# Behavioural test of the BUILT xymongrep binary: hosts.cfg tag selection.
+#
+# This is the suite's first test that drives a compiled tool -- the
+# require_bin consumer that tests/lib/assert.sh and the post-build suite run
+# in .github/workflows/build.yml were staged for. It runs in three
+# environments:
+#   - build.yml (server leg): common/xymongrep was just built; the in-tree
+#     default below finds it;
+#   - tests.yml (no build): require_bin skips with 77;
+#   - Debian autopkgtest: the control file exports
+#     XYMONGREP=/usr/lib/xymon/client/bin/xymongrep (or the server-package
+#     path) and the test exercises the INSTALLED binary. Unlike the
+#     source-reading tests in this suite, running the shipped binary is what
+#     gives library-transition CI (libpcre2, OpenSSL, ...) something that can
+#     actually break at runtime.
+#
+# What it asserts is xymongrep's documented selection contract
+# (common/xymongrep.1, stable since the bbhostgrep days) -- easy to break in
+# a hosts.cfg-parser or tag-walk rework, and exercised through the real
+# load_hostnames()/xmh_item() path in libxymon:
+#   - a bare test name matches a tag exactly (case-insensitive), so `http`
+#     does NOT select `http://...` URL tags;
+#   - a trailing `*` prefix-matches, so `http*` is how URL tags are selected;
+#   - only the matched tags are echoed back, not the host's full tag list;
+#   - a matched dialup host gets the `dialup` flag appended, dropped by
+#     --noextras (the behaviour PR #94's --no-dialup will key on; that PR
+#     extends this file once merged).
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+# Server builds produce common/xymongrep; client-only builds ship the same
+# tool as client/xymongrep. Probe the server path first, fall back to the
+# client one; an explicit $XYMONGREP (CMake out-of-source, autopkgtest) is
+# used verbatim by require_bin.
+default="common/xymongrep"
+if [ -z "${XYMONGREP:-}" ] && [ ! -x "$(find_root)/$default" ] \
+		&& [ -x "$(find_root)/client/xymongrep" ]; then
+	default="client/xymongrep"
+fi
+require_bin XYMONGREP "$default"
+
+work=$(mktempdir)
+cat >"$work/hosts.cfg" <<'EOF'
+1.2.3.4		www.example.com		# http://www.example.com conn
+5.6.7.8		db.example.com		# conn pop3
+9.9.9.9		dial.example.com	# dialup http://dial.example.com
+0.0.0.0		notags.example.com	#
+EOF
+
+# --hosts= keeps the test hermetic: it bypasses both the $HOSTSCFG fallback
+# and the try-xymond-first path of load_hostnames(), so no server is needed.
+
+# Exact tag match: `conn` selects the two hosts tagged conn and echoes only
+# the matched tag.
+out=$("$XYMONGREP" --hosts="$work/hosts.cfg" conn)
+assert_contains "www.example.com # conn" "$out" "exact match must select www.example.com"
+assert_contains "db.example.com # conn" "$out" "exact match must select db.example.com"
+assert_not_contains "pop3" "$out" \
+	"only the matched tag is echoed, not the host's full tag list"
+assert_not_contains "dial.example.com" "$out" "hosts without the tag must not appear"
+assert_not_contains "notags.example.com" "$out" "hosts with no tags must not appear"
+
+# Exact means exact: a bare `http` must not prefix-match URL tags.
+out=$("$XYMONGREP" --hosts="$work/hosts.cfg" http)
+[ -z "$out" ] || fail "bare 'http' must not match http:// URL tags (got: $out)"
+
+# Trailing-* prefix match is how URL tags are selected; the matched dialup
+# host carries the appended `dialup` flag (extras are on by default).
+out=$("$XYMONGREP" --hosts="$work/hosts.cfg" 'http*')
+assert_contains "www.example.com # http://www.example.com" "$out" \
+	"http* must select the URL tag"
+assert_contains "dial.example.com # http://dial.example.com dialup" "$out" \
+	"matched dialup host must carry the appended dialup flag"
+assert_not_contains "db.example.com" "$out" \
+	"http* must not select hosts without an http tag"
+
+# --noextras drops the appended flags, leaving only the matched tags.
+out=$("$XYMONGREP" --noextras --hosts="$work/hosts.cfg" 'http*')
+assert_not_contains "dialup" "$out" "--noextras must drop the dialup flag"
+
+pass "xymongrep tag selection contract holds (exact, prefix-*, echoed tags, dialup flag)"

--- a/tests/testsuite
+++ b/tests/testsuite
@@ -1,0 +1,111 @@
+#!/bin/sh
+#
+# Run every executable regression test under tests/. Exit 0 if at least one
+# test passed and none failed; 1 if any failed; 77 if every test skipped
+# (suite verified nothing -- see the all-skip note near the end). Individual
+# tests follow the tests/README.md contract: exit 0 = pass, 77 = skip,
+# anything else = fail.
+#
+# Output adapts automatically: GitHub Actions log annotations when run under
+# Actions ($GITHUB_ACTIONS=true), plain human-readable output otherwise. Both
+# the CI workflow and a developer run the same code path.
+#
+# Usage: ./tests/testsuite        (from anywhere; resolves the repo root itself)
+#        make test
+#
+set -u
+
+# Resolve the repo root from this script's own location, so it works from any cwd.
+root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd) || exit 2
+cd "$root" || exit 2
+
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then gh=1; else gh=0; fi
+
+# Every test is bash by contract (tests/README.md); this runner stays POSIX sh
+# so it can deliver the skip below even where bash is absent. Without this
+# check, each test's exec would fail with rc=127 and count as FAIL -- but a
+# missing interpreter is a missing host dependency, not a regression, so skip
+# the whole suite the same way an individual test skips a missing tool.
+if ! command -v bash >/dev/null 2>&1; then
+	printf 'SKIP: bash not found -- every test requires bash (see tests/README.md)\n' >&2
+	exit 77
+fi
+
+group() {
+	if [ "$gh" = 1 ]; then printf '::group::%s\n' "$1"; else printf '\n----- %s -----\n' "$1"; fi
+}
+endgroup() {
+	if [ "$gh" = 1 ]; then printf '::endgroup::\n'; fi
+}
+errline() {
+	if [ "$gh" = 1 ]; then printf '::error::%s\n' "$1"; else printf 'FAIL: %s\n' "$1"; fi
+}
+
+# Discover executable *.sh under tests/. Sourced helpers (tests/lib/) and shared
+# data (tests/fixtures/) are not +x, so they are not picked up -- see README.
+# This runner has no .sh extension, so it never discovers itself.
+#
+# The explicit lib/ and fixtures/ excludes back up the exec-bit rule on
+# checkouts where every file reads as executable (FAT/NTFS mounts, trees with
+# core.fileMode=false): there, a shebang-less helper like lib/assert.sh would
+# otherwise be discovered, run as sh, define its functions, exit 0 -- and count
+# as a pass that verified nothing.
+tests=$(find tests -type f -name '*.sh' -perm -u+x \
+	! -path 'tests/lib/*' ! -path 'tests/fixtures/*' | sort)
+
+# Zero discovered tests is a failure, not a quiet success: the runner ships
+# alongside the tests, so an empty result means something is wrong -- lost
+# executable bits, a packaging omission, or a broken discovery path -- and
+# treating it as green would let CI go green while running nothing.
+if [ -z "$tests" ]; then
+	errline "No executable tests found under tests/ (lost +x bit, packaging omission, or broken discovery)"
+	exit 1
+fi
+
+pass=0; skip=0; fail=0; failed=''
+# Iterate line-by-line rather than `for t in $tests`: unquoted word-splitting
+# breaks on any path containing a space (find emits newline-separated paths, but
+# the default IFS splits on spaces and tabs too). The here-doc keeps the loop in
+# this shell -- not a `| while` subshell -- so the counters below survive it.
+while IFS= read -r t; do
+	[ -n "$t" ] || continue
+	group "$t"
+	"./$t"
+	rc=$?
+	case $rc in
+		0)  printf '  ok\n';           pass=$((pass + 1)) ;;
+		77) printf '  skip (rc=77)\n'; skip=$((skip + 1)) ;;
+		*)  errline "$t FAILED (rc=$rc)"
+		    fail=$((fail + 1))
+		    failed="${failed}  - ${t} (rc=${rc})
+" ;;
+	esac
+	endgroup
+done <<EOF
+$tests
+EOF
+
+printf '\n----- summary -----\n'
+printf 'passed:  %d\n' "$pass"
+printf 'skipped: %d\n' "$skip"
+printf 'failed:  %d\n' "$fail"
+
+if [ "$fail" -gt 0 ]; then
+	printf '\nfailing tests:\n%s' "$failed"
+	exit 1
+fi
+
+# Every discovered test skipped means the suite exercised nothing: in a tree
+# that ships tests/ without the code those tests guard (a packaging omission,
+# or an autopkgtest run against an installed package with no source), each test
+# hits an absent precondition and skips. Reporting exit 0 here is a false green
+# -- CI/autopkgtest would record a pass while nothing was actually verified.
+# Propagate the all-skip upward as a skip (exit 77, the same convention the
+# individual tests use; see skip() in tests/lib/assert.sh) so the layer above
+# sees "skipped", not "passed". The empty-discovery case already exited above,
+# so reaching here with pass=0 and fail=0 means skip>0.
+if [ "$pass" -eq 0 ]; then
+	printf 'SKIP: every test skipped -- suite verified nothing (tests/ shipped without the code under test?)\n' >&2
+	exit 77
+fi
+exit 0

--- a/tests/web/svcstatus-trends-overflow.sh
+++ b/tests/web/svcstatus-trends-overflow.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/svcstatus-trends-overflow.sh
+#
+# Regression guard for the trends-page buffer overflow fixed by
+# xymon-monitoring/xymon#38.
+#
+# generate_trends() appends each graph's <rrdlink> into a growable buffer
+# (allrrdlinks). The bug had two parts in web/svcstatus-trends.c:
+#   1. the size check used '>=' and ignored the NUL terminator, so the buffer
+#      could be left exactly at capacity, and
+#   2. the snprintf() return value was added straight to the write pointer.
+#      Per C99 snprintf returns what WOULD have been written, so on truncation
+#      the pointer advanced past the end of the buffer -- silently dropping all
+#      subsequent graphs (worst on hosts with many filesystems).
+#
+# A behavioural test would need the whole web CGI plus a Xymon/RRD environment
+# to reproduce, and .github build coverage already compiles the file; what we
+# guard here is that the *fix* survives future edits -- the dangerous
+# advance-by-snprintf pattern stays gone and the truncation handling stays
+# present. Skips cleanly if the file is absent (e.g. after a CMake/web rework).
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+FILE="$ROOT/web/svcstatus-trends.c"
+
+[ -f "$FILE" ] || skip "web/svcstatus-trends.c absent"
+src=$(cat "$FILE")
+
+# (1) The vulnerable pattern -- advancing the write pointer by snprintf()'s
+# return value -- must be gone.
+assert_not_contains "allrrdlinksend += snprintf(" "$src" \
+	"trends overflow regressed: write pointer advanced by raw snprintf() return (#38)"
+
+# (2) The size check must account for the NUL terminator (NEEDED+1 vs buflen),
+# not the old '>=' against the bare length.
+assert_contains "onelinklen + 1) > allrrdlinks_buflen" "$src" \
+	"trends buffer size check lost its NUL-terminator headroom (#38)"
+
+# (3) snprintf truncation/error must be detected and the pointer advanced only
+# by bytes actually written.
+assert_contains "(size_t)written >= available" "$src" \
+	"trends snprintf truncation check missing (#38)"
+assert_contains "allrrdlinksend += written;" "$src" \
+	"trends no longer advances by bytes actually written (#38)"
+
+pass "svcstatus-trends.c keeps the #38 buffer-overflow guards"


### PR DESCRIPTION
Restore the exact nine-commit series reviewed in #101 after #164 reverted its accidental squash merge. This branch points unchanged at the original #101 head, `74f79ab09780ca9c3a186b53aa7f0819c7a2ea7c`; it has not been rebased or rewritten.

Establish the project test infrastructure under `tests/`, including the standalone runner, assertion helpers, make and CI integration, source-package inclusion, downstream artifact overrides, and 11 initial regression scenarios.

Merge this PR with the normal **merge commit** strategy so the original commits remain in history.

Refs #97.