### PR TITLE
client/freebsd: env-var-controlled df/inode filesystem filter (#170)

### DIFF
--- a/client/xymonclient-freebsd.sh
+++ b/client/xymonclient-freebsd.sh
@@ -25,7 +25,10 @@ echo "[df]"
 # Exclude FS types via df "-t no<csv>": a default set, minus INCLUDE_TYPES, plus
 # EXCLUDE_TYPES. Remote (nfs) mounts are hidden by df -l (DF_LOCAL_ONLY=yes), not
 # by type, so DF_LOCAL_ONLY=no can surface them. The inode report also drops zfs
-# (no usable inode counts).
+# and tmpfs, whose inode counts carry no signal: zfs has no inode limit at all,
+# and FreeBSD tmpfs reports a constant itotal of 2^31-1 regardless of memory.
+# tmpfs/mfs are deliberately NOT excluded from the disk report: RAM-backed
+# capacity is real and fills up, matching the Linux client's default.
 : "${XYMONCLIENT_FS_INCLUDE_TYPES=}"
 : "${XYMONCLIENT_FS_EXCLUDE_TYPES=}"
 fs_excl_opt() {
@@ -86,7 +89,9 @@ fi
 echo "[inode]"
 # Same failure guard. Drop filesystems with no inode limit (df prints "-" in the
 # %iused column, field 8): they cannot run out of inodes, so the row is noise.
-if emit_df inode Inode -i zfs; then
+# tmpfs is excluded by type instead: its itotal is the 2^31-1 sentinel (not "-"),
+# identical on a 4GB and a 128GB box, so the row-level guard cannot catch it.
+if emit_df inode Inode -i zfs tmpfs; then
 	printf '%s\n' "$_out" | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /

--- a/client/xymonclient-freebsd.sh
+++ b/client/xymonclient-freebsd.sh
@@ -21,19 +21,79 @@ uptime
 echo "[who]"
 who
 echo "[df]"
-# The sed stuff is to make sure lines are not split into two.
-df -H -tnonfs,nullfs,cd9660,procfs,devfs,linprocfs,fdescfs,autofs | sed -e '/^[^ 	][^ 	]*$/{
+# --- filesystem filter (configurable; see xymonclient.cfg.DIST) --------------
+# Exclude FS types via df "-t no<csv>": a default set, minus INCLUDE_TYPES, plus
+# EXCLUDE_TYPES. Remote (nfs) mounts are hidden by df -l (DF_LOCAL_ONLY=yes), not
+# by type, so DF_LOCAL_ONLY=no can surface them. The inode report also drops zfs
+# (no usable inode counts).
+: "${XYMONCLIENT_FS_INCLUDE_TYPES=}"
+: "${XYMONCLIENT_FS_EXCLUDE_TYPES=}"
+fs_excl_opt() {
+	# $@ = extra per-report excludes (e.g. zfs for inode).
+	# noglob: treat a type like "tmp*" as a literal token, not a filename glob.
+	case $- in *f*) _restoreglob=no ;; *) _restoreglob=yes; set -f ;; esac
+	_l=""
+	# Default + per-report excludes, minus any INCLUDE_TYPES.
+	for _t in nullfs cd9660 procfs devfs linprocfs fdescfs autofs "$@"; do
+		for _i in $XYMONCLIENT_FS_INCLUDE_TYPES; do [ "$_t" = "$_i" ] && continue 2; done
+		case " $_l " in *" $_t "*) ;; *) _l="$_l $_t" ;; esac
+	done
+	# EXCLUDE_TYPES last, so a type in both lists stays excluded (EXCLUDE wins).
+	for _t in $XYMONCLIENT_FS_EXCLUDE_TYPES; do
+		case " $_l " in *" $_t "*) ;; *) _l="$_l $_t" ;; esac
+	done
+	_csv=`echo $_l | tr ' ' ','`
+	[ "$_restoreglob" = yes ] && set +f
+	[ -n "$_csv" ] && printf -- '-tno%s' "$_csv"
+}
+# XYMONCLIENT_FS_DF_LOCAL_ONLY: "yes" (default) adds df -l to hide remote (nfs);
+# "no" surfaces them. Any other value warns and falls back to yes.
+DFLOCALONLY="${XYMONCLIENT_FS_DF_LOCAL_ONLY:-yes}"
+case "$DFLOCALONLY" in
+	yes|no) ;;
+	*) echo "xymonclient-freebsd: invalid XYMONCLIENT_FS_DF_LOCAL_ONLY '$DFLOCALONLY', using yes" >&2; DFLOCALONLY=yes ;;
+esac
+DFLOCAL=""; [ "$DFLOCALONLY" = yes ] && DFLOCAL="-l"
+# run_df FLAG [extra-excludes...]: df rows for one report behind the FS filter
+# and local-only flag. The seam where the remote-df sentinel will hook.
+run_df() {
+	_flag="$1"; shift
+	_excl=`fs_excl_opt "$@"`
+	df "$_flag" $DFLOCAL $_excl
+}
+# emit_df KIND LABEL FLAG [extra-excludes...]: run_df + failure guard. On a
+# non-zero df with no output, print a one-line marker (no df header) so the
+# server goes yellow not green, and return 1 so the caller skips formatting; else
+# leave the rows in $_out and return 0 to format. A non-zero df that still prints
+# mounts flows through unchanged.
+emit_df() {
+	_kind="$1"; _label="$2"; shift 2
+	_out=`run_df "$@"`; _rc=$?
+	if [ -z "$_out" ] && [ "$_rc" -ne 0 ]; then
+		echo "xymonclient-freebsd: df $_kind collection failed (status $_rc) with no output; reporting data as unavailable" >&2
+		echo "$_label report collection failed: df exited $_rc with no output"
+		return 1
+	fi
+	return 0
+}
+# The sed joins lines df split in two.
+if emit_df disk Disk -H; then
+	printf '%s\n' "$_out" | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
 }'
