### PR TITLE
client/darwin: env-var-controlled df/inode filesystem filter (#170)

### DIFF
--- a/client/xymonclient-darwin.sh
+++ b/client/xymonclient-darwin.sh
@@ -26,29 +26,123 @@ uptime
 echo "[who]"
 who
 
-FILESYSTEMS=`mount | sed -E '/[\( ](nobrowse|afs|read-only)[ ,\)]/d;s/^.* on (.*) \(.*$/\1/'`
-
 echo "[df]"
-(IFS=$'\n'
- set $FILESYSTEMS
- df -P -H $1; shift
- while test $# -gt 0
- do
-   df -P -H $1 | tail -1 | sed 's/\([^ ]\) \([^ ]\)/\1_\2/g'
-   shift
- done) | column -t -s " " | sed -e 's!Mounted *on!Mounted on!'
+# --- filesystem filter (configurable; see xymonclient.cfg.DIST) --------------
+# macOS df selects per path, not with -t, so the filter is applied to the
+# mount(8) list: drop the noise nobrowse/read-only attributes plus EXCLUDE_TYPES,
+# keep INCLUDE_TYPES.
+: "${XYMONCLIENT_FS_INCLUDE_TYPES=}"
+: "${XYMONCLIENT_FS_EXCLUDE_TYPES=}"
+# DF_LOCAL_ONLY: "yes" (default) keeps only mounts mount(8) flags "local"
+# (MNT_LOCAL, what df -l selects elsewhere), hiding remote mounts (nfs, smbfs,
+# afs, ...); "no" surfaces them; invalid warns and uses yes. (df is per-path
+# here, where -l is ignored, so we filter mount(8) output instead.)
+DFLOCALONLY="${XYMONCLIENT_FS_DF_LOCAL_ONLY:-yes}"
+case "$DFLOCALONLY" in
+	yes|no) ;;
+	*) echo "xymonclient-darwin: invalid XYMONCLIENT_FS_DF_LOCAL_ONLY '$DFLOCALONLY', using yes" >&2; DFLOCALONLY=yes ;;
+esac
+# Escape ERE metachars (and the sed delimiter) so a type is matched literally in
+# the mount(8) filter, not as a regex (e.g. "fuse.*" must not match "fuseblk").
+_re_escape() { printf '%s' "$1" | sed 's,[]\^$.*+?()[{}|/],\\&,g'; }
+# noglob: treat a token like "tmp*" literally, not as a filename glob.
+case $- in *f*) _restoreglob=no ;; *) _restoreglob=yes; set -f ;; esac
+_dflt=""
+# Always-drop attributes (apply to local volumes too, so independent of
+# LOCAL_ONLY), minus INCLUDE_TYPES. Remote mounts are handled by the local filter.
+# Modern macOS (Catalina+) seals / read-only and flags every system volume -
+# including the data volume holding all user files - "nobrowse". Apple marks
+# that one "root data": it is exempted from these DEFAULT drops, so the one
+# volume that can actually fill is always reported. (The sealed read-only root
+# cannot fill and stays dropped; writes land on the data volume.)
+for _t in nobrowse read-only; do
+	for _i in $XYMONCLIENT_FS_INCLUDE_TYPES; do [ "$_t" = "$_i" ] && continue 2; done
+	_dflt="$_dflt|`_re_escape "$_t"`"
+done
+# EXCLUDE_TYPES are applied separately and unconditionally: an explicit admin
+# exclude beats both INCLUDE_TYPES (EXCLUDE wins) and the root-data exemption.
+_user=""
+for _t in $XYMONCLIENT_FS_EXCLUDE_TYPES; do
+	_user="$_user|`_re_escape "$_t"`"
+done
+[ "$_restoreglob" = yes ] && set +f
+_dflt="${_dflt#|}"
+_user="${_user#|}"
+# Mirror df -l: with LOCAL_ONLY=yes keep only mounts flagged "local" (MNT_LOCAL),
+# dropping remote mounts regardless of type.
+_localfilter=""
+[ "$DFLOCALONLY" = yes ] && _localfilter='/[(, ]local[,) ]/!d;'
+# fs_list [extra-type-excludes...]: mount points surviving the filter, one per
+# line. Extra excludes are per-report (apfs for the inode report) and applied
+# like EXCLUDE_TYPES (unconditional).
+fs_list() {
+	_prog="$_localfilter"
+	[ -n "$_dflt" ] && _prog="$_prog/[(, ]root data[,)]/!{/[\( ]($_dflt)[ ,\)]/d;};"
+	_x="$_user"
+	for _t; do _x="$_x|`_re_escape "$_t"`"; done
+	_x="${_x#|}"
+	[ -n "$_x" ] && _prog="$_prog/[\( ]($_x)[ ,\)]/d;"
+	mount | sed -E "${_prog}s/^.* on (.*) \(.*$/\1/"
+}
+FILESYSTEMS=`fs_list`
+# apfs is excluded from the inode report: its ifree is derived from the shared
+# container free space (identical across a container's volumes, %iused pinned
+# at 0%), so the numbers carry no exhaustion signal - the ZFS situation,
+# measured on a real Mac. On an all-APFS system this list is empty and the
+# [inode] section legitimately so: "nothing inode-limited to monitor" is data,
+# not a failure.
+FILESYSTEMS_INODE=`fs_list apfs`
+# emit_df KIND LABEL: print the table in $_out, or -- when df produced nothing --
+# a one-line marker (no df header) so the server goes yellow not green. macOS df
+# is queried per path (into $_out above), so this only applies the guard; that
+# per-path loop is the seam where the remote-df sentinel will route non-local mounts.
+emit_df() {
+	if [ -n "$_out" ]; then
+		printf '%s\n' "$_out"
+		return
+	fi
+	echo "xymonclient-darwin: df $1 collection failed with no output; reporting data as unavailable" >&2
+	echo "$2 report collection failed: df produced no output"
+}
+# Never run df with an empty list: no path means "report every mount", which
+# would defeat the filter. An empty list is itself reportable - if a macOS
+# change (or a config mistake) filters everything away, the marker turns the
+# column yellow instead of silently blanking disk monitoring.
+if [ -n "$FILESYSTEMS" ]; then
+	# Render the table by probing each path; emit_df turns empty output (every
+	# probe failed) into a failure marker. A partial run still prints rows.
+	_out=$( (IFS=$'\n'
+	 set -f		# a mountpoint containing a glob char must not expand
+	 set $FILESYSTEMS
+	 df -P -H $1; shift
+	 while test $# -gt 0
+	 do
+	   df -P -H $1 | tail -1 | sed 's/\([^ ]\) \([^ ]\)/\1_\2/g'
+	   shift
+	 done) | column -t -s " " | sed -e 's!Mounted *on!Mounted on!' )
+else
+	echo "xymonclient-darwin: no filesystems survived the mount filter; check XYMONCLIENT_FS_* settings" >&2
+	_out=""
+fi
+emit_df disk Disk
 
 echo "[inode]"
