### PR TITLE
client/openbsd: env-var-controlled df/inode filesystem filter (#170)

### DIFF
--- a/client/xymonclient-openbsd.sh
+++ b/client/xymonclient-openbsd.sh
@@ -20,17 +20,79 @@ uptime
 echo "[who]"
 who
 echo "[df]"
-df -k -tnonfs,kernfs,procfs,cd9660 | sed -e '/^[^ 	][^ 	]*$/{
+# --- filesystem filter (configurable; see xymonclient.cfg.DIST) --------------
+# Exclude FS types via df "-t no<csv>": a default set, minus INCLUDE_TYPES, plus
+# EXCLUDE_TYPES. Remote (nfs) mounts are hidden by df -l (DF_LOCAL_ONLY=yes), not
+# by type, so DF_LOCAL_ONLY=no can surface them.
+# tmpfs is deliberately kept in BOTH reports, unlike FreeBSD's inode report:
+# OpenBSD's tmpfs statfs reports memory-derived inode counts (f_files scales
+# with available RAM, sys/tmpfs/tmpfs_vfsops.c), a real exhaustion signal -
+# not FreeBSD's constant INT_MAX cap, which carries none.
+: "${XYMONCLIENT_FS_INCLUDE_TYPES=}"
+: "${XYMONCLIENT_FS_EXCLUDE_TYPES=}"
+fs_excl_opt() {
+	# noglob: treat a type like "tmp*" as a literal token, not a filename glob.
+	case $- in *f*) _restoreglob=no ;; *) _restoreglob=yes; set -f ;; esac
+	_l=""
+	# Default excludes, minus any INCLUDE_TYPES.
+	for _t in kernfs procfs cd9660; do
+		for _i in $XYMONCLIENT_FS_INCLUDE_TYPES; do [ "$_t" = "$_i" ] && continue 2; done
+		case " $_l " in *" $_t "*) ;; *) _l="$_l $_t" ;; esac
+	done
+	# EXCLUDE_TYPES last, so a type in both lists stays excluded (EXCLUDE wins).
+	for _t in $XYMONCLIENT_FS_EXCLUDE_TYPES; do
+		case " $_l " in *" $_t "*) ;; *) _l="$_l $_t" ;; esac
+	done
+	_csv=`echo $_l | tr ' ' ','`
+	[ "$_restoreglob" = yes ] && set +f
+	[ -n "$_csv" ] && printf -- '-tno%s' "$_csv"
+}
+DFLOCALONLY="${XYMONCLIENT_FS_DF_LOCAL_ONLY:-yes}"
+case "$DFLOCALONLY" in
+	yes|no) ;;
+	*) echo "xymonclient-openbsd: invalid XYMONCLIENT_FS_DF_LOCAL_ONLY '$DFLOCALONLY', using yes" >&2; DFLOCALONLY=yes ;;
+esac
+DFLOCAL=""; [ "$DFLOCALONLY" = yes ] && DFLOCAL="-l"
+# run_df FLAG [extra-excludes...]: df rows for one report behind the FS filter
+# and local-only flag. The seam where the remote-df sentinel will hook.
+run_df() {
+	_flag="$1"; shift
+	_excl=`fs_excl_opt "$@"`
+	df "$_flag" $DFLOCAL $_excl
+}
+# emit_df KIND LABEL FLAG [extra-excludes...]: run_df + failure guard. On a
+# non-zero df with no output, print a one-line marker (no df header) so the
+# server goes yellow not green, and return 1 so the caller skips formatting; else
+# leave the rows in $_out and return 0 to format. A non-zero df that still prints
+# mounts flows through unchanged.
+emit_df() {
+	_kind="$1"; _label="$2"; shift 2
+	_out=`run_df "$@"`; _rc=$?
+	if [ -z "$_out" ] && [ "$_rc" -ne 0 ]; then
+		echo "xymonclient-openbsd: df $_kind collection failed (status $_rc) with no output; reporting data as unavailable" >&2
+		echo "$_label report collection failed: df exited $_rc with no output"
+		return 1
+	fi
+	return 0
+}
+# The sed joins lines df split in two.
+if emit_df disk Disk -k; then
+printf '%s\n' "$_out" | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
 }'
