### PR TITLE
xymond: revive the dead bogus-status guard in handle_status() (fixes #210)

### DIFF
--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -1436,7 +1436,7 @@ void handle_status(unsigned char *msg, char *sender, char *hostname, char *testn
 			  textornull(hostname), textornull(testname), textornull(sender));
 		return;
 	}
-	if (msg_data(msg, 0) == (char *)msg, 0) {
+	if (msg_data(msg, 0) == (char *)msg) {
 		errprintf("Bogus status message: msg_data finds no host.test. Sent from: '%s', data:'%s'\n",
 			  sender, msg);
 		return;


### PR DESCRIPTION
Fixes #210. The rejection of messages where `msg_data()` finds no `host.test` was written as `if (msg_data(msg, 0) == (char *)msg, 0)` — the comma operator makes the condition constant false, so the guard and its diagnostic never fired. This removes the `, 0`.

Safety of reactivating: `msg_data()` only returns its argument when the message contains no `.` at all, which cannot happen for a status that passed `get_hts()` (the `.` separating `host.test` is mandatory there). Validated live against a running xymond: normal statuses still accepted (`guardok|green` on the board), no spurious rejections logged.