### PR TITLE
svcstatus: do not crash when SCRIPT_NAME is not set (fixes #209)

### DIFF
--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -151,6 +151,7 @@ static int parse_query(void)
 		char *hostquoted = htmlquoted(hostname);
 
 		req = getenv("SCRIPT_NAME");
+		if (!req) req = "";	/* Only set when invoked as a CGI - do not crash outside one */
 		SBUF_MALLOC(clienturi, strlen(req) + 10 + strlen(hostquoted));
 		strncpy(clienturi, req, clienturi_buflen);
 		p = strchr(clienturi, '?'); if (p) *p = '\0'; else p = clienturi + strlen(clienturi);


### PR DESCRIPTION
Fixes #209. One-line fix: `parse_query()` ran `strlen()` on `getenv("SCRIPT_NAME")` unchecked — a web server always sets it, but any other invocation (shell debugging, test harnesses, misconfigured wrappers) segfaulted before producing any output. A missing `SCRIPT_NAME` is now treated as empty.

Validated live: the same invocation that segfaulted (`rc=139`, `SIGSEGV` at NULL in libc `strlen`) now exits `rc=1` with a proper error page.