+fi
 echo "[inode]"
-df -i -tnonfs,kernfs,procfs,cd9660 | sed -e '/^[^       ][^     ]*$/{
+# Same failure guard. Drop filesystems with no inode limit (df prints "-" in
+# the %iused column, field 8): they cannot run out of inodes, so the row is noise.
+if emit_df inode Inode -i; then
+printf '%s\n' "$_out" | sed -e '/^[^ 	][^ 	]*$/{
 N
-s/[     ]*\n[   ]*/ /
+s/[ 	]*\n[ 	]*/ /
 }' | awk '
 NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9} 
-NR>=2{printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
+(NR>=2 && $8 != "-"){printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
+fi
 echo "[mount]"
 mount
 echo "[meminfo]"

--- a/client/xymonclient-openbsd.sh
+++ b/client/xymonclient-openbsd.sh
@@ -20,17 +20,81 @@ uptime
 echo "[who]"
 who
 echo "[df]"
-df -k -tnonfs,kernfs,procfs,cd9660 | sed -e '/^[^ 	][^ 	]*$/{
+# --- filesystem filter (configurable; see xymonclient.cfg.DIST) --------------
+# Exclude FS types via df "-t no<csv>": a default set, minus INCLUDE_TYPES, plus
+# EXCLUDE_TYPES. Remote (nfs) mounts are hidden by df -l (DF_LOCAL_ONLY=yes), not
+# by type, so DF_LOCAL_ONLY=no can surface them.
+# tmpfs is deliberately kept in BOTH reports, unlike FreeBSD's inode report:
+# OpenBSD's tmpfs statfs reports memory-derived inode counts (f_files scales
+# with available RAM, sys/tmpfs/tmpfs_vfsops.c), a real exhaustion signal -
+# not FreeBSD's constant INT_MAX cap, which carries none.
+: "${XYMONCLIENT_FS_INCLUDE_TYPES=}"
+: "${XYMONCLIENT_FS_EXCLUDE_TYPES=}"
+fs_excl_opt() {
+	# noglob: treat a type like "tmp*" as a literal token, not a filename glob.
+	case $- in *f*) _restoreglob=no ;; *) _restoreglob=yes; set -f ;; esac
+	_l=""
+	# Default excludes, minus any INCLUDE_TYPES.
+	for _t in kernfs procfs cd9660 "$@"; do
+		for _i in $XYMONCLIENT_FS_INCLUDE_TYPES; do [ "$_t" = "$_i" ] && continue 2; done
+		case " $_l " in *" $_t "*) ;; *) _l="$_l $_t" ;; esac
+	done
+	# EXCLUDE_TYPES last, so a type in both lists stays excluded (EXCLUDE wins).
+	for _t in $XYMONCLIENT_FS_EXCLUDE_TYPES; do
+		case " $_l " in *" $_t "*) ;; *) _l="$_l $_t" ;; esac
+	done
+	_csv=`echo $_l | tr ' ' ','`
+	[ "$_restoreglob" = yes ] && set +f
+	[ -n "$_csv" ] && printf -- '-tno%s' "$_csv"
+}
+DFLOCALONLY="${XYMONCLIENT_FS_DF_LOCAL_ONLY:-yes}"
+case "$DFLOCALONLY" in
+	yes|no) ;;
+	*) echo "xymonclient-openbsd: invalid XYMONCLIENT_FS_DF_LOCAL_ONLY '$DFLOCALONLY', using yes" >&2; DFLOCALONLY=yes ;;
+esac
+DFLOCAL=""; [ "$DFLOCALONLY" = yes ] && DFLOCAL="-l"
+# run_df FLAG [extra-excludes...]: df rows for one report behind the FS filter
+# and local-only flag. The seam where the remote-df sentinel will hook.
+run_df() {
+	_flag="$1"; shift
+	_excl=`fs_excl_opt "$@"`
+	df "$_flag" $DFLOCAL $_excl
+}
+# emit_df KIND LABEL FLAG [extra-excludes...]: run_df + failure guard. On a
+# non-zero df with no output, print a one-line marker (no df header) so the
+# server goes yellow not green, and return 1 so the caller skips formatting; else
+# leave the rows in $_out and return 0 to format. A non-zero df that still prints
+# mounts flows through unchanged.
+emit_df() {
+	_kind="$1"; _label="$2"; shift 2
+	_out=`run_df "$@"`; _rc=$?
+	if [ -z "$_out" ] && [ "$_rc" -ne 0 ]; then
+		echo "xymonclient-openbsd: df $_kind collection failed (status $_rc) with no output; reporting data as unavailable" >&2
+		echo "$_label report collection failed: df exited $_rc with no output"
+		return 1
+	fi
+	return 0
+}
+# The sed joins lines df split in two.
+if emit_df disk Disk -k; then
+printf '%s\n' "$_out" | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
 }'
