### PR TITLE
client_config: honor first-match for DS (RRD dataset) rules (#32)

### DIFF
--- a/xymond/client_config.c
+++ b/xymond/client_config.c
@@ -3085,9 +3085,11 @@ strbuffer_t *check_rrdds_thresholds(char *hostname, char *classname, char *pagep
 	rrdtplnames_t *tpl;
 	double val;
 	void *hinfo;
+	strbuffer_t *seen;
 
 	if (!resbuf) resbuf = newstrbuffer(0);
 	clearstrbuffer(resbuf);
+	seen = newstrbuffer(0);
 
 	hinfo = hostinfo(hostname);
 	rule = getrule(hostname, pagepaths, classname, hinfo, C_RRDDS);
@@ -3122,6 +3124,20 @@ strbuffer_t *check_rrdds_thresholds(char *hostname, char *classname, char *pagep
 
 		if (vallist[tpl->idx] == NULL) goto nextrule;
 		val = atof(vallist[tpl->idx]);
+
+		/*
+		 * First match wins per (column, dataset, severity). Once a rule of a
+		 * given colour applies to this target, later rules for the same target
+		 * and colour are shadowed - even if this rule's threshold does not
+		 * trigger - matching the top-to-bottom first-match semantics documented
+		 * for analysis.cfg (put the specific settings first, the generic ones
+		 * last). Different colours are kept, so a yellow and a red threshold on
+		 * one dataset both still apply. Issue #32.
+		 */
+		snprintf(msgline, sizeof(msgline), "\001%s\002%s\002%s\001",
+			 rule->rule.rrdds.column, rule->rule.rrdds.rrdds, colorname(rule->rule.rrdds.color));
+		if (strstr(STRBUF(seen), msgline)) goto nextrule;
+		addtobuffer(seen, msgline);
 
 		/* Do the checks */
 		if (rule->flags & RRDDSCHK_INTVL) {
@@ -3214,6 +3230,7 @@ nextrule:
 
 	if (valscopy) xfree(valscopy);
 	if (vallist) xfree(vallist);
+	freestrbuffer(seen);
 
 	return (STRBUFLEN(resbuf) > 0) ? resbuf : NULL;
 }


### PR DESCRIPTION
Closes #32.

## Problem

`analysis.cfg` is documented as first-match (`analysis.cfg.5`):

> The entire file is evaluated from the top to bottom, and the first match found is used. So you should put the specific settings first, and the generic ones last.

Every threshold type honors this — `get_disk_thresholds()` and its inode/proc/port/load siblings walk to the **first** pattern-matching rule and use it. `check_rrdds_thresholds()` did not: it looped over **every** matching `DS` rule and emitted a `modify` for each, so a later wildcard rule was not shadowed by an earlier specific one — both applied:

```
DS conn tcp.conn.rrd:sec >0.5 COLOR=red HOST=web1   # web1 tolerates more
DS conn tcp.conn.rrd:sec >0.1 COLOR=red             # general default
```

On `web1` both evaluated, so the general `>0.1` rule wrongly fired alongside the specific `>0.5` override — duplicate/conflicting `modify conn` lines.

## Fix

Track the `(column, dataset, colour)` targets already decided in this check pass and skip later rules for the same target, so the first matching rule wins — as for disk/inode/proc/load. The target is recorded as soon as a rule *applies* to it (its dataset is present in the RRD and has a value), **even when that rule's threshold does not trigger** — matching the disk semantics, where the first matching rule defines the check rather than falling through to a more general rule.

Two reasons the key is finer than disk's simple "return on first match":
- One DS check pass legitimately fires rules for *different* `(column, dataset)` targets in the same RRD, so the loop must continue across targets.
- **Severity (colour) is part of the key**, so a specific rule shadows only later rules of the **same** colour. A yellow threshold and a red threshold on one dataset both still fire (multi-level DS alerting keeps working — that is the only way DS expresses two levels), while a specific-vs-general pair of the same colour no longer both apply.

## Status

Compiles clean. A regression harness around `check_rrdds_thresholds()` (config + rule tree + dataset names) would be a good follow-up; I can add one if wanted.
