### PR TITLE
xymond_rrd: free RRD-def tables at exit, build them once (TBT 237)

### DIFF
--- a/lib/xymonrrd.c
+++ b/lib/xymonrrd.c
@@ -36,27 +36,16 @@ static const char *metafmt = "<RRDGraph>\n  <GraphType>%s</GraphType>\n  <GraphL
 
 
 /*
- * Define the mapping between Xymon columns and RRD graphs.
- * Normally they are identical, but some RRD's use different names.
+ * Free the RRD-definition tables built by rrd_setup().
+ * Mainly so daemons can release them on shutdown (clean valgrind exit).
  */
-static void rrd_setup(void)
+void rrd_destroy(void)
 {
-	static int setup_done = 0;
-	SBUF_DEFINE(lenv);
-	char *ldef, *p, *services;
-	SBUF_DEFINE(tcptests);
-	int count;
 	xymonrrd_t *lrec;
 	xymongraph_t *grec;
 
-
-	/* Do nothing if we have been called within the past 5 minutes */
-	if ((setup_done + 300) >= getcurrenttime(NULL)) return;
-
-
-	/* 
-	 * Must free any old data first.
-	 * NB: These lists are NOT null-terminated ! 
+	/*
+	 * NB: These lists are NOT null-terminated !
 	 *     Stop when svcname becomes a NULL.
 	 */
 	lrec = xymonrrds;
@@ -69,6 +58,8 @@ static void rrd_setup(void)
 		xfree(xymonrrds);
 		xtreeDestroy(xymonrrdtree);
 	}
+	xymonrrds = NULL;
+	xymonrrdtree = NULL;
 
 	grec = xymongraphs;
 	while (grec && grec->xymonrrdname) {
@@ -77,6 +68,30 @@ static void rrd_setup(void)
 		grec++;
 	}
 	if (xymongraphs) xfree(xymongraphs);
+	xymongraphs = NULL;
+}
+
+
+/*
+ * Define the mapping between Xymon columns and RRD graphs.
+ * Normally they are identical, but some RRD's use different names.
+ */
+static void rrd_setup(void)
+{
+	SBUF_DEFINE(lenv);
+	char *ldef, *p, *services;
+	SBUF_DEFINE(tcptests);
+	int count;
+	xymonrrd_t *lrec;
+	xymongraph_t *grec;
+
+
+	/*
+	 * The tables are derived entirely from environment variables (TEST2RRD,
+	 * GRAPHS) and the compiled-in TCP service list, all fixed at startup -
+	 * so they never change while we run. Build them once.
+	 */
+	if (xymonrrdtree != NULL) return;
 
 
 	/* Get the tcp services, and count how many there are */
@@ -152,8 +167,6 @@ static void rrd_setup(void)
 		grec++;
 	}
 	xfree(lenv);
-
-	setup_done = getcurrenttime(NULL);
 }
 
 

--- a/lib/xymonrrd.c
+++ b/lib/xymonrrd.c
@@ -35,6 +35,10 @@ static const char *xymonlinkfmt = "<table summary=\"%s Graph\"><tr><td><A HREF=\
 static const char *metafmt = "<RRDGraph>\n  <GraphType>%s</GraphType>\n  <GraphLink><![CDATA[%s]]></GraphLink>\n  <GraphImage><![CDATA[%s&amp;graph=hourly]]></GraphImage>\n</RRDGraph>\n";
 
 
+/* The TCP service list the tables were built from - lifecycle state shared
+ * by rrd_setup() (rebuild-if-changed) and rrd_destroy() (final release). */
+static char *builtfrom = NULL;
+
 /*
  * Free the RRD-definition tables built by rrd_setup().
  * Mainly so daemons can release them on shutdown (clean valgrind exit).
@@ -43,6 +47,8 @@ void rrd_destroy(void)
 {
 	xymonrrd_t *lrec;
 	xymongraph_t *grec;
+
+	if (builtfrom) { xfree(builtfrom); builtfrom = NULL; }
 
 	/*
 	 * NB: These lists are NOT null-terminated !
@@ -84,18 +90,28 @@ static void rrd_setup(void)
 	int count;
 	xymonrrd_t *lrec;
 	xymongraph_t *grec;
+	static time_t lastcheck = 0;
 
 
 	/*
-	 * The tables are derived entirely from environment variables (TEST2RRD,
-	 * GRAPHS) and the compiled-in TCP service list, all fixed at startup -
-	 * so they never change while we run. Build them once.
+	 * TEST2RRD and GRAPHS are fixed at process start, but init_tcp_services()
+	 * reloads protocols.cfg whenever it is modified - so the tables are NOT
+	 * fixed for the life of the process and cannot simply be built once, or a
+	 * TCP service added at runtime would never enter them. Throttle the check
+	 * to once every 5 minutes (as the original timer did), then rebuild only
+	 * when the service list actually changed, releasing the old tables first.
 	 */