+fi
 echo "[inode]"
-df -i -tnonfs,kernfs,procfs,cd9660 | sed -e '/^[^       ][^     ]*$/{
+# Same failure guard. Drop filesystems with no inode accounting: OpenBSD df -i
+# reports these as itotal 0 (iused=ifree=0, %iused shown as 100%, NOT "-" as on
+# FreeBSD), so guard on the total (fields 6+7) rather than the %iused text -- a
+# 0-total row cannot run out of inodes and would otherwise read as 100% full.
+if emit_df inode Inode -i; then
+printf '%s\n' "$_out" | sed -e '/^[^ 	][^ 	]*$/{
 N
-s/[     ]*\n[   ]*/ /
+s/[ 	]*\n[ 	]*/ /
 }' | awk '
-NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9} 
-NR>=2{printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
+NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9}
+(NR>=2 && ($6 + $7) > 0){printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
+fi
 echo "[mount]"
 mount
 echo "[meminfo]"

--- a/tests/client/fs-filter-openbsd.sh
+++ b/tests/client/fs-filter-openbsd.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-filter-openbsd.sh
+#
+# Regression guard for the df/inode filesystem filter ported to
+# xymonclient-openbsd.sh (issue #170): XYMONCLIENT_FS_{INCLUDE,EXCLUDE}_TYPES
+# via df "-t no<csv>", df -l (XYMONCLIENT_FS_DF_LOCAL_ONLY), and the inode "-"
+# (no inode limit) row drop.
+#
+# Mock-tested on any host (df-argv construction). Real OpenBSD df still needs
+# verifying on OpenBSD.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"
+
+# Resolve SCRIPT, apply the dangling-override / skip-if-absent contract, assert
+# the filter is present, set up TMP/STUB/DF_LOG/INODE_LOG/STDERR_LOG/PATH.
+fsf_setup openbsd XYMONCLIENT_OPENBSD
+
+cat > "$STUB/df" <<EOF
+#!/usr/bin/env bash
+# DF_FAIL=1 simulates a df that exits non-zero with no output (e.g. killed).
+[ -n "\${DF_FAIL:-}" ] && exit 1
+if [[ " \$* " =~ " -i " ]]; then
+	echo "\$*" >> "$INODE_LOG"
+	printf 'Filesystem 1K-blocks Used Avail Capacity iused ifree %%iused Mounted on\n'
+	printf '/dev/sd0a 100 50 50 50%% 1000 9000 10%% /\n'
+	printf 'nolimitfs 200 1 199 1%% 0 0 - /nolimit\n'
+else
+	echo "\$*" >> "$DF_LOG"
+	printf 'Filesystem 1K-blocks Used Avail Capacity Mounted on\n'
+	printf '/dev/sd0a 100 50 50 50%% /\n'
+fi
+EOF
+chmod +x "$STUB/df"
+
+# Decoy files in the snippet's working directory ($TMP): if the script let a
+# configured type token glob, "procf*"/"fuse.*" would expand to these filenames.
+: > "$TMP/procfs"
+: > "$TMP/fuse.sshfs"
+
+SNIPPET="$TMP/df-section.sh"
+fsf_extract "$SNIPPET"
+run() { fsf_run "$SNIPPET" "$DF_LOG"; }
+
+# --- default ----------------------------------------------------------------
+args=$(run)
+assert_contains " -k " "$args" "disk df keeps -k"
+assert_contains " -l " "$args" "default is local-only (df -l)"
+assert_contains " -tnokernfs,procfs,cd9660 " "$args" \
+	"default excludes pseudo types via -t no<csv>"
+assert_not_contains "nonfs" "$args" "nfs is hidden by df -l, not by the type list"
+
+inode_args=$(printf ' %s ' "$(tr '\n' ' ' < "$INODE_LOG")")
+assert_contains " -i " "$inode_args" "inode df uses -i"
+# tmpfs stays in both reports (unlike FreeBSD): OpenBSD's tmpfs inode counts
+# are memory-derived (real signal), not FreeBSD's INT_MAX sentinel.
+assert_not_contains "tmpfs" "$args"       "the disk report keeps tmpfs"
+assert_not_contains "tmpfs" "$inode_args" "the inode report keeps tmpfs (memory-derived counts)"
+
+# --- INCLUDE / EXCLUDE / DF_LOCAL_ONLY --------------------------------------
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=kernfs run)
+assert_not_contains "kernfs" "$args" "INCLUDE_TYPES=kernfs un-excludes kernfs"
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES=ext2fs run)
+assert_contains "ext2fs" "$args" "EXCLUDE_TYPES=ext2fs adds ext2fs"
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=no run)
+assert_not_contains " -l " "$args" "DF_LOCAL_ONLY=no drops -l"
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=bogus run)
+assert_contains " -l " "$args" "invalid DF_LOCAL_ONLY falls back to local-only"
+assert_contains "invalid XYMONCLIENT_FS_DF_LOCAL_ONLY" "$(cat "$STDERR_LOG")" \
+	"invalid DF_LOCAL_ONLY warns"
+
+# Type tokens are literal, not shell globs. With $TMP as the working directory,
+# "procf*" must not expand to the decoy file and accidentally un-exclude procfs.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES='procf*' run)
+assert_contains ",procfs," "$args" \
+	"include type tokens must not undergo pathname expansion"
+
+# Likewise an exclude glob must stay literal, not become the decoy filename.
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES='fuse.*' run)
+assert_contains "fuse.*" "$args" \
+	"exclude type tokens must not undergo pathname expansion"
+assert_not_contains "fuse.sshfs" "$args" \
+	"exclude type glob must not expand to a working-directory filename"
+
+# --- include + exclude precedence: exclude wins -----------------------------
+# A type named in both lists stays excluded: EXCLUDE is applied last (documented
+# contract). ext2fs is not a default, so its presence is unambiguous.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=ext2fs XYMONCLIENT_FS_EXCLUDE_TYPES=ext2fs run)
+assert_contains "ext2fs" "$args" \
+	"a type in both include and exclude lists must stay excluded (exclude wins)"
+
+# --- inode "-" (no inode limit) rows are dropped ----------------------------
+out=$( cd "$TMP"; /bin/sh "$SNIPPET" 2>/dev/null )
+inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
+assert_not_contains "/nolimit" "$inode_section" \
+	"inode report drops the no-inode-limit filesystem (%iused '-')"
+
+# --- false-green guard: df fails with no output -> marker, not empty section --
+out=$( cd "$TMP"; DF_FAIL=1 /bin/sh "$SNIPPET" 2>/dev/null )
+assert_contains "Disk report collection failed" "$out" \
+	"a failed disk df emits a failure marker"
+assert_contains "Inode report collection failed" "$out" \
+	"a failed inode df emits a failure marker"
+assert_not_contains "Filesystem" "$out" \
+	"failure marker carries no df header (server reads a header-less section as yellow)"
+
+pass "xymonclient-openbsd.sh FS filter: types, local-only, inode '-' drop, df-failure marker"