+fi
 echo "[inode]"
-# The sed stuff is to make sure lines are not split into two.
-df -i -tnonfs,nullfs,cd9660,procfs,devfs,linprocfs,fdescfs,autofs,zfs | sed -e '/^[^ 	][^ 	]*$/{
+# Same failure guard. Drop filesystems with no inode limit (df prints "-" in the
+# %iused column, field 8): they cannot run out of inodes, so the row is noise.
+if emit_df inode Inode -i zfs; then
+	printf '%s\n' "$_out" | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
 }' | awk '
-NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9} 
-NR>=2{printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
+NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9}
+(NR>=2 && $8 != "-"){printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
+fi
 echo "[mount]"
 mount
 echo "[meminfo]"

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,7 +21,7 @@ under CI — the workflow and a developer run the exact same runner.
 Once the tree is configured, `make test` runs the same thing. A single
 test also runs standalone — what reviewers do:
 
-    ./tests/client/fs-filter.sh
+    ./tests/client/fs-filter-linux.sh
 
 `bash` is a hard prerequisite of the suite (every test uses it; see
 Conventions). The runner itself is POSIX sh, and on a host without bash it
@@ -73,7 +73,7 @@ maintenance.
 ## Conventions
 
 - **One file per scenario set.** Filename describes the area, not the
-  PR: `tests/client/fs-filter.sh`, `tests/packaging/fhs-paths.sh`.
+  PR: `tests/client/fs-filter-linux.sh`, `tests/packaging/fhs-paths.sh`.
   Split when a file passes ~200 lines.
 - **Executable. Bash. Strict mode.** First line:
   `#!/usr/bin/env bash`. Second line: `set -euo pipefail`.

--- a/tests/client/dpkg-report.sh
+++ b/tests/client/dpkg-report.sh
@@ -11,7 +11,7 @@
 # We run the script's actual reformat pipeline with a `dpkg` stub on PATH that
 # emits a canned `dpkg -l` table, and assert the output keeps status/name/
 # version and drops the architecture/description columns and the header. Like
-# fs-filter.sh, this extracts the pipeline from the script, so a restructuring
+# fs-filter-linux.sh, this extracts the pipeline from the script, so a restructuring
 # that breaks that line stops catching the logic -- a conscious trade. Skips
 # only when the environment is absent (no client script, or no awk); if a
 # present client script has lost the dpkg reformat pipeline, that is a

--- a/tests/client/fs-filter-common.sh
+++ b/tests/client/fs-filter-common.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-filter-common.sh
+#
+# Shared scaffolding for the per-OS df/inode filesystem-filter regression
+# guards (fs-filter.sh for Linux, fs-filter-freebsd.sh for FreeBSD, ...).
+# Each client script implements the same XYMONCLIENT_FS_* contract but shells
+# out to a different df (Linux: -x <type> per type; BSD: -t no<csv>), so the
+# *assertions* are necessarily OS-specific and live in the caller. Everything
+# up to "run the [df] block under a recording df stub and hand me its argv" is
+# identical, and lives here.
+#
+# Source order in a caller:
+#     . "$(dirname "$0")/../lib/assert.sh"
+#     . "$(dirname "$0")/fs-filter-common.sh"
+#     fsf_setup linux XYMONCLIENT_LINUX        # -> SCRIPT, TMP, STUB, *_LOG, PATH
+#     ... write the df stub + decoy files (OS-specific) ...
+#     fsf_extract "$TMP/df-inode-section.sh"   # [df]..[mount] minus trailing echo
+#     args=$(fsf_run "$TMP/df-inode-section.sh" "$DF_LOG")
+#     assert_contains ...                      # OS-specific
+#
+# The df stub and decoy glob files are deliberately NOT generated here: their
+# routing predicate and table layout differ per OS, and threading multi-line
+# heredocs through a function arg is uglier than the few lines it would save.
+
+# fsf_setup OS_LABEL ENV_VAR
+#   OS_LABEL  short uname token, e.g. linux / freebsd (only used in messages)
+#   ENV_VAR   name of the autopkgtest override var, e.g. XYMONCLIENT_LINUX
+#
+# Resolves the client script (in-tree default, ENV_VAR points at the installed
+# copy), applies the same fail-on-dangling-override / skip-if-absent contract
+# as the rest of the suite, asserts the FS filter is still present (its absence
+# is a regression, not a skip), and exports the working dirs/logs every caller
+# needs: TMP, STUB, DF_LOG, INODE_LOG, STDERR_LOG, SCRIPT, and PATH (STUB first).
+fsf_setup() {
+	_os=$1
+	_envvar=$2
+
+	# Indirect-expand ${ENV_VAR:-default}. eval keeps this POSIX (no namerefs).
+	eval "SCRIPT=\"\${$_envvar:-\$(find_root)/client/xymonclient-$_os.sh}\""
+
+	if [ ! -f "$SCRIPT" ]; then
+		# ENV_VAR set means the caller asserts the installed script lives
+		# there; a dangling path is a broken package layout, not a green skip.
+		eval "_override=\"\${$_envvar:-}\""
+		[ -z "$_override" ] || fail "$_envvar set to '$SCRIPT' but no such file -- broken package layout, not a skip"
+		skip "$SCRIPT missing"
+	fi
+	# The filter has landed, so its disappearance must FAIL (regress), not skip.
+	grep -q 'XYMONCLIENT_FS_INCLUDE_TYPES' "$SCRIPT" \
+		|| fail "FS filter missing from $SCRIPT (regressed)"
+
+	TMP=$(mktempdir)
+	STUB="$TMP/bin"
+	mkdir -p "$STUB"
+	DF_LOG="$TMP/df.args"
+	INODE_LOG="$TMP/inode.args"
+	STDERR_LOG="$TMP/stderr"
+	export PATH="$STUB:$PATH"
+}
+
+# fsf_extract OUTFILE [SED_EXPR] [STOP]
+#   Extract the report-generating block -- from `echo "[df]"` up to but not
+#   including the STOP marker -- into OUTFILE so it can run in isolation under
+#   the df stub. STOP defaults to the bracket-escaped `\[mount\]`, which yields
+#   the combined [df]+[inode] block; the [inode] block reuses the EXCLUDES the
+#   [df] block computed, so the two must be extracted together. Pass STOP as
+#   `\[inode\]` to capture the [df] block alone. `sed '$d'` drops the trailing
+#   `echo "$STOP"` line (portable last-line delete; `head -n -1` is GNU-only).
+#   SED_EXPR, if given (may be ""), is an extra `sed -e` applied to the block --
+#   Linux uses it to repoint /proc/filesystems at a fixture.
+fsf_extract() {
+	_out=$1
+	_sed=${2:-}
+	_stop=${3:-'\[mount\]'}
+	if [ -n "$_sed" ]; then
+		sed -n "/^echo \"\[df\]\"/,/^echo \"$_stop\"/p" "$SCRIPT" \
+			| sed '$d' \
+			| sed -e "$_sed" > "$_out"
+	else
+		sed -n "/^echo \"\[df\]\"/,/^echo \"$_stop\"/p" "$SCRIPT" \
+			| sed '$d' > "$_out"
+	fi
+}
+
+# fsf_run SNIPPET LOGFILE [ENV...]
+#   Truncate the arg logs, run SNIPPET in a fresh subshell with $TMP as cwd
+#   (so decoy glob files are in scope), and echo the recorded argv from LOGFILE
+#   with newlines flattened and space-padded, so substring assertions like
+#   `assert_contains " -l " ...` match at the line ends too. Per-case env vars
+#   are passed inline on the command-substitution side by the caller, e.g.
+#       args=$(XYMONCLIENT_FS_INCLUDE_TYPES=tmpfs fsf_run "$snip" "$DF_LOG")
+#   Do NOT also set them on the outer `args=$(...)`; see the leak note in the
+#   Linux test header.
+fsf_run() {
+	_snippet=$1
+	_logfile=$2
+	: > "$DF_LOG"
+	: > "$INODE_LOG"
+	: > "$STDERR_LOG"
+	(
+		cd "$TMP" || exit 1
+		/bin/sh "$_snippet" >/dev/null 2>"$STDERR_LOG"
+	)
+	printf ' %s ' "$(tr '\n' ' ' < "$_logfile")"
+}

--- a/tests/client/fs-filter-freebsd.sh
+++ b/tests/client/fs-filter-freebsd.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-filter-freebsd.sh
+#
+# Regression guard for the df/inode filesystem filter ported to
+# xymonclient-freebsd.sh (issue #170). FreeBSD df excludes by type with
+# "-t no<csv>"; the script builds that list from XYMONCLIENT_FS_{INCLUDE,
+# EXCLUDE}_TYPES, hides remote fs with df -l (XYMONCLIENT_FS_DF_LOCAL_ONLY),
+# and drops no-inode-limit rows ("-") from [inode].
+#
+# Mock-tested on any host: extract the [df]..[mount] block, run it with a df
+# stub that records argv, and assert the constructed options. (Real FreeBSD df
+# output semantics still need verifying on FreeBSD.)
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SCRIPT="${XYMONCLIENT_FREEBSD:-$ROOT/client/xymonclient-freebsd.sh}"
+if [ ! -f "$SCRIPT" ]; then
+	[ -z "${XYMONCLIENT_FREEBSD:-}" ] || fail "XYMONCLIENT_FREEBSD set to '$SCRIPT' but no such file -- broken layout, not a skip"
+	skip "$SCRIPT missing"
+fi
+grep -q 'XYMONCLIENT_FS_INCLUDE_TYPES' "$SCRIPT" || fail "FS filter missing from $SCRIPT (regressed)"
+
+TMP=$(mktempdir)
+STUB="$TMP/bin"; mkdir -p "$STUB"
+DF_LOG="$TMP/df.args"; INODE_LOG="$TMP/inode.args"
+STDERR_LOG="$TMP/stderr"
+
+# df stub: record argv (inode -i calls routed separately) and emit a table. The
+# inode table includes a "tank" row with "-" %iused (a no-inode-limit fs).
+cat > "$STUB/df" <<EOF
+#!/usr/bin/env bash
+# DF_FAIL=1 simulates a df that exits non-zero with no output (e.g. killed).
+[ -n "\${DF_FAIL:-}" ] && exit 1
+if [[ " \$* " =~ " -i " ]]; then
+	echo "\$*" >> "$INODE_LOG"
+	printf 'Filesystem Size Used Avail Capacity iused ifree %%iused Mounted on\n'
+	printf '/dev/ada0p2 100 50 50 50%% 1000 9000 10%% /\n'
+	printf 'tank 200 1 199 1%% 0 0 - /tank\n'
+else
+	echo "\$*" >> "$DF_LOG"
+	printf 'Filesystem Size Used Avail Capacity Mounted on\n'
+	printf '/dev/ada0p2 100G 50G 50G 50%% /\n'
+fi
+EOF
+chmod +x "$STUB/df"
+export PATH="$STUB:$PATH"
+
+# Decoy files in the snippet's working directory ($TMP): if the script let a
+# configured type token glob, "procf*"/"fuse.*" would expand to these filenames.
+: > "$TMP/procfs"
+: > "$TMP/fuse.sshfs"
+
+SNIPPET="$TMP/df-section.sh"
+sed -n '/^echo "\[df\]"/,/^echo "\[mount\]"/p' "$SCRIPT" | sed '$d' > "$SNIPPET"
+
+run() {  # run the block; echo the disk df argv (newlines flattened, padded)
+	: > "$DF_LOG"; : > "$INODE_LOG"; : > "$STDERR_LOG"
+	( cd "$TMP"; /bin/sh "$SNIPPET" >/dev/null 2>"$STDERR_LOG" )
+	printf ' %s ' "$(tr '\n' ' ' < "$DF_LOG")"
+}
+
+# --- default behaviour ------------------------------------------------------
+args=$(run)
+assert_contains " -H " "$args" "disk df keeps -H"
+assert_contains " -l " "$args" "default is local-only (df -l)"
+assert_contains " -tnonullfs,cd9660,procfs,devfs,linprocfs,fdescfs,autofs " "$args" \
+	"default excludes pseudo types via -t no<csv>"
+assert_not_contains "nonfs" "$args" "nfs is hidden by df -l, not by the type list"
+
+inode_args=$(printf ' %s ' "$(tr '\n' ' ' < "$INODE_LOG")")
+assert_contains " -i " "$inode_args" "inode df uses -i"
+assert_contains "zfs" "$inode_args" "inode report excludes zfs by default"
+
+# --- INCLUDE / EXCLUDE_TYPES ------------------------------------------------
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=nullfs run)
+assert_not_contains "nullfs" "$args" "INCLUDE_TYPES=nullfs un-excludes nullfs"
+assert_contains "cd9660" "$args" "INCLUDE_TYPES=nullfs leaves the other excludes"
+
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES=ext2fs run)
+assert_contains "ext2fs" "$args" "EXCLUDE_TYPES=ext2fs adds ext2fs to the list"
+assert_contains "cd9660" "$args" "EXCLUDE_TYPES leaves the defaults"
+
+# Type tokens are literal, not shell globs. With $TMP as the working directory,
+# "procf*" must not expand to the decoy file and accidentally un-exclude procfs.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES='procf*' run)
+assert_contains ",procfs," "$args" \
+	"include type tokens must not undergo pathname expansion"
+
+# Likewise an exclude glob must stay literal, not become the decoy filename.
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES='fuse.*' run)
+assert_contains "fuse.*" "$args" \
+	"exclude type tokens must not undergo pathname expansion"
+assert_not_contains "fuse.sshfs" "$args" \
+	"exclude type glob must not expand to a working-directory filename"
+
+# --- include + exclude precedence: exclude wins -----------------------------
+# A type named in both lists stays excluded: EXCLUDE is applied last (documented
+# contract, "If a type appears in both lists, EXCLUDE wins"). ext2fs is not a
+# default, so its presence is unambiguous.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=ext2fs XYMONCLIENT_FS_EXCLUDE_TYPES=ext2fs run)
+assert_contains "ext2fs" "$args" \
+	"a type in both include and exclude lists must stay excluded (exclude wins)"
+
+# --- DF_LOCAL_ONLY ----------------------------------------------------------
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=no run)
+assert_not_contains " -l " "$args" "DF_LOCAL_ONLY=no drops -l (surfaces remote)"
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=bogus run)
+assert_contains " -l " "$args" "invalid DF_LOCAL_ONLY falls back to local-only"
+assert_contains "invalid XYMONCLIENT_FS_DF_LOCAL_ONLY" "$(cat "$STDERR_LOG")" \
+	"invalid DF_LOCAL_ONLY warns"
+
+# --- inode "-" (no inode limit) rows are dropped ----------------------------
+out=$( cd "$TMP"; /bin/sh "$SNIPPET" 2>/dev/null )
+inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
+assert_not_contains "/tank" "$inode_section" \
+	"inode report drops the no-inode-limit filesystem (%iused '-')"
+
+# --- false-green guard: df fails with no output -> marker, not empty section --
+out=$( cd "$TMP"; DF_FAIL=1 /bin/sh "$SNIPPET" 2>/dev/null )
+assert_contains "Disk report collection failed" "$out" \
+	"a failed disk df emits a failure marker"
+assert_contains "Inode report collection failed" "$out" \
+	"a failed inode df emits a failure marker"
+assert_not_contains "Filesystem" "$out" \
+	"failure marker carries no df header (server reads a header-less section as yellow)"
+
+pass "xymonclient-freebsd.sh FS filter: types, local-only, inode '-' drop, df-failure marker"

