### PR TITLE
client/netbsd: env-var-controlled df filesystem filter (#170)

### DIFF
--- a/client/xymonclient-netbsd.sh
+++ b/client/xymonclient-netbsd.sh
@@ -20,10 +20,64 @@ uptime
 echo "[who]"
 who
 echo "[df]"
-df -P -tnonfs,kernfs,procfs,cd9660,null | sed -e '/^[^ 	][^ 	]*$/{
+# --- filesystem filter (configurable; see xymonclient.cfg.DIST) --------------
+# Exclude FS types via df "-t no<csv>": a default set, minus INCLUDE_TYPES, plus
+# EXCLUDE_TYPES. Remote (nfs) mounts are hidden by df -l (DF_LOCAL_ONLY=yes), not
+# by type, so DF_LOCAL_ONLY=no can surface them.
+: "${XYMONCLIENT_FS_INCLUDE_TYPES=}"
+: "${XYMONCLIENT_FS_EXCLUDE_TYPES=}"
+fs_excl_opt() {
+	# noglob: treat a type like "tmp*" as a literal token, not a filename glob.
+	case $- in *f*) _restoreglob=no ;; *) _restoreglob=yes; set -f ;; esac
+	_l=""
+	# Default excludes, minus any INCLUDE_TYPES.
+	for _t in kernfs procfs cd9660 null; do
+		for _i in $XYMONCLIENT_FS_INCLUDE_TYPES; do [ "$_t" = "$_i" ] && continue 2; done
+		case " $_l " in *" $_t "*) ;; *) _l="$_l $_t" ;; esac
+	done
+	# EXCLUDE_TYPES last, so a type in both lists stays excluded (EXCLUDE wins).
+	for _t in $XYMONCLIENT_FS_EXCLUDE_TYPES; do
+		case " $_l " in *" $_t "*) ;; *) _l="$_l $_t" ;; esac
+	done
+	_csv=`echo $_l | tr ' ' ','`
+	[ "$_restoreglob" = yes ] && set +f
+	[ -n "$_csv" ] && printf -- '-tno%s' "$_csv"
+}
+DFLOCALONLY="${XYMONCLIENT_FS_DF_LOCAL_ONLY:-yes}"
+case "$DFLOCALONLY" in
+	yes|no) ;;
+	*) echo "xymonclient-netbsd: invalid XYMONCLIENT_FS_DF_LOCAL_ONLY '$DFLOCALONLY', using yes" >&2; DFLOCALONLY=yes ;;
+esac
+DFLOCAL=""; [ "$DFLOCALONLY" = yes ] && DFLOCAL="-l"
+# run_df FLAG [extra-excludes...]: df rows for one report behind the FS filter
+# and local-only flag. The seam where the remote-df sentinel will hook.
+run_df() {
+	_flag="$1"; shift
+	_excl=`fs_excl_opt "$@"`
+	df "$_flag" $DFLOCAL $_excl
+}
+# emit_df KIND LABEL FLAG [extra-excludes...]: run_df + failure guard. On a
+# non-zero df with no output, print a one-line marker (no df header) so the
+# server goes yellow not green, and return 1 so the caller skips formatting; else
+# leave the rows in $_out and return 0 to format. A non-zero df that still prints
+# mounts flows through unchanged.
+emit_df() {
+	_kind="$1"; _label="$2"; shift 2
+	_out=`run_df "$@"`; _rc=$?
+	if [ -z "$_out" ] && [ "$_rc" -ne 0 ]; then
+		echo "xymonclient-netbsd: df $_kind collection failed (status $_rc) with no output; reporting data as unavailable" >&2
+		echo "$_label report collection failed: df exited $_rc with no output"
+		return 1
+	fi
+	return 0
+}
+# The sed joins lines df split in two.
+if emit_df disk Disk -P; then
+	printf '%s\n' "$_out" | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
 }'
+fi
 echo "[mount]"
 mount
 echo "[meminfo]"

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -109,6 +109,32 @@ LOGFETCHOPTS=""
 # XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
 
 
+# Filesystem reporting (NetBSD client) -- used by xymonclient-netbsd.sh when
+# collecting df data (NetBSD has no inode report). Exclusions are passed to
+# df as "-t no<csv>"; the default excluded types are kernfs, procfs, cd9660
+# and null, and df runs with -l (local mounts only) by default.
+#
+# XYMONCLIENT_FS_INCLUDE_TYPES: whitespace-separated default-excluded types
+#    to surface again (e.g. "procfs"). Empty by default.
+#
+# XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated FS types to exclude on
+#    top of the defaults (e.g. "tmpfs mfs"). Empty by default. If a type
+#    appears in both lists, EXCLUDE wins (it is applied after INCLUDE).
+#
+# XYMONCLIENT_FS_DF_LOCAL_ONLY: "yes" (default) passes -l to df, hiding
+#    remote (nfs) mounts; "no" reports them too. Any other value produces a
+#    warning and falls back to "yes". The same WARNING as for Linux above
+#    applies: with "no", a stale or hard-blocked remote mount can wedge df
+#    and turn the whole host PURPLE until the mount recovers.
+#
+#    A df that exits non-zero with no output is marked failed (yellow)
+#    rather than left empty, so a failed probe is not silently green.
+#
+# XYMONCLIENT_FS_INCLUDE_TYPES=""
+# XYMONCLIENT_FS_EXCLUDE_TYPES=""
+# XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
+
+
 # Local Mode (Only) Options
 #
 # Running the Xymon client in local-config mode will cause threshold evaluation to

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -36,23 +36,36 @@ $XYMONHOME/logs
 Directory used for temporary files. Default: $XYMONHOME/tmp/
 
 .IP XYMONCLIENT_FS_INCLUDE_TYPES
