### PR TITLE
xymond: persist drop/rename via checkpoint so it survives a restart (#201)

### DIFF
--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -2639,6 +2639,14 @@ void handle_dropnrename(enum droprencmd_t cmd, char *sender, char *hostname, cha
 		break;
 	}
 
+	/*
+	 * Persist this mutation promptly: the main loop checkpoints only when
+	 * "now > nextcheckpoint", so forcing it to 0 triggers a checkpoint next
+	 * cycle instead of waiting up to checkpointinterval - closing the window
+	 * where a restart would reload a stale checkpoint and resurrect the drop.
+	 */
+	nextcheckpoint = 0;
+
 done:
 	MEMUNDEFINE(hostip);
 


### PR DESCRIPTION
Closes #201.

`handle_dropnrename()` removes the host/test in memory but never forces a checkpoint. Checkpoints are written only on the timer (default 600 s) or a clean shutdown, so a `drop` followed by an unclean stop — or any restart loading a `.chk` older than the drop — resurrects the dropped host/test, and with it the alert tied to the stale status. Exactly the reported symptom: drop + restart did not clear it; deleting `server/tmp/*.chk` did.

**Fix:** set `nextcheckpoint = 0` after a successful drop/rename (the idiom the `SIGUSR1` handler already uses), so the main loop checkpoints on the next cycle instead of waiting up to `checkpointinterval`. Runs only on a real mutation — the not-found paths jump straight to `done`. No behavior change beyond making drops durable.

**Verified by reproduction** (local xymond, own listener + checkpoint file):

- **main**: red status → forced checkpoint (SIGUSR1) → `drop HOST TEST` (gone from the board) → `kill -9` → restart with `--restart` = the dropped test is back on the board, red, straight from the stale checkpoint.
- **clean shutdown is safe even without the fix** (exit writes a checkpoint) — the window is exactly an unclean stop or a stale-checkpoint restart.
- **with this patch**: the checkpoint is rewritten within one loop cycle of the drop; the same `kill -9` + restart resurrects nothing.

**Scope:** this is the whole fix for #201's confirmed bug. The by-design behaviours around orphaned columns (purple-forever, alerts outliving their status) are tracked separately in #214, with #204 as the diagnostic follow-up — neither blocks this fix.