--- a/tests/client/fs-filter-freebsd.sh
+++ b/tests/client/fs-filter-freebsd.sh
@@ -7,7 +7,9 @@
 # xymonclient-freebsd.sh (issue #170). FreeBSD df excludes by type with
 # "-t no<csv>"; the script builds that list from XYMONCLIENT_FS_{INCLUDE,
 # EXCLUDE}_TYPES, hides remote fs with df -l (XYMONCLIENT_FS_DF_LOCAL_ONLY),
-# and drops no-inode-limit rows ("-") from [inode].
+# drops no-inode-limit rows ("-") from [inode], and excludes zfs and tmpfs
+# from [inode] by type (zfs has no inode limit; FreeBSD tmpfs reports the
+# 2^31-1 sentinel as itotal, so the "-" row guard cannot catch it).
 #
 # Mock-tested on any host: extract the [df]..[mount] block, run it with a df
 # stub that records argv, and assert the constructed options. (Real FreeBSD df
@@ -67,6 +69,17 @@ assert_not_contains "nonfs" "$args" "nfs is hidden by df -l, not by the type lis
 inode_args=$(printf ' %s ' "$(tr '\n' ' ' < "$INODE_LOG")")
 assert_contains " -i " "$inode_args" "inode df uses -i"
 assert_contains "zfs" "$inode_args" "inode report excludes zfs by default"