--- a/tests/client/fs-filter-openbsd.sh
+++ b/tests/client/fs-filter-openbsd.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-filter-openbsd.sh
+#
+# Regression guard for the df/inode filesystem filter ported to
+# xymonclient-openbsd.sh (issue #170): XYMONCLIENT_FS_{INCLUDE,EXCLUDE}_TYPES
+# via df "-t no<csv>", df -l (XYMONCLIENT_FS_DF_LOCAL_ONLY), and the inode "-"
+# (no inode limit) row drop.
+#
+# Mock-tested on any host (df-argv construction). Real OpenBSD df still needs
+# verifying on OpenBSD.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"
+
+# Resolve SCRIPT, apply the dangling-override / skip-if-absent contract, assert
+# the filter is present, set up TMP/STUB/DF_LOG/INODE_LOG/STDERR_LOG/PATH.
+fsf_setup openbsd XYMONCLIENT_OPENBSD
+
+cat > "$STUB/df" <<EOF
+#!/usr/bin/env bash
+# DF_FAIL=1 simulates a df that exits non-zero with no output (e.g. killed).
+[ -n "\${DF_FAIL:-}" ] && exit 1
+if [[ " \$* " =~ " -i " ]]; then
+	echo "\$*" >> "$INODE_LOG"
+	printf 'Filesystem 1K-blocks Used Avail Capacity iused ifree %%iused Mounted on\n'
+	printf '/dev/sd0a 100 50 50 50%% 1000 9000 10%% /\n'
+	printf 'nolimitfs 200 1 199 1%% 0 0 100%% /nolimit\n'
+else
+	echo "\$*" >> "$DF_LOG"
+	printf 'Filesystem 1K-blocks Used Avail Capacity Mounted on\n'
+	printf '/dev/sd0a 100 50 50 50%% /\n'
+fi
+EOF
+chmod +x "$STUB/df"
+
+# Decoy files in the snippet's working directory ($TMP): if the script let a
+# configured type token glob, "procf*"/"fuse.*" would expand to these filenames.
+: > "$TMP/procfs"
+: > "$TMP/fuse.sshfs"
+
+SNIPPET="$TMP/df-section.sh"
+fsf_extract "$SNIPPET"
+run() { fsf_run "$SNIPPET" "$DF_LOG"; }
+
+# --- default ----------------------------------------------------------------
+args=$(run)
+assert_contains " -k " "$args" "disk df keeps -k"
+assert_contains " -l " "$args" "default is local-only (df -l)"
+assert_contains " -tnokernfs,procfs,cd9660 " "$args" \
+	"default excludes pseudo types via -t no<csv>"
+assert_not_contains "nonfs" "$args" "nfs is hidden by df -l, not by the type list"
+
+inode_args=$(printf ' %s ' "$(tr '\n' ' ' < "$INODE_LOG")")
+assert_contains " -i " "$inode_args" "inode df uses -i"
+# tmpfs stays in both reports (unlike FreeBSD): OpenBSD's tmpfs inode counts
+# are memory-derived (real signal), not FreeBSD's INT_MAX sentinel.
+assert_not_contains "tmpfs" "$args"       "the disk report keeps tmpfs"
+assert_not_contains "tmpfs" "$inode_args" "the inode report keeps tmpfs (memory-derived counts)"
+
+# --- INCLUDE / EXCLUDE / DF_LOCAL_ONLY --------------------------------------
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=kernfs run)
+assert_not_contains "kernfs" "$args" "INCLUDE_TYPES=kernfs un-excludes kernfs"
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES=ext2fs run)
+assert_contains "ext2fs" "$args" "EXCLUDE_TYPES=ext2fs adds ext2fs"
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=no run)
+assert_not_contains " -l " "$args" "DF_LOCAL_ONLY=no drops -l"
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=bogus run)
+assert_contains " -l " "$args" "invalid DF_LOCAL_ONLY falls back to local-only"
+assert_contains "invalid XYMONCLIENT_FS_DF_LOCAL_ONLY" "$(cat "$STDERR_LOG")" \
+	"invalid DF_LOCAL_ONLY warns"
+
+# Type tokens are literal, not shell globs. With $TMP as the working directory,
+# "procf*" must not expand to the decoy file and accidentally un-exclude procfs.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES='procf*' run)
+assert_contains ",procfs," "$args" \
+	"include type tokens must not undergo pathname expansion"
+
+# Likewise an exclude glob must stay literal, not become the decoy filename.
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES='fuse.*' run)
+assert_contains "fuse.*" "$args" \
+	"exclude type tokens must not undergo pathname expansion"
+assert_not_contains "fuse.sshfs" "$args" \
+	"exclude type glob must not expand to a working-directory filename"
+
+# --- include + exclude precedence: exclude wins -----------------------------
+# A type named in both lists stays excluded: EXCLUDE is applied last (documented
+# contract). ext2fs is not a default, so its presence is unambiguous.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=ext2fs XYMONCLIENT_FS_EXCLUDE_TYPES=ext2fs run)
+assert_contains "ext2fs" "$args" \
+	"a type in both include and exclude lists must stay excluded (exclude wins)"
+
+# --- no-inode-accounting rows are dropped -----------------------------------
+# OpenBSD df -i reports these as itotal 0 with %iused shown as 100% (not "-"),
+# so a text guard on the %iused column would miss them and the row would read
+# as 100% full; the fixture uses the real "0 0 100%" shape.
+out=$( cd "$TMP"; /bin/sh "$SNIPPET" 2>/dev/null )
+inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
+assert_not_contains "/nolimit" "$inode_section" \
+	"inode report drops the no-inode-accounting filesystem (itotal 0, %iused 100%)"
+assert_contains "/dev/sd0a" "$inode_section" \
+	"inode report keeps a filesystem with real inode accounting (itotal > 0)"
+
+# --- false-green guard: df fails with no output -> marker, not empty section --
+out=$( cd "$TMP"; DF_FAIL=1 /bin/sh "$SNIPPET" 2>/dev/null )
+assert_contains "Disk report collection failed" "$out" \
+	"a failed disk df emits a failure marker"
+assert_contains "Inode report collection failed" "$out" \
+	"a failed inode df emits a failure marker"
+assert_not_contains "Filesystem" "$out" \
+	"failure marker carries no df header (server reads a header-less section as yellow)"
+
+pass "xymonclient-openbsd.sh FS filter: types, local-only, zero-inode-total drop, df-failure marker"