-Whitespace-separated Linux filesystem types to include in the
-client's disk and inode reports even when they are normally excluded
-as pseudo (\fBnodev\fR) filesystems. Types are matched as exact df type
-tokens. Defaults to \fBzfs virtiofs tmpfs\fR \(em real local filesystems
+Whitespace-separated filesystem types to include in the client's disk
+(and, where supported, inode) reports even when the client's defaults
+would exclude them. Types are matched as exact df type tokens; the
+default exclusions and the mechanism are per-OS, and clients not
+listed here do not use the variable.
+.br
+On Linux: types normally excluded
+as pseudo (\fBnodev\fR) filesystems. Defaults to \fBzfs virtiofs tmpfs\fR
+\(em real local filesystems
 that merely happen to be flagged nodev. Set to "" to restore the
 historical behaviour of dropping every nodev type. Including remote
 filesystems also requires XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
+.br
+On NetBSD: names types from the default df exclude set
+(\fBkernfs procfs cd9660 null\fR, passed to df as \fB\-t no<list>\fR)
+to surface again. Empty by default. NetBSD has no inode report.
 
 .IP XYMONCLIENT_FS_EXCLUDE_TYPES
-Whitespace-separated Linux filesystem types to exclude in addition
-to the default pseudo-filesystem exclusions. Matching is on the exact
-df type token, and nodev types (overlay, fuse, ...) are already excluded
+Whitespace-separated filesystem types to exclude in addition to the
+client's default exclusions. Matching is on the exact df type token.
+If a type appears in both include and exclude settings, exclusion
+takes precedence on every OS.
+.br
+On NetBSD: adds types to the \fBdf \-t no<list>\fR exclude set
+(default \fBkernfs procfs cd9660 null\fR). Empty by default.
+.br
+On Linux: nodev types (overlay, fuse, ...) are already excluded
 by default, so an effective entry names a type that is not a nodev
 default \(em a device-backed type, or a specific FUSE subtype such as
 \fBfuse.sshfs\fR that the bare nodev \fBfuse\fR default cannot match.
-If a type appears in
-both include and exclude settings, exclusion takes precedence.
 Defaults to \fBiso9660 squashfs fuse.snapfuse\fR \(em read-only images
 reported 100% full by design (snaps mount as squashfs, or as
 fuse.snapfuse where snapd falls back to FUSE); none is a nodev type, so

--- a/tests/client/fs-filter-netbsd.sh
+++ b/tests/client/fs-filter-netbsd.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-filter-netbsd.sh
+#
+# Regression guard for the df filesystem filter ported to
+# xymonclient-netbsd.sh (issue #170). NetBSD's client has no [inode] section;
+# this covers the [df] type filter (XYMONCLIENT_FS_{INCLUDE,EXCLUDE}_TYPES via
+# df "-t no<csv>") and df -l (XYMONCLIENT_FS_DF_LOCAL_ONLY).
+#
+# Mock-tested on any host (df-argv construction). Real NetBSD df still needs
+# verifying on NetBSD.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"
+
+# Resolve SCRIPT, apply the dangling-override / skip-if-absent contract, assert
+# the filter is present, set up TMP/STUB/DF_LOG/INODE_LOG/STDERR_LOG/PATH.
+# (INODE_LOG is unused here: NetBSD's client has no [inode] section.)
+fsf_setup netbsd XYMONCLIENT_NETBSD
+
+cat > "$STUB/df" <<EOF
+#!/usr/bin/env bash
+# DF_FAIL=1 simulates a df that exits non-zero with no output (e.g. killed).
+[ -n "\${DF_FAIL:-}" ] && exit 1
+echo "\$*" >> "$DF_LOG"
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf '/dev/wd0a 100 50 50 50%% /\n'
+EOF
+chmod +x "$STUB/df"
+
+# Decoy files in the snippet's working directory ($TMP): if the script let a
+# configured type token glob, "procf*"/"fuse.*" would expand to these filenames.
+: > "$TMP/procfs"
+: > "$TMP/fuse.sshfs"
+
+SNIPPET="$TMP/df-section.sh"
+fsf_extract "$SNIPPET"
+run() { fsf_run "$SNIPPET" "$DF_LOG"; }
+
+# --- default ----------------------------------------------------------------
+args=$(run)
+assert_contains " -P " "$args" "disk df keeps -P"
+assert_contains " -l " "$args" "default is local-only (df -l)"
+assert_contains " -tnokernfs,procfs,cd9660,null " "$args" \
+	"default excludes pseudo types via -t no<csv>"
+assert_not_contains "nonfs" "$args" "nfs is hidden by df -l, not by the type list"
+
+# --- INCLUDE / EXCLUDE_TYPES ------------------------------------------------
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=kernfs run)
+assert_not_contains "kernfs" "$args" "INCLUDE_TYPES=kernfs un-excludes kernfs"
+assert_contains "procfs" "$args" "INCLUDE_TYPES=kernfs leaves the others"
+
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES=ext2fs run)
+assert_contains "ext2fs" "$args" "EXCLUDE_TYPES=ext2fs adds ext2fs"
+
+# Type tokens are literal, not shell globs. With $TMP as the working directory,
+# "procf*" must not expand to the decoy file and accidentally un-exclude procfs.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES='procf*' run)
+assert_contains ",procfs," "$args" \
+	"include type tokens must not undergo pathname expansion"
+
+# Likewise an exclude glob must stay literal, not become the decoy filename.
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES='fuse.*' run)
+assert_contains "fuse.*" "$args" \
+	"exclude type tokens must not undergo pathname expansion"
+assert_not_contains "fuse.sshfs" "$args" \
+	"exclude type glob must not expand to a working-directory filename"
+
+# --- include + exclude precedence: exclude wins -----------------------------
+# A type named in both lists stays excluded: EXCLUDE is applied last (documented
+# contract). ext2fs is not a default, so its presence is unambiguous.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=ext2fs XYMONCLIENT_FS_EXCLUDE_TYPES=ext2fs run)
+assert_contains "ext2fs" "$args" \
+	"a type in both include and exclude lists must stay excluded (exclude wins)"
+
+# --- DF_LOCAL_ONLY ----------------------------------------------------------
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=no run)
+assert_not_contains " -l " "$args" "DF_LOCAL_ONLY=no drops -l"
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=bogus run)
+assert_contains " -l " "$args" "invalid DF_LOCAL_ONLY falls back to local-only"
+assert_contains "invalid XYMONCLIENT_FS_DF_LOCAL_ONLY" "$(cat "$STDERR_LOG")" \
+	"invalid DF_LOCAL_ONLY warns"
+
+# --- false-green guard: df fails with no output -> marker, not empty section --
+out=$( cd "$TMP"; DF_FAIL=1 /bin/sh "$SNIPPET" 2>/dev/null )
+assert_contains "Disk report collection failed" "$out" \
+	"a failed df emits a failure marker"
+assert_not_contains "Filesystem" "$out" \
+	"failure marker carries no df header (server reads a header-less section as yellow)"
+
+pass "xymonclient-netbsd.sh FS filter: types, local-only, df-failure marker"