+assert_contains "tmpfs" "$inode_args" \
+	"inode report excludes tmpfs (itotal is the 2^31-1 sentinel, not a limit)"
+assert_not_contains "tmpfs" "$args" \
+	"the disk report keeps tmpfs (RAM-backed capacity is real)"
+
+# The per-report excludes go through the INCLUDE filter, so an admin who wants
+# the tmpfs inode rows back has the documented escape hatch.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=tmpfs run)
+inode_args=$(printf ' %s ' "$(tr '\n' ' ' < "$INODE_LOG")")
+assert_not_contains "tmpfs" "$inode_args" \
+	"INCLUDE_TYPES=tmpfs un-excludes tmpfs from the inode report"
 
 # --- INCLUDE / EXCLUDE_TYPES ------------------------------------------------
 args=$(XYMONCLIENT_FS_INCLUDE_TYPES=nullfs run)
@@ -121,4 +134,4 @@ assert_contains "Inode report collection failed" "$out" \
 assert_not_contains "Filesystem" "$out" \
 	"failure marker carries no df header (server reads a header-less section as yellow)"
 
-pass "xymonclient-freebsd.sh FS filter: types, local-only, inode '-' drop, df-failure marker"
+pass "xymonclient-freebsd.sh FS filter: types, local-only, inode zfs/tmpfs+'-' drop, df-failure marker"

