### PR TITLE
xymonnet: NUL-terminate cmdpath in run_rpcinfo_service

### DIFF
--- a/xymonnet/xymonnet.c
+++ b/xymonnet/xymonnet.c
@@ -1105,6 +1105,7 @@ void run_rpcinfo_service(service_t *service)
 
 	p = xgetenv("RPCINFO");
 	strncpy(cmdpath, (p ? p : "rpcinfo"), sizeof(cmdpath));
+	cmdpath[sizeof(cmdpath)-1] = '\0';	/* strncpy may not terminate */
 	for (t=service->items; (t); t = t->next) {
 		/* Do not run RPCINFO test if host does not resolve in DNS or is down */
 		if (!t->host->dnserror && (t->host->downcount == 0) && !t->host->pingerror) {


### PR DESCRIPTION
Fixes #184

`strncpy()` does not terminate the destination when the source is at least `sizeof(cmdpath)` bytes, so an `RPCINFO` value of `PATH_MAX` or longer left `cmdpath` unterminated and the later use as a C string read past the buffer.

This forces termination after the copy.

Pre-existing latent bug on `main`, in the RPC path.

Same idiom as Henrik's 2005 termination sweeps (`338496e18`, `6a6f92d12`), which fixed other strncpy sites but missed this one.