### PR TITLE
xymonproxy: tighten the two-way message list; don't broadcast queries (TBT 12 + devel eea86fb51)

### DIFF
--- a/xymonproxy/xymonproxy.c
+++ b/xymonproxy/xymonproxy.c
@@ -561,11 +561,16 @@ int main(int argc, char *argv[])
 				 * at the front of the buffer, we need to skip that when looking at
 				 * what type of message it is. Hence the "cwalk->buf+6".
 				 */
-				if (strncmp(cwalk->buf+6, "client", 6) == 0) {
+				if ((strncmp(cwalk->buf+6, "client ", 7) == 0) || (strncmp(cwalk->buf+6, "client/", 7) == 0)) {
 					/*
-					 * "client" messages go to all Xymon servers, but
+					 * "client" data messages go to all Xymon servers, but
 					 * we will only pass back the response from one of them
 					 * (the last one).
+					 * Match "client " and "client/" exactly: the client-
+					 * prefixed query commands ("clientlog", "clientsubmit",
+					 * "clientconfig") are two-way requests handled below and
+					 * must not be broadcast or get the [proxy] section
+					 * appended.
 					 */
 					shutdown(cwalk->csocket, SHUT_RD);
 					msgs_other++;
@@ -580,12 +585,20 @@ int main(int argc, char *argv[])
 					}
 				}
 				else if ((strncmp(cwalk->buf+6, "query", 5) == 0)  ||
+				         (strncmp(cwalk->buf+6, "client", 6) == 0) ||
+				         (strncmp(cwalk->buf+6, "xymond", 6) == 0) ||
+				         (strncmp(cwalk->buf+6, "hobbitd", 7) == 0) ||
+				         (strncmp(cwalk->buf+6, "hostinfo", 8) == 0) ||
 				         (strncmp(cwalk->buf+6, "config", 6) == 0) ||
+				         (strncmp(cwalk->buf+6, "ghostlist", 9) == 0) ||
 				         (strncmp(cwalk->buf+6, "ping", 4) == 0) ||
 				         (strncmp(cwalk->buf+6, "download", 8) == 0)) {
-					/* 
-					 * These requests get a response back, but send no data.
-					 * Send these to the last of the Xymon servers only.
+					/*
+					 * Two-way requests: these get a response back but send
+					 * no data, so send them to one server only (the last)
+					 * rather than broadcasting. Includes the client-prefixed
+					 * query commands (clientlog etc.) and the board/log
+					 * queries (xymond*, hobbitd*, hostinfo, ghostlist).
 					 */
 					shutdown(cwalk->csocket, SHUT_RD);
 					msgs_other++;


### PR DESCRIPTION
## Problem

xymonproxy classifies each message by prefix to decide routing. Two related mis-classifications:

1. The client-data test was `strncmp(buf+6, "client", 6)` — it also caught the client-prefixed **query** commands (`clientlog`, `clientsubmit`, `clientconfig`), which were then broadcast to every server with a `[proxy]` ClientIP section appended (meant for data), response relayed from the last server only.
2. Several genuine two-way **query** commands weren't in the response-expecting list at all — `xymond*`/`hobbitd*` board and log queries, `hostinfo`, `ghostlist` — so they were mis-handled the same way.

## Fix

- Match client **data** exactly: `"client "` and `"client/"`.
- Route the client-prefixed queries **and** the board/log/hostinfo/ghostlist queries with the response group (`snum = 1`): sent to one server, response relayed, no broadcast, no `[proxy]` section.

## Origin / credits

Terabithia patch `12 xymon.proxy-clientlog` (J.C. Cleaver) tightened the match; completed here to the full two-way list per devel `eea86fb51` (same tightening plus the broader query set). Independent of the larger proxy reworks `c5beaee4b` (TBT 103) and `c94627a8f` (TBT 225) — touches only the classification block.

## Testing

Full server build; `tests/testsuite` 14/14 pass.

Refs: #29 (TBT `12`), #106 (`eea86fb51`).