### PR TITLE
lib/matching: use strcasecmp for case-insensitive literal name matching

### DIFF
--- a/lib/matching.c
+++ b/lib/matching.c
@@ -100,11 +100,11 @@ int namematch(const char *needle, char *haystack, pcre2_code *pcrecode)
 
 		if (!found) {
 			if (*tok == '!') {
-				found = (strcmp(tok+1, needle) == 0);
+				found = (strcasecmp(tok+1, needle) == 0);
 				if (found) result = 0;
 			}
 			else {
-				found = (strcmp(tok, needle) == 0);
+				found = (strcasecmp(tok, needle) == 0);
 				if (found) result = 1;
 			}
 		}


### PR DESCRIPTION
Fixes #192 — root-cause issue (case-insensitive host load vs case-sensitive literal match).

## Summary

- `namematch()` in `lib/matching.c` used `strcmp` for literal string patterns (`HOST=`, `SERVICE=`, `PAGE=`, `CLASS=`, etc. in `alerts.cfg`, `analysis.cfg` and similar config files), making them case-sensitive
- Regex patterns (with `%`-prefix) were already case-insensitive via `PCRE2_CASELESS`
- The host lookup tree in `loadhosts.c` already uses `strcasecmp` as its comparator
- This patch replaces the two `strcmp` calls in the literal-match path with `strcasecmp`, aligning all three code paths

## Test plan

- [ ] Verify `HOST=MyServer` in `alerts.cfg` matches a host defined as `myserver` in `hosts.cfg`
- [ ] Verify `HOST=myserver` matches `MYSERVER`
- [ ] Verify negation still works: `HOST=!MyServer` excludes the host regardless of case
- [ ] Verify comma-separated lists work: `HOST=myserver,OtherHost`
- [ ] Verify regex patterns (`HOST=%myserver.*`) are unaffected
- [ ] Run regression suite: `./tests/testsuite`