### PR DESCRIPTION
Part of #170 — ports the df filesystem-filter env vars to the NetBSD client
(NetBSD has no `[inode]` section, so `[df]` only).

Adds `XYMONCLIENT_FS_INCLUDE_TYPES` / `_EXCLUDE_TYPES` / `_DF_LOCAL_ONLY`,
building the df `-t no<csv>` exclude list from a default set minus INCLUDE plus
EXCLUDE (EXCLUDE wins). Remote mounts are hidden by `df -l` (DF_LOCAL_ONLY=yes),
not by type, so `no` can surface them. A df that exits non-zero with no output is
surfaced as a yellow failure marker, not read as green. df is factored behind
`run_df`/`emit_df` so the planned remote-df sentinel (separate follow-up) hooks
in additively.

Mock-tested in `tests/client/fs-filter-netbsd.sh` (argv construction,
INCLUDE/EXCLUDE precedence, literal-token handling, local-only, failure marker).
Real NetBSD df behaviour still to be verified on-platform.

Independent of the other #170 OS PRs (touches only `client/xymonclient-netbsd.sh`
+ its test). Docs are included: a NetBSD block in xymonclient.cfg.DIST and per-OS scoping in the xymonclient.cfg.5 entries (previously described as Linux-only).

---
**Update (rebase + consistency pass):** rebased onto post-#175 main; test converted to the shared `fs-filter-common.sh` scaffolding and brought to family parity (EXCLUDE leaves-the-defaults assert, invalid `DF_LOCAL_ONLY` warns).

**Why no `[inode]` handling:** verified end-to-end that NetBSD inode monitoring has never existed - the client script has no `[inode]` section and `xymond/client/netbsd.c` has no parsing for one - so this PR filters only the report that exists. Adding inode support is a separate two-sided feature; for whoever builds it: NetBSD's `df -i` exists, and NetBSD tmpfs reports memory-derived inode counts at source (`tmpfs_statvfs`, the computation OpenBSD inherited), so tmpfs would be KEPT there - FreeBSD's INT_MAX sentinel is FreeBSD-only divergence.

**Open before merge:** on-platform verification against real NetBSD df output (the #175 gate).