--- a/tests/client/fs-filter-freebsd.sh
+++ b/tests/client/fs-filter-freebsd.sh
@@ -16,19 +16,14 @@
 set -euo pipefail
 # shellcheck source=tests/lib/assert.sh
 . "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"
 
-ROOT=$(find_root)
-SCRIPT="${XYMONCLIENT_FREEBSD:-$ROOT/client/xymonclient-freebsd.sh}"
-if [ ! -f "$SCRIPT" ]; then
-	[ -z "${XYMONCLIENT_FREEBSD:-}" ] || fail "XYMONCLIENT_FREEBSD set to '$SCRIPT' but no such file -- broken layout, not a skip"
-	skip "$SCRIPT missing"
-fi
-grep -q 'XYMONCLIENT_FS_INCLUDE_TYPES' "$SCRIPT" || fail "FS filter missing from $SCRIPT (regressed)"
-
-TMP=$(mktempdir)
-STUB="$TMP/bin"; mkdir -p "$STUB"
-DF_LOG="$TMP/df.args"; INODE_LOG="$TMP/inode.args"
-STDERR_LOG="$TMP/stderr"
+# Resolve SCRIPT (in-tree default; $XYMONCLIENT_FREEBSD points at the installed
+# copy), apply the dangling-override / skip-if-absent contract, assert the FS
+# filter is still present (its absence is a regression, not a skip), and set up
+# TMP/STUB/DF_LOG/INODE_LOG/STDERR_LOG/PATH.
+fsf_setup freebsd XYMONCLIENT_FREEBSD
 
 # df stub: record argv (inode -i calls routed separately) and emit a table. The
 # inode table includes a "tank" row with "-" %iused (a no-inode-limit fs).
