### PR TITLE
RFC/WIP: xymond: retire stale-purple statuses that the config no longer produces (#201)

### DIFF
--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -5177,6 +5177,26 @@ void check_purple_status(void)
 						if (!lwalk->dismsg) lwalk->dismsg = strdup(cause);                                         
 					}
 
+					/*
+					 * Issue #201: flag a client-column reconciliation problem.
+					 * If the host is still sending client data (its last client
+					 * report is at/after this column's expiry) yet this column has
+					 * gone purple, the client has stopped producing a column it
+					 * used to send - typically retired by a config or class change
+					 * (e.g. linux -> freebsd after a reinstall). Such a column ages
+					 * to purple and keeps alerting with no removal path. We do NOT
+					 * drop it here (a manual "xymon drop" remains the fix, made
+					 * durable by the drop-checkpoint change); instead we warn via
+					 * the xymond column so an operator can tell this apart from a
+					 * genuinely dead client and retire it. The conn/ping column is
+					 * server-generated, not sent by the client, so it is excluded.
+					 */
+					if ((newcolor == COL_PURPLE) && hwalk->clientmsgs && (lwalk != hwalk->pinglog) &&
+					    ((hwalk->clientmsgtstamp + (now - gettimer())) >= lwalk->validtime)) {
+						errprintf("Client-column reconciliation: host '%s' still reports client data but column '%s' has gone purple (no longer sent) - likely retired by a config/class change; investigate or 'xymon drop %s %s'\n",
+							hwalk->hostname, lwalk->test->name, hwalk->hostname, lwalk->test->name);
+					}
+
 					handle_status(lwalk->message, "xymond", 
 						hwalk->hostname, lwalk->test->name, lwalk->grouplist, lwalk, newcolor, NULL, 0);
 					lwalk = lwalk->next;


### PR DESCRIPTION
Draft / RFC for bug **B** of #201 — **no behavioural change yet**, just a documented scaffold at the fix site to agree the approach.

**Problem:** when a client's applicable ruleset changes (e.g. class `linux` -> `freebsd` after an OS reinstall), a test the old class emitted stops being reported. It ages to purple in `check_purple_status()`, and because purple is in the default `ALERTCOLORS` (`red,yellow,purple`) it **keeps paging forever**, with no removal path — unlike the `H_SUMMARY` case just above it, which is dropped. Combined with bug A (#… drop-checkpoint PR) it also survives restarts.

**This PR** adds only a TODO at the exact spot describing the proposed fix; it ships no code change, so it is safe to sit as an RFC.

**Proposed fix (opt-in, default off — existing installs rely on purple = "client died"):**
- add `PURPLERETIRE=<seconds>` (0 = disabled);
- when a non-summary log has been purple longer than that, drop it like the `H_SUMMARY` case **and** post an `@@droptest` to the page channel so `xymond_alert` clears the active alert (freeing the log alone would not) — cleanest via `handle_dropnrename(CMD_DROPTEST,…)`, but that mutates `hwalk->logs` mid-walk so the loop cursor must be advanced first.

**Open question for maintainers:** opt-in purple-retire as above, or instead make a class change actively invalidate the old class's columns in `xymond_client` (no timeout). Happy to implement whichever is preferred.

Refs #201.