### PR TITLE
xymond: record ntp test offset in milliseconds

### DIFF
--- a/xymond/rrd/do_net.c
+++ b/xymond/rrd/do_net.c
@@ -130,7 +130,9 @@ int do_net_rrd(char *hostname, char *testname, char *classname, char *pagepaths,
 		}
 		
 		if (offsetval) {
-			snprintf(dataforntpstat, sizeof(dataforntpstat), "offset=%s", offsetval);
+			/* ntpdate/sntp report the offset in seconds; the ntpstat RRD DS is
+			 * milliseconds (offsetms), so scale before recording. */
+			snprintf(dataforntpstat, sizeof(dataforntpstat), "offset=%.6f", atof(offsetval) * 1000.0);
 			do_ntpstat_rrd(hostname, testname, classname, pagepaths, dataforntpstat, tstamp);
 		}
 


### PR DESCRIPTION
Fixes #196.

`do_net.c` forwards the network `ntp` test offset (from ntpdate/sntp, in seconds) to the ntpstat RRD handler, whose DS is milliseconds (`offsetms`), stored unscaled — so the recorded offset, and the NTP offset graph, were ~1000x too small. Scale seconds to milliseconds before recording.

Only the network `ntp` path is affected; the client `ntpstat` test (`ntpq -c rv`, already ms) is untouched.

Note: PR #158 rewrites this same `do_net.c` block and will need to rebase onto this.
