### PR TITLE
svcstatus: break locator redirect loops with SKIPLOC (split from #46)

### DIFF
--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -40,6 +40,7 @@ static char *accessfn = NULL;
 static char *hostname = NULL;
 static char *service = NULL;
 static char *tstamp = NULL;
+static char *skiploc = NULL;
 static char *nkprio = NULL, *nkttgroup = NULL, *nkttextra = NULL;
 static enum { FRM_STATUS, FRM_CLIENT } outform = FRM_STATUS;
 STATIC_SBUF_DEFINE(clienturi);
@@ -105,6 +106,9 @@ static int parse_query(void)
 		}
 		else if (strcasecmp(cwalk->name, "NKTTEXTRA") == 0) {
 			nkttextra = strdup(cwalk->value);
+		}
+		else if ((strcasecmp(cwalk->name, "SKIPLOC") == 0)   && cwalk->value && strlen(cwalk->value) && (strcmp(cwalk->value, "1") == 0)) {
+			skiploc = strdup(cwalk->value);
 		}
 		else if ((strcmp(cwalk->name, "backsecs") == 0)   && cwalk->value && strlen(cwalk->value)) {
 			backsecs += atoi(cwalk->value);
@@ -302,7 +306,7 @@ int do_request(void)
 		strncpy(timesincechange, "0 minutes", sizeof(timesincechange));
 
 		if (strcmp(service, xgetenv("TRENDSCOLUMN")) == 0) {
-			if (locatorbased) {
+			if (locatorbased && !skiploc) {
 				char *cgiurl, *qres;
 
 				qres = locator_query(hostname, ST_RRD, &cgiurl);
@@ -311,7 +315,7 @@ int do_request(void)
 				}
 				else {
 					/* Redirect browser to the real server */
-					fprintf(stdout, "Location: %s/svcstatus.sh?HOST=%s&SERVICE=%s\n\n",
+					fprintf(stdout, "Location: %s/svcstatus.sh?HOST=%s&SERVICE=%s&SKIPLOC=1\n\n",
 						cgiurl, hostname, service);
 					return 0;
 				}
@@ -702,6 +706,7 @@ int do_request(void)
 	if (hostname) xfree(hostname);
 	if (service) xfree(service);
 	if (tstamp) xfree(tstamp);
+	if (skiploc) xfree(skiploc);
 
 	/* Cleanup main vars */
 	if (clientid) xfree(clientid);
@@ -785,7 +790,7 @@ int main(int argc, char *argv[])
 	redirect_cgilog("svcstatus");
 
 	*errortxt = '\0';
-	hostname = service = tstamp = NULL;
+	hostname = service = tstamp = skiploc = NULL;
 	if (do_request() != 0) {
 		fprintf(stdout, "%s", errortxt);
 		return 1;


### PR DESCRIPTION
> **Superseded by the closing decision (2026-07-02):** the skiploc change stays with **#151**; the "single carrier" claim below reflects the plan before this PR was closed. #46 briefly re-carried the patch after its 2026-07-03 rebase, then dropped `web/svcstatus.c` the same day — **#151 is the sole carrier**.

Splits the single behavioural change to `web/svcstatus.c` out of the 45-file backport bundle **#46**, so it can be reviewed and merged on its own. Cherry-picked unchanged (original commit `a0822c27`, jccleaver, 2019 — authorship preserved); applies cleanly on current `main` (PCRE2, path-traversal fix) and builds without warnings.

## What

In a locator-based multi-server setup, `svcstatus` redirects a trends request to the server owning the RRD files. That server, itself locator-based, redirects again — looping instead of serving the page. The redirect now appends `SKIPLOC=1`, telling the target to serve the page directly. No effect on single-server setups (`locatorbased` is false, the parameter is never emitted).

## Why split

- #46 mixes this one behavioural change with 44 files of packaging/webfiles backports; a contested file deserves its own review.
- It dissolves the last merge-order gate in the **#107** checklist for **#44** (custom graphs): #44 rewrites the adjacent `TRENDSCOLUMN` line (NULL-guard). Whichever lands second resolves one two-line block; the combined result is documented in both places: `if (trendscolumn && ...) { if (locatorbased && !skiploc) {`.
- **This PR is the single carrier of the change**: #151 dropped its identical copy, the #44 rework branch (`fix/pr44-custom-graphs`) carries none, and #46 should drop `web/svcstatus.c` on its next rebase.

Runtime validation in a real locator/multi-server setup has not been done here — the change is 2019 4.4-branch code that has been in production in that line; review is of the cherry-pick's fit on `main`.