@@ -48,21 +43,18 @@ else
 fi
 EOF
 chmod +x "$STUB/df"
-export PATH="$STUB:$PATH"
 
 # Decoy files in the snippet's working directory ($TMP): if the script let a
 # configured type token glob, "procf*"/"fuse.*" would expand to these filenames.
 : > "$TMP/procfs"
 : > "$TMP/fuse.sshfs"
 
+# Combined [df]+[inode] block (default stop at [mount]); the [inode] block reuses
+# the exclude list the [df] block built, so they run together. run() is a thin
+# shim over fsf_run (fs-filter-common.sh) returning the disk df argv, padded.
 SNIPPET="$TMP/df-section.sh"
-sed -n '/^echo "\[df\]"/,/^echo "\[mount\]"/p' "$SCRIPT" | sed '$d' > "$SNIPPET"
-
-run() {  # run the block; echo the disk df argv (newlines flattened, padded)
-	: > "$DF_LOG"; : > "$INODE_LOG"; : > "$STDERR_LOG"
-	( cd "$TMP"; /bin/sh "$SNIPPET" >/dev/null 2>"$STDERR_LOG" )
-	printf ' %s ' "$(tr '\n' ' ' < "$DF_LOG")"
-}
+fsf_extract "$SNIPPET"
+run() { fsf_run "$SNIPPET" "$DF_LOG"; }
 
 # --- default behaviour ------------------------------------------------------
 args=$(run)