-(IFS=$'\n'
- set $FILESYSTEMS
- df -P -i $1; shift
- while test $# -gt 0
- do
-   df -P -H $1 | tail -1 | sed 's/\([^0123456789% ]\) \([^ ]\)/\1_\2/g'
-   shift
- done) | awk '
-NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9} 
-(NR>=2 && $6>0) {printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
+# Empty list here is legitimate (all-APFS Mac: nothing inode-limited exists),
+# so unlike the disk report there is no marker - the section stays empty.
+if [ -n "$FILESYSTEMS_INODE" ]; then
+	_out=$( (IFS=$'\n'
+	 set -f		# a mountpoint containing a glob char must not expand
+	 set $FILESYSTEMS_INODE
+	 df -P -i $1; shift
+	 while test $# -gt 0
+	 do
+	   df -P -i $1 | tail -1 | sed 's/\([^0123456789% ]\) \([^ ]\)/\1_\2/g'
+	   shift
+	 done) | awk '
+NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9}
+(NR>=2 && $6>0) {printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}' )
+	emit_df inode Inode
+fi
 
 echo "[mount]"
 mount

--- a/tests/client/fs-filter-darwin.sh
+++ b/tests/client/fs-filter-darwin.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-filter-darwin.sh
+#
+# Regression guard for the df/inode filesystem filter ported to
+# xymonclient-darwin.sh (issue #170). macOS df selects per path (no -t), so the
+# filter is applied when building the filesystem list from mount(8):
+# XYMONCLIENT_FS_EXCLUDE_TYPES drops extra attributes/types, INCLUDE_TYPES keeps
+# defaults, and XYMONCLIENT_FS_DF_LOCAL_ONLY keeps only MNT_LOCAL filesystems
+# (mount(8) marks them "local"), mirroring df -l on the Linux/*BSD clients.
+# Modern-macOS semantics (fixture measured on a real Apple-silicon Mac):
+# the "root data"-flagged data volume survives its nobrowse flag, the sealed
+# read-only root is dropped, apfs never reaches the [inode] report (container-
+# derived ifree carries no signal), an all-apfs inode list is silent-empty,
+# and an empty DISK list emits the yellow marker instead of a silent blank.
+#
+# Mock-tested on any host (mount-filtering + df-argv). The snippet uses IFS=$'\n',
+# which the macOS /bin/sh (bash) supports but dash does not, so we run it with
+# bash here, matching macOS. Real macOS df/mount still need verifying on macOS.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"
+
+# Resolve SCRIPT, apply the dangling-override / skip-if-absent contract, assert
+# the filter is present, set up TMP/STUB/DF_LOG/INODE_LOG/STDERR_LOG/PATH.
+fsf_setup darwin XYMONCLIENT_DARWIN
+command -v column >/dev/null 2>&1 || skip "column(1) not available"
+
+# mount stub: macOS-style lines. Local filesystems carry the "local" attribute
+# (MNT_LOCAL); remote ones (afs, nfs) do not. Covers each default-dropped
+# attribute (nobrowse, read-only) and both a local and a remote read-only/remote
+# mount so LOCAL_ONLY and the attribute filter can be told apart.
+# Mirrors a real Apple-silicon Mac mini (measured 2026-07): sealed read-only
+# root, every system volume nobrowse, the data volume marked "root data" -
+# plus test extras: an external apfs disk, two hfs USB disks (the inode
+# report's non-apfs population), a local read-only image, and remote mounts.
+cat > "$STUB/mount" <<'EOF'
+#!/usr/bin/env bash
+cat <<'MOUNT'
+/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+devfs on /dev (devfs, local, nobrowse)
+/dev/disk3s6 on /System/Volumes/VM (apfs, local, noexec, journaled, noatime, nobrowse)
+/dev/disk3s5 on /System/Volumes/Data (apfs, local, journaled, nobrowse, protect, root data)
+map auto_home on /System/Volumes/Data/home (autofs, automounted, nobrowse)
+/dev/disk5s1 on /Volumes/External (apfs, local, nodev, nosuid, journaled)
+/dev/disk6s1 on /Volumes/USBHFS (hfs, local, nodev, nosuid, journaled)
+/dev/disk7s1 on /Volumes/USBHFS2 (hfs, local, nodev, nosuid, journaled)
+/dev/disk2 on /Volumes/CD (cd9660, local, read-only, nobrowse)
+remote:/exp on /Volumes/nfs (nfs, nodev, nosuid)
+MOUNT
+EOF
+chmod +x "$STUB/mount"
+# df stub: record argv (last arg is the mountpoint). Inode (-i) calls are routed
+# to a separate log and emit the wider macOS "df -i" table; disk calls emit the
+# plain table. This lets the test prove the [inode] block queries every
+# filesystem in inode mode, not disk mode.
+cat > "$STUB/df" <<EOF
+#!/usr/bin/env bash
+# DF_FAIL=1 simulates a df that exits non-zero with no output (e.g. killed).
+[ -n "\${DF_FAIL:-}" ] && exit 1
+for _m; do :; done   # _m = last arg = the mountpoint df was asked about
+if [[ " \$* " =~ " -i " ]]; then
+	echo "\$*" >> "$INODE_LOG"
+	printf 'Filesystem 1024-blocks Used Available Capacity iused ifree %%iused Mounted on\n'
+	printf '/dev/disk 100 50 50 50%% 1000 9000 10%% %s\n' "\$_m"
+else
+	echo "\$*" >> "$DF_LOG"
+	printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+	printf '/dev/disk 100 50 50 50%% %s\n' "\$_m"
+fi
+EOF
+chmod +x "$STUB/df"
+# Decoy files in the snippet's working directory ($TMP): if the script let a
+# configured type token glob, "read-onl*"/"hf*" would expand to these filenames.
+: > "$TMP/read-only"
+: > "$TMP/hfs"
+
+SNIPPET="$TMP/df-section.sh"
+fsf_extract "$SNIPPET"
+
+# Not fsf_run: the snippet uses IFS=$'\n', which macOS /bin/sh (bash) supports
+# but dash does not, so it must run under bash here, matching macOS.
+run() {
+	: > "$DF_LOG"; : > "$INODE_LOG"; : > "$STDERR_LOG"
+	( cd "$TMP"; bash "$SNIPPET" >/dev/null 2>"$STDERR_LOG" )
+	printf ' %s ' "$(tr '\n' ' ' < "$DF_LOG")"
+}
+
+# --- default: modern-macOS semantics -----------------------------------------
+# The data volume survives its nobrowse flag via the "root data" exemption;
+# the sealed read-only root cannot fill and is dropped; system helpers,
+# devfs, remote and read-only mounts are dropped.
+args=$(run)
+assert_contains "/System/Volumes/Data" "$args" "root-data exemption keeps the data volume despite nobrowse"
+assert_contains "/Volumes/External" "$args"    "default keeps a plain local fs"
+assert_contains "/Volumes/USBHFS " "$args"     "default keeps a second local fs"
+assert_not_contains " -H / " "$args"           "default drops the sealed read-only root (cannot fill)"
+assert_not_contains "/System/Volumes/VM" "$args" "default drops a nobrowse system helper"
+assert_not_contains "/dev " "$args"            "default drops devfs (nobrowse)"
+assert_not_contains "/Volumes/nfs" "$args"     "default (local-only) drops the nfs (remote) mount"
+assert_not_contains "home" "$args"             "default drops the autofs map (nobrowse)"
+assert_not_contains "/Volumes/CD" "$args"      "default drops a read-only mount"
+
+# --- EXCLUDE_TYPES drops an extra type --------------------------------------
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES=hfs run)
+assert_not_contains "/Volumes/USBHFS" "$args" "EXCLUDE_TYPES=hfs drops the hfs mounts"
+assert_contains "/Volumes/External" "$args"   "EXCLUDE_TYPES=hfs leaves other types alone"
+
+# An explicit exclude beats the root-data exemption: the admin said apfs goes.
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES=apfs run)
+assert_not_contains "/System/Volumes/Data" "$args" "EXCLUDE_TYPES=apfs beats the root-data exemption"
+assert_not_contains "/Volumes/External" "$args"    "EXCLUDE_TYPES=apfs drops every apfs mount"
+assert_contains "/Volumes/USBHFS " "$args"         "EXCLUDE_TYPES=apfs leaves hfs alone"
+
+# --- INCLUDE_TYPES un-excludes a default-dropped attribute ------------------
+# read-only is an always-drop attribute; including it surfaces the sealed
+# root (but not the CD image, which is also nobrowse). nobrowse surfaces the
+# system helper volumes.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=read-only run)
+assert_contains " -H / " "$args" "INCLUDE_TYPES=read-only surfaces the sealed root"
+assert_not_contains "/Volumes/CD" "$args" "INCLUDE_TYPES=read-only still drops the nobrowse read-only mount"
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=nobrowse run)
+assert_contains "/System/Volumes/VM" "$args" "INCLUDE_TYPES=nobrowse surfaces the system helper volumes"
+
+# --- XYMONCLIENT_FS_DF_LOCAL_ONLY -------------------------------------------
+# "no" surfaces remote filesystems (parity with df -l elsewhere).
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=no run)
+assert_contains "/Volumes/nfs" "$args" "DF_LOCAL_ONLY=no surfaces the nfs (remote) mount"
+assert_contains "/System/Volumes/Data" "$args" "DF_LOCAL_ONLY=no still keeps local filesystems"
+# An invalid value warns and falls back to local-only (remote stays hidden).
+args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=bogus run)
+assert_not_contains "/net/server" "$args" "invalid DF_LOCAL_ONLY falls back to local-only"
+assert_contains "invalid XYMONCLIENT_FS_DF_LOCAL_ONLY" "$(cat "$STDERR_LOG")" "invalid DF_LOCAL_ONLY warns"
+
+# --- type tokens are literal, not shell globs or regexes --------------------
+# With $TMP as the working directory (decoy files read-only/hfs present), an
+# include glob must not expand to "read-only" and surface the sealed root.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES='read-onl*' run)
+assert_not_contains " -H / " "$args" \
+	"include type tokens must not undergo pathname expansion"
+# An exclude glob must not expand to "hfs" and drop the hfs mounts.
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES='hf*' run)
+assert_contains "/Volumes/USBHFS " "$args" \
+	"exclude type tokens must not undergo pathname expansion"
+# An exclude token must be matched literally in the mount filter, not as an ERE:
+# "hf." must not match "hfs" via the regex "." metacharacter.
+args=$(XYMONCLIENT_FS_EXCLUDE_TYPES='hf.' run)
+assert_contains "/Volumes/USBHFS " "$args" \
+	"exclude type tokens must be matched literally, not as a regex"
+
+# --- include + exclude precedence: exclude wins -----------------------------
+# A type named in both lists stays excluded: EXCLUDE is applied last (documented
+# contract). read-only in both must keep the local read-only mount dropped.
+args=$(XYMONCLIENT_FS_INCLUDE_TYPES=read-only XYMONCLIENT_FS_EXCLUDE_TYPES=read-only run)
+assert_not_contains " -H / " "$args" \
+	"a type in both include and exclude lists must stay excluded (exclude wins)"
+
+# --- [inode]: apfs excluded, every remaining fs queried in inode mode -------
+# apfs ifree is container-derived (identical across volumes, %iused pinned at
+# 0% - measured on a real Mac), so apfs rows never reach the inode report;
+# the two hfs USB disks do. Regression guard retained: the loop body once used
+# `df -P -H` for the 2nd+ filesystem, mislabelling disk data as inode data.
+args=$(run)
+inode_args=$(printf ' %s ' "$(tr '\n' ' ' < "$INODE_LOG")")
+assert_contains " -i " "$inode_args" "inode report uses df -i"
+assert_not_contains " -H " "$inode_args" "inode report must NOT use df -H (would mislabel disk as inode)"
+assert_not_contains "Data" "$inode_args" "apfs volumes are excluded from the inode report"
+assert_equal 2 "$(grep -c . "$INODE_LOG")" "inode report queries every kept filesystem, not just the first"
+
+out=$( cd "$TMP"; bash "$SNIPPET" 2>/dev/null )
+inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
+assert_contains "/Volumes/USBHFS2" "$inode_section" "inode report includes the 2nd filesystem's row"
+
+# All-APFS Mac: the inode list is legitimately empty - the section must be
+# empty and silent (nothing inode-limited exists), NOT a failure marker.
+: > "$INODE_LOG"
+out=$( cd "$TMP"; XYMONCLIENT_FS_EXCLUDE_TYPES=hfs bash "$SNIPPET" 2>/dev/null )
+inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
+assert_not_contains "collection failed" "$inode_section" \
+	"an all-apfs inode list is empty data, not a failure"
+assert_equal "" "$(cat "$INODE_LOG")" "no inode df runs on an all-apfs system"
+assert_contains "/System/Volumes/Data" "$out" "the disk report still carries the data volume"
+
+# --- empty disk list: no path-less df, and a LOUD marker ---------------------
+# If every mount is excluded, df must not run with no path (which would list
+# all mounts and defeat the filter) - and the disk report must go yellow, not
+# silently green: on a modern Mac a wrong default here blanks all monitoring.
+: > "$DF_LOG"; : > "$INODE_LOG"
+out=$( cd "$TMP"; XYMONCLIENT_FS_EXCLUDE_TYPES="apfs hfs" bash "$SNIPPET" 2>/dev/null )
+assert_equal "" "$(cat "$DF_LOG")"    "all-excluded: disk df not run with an empty path"
+assert_equal "" "$(cat "$INODE_LOG")" "all-excluded: inode df not run with an empty path"
+assert_contains "Disk report collection failed" "$out" \
+	"an empty disk list emits the failure marker (yellow), never a silent blank"
+
+# --- false-green guard: df fails with no output -> marker, not empty section --
+# Mirrors the *BSD clients: a df that produces nothing must emit a failure
+# marker (no df header) so the server goes yellow, not green.
+out=$( cd "$TMP"; DF_FAIL=1 bash "$SNIPPET" 2>/dev/null )
+assert_contains "Disk report collection failed" "$out" \
+	"a failed disk df emits a failure marker"
+assert_contains "Inode report collection failed" "$out" \
+	"a failed inode df emits a failure marker"
+assert_not_contains "Filesystem" "$out" \
+	"failure marker carries no df header (server reads a header-less section as yellow)"
+
+pass "xymonclient-darwin.sh FS filter: root-data exemption, apfs-free inode report, empty-list marker"