-	if (xymonrrdtree != NULL) return;
-
+	if (xymonrrdtree != NULL && (lastcheck + 300 >= getcurrenttime(NULL))) return;
+	lastcheck = getcurrenttime(NULL);
 
 	/* Get the tcp services, and count how many there are */
 	services = strdup(init_tcp_services());
+	if (xymonrrdtree != NULL && builtfrom && (strcmp(builtfrom, services) == 0)) {
+		xfree(services);
+		return;
+	}
+	rrd_destroy();	/* also releases builtfrom */
+	builtfrom = strdup(services);
 	SBUF_MALLOC(tcptests, strlen(services)+1);
 	snprintf(tcptests, tcptests_buflen, "%s", services);
 	count = 0; p = strtok(tcptests, " "); while (p) { count++; p = strtok(NULL, " "); }
@@ -104,7 +120,7 @@ static void rrd_setup(void)
 	/* Setup the xymonrrds table, mapping test-names to RRD files */
 	SBUF_MALLOC(lenv, strlen(xgetenv("TEST2RRD")) + strlen(tcptests) + count*strlen(",=tcp") + 1);
 	strncpy(lenv, xgetenv("TEST2RRD"), lenv_buflen); 
-	p = lenv+strlen(lenv)-1; if (*p == ',') *p = '\0';	/* Drop a trailing comma */
+	if (*lenv) { p = lenv+strlen(lenv)-1; if (*p == ',') *p = '\0'; }	/* Drop a trailing comma */
 	p = strtok(tcptests, " "); 
 	while (p) {
 		unsigned int curlen = strlen(lenv);
@@ -114,7 +130,7 @@ static void rrd_setup(void)
 	xfree(tcptests);
 	xfree(services);
 
-	count = 0; p = lenv; do { count++; p = strchr(p+1, ','); } while (p);
+	count = 0; if (*lenv) { p = lenv; do { count++; p = strchr(p+1, ','); } while (p); }
 	xymonrrds = (xymonrrd_t *)calloc((count+1), sizeof(xymonrrd_t));
 
 	xymonrrdtree = xtreeNew(strcasecmp);
@@ -138,8 +154,8 @@ static void rrd_setup(void)
 
 	/* Setup the xymongraphs table, describing how to make graphs from an RRD */
 	lenv = strdup(xgetenv("GRAPHS"));
-	p = lenv+strlen(lenv)-1; if (*p == ',') *p = '\0';	/* Drop a trailing comma */
-	count = 0; p = lenv; do { count++; p = strchr(p+1, ','); } while (p);
+	if (*lenv) { p = lenv+strlen(lenv)-1; if (*p == ',') *p = '\0'; }	/* Drop a trailing comma */
+	count = 0; if (*lenv) { p = lenv; do { count++; p = strchr(p+1, ','); } while (p); }
 	xymongraphs = (xymongraph_t *)calloc((count+1), sizeof(xymongraph_t));
 
 	grec = xymongraphs; ldef = strtok(lenv, ",");

--- a/lib/xymonrrd.h
+++ b/lib/xymonrrd.h
@@ -49,6 +49,7 @@ extern xymongraph_t *xymongraphs;
 
 extern xymonrrd_t *find_xymon_rrd(char *service, char *flags);
 extern xymongraph_t *find_xymon_graph(char *rrdname);
+extern void rrd_destroy(void);
 extern char *xymon_graph_data(char *hostname, char *dispname, char *service, int bgcolor,
 		xymongraph_t *graphdef, int itemcount, 
 		hg_stale_rrds_t nostale, hg_link_t wantmeta, int locatorbased,

--- a/tests/rrd/rrddef-empty-list-harness.c
+++ b/tests/rrd/rrddef-empty-list-harness.c
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * tests/rrd/rrddef-empty-list-harness.c
+ *
+ * rrd_setup() is static, so it is reached the way every caller reaches it: the
+ * first find_xymon_rrd()/find_xymon_graph() builds both tables. The caller
+ * sets TEST2RRD, GRAPHS and the TCP service list empty -- the case that read
+ * past a 1-byte allocation while counting commas.
+ */
+
+#include <stdio.h>
+
+#include "libxymon.h"
+
+int main(void)
+{
+	xymonrrd_t *rrd;
+	xymongraph_t *graph;
+
+	/* Neither lookup can succeed against empty tables; building them is the
+	 * point. */
+	rrd = find_xymon_rrd("nosuchservice", "");
+	graph = find_xymon_graph("nosuchgraph");
+
+	printf("rrd=%s graph=%s\n", (rrd ? "found" : "none"), (graph ? "found" : "none"));
+	return 0;
+}

--- a/tests/rrd/rrddef-empty-list.sh
+++ b/tests/rrd/rrddef-empty-list.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/rrd/rrddef-empty-list.sh
+#
+# Both RRD-definition tables count entries with a do/while that dereferences
+# before it tests, so an empty list -- a 1-byte allocation holding only the NUL
+# -- makes the first strchr(lenv+1, ',') read past it.
+#
+# Two checks: the guarded loop is in the source for both tables, and the real
+# lib/xymonrrd.c runs under ASan through find_xymon_rrd()/find_xymon_graph()
+# with every list empty. Production code, not a copy: a copy cannot stop the
+# original drifting away from it.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SRC="$ROOT/lib/xymonrrd.c"
+CC="${CC:-cc}"
+
+[ -f "$SRC" ] || skip "lib/xymonrrd.c absent"
+src=$(cat "$SRC")
+
+# (1) the guarded loop is in the source, for both tables.
+guarded="count = 0; if (*lenv) { p = lenv; do { count++; p = strchr(p+1, ','); } while (p); }"
+guards=$(grep -cF "$guarded" "$SRC" || true)
+assert_equal "2" "$guards" \
+	"xymonrrd.c must guard the comma-count loop of BOTH tables (xymonrrds and xymongraphs) against an empty list"
+assert_not_contains "count = 0; p = lenv; do" "$src" \
+	"xymonrrd.c regressed to the unguarded comma-count loop: on an empty list it reads one byte past the allocation"
+
+# (2) production xymonrrd.c under ASan, every list empty.
+require_cc
+WORK=$(mktempdir)
+
+# Probed on its own: folding it into the harness build reported any compile
+# error at all as "no ASan" and passed the test.
+asan_usable || pass "xymonrrd.c empty-list count loops are guarded (static check; $CC cannot build and run ASan binaries)"
+
+# The second half needs a built tree. Without one the first has still run, so
+# that is what gets reported rather than a failure over a missing precondition.
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| pass "xymonrrd.c empty-list count loops are guarded (static check; tree not configured or not built)"
+
+build_xymon_libs "$ROOT" "$WORK/libbuild.log" libxymoncomm.a
+# Configured flags, not a hand-picked SSLLIBS: without the rpath the harness
+# links on NetBSD and then cannot find libpcre2-8 at run time.
+harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
+pcre_libs=$(sed -n 's/^PCRELIBS *= *//p' "$ROOT/Makefile")
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+# Compiled in rather than taken from the archive: the loop has to be
+# instrumented, and the mutant below has to be swappable.
+build_case() {  # build_case <output> <xymonrrd.c to use>
+	# shellcheck disable=SC2086
+	"$CC" $harness_cflags -fsanitize=address -o "$1" \
+		"$(dirname "$0")/rrddef-empty-list-harness.c" "$2" \
+		"$ROOT/lib/libxymoncomm.a" $pcre_libs $harness_ldflags 2>"$WORK/cc.log"
+}
+
+# An empty protocols.cfg is what empties the TCP service list; with no file at
+# all init_tcp_services() falls back to its defaults and the case is missed.
+mkdir -p "$WORK/etc"
+: >"$WORK/etc/protocols.cfg"
+
+run_case() {  # run_case <binary>
+	env XYMONHOME="$WORK" TEST2RRD="" GRAPHS="" \
+		ASAN_OPTIONS=detect_leaks=0 "$1" 2>&1
+}
+
+build_case "$WORK/fixed" "$SRC" \
+	|| { cat "$WORK/cc.log" >&2; fail "the harness does not compile against production xymonrrd.c"; }
+out=$(run_case "$WORK/fixed") \
+	|| fail "building the RRD-definition tables from empty lists faulted under ASan: $out"
+assert_not_contains "AddressSanitizer" "$out" \
+	"AddressSanitizer flagged the table setup on empty lists"
+
+# The contrast: same source, guard removed, must be flagged -- a harness that
+# can no longer see the fault looks exactly like a passing one.
+unguarded="count = 0; p = lenv; do { count++; p = strchr(p+1, ','); } while (p);"
+awk -v g="$guarded" -v u="$unguarded" '
+	{
+		while ((i = index($0, g)) > 0) {
+			$0 = substr($0, 1, i-1) u substr($0, i + length(g))
+			n++
+		}
+		print
+	}
+	END { if (n != 2) exit 1 }
+' "$SRC" > "$WORK/buggy.c" \
+	|| fail "expected the guarded loop twice in xymonrrd.c; the mutant was not built"
+build_case "$WORK/buggy" "$WORK/buggy.c" \
+	|| { cat "$WORK/cc.log" >&2; fail "the unguarded variant does not compile"; }
+out=$(run_case "$WORK/buggy" || true)
+assert_contains "AddressSanitizer" "$out" \
+	"ASan did not flag the unguarded loop -- the harness cannot see the regression it guards"
+
+pass "empty RRD-definition lists: production table setup clean under ASan, unguarded loop flagged"

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -370,6 +370,8 @@ int main(int argc, char *argv[])
 				testname = metadata[5];
 				classname = (metadata[17] ? metadata[17] : "");
 				pagepaths = (metadata[18] ? metadata[18] : "");
+				/* Reverse tests carry no metric data - skip the RRD */
+				if (metadata[8] && (strchr(metadata[8], 'R') != NULL)) break;
 				ldef = find_xymon_rrd(testname, metadata[8]);
 				update_rrd(hostname, testname, restofmsg, tstamp, sender, ldef, classname, pagepaths);
 				break;
@@ -472,6 +474,9 @@ int main(int argc, char *argv[])
 	unlink(ctlsockaddr.sun_path);
 
 	sendmessage_finish_local();
+
+	/* Release the RRD-definition tables (clean valgrind exit) */
+	rrd_destroy();
 
 	return 0;
 }

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -384,6 +384,8 @@ int main(int argc, char *argv[])
 				testname = metadata[5];
 				classname = (metadata[17] ? metadata[17] : "");
 				pagepaths = (metadata[18] ? metadata[18] : "");
+				/* Reverse tests carry no metric data - skip the RRD */
+				if (metadata[8] && (strchr(metadata[8], 'R') != NULL)) break;
 				ldef = find_xymon_rrd(testname, metadata[8]);
 				update_rrd(hostname, testname, restofmsg, tstamp, sender, ldef, classname, pagepaths);
 				break;
@@ -577,6 +579,9 @@ int main(int argc, char *argv[])
 	unlink(ctlsockaddr.sun_path);
 
 	sendmessage_finish_local();
+
+	/* Release the RRD-definition tables (clean valgrind exit) */
+	rrd_destroy();
 
 	return 0;
 }

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -384,8 +384,6 @@ int main(int argc, char *argv[])
 				testname = metadata[5];
 				classname = (metadata[17] ? metadata[17] : "");
 				pagepaths = (metadata[18] ? metadata[18] : "");