--- a/tests/client/fs-filter-linux.sh
+++ b/tests/client/fs-filter-linux.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# tests/client/fs-filter.sh
+# tests/client/fs-filter-linux.sh
 #
 # Regression guard for xymon-monitoring/xymon#96 (refs #49):
 # xymonclient-linux.sh respects four environment variables that tune
@@ -27,28 +27,16 @@
 set -euo pipefail
 # shellcheck source=tests/lib/assert.sh
 . "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"
 
-ROOT=$(find_root)
-# Default: the in-tree script. $XYMONCLIENT_LINUX (autopkgtest) points at the
-# INSTALLED script -- /usr/lib/xymon/client/bin/xymonclient-linux.sh on Debian
-# -- so the test exercises what the package actually ships, distro patches
-# included. Same-version artifacts only; see "Path discovery" in
-# tests/README.md.
-SCRIPT="${XYMONCLIENT_LINUX:-$ROOT/client/xymonclient-linux.sh}"
-
-# Same fail-on-explicit-override contract as require_bin (lib/assert.sh):
-# $XYMONCLIENT_LINUX set means the caller asserts the installed script exists
-# there, so a dangling path is a broken package layout and must not skip green.
-if [ ! -f "$SCRIPT" ]; then
-	[ -z "${XYMONCLIENT_LINUX:-}" ] || fail "XYMONCLIENT_LINUX explicitly set to '$SCRIPT' but no such file -- broken package layout, not a skip"
-	skip "$SCRIPT missing"
-fi
-# The #49 env-var FS filter has landed (PR #96), so this is now a real
-# regression guard: if the env-var logic ever disappears from the script the
-# assertions below must FAIL, not skip. Do not reinstate a "feature not landed"
-# skip here -- absence of the filter is a regression, per tests/README.md.
-
-TMP=$(mktempdir)
+# Resolve SCRIPT (in-tree default; $XYMONCLIENT_LINUX, set by autopkgtest, points
+# at the INSTALLED script so we test what the package ships -- same-version
+# artifacts only, see "Path discovery" in tests/README.md), apply the
+# fail-on-dangling-override / skip-if-absent contract, assert the #49/#96 FS
+# filter is still present (its absence is a regression, not a skip, per
+# tests/README.md), and set up TMP/STUB/DF_LOG/INODE_LOG/STDERR_LOG/PATH.
+fsf_setup linux XYMONCLIENT_LINUX
 
 # --- fixtures ----------------------------------------------------------------
 
@@ -74,38 +62,23 @@ EOF
 : > "$TMP/tmpfs"
 : > "$TMP/fuse.sshfs"
 
-# Extract just the [df] block from xymonclient-linux.sh and rewrite the
-# /proc/filesystems reference. Drop the trailing `echo "[inode]"` line with
-# `sed '$d'` (portable last-line delete; `head -n -1` is a GNU extension and
-# OpenBSD head(1) rejects a negative count) so we exit cleanly after one df
-# invocation per run.
+# Extract just the [df] block (stop at [inode]) and the combined [df]+[inode]
+# block (stop at [mount]), rewriting the /proc/filesystems reference at the
+# fixture in both. The [inode] block reuses the EXCLUDES/ROOTFS the [df] block
+# computed, so the combined block must run them together -- a lone [inode]
+# snippet would see an empty EXCLUDES.
+PROC_REWRITE="s!/proc/filesystems!$TMP/proc.filesystems!g"
 SNIPPET="$TMP/df-section.sh"
-sed -n '/^echo "\[df\]"/,/^echo "\[inode\]"/p' "$SCRIPT" \
-	| sed '$d' \
-	| sed "s!/proc/filesystems!$TMP/proc.filesystems!g" \
-	> "$SNIPPET"
-
-# Combined [df]+[inode] block (stops before [mount], drops that trailing echo).
-# The [inode] block reuses the EXCLUDES/ROOTFS computed at the top of the [df]
-# block, so the two must be extracted together to run the inode invocation in
-# isolation -- a lone [inode] snippet would see an empty EXCLUDES.
+fsf_extract "$SNIPPET" "$PROC_REWRITE" '\[inode\]'
 COMBINED="$TMP/df-inode-section.sh"
-sed -n '/^echo "\[df\]"/,/^echo "\[mount\]"/p' "$SCRIPT" \
-	| sed '$d' \
-	| sed "s!/proc/filesystems!$TMP/proc.filesystems!g" \
-	> "$COMBINED"
+fsf_extract "$COMBINED" "$PROC_REWRITE"
 
 # --- stubs -------------------------------------------------------------------