### PR DESCRIPTION
Part of #170 — ports the df/inode filesystem-filter env vars to the OpenBSD client.

Adds `XYMONCLIENT_FS_INCLUDE_TYPES` / `_EXCLUDE_TYPES` / `_DF_LOCAL_ONLY`,
building the df `-t no<csv>` exclude list from a default set minus INCLUDE plus
EXCLUDE (EXCLUDE wins). Remote mounts are hidden by `df -l` (DF_LOCAL_ONLY=yes),
not by type, so `no` can surface them. A df that exits non-zero with no output is
surfaced as a yellow failure marker, not read as green. df is factored behind
`run_df`/`emit_df` so the planned remote-df sentinel (separate follow-up) hooks
in additively.

Mock-tested in `tests/client/fs-filter-openbsd.sh` (argv construction,
INCLUDE/EXCLUDE precedence, literal-token handling, local-only, failure marker).
Real OpenBSD df behaviour still to be verified on-platform.

Independent of the other #170 OS PRs (touches only `client/xymonclient-openbsd.sh`
+ its test). Docs (cfg.DIST/man scoping) follow in a separate PR.

---
**Update (rebase + consistency pass):** rebased onto post-#175 main; test converted to the shared `fs-filter-common.sh` scaffolding and brought to family parity (INCLUDE/EXCLUDE leave-the-others asserts, invalid `DF_LOCAL_ONLY` warns).

**tmpfs is deliberately KEPT in both reports** — the opposite of FreeBSD's inode report, and source-verified: OpenBSD's `tmpfs` statfs reports memory-derived inode counts (`sys/tmpfs/tmpfs_vfsops.c`: `freenodes = MIN(limit remaining, avail mem / node size)`), a real exhaustion signal. FreeBSD's INT_MAX-capped `f_files` is its own divergence from this very code it ported. Pinned by test assertions so nobody "harmonizes" it into breakage.

**Open before un-drafting:** on-platform verification against real OpenBSD df/mount output (the #175 gate).