### PR DESCRIPTION
Part of #170 — ports the df/inode filesystem-filter env vars to the macOS client.

macOS df selects per path (not `-t`), so the filter is applied to `mount(8)`
output: drop the noise nobrowse/read-only attributes plus EXCLUDE_TYPES, keep
INCLUDE_TYPES (EXCLUDE wins). `DF_LOCAL_ONLY=yes` keeps only mounts mount(8)
flags `local` (MNT_LOCAL, the same flag `df -l` selects elsewhere), hiding remote
mounts (nfs, smbfs, afs, ...); `no` surfaces them. Empty output (every per-path
probe failed) is surfaced as a yellow failure marker, not read as green. The
per-path loop is factored behind `emit_df` and is the seam where the planned
remote-df sentinel (separate follow-up) will route non-local mounts.

Mock-tested in `tests/client/fs-filter-darwin.sh` (mount-based filter, inode
mode, empty-filter guard). Real macOS df behaviour still to be verified
on-platform.

Independent of the other #170 OS PRs (touches only `client/xymonclient-darwin.sh`
+ its test). Docs (cfg.DIST/man scoping) follow in a separate PR.

---
**Update (rebase + consistency pass):** rebased onto post-#175 main; test adopts `fsf_setup`/`fsf_extract` from the shared scaffolding. The runner stays deliberately custom: the snippet needs `bash` (macOS `/bin/sh` is bash; `IFS=$'\n'`), while `fsf_run` uses `/bin/sh` - commented in place so it doesn't get "simplified" back. Test coverage was already the family's most complete (invalid-value warn, precedence, literal-not-ERE, empty-filter guard, df-failure marker).