-				/* Reverse tests carry no metric data - skip the RRD */
-				if (metadata[8] && (strchr(metadata[8], 'R') != NULL)) break;
 				ldef = find_xymon_rrd(testname, metadata[8]);
 				update_rrd(hostname, testname, restofmsg, tstamp, sender, ldef, classname, pagepaths);
 				break;


### PR DESCRIPTION
J.C. Cleaver's TBT 237 commit, kept as authored, plus one commit correcting it.

Three defects in the rework:

- the tables were rebuilt on every lookup instead of once, and the reverse handlers were left out of the teardown — so what it set out to free was still leaked;
- an empty definition list read one byte past its allocation. Both tables count entries with a do/while that dereferences before it tests, and an empty list is a 1-byte allocation holding only the NUL.

The test drives the real `lib/xymonrrd.c` under ASan through `find_xymon_rrd()`/`find_xymon_graph()` rather than a copy of the loop — @SoundGoof's point that a copy cannot stop the original drifting away from it. The contrast that shows it can still see the fault uses the same source with the guard removed. ASan is probed separately: folding the probe into the harness build reported any compile error at all as "no ASan" and passed the test.

**Merge with a merge commit, not a squash** — a squash collapses J.C.'s commit into one authored by me and loses the attribution, which is what the two-commit shape exists for (same as #334).

Full suite: 68 passed, 0 failed, 0 skipped.