-
-STUB="$TMP/bin"
-mkdir -p "$STUB"
 
 # df stub: append its full argv to a log file, emit a minimal valid table
 # so the downstream `sed` in the script has something to chew on. The [df] and
 # [inode] blocks both shell out to df; route the inode invocation (`df -Pil` /
 # `df -i`) to its own log so each block's flags can be asserted independently.
-DF_LOG="$TMP/df.args"
-INODE_LOG="$TMP/inode.args"
 cat > "$STUB/df" <<EOF
 #!/usr/bin/env bash
 if [[ " \$* " =~ -P[a-zA-Z]*i ]] || [[ " \$* " =~ " -i " ]]; then
@@ -126,42 +99,15 @@ echo "/dev/sda1"
 EOF
 chmod +x "$STUB/readlink"
 
-STDERR_LOG="$TMP/stderr"
-
-export PATH="$STUB:$PATH"
-
 # --- runner ------------------------------------------------------------------
 
-# run_snippet: invoke the extracted block in a fresh subshell, return the
-# command-line df was called with. Per-case env vars are passed via an inline
-# prefix on the caller's `args=$(VAR=val run_snippet)`; see the leak warning
-# below.
-run_snippet() {
-	: > "$DF_LOG"
-	: > "$INODE_LOG"
-	: > "$STDERR_LOG"
-	(
-		cd "$TMP"
-		/bin/sh "$SNIPPET" >/dev/null 2>"$STDERR_LOG"
-	)
-	# Pad with spaces so substring assertions for " -x tmpfs " work even
-	# at the ends of the line.
-	printf ' %s ' "$(cat "$DF_LOG")"
-}
-
-# run_inode: run the combined [df]+[inode] block and return the argv the
-# *inode* df invocation was called with (the df stub routes it to INODE_LOG).
-# Per-case env vars are passed via an inline prefix, same as run_snippet.
-run_inode() {
-	: > "$DF_LOG"
-	: > "$INODE_LOG"
-	: > "$STDERR_LOG"
-	(
-		cd "$TMP"
-		/bin/sh "$COMBINED" >/dev/null 2>"$STDERR_LOG"
-	)
-	printf ' %s ' "$(cat "$INODE_LOG")"
-}
+# run_snippet runs the [df]-only block and returns the df argv; run_inode runs
+# the combined block and returns the *inode* invocation's argv (the df stub
+# routes it to INODE_LOG). Both are thin shims over fsf_run (fs-filter-common.sh)
+# so the call sites and the inline per-case env prefix stay unchanged; see the
+# leak warning below.
+run_snippet() { fsf_run "$SNIPPET" "$DF_LOG"; }
+run_inode()   { fsf_run "$COMBINED" "$INODE_LOG"; }
 
 # Callers pass per-case env vars via the inline prefix on the
 # `args=$(VAR=val run_snippet)` invocation. Do NOT also set them on


### PR DESCRIPTION
Part of #170 — ports the df/inode filesystem-filter env vars to the FreeBSD client.

Adds `XYMONCLIENT_FS_INCLUDE_TYPES` / `_EXCLUDE_TYPES` / `_DF_LOCAL_ONLY` to
`xymonclient-linux.sh`'s FreeBSD sibling, building the df `-t no<csv>` exclude
list from a default set minus INCLUDE plus EXCLUDE (EXCLUDE wins). The inode
report also drops `zfs` (no usable inode counts). Remote mounts are hidden by
`df -l` (DF_LOCAL_ONLY=yes), not by type, so `no` can surface them. A df that
exits non-zero with no output is surfaced as a yellow failure marker, not read
as green. df is factored behind `run_df`/`emit_df` so the planned remote-df
sentinel (separate follow-up) hooks in additively.

Mock-tested in `tests/client/fs-filter-freebsd.sh` (argv construction,
INCLUDE/EXCLUDE precedence, literal-token handling, local-only, failure marker).
Real FreeBSD df behaviour still to be verified on-platform.

Independent of the other #170 OS PRs (touches only `client/xymonclient-freebsd.sh`
+ its test). Docs (cfg.DIST/man scoping) follow in a separate PR.

**Update (on-platform verification):** running this branch on a real FreeBSD server surfaced that FreeBSD tmpfs reports `itotal = 2147483647` — the 2³¹−1 sentinel, identical on a 4GB and a 128GB machine. Not a limit (exhausting it would take ~9.5TB of RAM), so the metric carries no signal, and the `-` row-guard can't catch it because a number is printed. `e441c053c` excludes tmpfs from the **inode** report by type, next to zfs; the **disk** report keeps tmpfs (RAM-backed capacity is real, matching the Linux default) and mfs stays in both (UFS-in-RAM, genuine inode table). `INCLUDE_TYPES=tmpfs` remains the escape hatch, now pinned by a test.