**Contract note, stated plainly:** on Darwin, `INCLUDE_TYPES`/`EXCLUDE_TYPES` operate on the mixed namespace of filesystem types *and* mount attributes as `mount(8)` prints them (`nobrowse`, `read-only`, `local`) - macOS df has no type selection, so the filter works on the mount list. Same variables, wider vocabulary; documented rather than pretended away.

**Open before un-drafting:** (1) on-platform verification against real macOS df/mount output (the #175 gate); (2) the APFS inode question - the tmpfs-sentinel analog: APFS's `df -i` free-inode figure is believed space-derived (ZFS-style, meaningless); measure `df -i /` on a real Mac and decide whether APFS joins the inode-report exclusion before this merges.

**Migration note (behavior change, the only removal-by-default in the #170 family):** the original script dropped only `afs` by name - **nfs and smbfs mounts were shown** in the disk report. The new default (`DF_LOCAL_ONLY=yes` keeps only `local`-flagged mounts) hides all remote mounts, consistent with df -l on the other clients. A macOS host that monitored an NFS/SMB mount through the disk report must set `XYMONCLIENT_FS_DF_LOCAL_ONLY=no` to keep it.

**Also fixed while porting (both test-pinned):** the original inode loop queried the 2nd+ filesystems with `df -P -H` (disk mode inside the inode report), and an all-excluded filter ran `df` with no path - listing every mount and defeating the filter. Latest push additionally sets noglob inside the per-path subshells so a mountpoint containing a glob character cannot expand against the working directory.

---
**Redesign for modern macOS (measured on a real Apple-silicon Mac, 2026-07).** Live `mount`/`df -i` output showed the previous defaults were pre-Catalina fossils: Apple now seals `/` read-only and flags every system volume - including the data volume holding all user files - `nobrowse`, so the default attribute drops excluded **every mount** on a modern Mac. (The original script masked this with its empty-list bug: a path-less `df` reported everything, filter defeated.) Three changes:

1. **`root data` exemption**: Apple marks the data volume with the `root data` attribute; it is exempted from the *default* drops, so the one volume that can actually fill is always reported. The sealed read-only root stays dropped (it cannot fill). An explicit `EXCLUDE_TYPES` entry still beats the exemption; `INCLUDE_TYPES=nobrowse` still resurrects the helper volumes.
2. **`apfs` excluded from the `[inode]` report**: measured `ifree` is container-derived - identical (3,780,253,960) across every volume of a container while `iused` varies, `%iused` pinned at 0% - the ZFS situation; no exhaustion signal exists. On an all-APFS Mac the inode list is legitimately empty and the section stays silent-empty (data, not failure).
3. **Empty disk list → yellow marker**: if a future macOS attribute change (or a config mistake) ever filters everything away again, the disk column goes visibly yellow instead of silently blank.

The test fixture is now the measured modern-Mac mount table (sealed root, nobrowse system volumes, root-data-flagged data volume) plus external/hfs/remote extras; new assertions pin the exemption, exclude-beats-exemption, the apfs-free inode report, the all-apfs silent-empty case, and the empty-list marker.