### PR TITLE
tests: fix rrd-api-compat probe shadowing macOS <Availability.h>

### DIFF
--- a/tests/buildsystem/rrd-api-compat.sh
+++ b/tests/buildsystem/rrd-api-compat.sh
@@ -72,8 +72,15 @@ EOF
 check() {                      # $1 = legacy|const   $2 = RRD_CONST_ARGS value
 	write_mock_rrd_h "$1"
 	printf '  %-7s API (RRD_CONST_ARGS=%s) ... ' "$1" "$2"
+	# -iquote (not -I) for lib/: the probe reaches rrd_api_compat.h via a
+	# quoted include, so -iquote suffices -- and it keeps lib/ off the angle-
+	# bracket (<...>) search path. With -I, lib/availability.h shadows the
+	# macOS SDK's <Availability.h> on a case-insensitive filesystem (the names
+	# differ only in case), so the SDK's own <time.h>/<stdio.h> pull in the
+	# wrong header and the probe fails to compile with bogus errors. $WORK
+	# stays on -I because rrd_api_compat.h includes the mock <rrd.h>.
 	if ! "$CC" -std=c99 -Wall -Wextra -Werror "-DRRD_CONST_ARGS=$2" \
-		-I"$WORK" -I"$ROOT/lib" \
+		-I"$WORK" -iquote "$ROOT/lib" \
 		-c "$WORK/probe.c" -o "$WORK/probe.o" 2>"$WORK/err"; then
 		echo "FAILED"
 		fail "rrd_api_compat.h does not compile for the $1 argv API:


### PR DESCRIPTION
## What

In `tests/buildsystem/rrd-api-compat.sh`, compile the probe with `-iquote "$ROOT/lib"` instead of `-I"$ROOT/lib"`.

Fixes #168.

## Why

`-I"$ROOT/lib"` is only needed so the probe's **quoted** include `#include "rrd_api_compat.h"` resolves — but `-I` also drops `lib/` onto the **angle-bracket** (`<...>`) search path. xymon's `lib/availability.h` differs from the macOS SDK's `<Availability.h>` only in case, so on a case-insensitive filesystem (the macOS default) the SDK's own `<time.h>` → `<Availability.h>` resolves to xymon's header, and the probe fails to compile:

```
lib/availability.h:46:26: error: unknown type name 'time_t'
.../MacOSX.sdk/usr/include/_time.h:157:16: error: missing ',' between enumerators
```

`-iquote` satisfies the quoted include without polluting the angle-bracket path, so `<Availability.h>` resolves to the SDK again. `$WORK` stays on `-I` because `rrd_api_compat.h` includes the mock `<rrd.h>`.

## Scope / safety

- **Test-harness only.** The real build reaches `availability.h` via quoted relative includes and never adds `lib/` to the angle path, so it was never affected.
- Behavior-neutral on Linux (case-sensitive FS); fixes the failure on macOS regardless of build variant.

## Test

- `shellcheck tests/buildsystem/rrd-api-compat.sh` — clean (only the suite-wide SC1091 source-not-followed info).
- `./tests/buildsystem/rrd-api-compat.sh` on Linux: still `PASS` (both legacy and const argv APIs compile).
