### PR TITLE
xymond: fix stack buffer overflow in combostatus evaluate()

### DIFF
--- a/xymond/combostatus.c
+++ b/xymond/combostatus.c
@@ -352,7 +352,7 @@ static long evaluate(char *symbolicexpr, char **resultexpr, value_t **valuelist,
 	result = compute(expr, &error);
 
 	if (error) {
-		sprintf(errtext, "compute(%s) returned error %d\n", expr, error);
+		snprintf(errtext, sizeof(errtext), "compute(%s) returned error %d\n", expr, error);
 		if (*errbuf == NULL) {
 			*errbuf = strdup(errtext);
 		}


### PR DESCRIPTION
## Problem

`evaluate()` in `xymond/combostatus.c` formats its error message into a fixed
1 KB stack buffer with an unbounded `sprintf()`:

```c
char expr[MAX_LINE_LEN];   /* 16384 bytes */
char errtext[1024];
...
if (error) {
        sprintf(errtext, "compute(%s) returned error %d\n", expr, error);
```

`expr` is built from the combo test expression (`combo.cfg`) and can be up to
`MAX_LINE_LEN` (16 KB). When `compute()` returns an error, any expression longer
than ~990 characters overflows the 1 KB `errtext` stack buffer, corrupting the
stack and potentially crashing `xymond`.

## Fix

Bound the write with `snprintf(errtext, sizeof(errtext), ...)`.

Config is admin-controlled, so this is primarily a robustness/correctness fix
rather than a remote vulnerability, but a long combo expression that fails to
compute should never overflow the stack.

Fixes #187
