### PR TITLE
xymond: do not crash in load_checkpoint() when MACHINEDOTS is undefined

### DIFF
--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -5002,7 +5002,7 @@ void load_checkpoint(char *fn)
 		if (strcmp(testname, xgetenv("CLIENTCOLUMN")) == 0) continue;
 
 		/* Rename the now-forgotten internal statuses */
-		if (strcmp(hostname, getenv("MACHINEDOTS")) == 0) {
+		if (strcmp(hostname, xgetenv("MACHINEDOTS")) == 0) {
 			if (strcmp(testname, "bbgen") == 0) testname = "xymongen";
 			else if (strcmp(testname, "bbtest") == 0) testname = "xymonnet";
 			else if (strcmp(testname, "hobbitd") == 0) testname = "xymond";


### PR DESCRIPTION
`load_checkpoint()` reads MACHINEDOTS with a raw `getenv()` — the only such call site; everything around it uses `xgetenv()`:

```c
/* Rename the now-forgotten internal statuses */
if (strcmp(hostname, getenv("MACHINEDOTS")) == 0) {
```

With the variable undefined, every restored status record does `strcmp(hostname, NULL)` and xymond segfaults on startup, right after logging "Loading saved state" — no error message. Since a clean shutdown always writes a checkpoint, an environment missing MACHINEDOTS becomes a startup crash loop under xymonlaunch.

Reachability is admittedly narrow: a stock xymonserver.cfg defines MACHINEDOTS, so this needs a manual start without `--env` (how it was found, while reproducing #201) or a pruned config. The asymmetry is that everywhere else the missing variable is tolerated silently — `xgetenv()` falls back to the built-in default (`$XYMONSERVERHOSTNAME`, ultimately the compile-time hostname) — while this one line turns it into a hard crash with a rough failure signature.

**Fix:** use `xgetenv()` like the surrounding lookups. One word.

**Verified A/B** (same checkpoint file with one red status record, MACHINEDOTS deliberately unset):
- unpatched: `Segmentation fault (core dumped)`, exit 139, log ends at "Loading saved state"
- patched: starts, restores the record (`xymondboard` shows it), clean SIGTERM shutdown
