### PR TITLE
htmllog: render custom GRAPHS_<service> graphs without a default graph (fixes #31, supersedes #44)

### DIFF
--- a/docs/howtograph.html
+++ b/docs/howtograph.html
@@ -242,6 +242,39 @@ Save the file, and when you click on the <b>trends</b> column you should
 see the slab graph at the bottom of the page.
 
 
+<h2>Show the graph on a status page: GRAPHS_&lt;columnname&gt;</h2>
+<p>To display graphs on a specific status page - including a custom column
+that has no default graph of its own - set GRAPHS_&lt;columnname&gt; in
+~xymon/server/etc/xymonserver.cfg to a comma-separated list of graph
+definitions:</p>
+
+<pre><tt>
+	GRAPHS_smart=&quot;smart-temp,tcp:smtp&quot;
+</tt></pre>
+
+<p>Each name needs a matching graphs.cfg section; <tt>bundle:instance</tt>
+(or <tt>bundle.instance</tt>) shows a single instance of a multi-file graph,
+like the smtp response time from the [tcp] section above. The setting
+<i>overrides</i> the column's default graph, so include that in the list to
+keep it (GRAPHS_cpu=&quot;la,smart-temp&quot;). Adding the graph to GRAPHS is
+only needed for the <b>trends</b> column - the status page works from
+GRAPHS_&lt;columnname&gt; alone.</p>
+
+<p>By default the page shows one image containing every RRD file the graph's
+FNPATTERN matches. To split it into groups of instances the way the
+<b>disk</b> column does, put the instance count in the body of the status
+message your script sends: <tt>&lt;!-- linecount=12 --&gt;</tt>. Groups hold
+5 instances unless the graph sets its own size in GRAPHS - note the double
+colon, and GRAPHS only, never inside GRAPHS_&lt;columnname&gt;:</p>
+
+<pre><tt>
+	GRAPHS=&quot;...,smart-temp::4,...&quot;
+</tt></pre>
+
+<p>On the <b>trends</b> column both the instance count and the splitting are
+automatic.</p>
+
+
 <h2>Common problems and pitfalls</h2>
 <h3>If your graph nearly always shows 0</h3>
 <p>You probably used the wrong RRD datatype for your data - see step 4.

--- a/lib/htmllog.c
+++ b/lib/htmllog.c
@@ -515,8 +515,21 @@ void generate_html_log(char *hostname, char *displayname, char *service, char *i
 				fprintf(output, "<!-- GRAPHS_%s: %s -->\n", service, graphsenv);
 				graphsptr = strtok(graphscopy,",");
 				while (graphsptr != NULL) {
-					graph->xymonrrdname = strdup(graphsptr);
-					fprintf(output, "%s\n", xymon_graph_data(hostname, displayname, graphsptr, color, graph, linecount, HG_WITHOUT_STALE_RRDS, HG_PLAIN_LINK, locatorbased, now-graphtime, now));
+					xymongraph_t localgraph, *owngdef;
+
+					/*
+					 * A stack-local gdef keeps the entry verbatim in the link
+					 * (a prefix-matched table entry would rewrite it to its
+					 * base name) and leaves the shared table unwritten - the
+					 * legacy strdup() into it leaked and corrupted later
+					 * lookups. maxgraphs: the entry's own GRAPHS record, else
+					 * the service's default graph.
+					 */
+					owngdef = find_xymon_graph(graphsptr);
+					memset(&localgraph, 0, sizeof(localgraph));
+					localgraph.xymonrrdname = graphsptr;
+					localgraph.maxgraphs = (owngdef ? owngdef->maxgraphs : (graph ? graph->maxgraphs : 0));
+					fprintf(output, "%s\n", xymon_graph_data(hostname, displayname, graphsptr, color, &localgraph, linecount, HG_WITHOUT_STALE_RRDS, HG_PLAIN_LINK, locatorbased, now-graphtime, now));
 					graphsptr = strtok(NULL,",");
 				}
 				xfree(graphscopy);

--- a/lib/htmllog.c
+++ b/lib/htmllog.c
@@ -509,17 +509,17 @@ void generate_html_log(char *hostname, char *displayname, char *service, char *i
 			snprintf(graphs, graphs_buflen, "GRAPHS_%s", service);
 			graphsenv=getenv(graphs);
 			if (graphsenv) {
+				/* strtok on a copy - the getenv() result is the live environment */
+				char *graphscopy = strdup(graphsenv);
+
 				fprintf(output, "<!-- GRAPHS_%s: %s -->\n", service, graphsenv);
-				/* check for strtokens */
-				graphsptr = strtok(graphsenv,",");
+				graphsptr = strtok(graphscopy,",");
 				while (graphsptr != NULL) {
-					// fprintf(output, "<!-- found: %s -->\n", graphsptr);
 					graph->xymonrrdname = strdup(graphsptr);
 					fprintf(output, "%s\n", xymon_graph_data(hostname, displayname, graphsptr, color, graph, linecount, HG_WITHOUT_STALE_RRDS, HG_PLAIN_LINK, locatorbased, now-graphtime, now));
-					// next token
 					graphsptr = strtok(NULL,",");
 				}
-
+				xfree(graphscopy);
 			}
 			else {
 				fprintf(output, "%s\n", xymon_graph_data(hostname, displayname, service, color, graph, linecount, HG_WITHOUT_STALE_RRDS, HG_PLAIN_LINK, locatorbased, now-graphtime, now));

--- a/lib/htmllog.c
+++ b/lib/htmllog.c
@@ -518,7 +518,7 @@ void generate_html_log(char *hostname, char *displayname, char *service, char *i
 				/* strtok on a copy - the getenv() result is the live environment */
 				char *graphscopy = strdup(graphsenv);
 
-				fprintf(output, "<!-- GRAPHS_%s: %s -->\n", service, graphsenv);
+				fprintf(output, "<!-- GRAPHS_%s: %s -->\n", service, htmlquoted(graphsenv));
 				graphsptr = strtok(graphscopy,",");
 				while (graphsptr != NULL) {
 					xymongraph_t localgraph, *owngdef;

--- a/lib/htmllog.c
+++ b/lib/htmllog.c
@@ -186,7 +186,7 @@ void generate_html_log(char *hostname, char *displayname, char *service, char *i
 	xymongraph_t *graph = NULL;
 	char *tplfile = "hostsvc";
 	SBUF_DEFINE(graphs);
-	char *graphsenv;
+	char *graphsenv = NULL;
 	char *graphsptr;
 	time_t now = getcurrenttime(NULL);
 
@@ -421,8 +421,18 @@ void generate_html_log(char *hostname, char *displayname, char *service, char *i
 					  service, rrd->xymonrrdname);
 			}
 		}
+
+		/* GRAPHS_<service> custom graphs render even when the service has no
+		 * default graph (issue #31) - but never for reverse tests, which
+		 * collect no RRD data. */
+		SBUF_MALLOC(graphs, 7 + strlen(service) + 1);
+		snprintf(graphs, graphs_buflen, "GRAPHS_%s", service);
+		graphsenv = getenv(graphs);
+		if (graphsenv && (*graphsenv == '\0')) graphsenv = NULL;	/* set-but-empty = not set */
+		if (flags && strchr(flags, 'R')) graphsenv = NULL;
+		xfree(graphs);
 	}
-	if (rrd && graph) {
+	if ((rrd && graph) || graphsenv) {
 		int may_have_rrd = 1;
 
 		/*
@@ -443,7 +453,7 @@ void generate_html_log(char *hostname, char *displayname, char *service, char *i
 			if (multigraphs == NULL) multigraphs = ",disk,inode,qtree,quotas,snapshot,TblSpace,if_load,";
 
 			/* Not all devmon statuses have graphs, so try to avoid generating graph links unless there is one */
-			if (strncmp(rrd->xymonrrdname,"devmon",6) == 0) may_have_rrd=0;
+			if (rrd && (strncmp(rrd->xymonrrdname,"devmon",6) == 0)) may_have_rrd=0;
 
 			/* 
 			 * Some reports (disk) use the number of lines as a rough measure for how many
@@ -504,10 +514,6 @@ void generate_html_log(char *hostname, char *displayname, char *service, char *i
 			fprintf(output, "<!-- linecount=%d -->\n", linecount);
 			fprintf(output, "<a name=\"begingraph\">&nbsp;</a>\n");
 
-			/* Get the GRAPHS_* environment setting */
-			SBUF_MALLOC(graphs, 7 + strlen(service) + 1);
-			snprintf(graphs, graphs_buflen, "GRAPHS_%s", service);
-			graphsenv=getenv(graphs);
 			if (graphsenv) {
 				/* strtok on a copy - the getenv() result is the live environment */
 				char *graphscopy = strdup(graphsenv);
@@ -537,7 +543,6 @@ void generate_html_log(char *hostname, char *displayname, char *service, char *i
 			else {
 				fprintf(output, "%s\n", xymon_graph_data(hostname, displayname, service, color, graph, linecount, HG_WITHOUT_STALE_RRDS, HG_PLAIN_LINK, locatorbased, now-graphtime, now));
 			}
-			xfree(graphs);
 		}
 	}
 

--- a/tests/web/html-log-custom-graphs-harness.c
+++ b/tests/web/html-log-custom-graphs-harness.c
@@ -1,0 +1,148 @@
+/* Regression test for issue #31: GRAPHS_<service> custom graphs must render
+ * on a status page even when the service has no default graph definition. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libxymon.h"
+
+static int failures = 0;
+
+static void expect_contains(const char *label, const char *text, const char *needle)
+{
+	if (!text || !strstr(text, needle)) {
+		fprintf(stderr, "%s: missing '%s'\n", label, needle);
+		failures++;
+	}
+}
+
+static void expect_not_contains(const char *label, const char *text, const char *needle)
+{
+	if (text && strstr(text, needle)) {
+		fprintf(stderr, "%s: unexpected '%s'\n", label, needle);
+		failures++;
+	}
+}
+
+static char *render_log_msg(const char *service, int is_history, const char *flags, const char *restofmsg)
+{
+	char *html = NULL;
+	size_t htmlsz = 0;
+	FILE *out;
+
+	out = open_memstream(&html, &htmlsz);
+	if (!out) { perror("open_memstream"); exit(2); }
+
+	generate_html_log("testhost", "Test Host", (char *)service, "127.0.0.1",
+			  COL_GREEN, 0, "tester", (char *)flags,
+			  0, "0 minutes", "green status ok", (char *)restofmsg,
+			  NULL, 0, NULL, NULL, 0, NULL,
+			  is_history, 1, 0, 0, NULL, NULL,
+			  NULL, NULL, NULL, 3600, out);
+
+	fclose(out);
+	return html;
+}
+
+static char *render_log(const char *service, int is_history)
+{
+	return render_log_msg(service, is_history, "", "status body");
+}
+
+int main(void)
+{
+	char *html;
+
+	histlocation = HIST_NONE;
+
+	/* The #31 case: "smart" has no default graph (not in TEST2RRD/GRAPHS),
+	 * only GRAPHS_smart. Before the fix, no graph section rendered at all. */
+	html = render_log("smart", 0);
+	expect_contains("custom graph without default", html, "<!-- GRAPHS_smart: smart-temp,smart-status -->");
+	expect_contains("custom graph without default", html, "<a name=\"begingraph\">");
+	expect_contains("custom graph without default", html, "service=smart-temp");
+	expect_contains("custom graph without default", html, "service=smart-status");
+	free(html);
+
+	/* The environment must not be mutated by tokenizing (legacy strtok bug):
+	 * a second render of the same page must still see the full list. */
+	html = render_log("smart", 0);
+	expect_contains("environment not mutated", html, "<!-- GRAPHS_smart: smart-temp,smart-status -->");
+	expect_contains("environment not mutated", html, "service=smart-status");
+	free(html);
+
+	/* Default path unchanged: cpu maps via TEST2RRD to la, no GRAPHS_cpu -
+	 * the legacy link uses the mapped RRD name. */
+	html = render_log("cpu", 0);
+	expect_contains("default graph unchanged", html, "<a name=\"begingraph\">");
+	expect_contains("default graph unchanged", html, "service=la");
+	free(html);
+
+	/* History pages never render graphs - unchanged. */
+	html = render_log("smart", 1);
+	expect_not_contains("history page has no graphs", html, "begingraph");
+	expect_not_contains("history page has no graphs", html, "GRAPHS_smart");
+	free(html);
+
+	/* A service with neither default graph nor GRAPHS_ renders no graph section. */
+	html = render_log("nograph", 0);
+	expect_not_contains("no graph config, no section", html, "begingraph");
+	free(html);
+
+	/* The GRAPHS "name:N" split size applies on status pages too: smart-temp
+	 * is listed as smart-temp:6 in GRAPHS, so 12 instances page as 2x6 -
+	 * while smart-status (not in GRAPHS, stack-local definition) pages on
+	 * the default balanced base of 5 -> 3x4. */
+	html = render_log_msg("smart", 0, "", "<!-- linecount=12 -->\nstatus body");
+	expect_contains("GRAPHS :N split on status page", html, "service=smart-temp&amp;graph_width=576&amp;graph_height=120&amp;first=1&amp;count=6");
+	expect_contains("GRAPHS :N split on status page", html, "service=smart-temp&amp;graph_width=576&amp;graph_height=120&amp;first=7&amp;count=6");
+	expect_contains("default split without GRAPHS entry", html, "service=smart-status&amp;graph_width=576&amp;graph_height=120&amp;first=1&amp;count=4");
+	free(html);
+
+	/* Instance-suffixed entries must reach the URL verbatim: "smart-temp.sda"
+	 * prefix-matches the smart-temp gdef but the link must not be rewritten
+	 * to the base graph, and "tcp.smtp" must not trip the tcp special-case
+	 * into "tcp:tcp.smtp" (its gdef is prefix-matched too - GRAPHS has tcp). */
+	html = render_log("dotted", 0);
+	expect_contains("dotted entry kept verbatim", html, "service=smart-temp.sda&amp;");
+	expect_contains("bundle instance kept verbatim", html, "service=tcp.smtp&amp;");
+	expect_not_contains("no doubled tcp special-case", html, "service=tcp:tcp.smtp");
+	free(html);
+
+	/* A set-but-empty GRAPHS_<service> must not emit an empty graph section
+	 * on a page that previously had none. */
+	html = render_log("emptyval", 0);
+	expect_not_contains("empty GRAPHS_ value ignored", html, "begingraph");
+	free(html);
+
+	/* Reverse tests (flag 'R') collect no RRD data, so GRAPHS_<service>
+	 * must not render dead graph links for them. */
+	html = render_log_msg("smart", 0, "oRdastle", "status body");
+	expect_not_contains("reverse test has no graphs", html, "begingraph");
+	free(html);
+
+	/* The value echoed into the page comment is HTML-quoted, so a hostile
+	 * value cannot break out of it (GRAPHS_hostile is "a-->b"). */
+	html = render_log("hostile", 0);
+	expect_contains("hostile value quoted in comment", html, "GRAPHS_hostile: a--&gt;b");
+	expect_not_contains("hostile value quoted in comment", html, "GRAPHS_hostile: a-->b");
+	free(html);
+
+	/* Rendering a GRAPHS_ page must not corrupt the shared graph table: the
+	 * legacy code overwrote the default gdef's name with the custom entry,
+	 * breaking every later lookup in the process ("mut" maps to la via
+	 * TEST2RRD and has GRAPHS_mut=smart-temp). */
+	html = render_log_msg("mut", 0, "", "status body");
+	free(html);
+	{
+		xymongraph_t *la = find_xymon_graph("la");
+		if (!la || strcmp(la->xymonrrdname, "la") != 0) {
+			fprintf(stderr, "shared gdef mutated: find_xymon_graph(\"la\") %s\n",
+				la ? la->xymonrrdname : "returns NULL");
+			failures++;
+		}
+	}
+
+	printf(failures ? "FAILED\n" : "ALL OK\n");
+	return failures ? 1 : 0;
+}

--- a/tests/web/html-log-custom-graphs.sh
+++ b/tests/web/html-log-custom-graphs.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/html-log-custom-graphs.sh
+#
+# Regression guard for issue #31: GRAPHS_<service> custom graphs must render
+# even when the service has no default graph definition. Drives the real
+# generate_html_log() through a small C harness; see the harness for the
+# full list of assertions.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+here=$(dirname "$0")
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+command -v make >/dev/null 2>&1 || skip "make not available"
+
+pcre_libs=${PCRELIBS:-}
+if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+fi
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-htmllog-graphs.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+# The harness links libxymoncomm. Like the require_bin tests, a tree that
+# was never configured/built skips (tests.yml runs on a bare tree; the
+# post-build suite in build.yml then exercises it for real) - the test
+# must not write config.h or other build artifacts into a bare tree. On
+# a built tree, refresh the archive incrementally so the harness tests
+# this tree's code, not a stale archive.
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+	"$here/html-log-custom-graphs-harness.c" "$ROOT/lib/libxymoncomm.a" \
+	$pcre_libs -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+XYMONHOME="$work" \
+CGIBINURL="/xymon-cgi" \
+RRDWIDTH=576 \
+RRDHEIGHT=120 \
+XYMONSKIN="/xymon/gifs" \
+XYMONWEB="/xymon" \
+IMAGEFILETYPE="gif" \
+TEST2RRD="cpu=la,disk,mut=la" \
+GRAPHS="la,disk,tcp,smart-temp::6" \
+GRAPHS_smart="smart-temp,smart-status" \
+GRAPHS_mut="smart-temp" \
+GRAPHS_dotted="smart-temp.sda,tcp.smtp" \
+GRAPHS_emptyval="" \
+GRAPHS_hostile="a-->b" \
+INFOCOLUMN="info" \
+TRENDSCOLUMN="trends" \
+ACKUNTILMSG="until %H:%M" \
+	"$work/harness" 2>"$work/stderr.log" || fail "harness assertions failed: $(cat "$work/stderr.log")"
+
+pass "custom GRAPHS_<service> graphs render without a default graph definition"


### PR DESCRIPTION
Fixes #31. **Supersedes #44** — keeps its diagnosis (Mark Felder co-authors the fix commit), drops the RRD-counting approach: a deep review of a corrected revision of it showed the count-gate regressed locator/distributed setups, filestore static pages, TEST2RRD-mapped columns and `--multigraphs` paging ([record in #107](https://github.com/xymon-monitoring/xymon/issues/107#issuecomment-4866693882)).

## The fix — additive only (+56/−16 in `lib/htmllog.c`)

The `GRAPHS_<service>` block sat inside the `(rrd && graph)` guard, so a custom graph on a column with **no default graph definition** never rendered. The guard is widened; such a column gets a stack-local gdef for the link. Nothing is gated on filesystem state, and the legacy `linecount`/locator/filestore paths are untouched — **no page that rendered graphs before can lose them.**

Six commits, one subject each, ordered preparation → fix (every line written once; all six build individually):
1. `strtok` no longer mutates the live `GRAPHS_<service>` environment value (second render saw a truncated list);
2. entries render **verbatim** through a stack-local gdef (`disk.sda1`/`tcp.smtp` reach the URL untouched — prefix-resolving them rewrote the link or tripped the `tcp:` special-case), the `GRAPHS` `name::N` split size is now honoured on status pages, and the shared graph table is never written (the legacy mutation corrupted every later lookup in long-running processes, and leaked) — this also makes the loop NULL-safe for a missing default graph, preparing:
3. the #31 guard fix — the guard-move itself, ~15 lines; set-but-empty value counts as not set;
4. hardening — the value echoed into the `<!-- GRAPHS_… -->` comment is HTML-quoted;
5. the regression test — runner-conformant (skips on an unbuilt tree, compile failure = FAIL with log), covering every behaviour above;
6. `howtograph.html` — the missing `GRAPHS_<columnname>` section plus combined-vs-split rendering (`<!-- linecount=N -->`, `GRAPHS name::N`).

## Validation

Harness through the real `generate_html_log()`; full suite 15/15, CI green. Live differential against a running xymond: upstream `svcstatus.cgi` renders **no** graph section on a custom column (#31 reproduced), this branch renders it — and with real RRD files the whole chain works (combined image via `showgraph.cgi`, automatic listing and count on the trends page, which needed no code change).

