### PR TITLE
etcfiles: optional .d include dirs for every server and client config (TBT 5/6)

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -27,14 +27,14 @@ COMMONTOOLS=xymon xymoncmd xymongrep xymoncfg xymondigest
 all: $(PROGRAMS) $(COMMONTOOLS) xymonclient.cfg clientlaunch.cfg $(EXTRATOOLS)
 
 xymonclient.cfg: xymonclient.cfg.DIST
-	cat xymonclient.cfg.DIST | sed -e 's!@XYMONHOSTIP@!$(XYMONHOSTIP)!g' >xymonclient.cfg
+	cat xymonclient.cfg.DIST | sed -e 's!@XYMONHOSTIP@!$(XYMONHOSTIP)!g' | sed -e 's!@XYMONHOME@!$(XYMONHOME)!g' >xymonclient.cfg
 	../build/bb-commands.sh >>xymonclient.cfg
 
 clientlaunch.cfg: clientlaunch.cfg.DIST
 ifeq ($(LOCALCLIENT),yes)
-	cat clientlaunch.cfg.DIST | sed -e 's!@CLIENTFLAGS@!--local!g' >clientlaunch.cfg
+	cat clientlaunch.cfg.DIST | sed -e 's!@CLIENTFLAGS@!--local!g' | sed -e 's!@XYMONHOME@!$(XYMONHOME)!g' >clientlaunch.cfg
 else
-	cat clientlaunch.cfg.DIST | sed -e 's!@CLIENTFLAGS@!!g' >clientlaunch.cfg
+	cat clientlaunch.cfg.DIST | sed -e 's!@CLIENTFLAGS@!!g' | sed -e 's!@XYMONHOME@!$(XYMONHOME)!g' >clientlaunch.cfg
 endif
 
 logfetch: logfetch.c $(XYMONCLIENTLIB)

--- a/client/clientlaunch.cfg.DIST
+++ b/client/clientlaunch.cfg.DIST
@@ -26,3 +26,6 @@
 	LOGFILE $XYMONCLIENTLOGS/xymonclient.log
 	INTERVAL 5m
 
+
+# Local additions: any file dropped into the directory below is included
+optional directory @XYMONHOME@/etc/clientlaunch.d

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -101,3 +101,6 @@ BBHOME="$XYMONHOME"
 BB="$XYMON"
 BBTMP="$XYMONTMP"
 BBCLIENTLOGS="$XYMONCLIENTLOGS"
+
+# Local additions: any file dropped into the directory below is included
+optional directory @XYMONHOME@/etc/xymonclient.cfg.d

--- a/xymond/Makefile
+++ b/xymond/Makefile
@@ -140,8 +140,9 @@ cfgfiles:
 	cat $(APACHECONF) | sed -e 's!@XYMONHOME@!$(XYMONHOME)!g' | sed -e 's!@INSTALLETCDIR@!$(INSTALLETCDIR)!g' | sed -e 's!@INSTALLWWWDIR@!$(INSTALLWWWDIR)!g' | sed -e 's!@CGIDIR@!$(CGIDIR)!g' | sed -e 's!@SECURECGIDIR@!$(SECURECGIDIR)!g' | sed -e 's!@XYMONHOSTURL@!$(XYMONHOSTURL)!g' | sed -e 's!@XYMONCGIURL@!$(XYMONCGIURL)!g' | sed -e 's!@SECUREXYMONCGIURL@!$(SECUREXYMONCGIURL)!g' >etcfiles/xymon-apache.conf
 	cat etcfiles/xymonserver.cfg.DIST | sed -e 's!@XYMONTOPDIR@!$(XYMONTOPDIR)!g'| sed -e 's!@XYMONLOGDIR@!$(XYMONLOGDIR)!g'| sed -e 's!@XYMONHOSTNAME@!$(XYMONHOSTNAME)!g'| sed -e 's!@XYMONHOSTIP@!$(XYMONHOSTIP)!g'| sed -e 's!@XYMONHOSTOS@!$(XYMONHOSTOS)!g' | sed -e 's!@XYMONHOSTURL@!$(XYMONHOSTURL)!g' | sed -e 's!@XYMONCGIURL@!$(XYMONCGIURL)!g' | sed -e 's!@SECUREXYMONCGIURL@!$(SECUREXYMONCGIURL)!g' | sed -e 's!@XYMONHOME@!$(XYMONHOME)!g' | sed -e 's!@XYMONVAR@!$(XYMONVAR)!g' | sed -e 's!@FPING@!$(FPING)!g' | sed -e 's!@MAILPROGRAM@!$(MAILPROGRAM)!g' | sed -e 's!@RUNTIMEDEFS@!$(RUNTIMEDEFS)!g' >etcfiles/xymonserver.cfg
 	../build/bb-commands.sh >>etcfiles/xymonserver.cfg
-	cat etcfiles/hosts.cfg.DIST | sed -e 's!@XYMONHOSTNAME@!$(XYMONHOSTNAME)!g' | sed -e 's!@XYMONHOSTIP@!$(XYMONHOSTIP)!g' >etcfiles/hosts.cfg
-	cat etcfiles/alerts.cfg.DIST | sed -e 's!@XYMONHOSTNAME@!$(XYMONHOSTNAME)!g' | sed -e 's!@XYMONHOSTIP@!$(XYMONHOSTIP)!g' >etcfiles/alerts.cfg
+	cat etcfiles/hosts.cfg.DIST | sed -e 's!@XYMONHOSTNAME@!$(XYMONHOSTNAME)!g' | sed -e 's!@XYMONHOSTIP@!$(XYMONHOSTIP)!g' | sed -e 's!@XYMONHOME@!$(XYMONHOME)!g' >etcfiles/hosts.cfg
+	cat etcfiles/alerts.cfg.DIST | sed -e 's!@XYMONHOSTNAME@!$(XYMONHOSTNAME)!g' | sed -e 's!@XYMONHOSTIP@!$(XYMONHOSTIP)!g' | sed -e 's!@XYMONHOME@!$(XYMONHOME)!g' >etcfiles/alerts.cfg
+	for f in analysis combo graphs client-local rrddefinitions; do sed -e 's!@XYMONHOME@!$(XYMONHOME)!g' etcfiles/$$f.cfg.DIST >etcfiles/$$f.cfg; done
 	cat etcfiles/tasks.cfg.DIST | sed -e 's!@XYMONHOME@!$(XYMONHOME)!g' | sed -e 's!@XYMONTOPDIR@!$(XYMONTOPDIR)!g' >etcfiles/tasks.cfg
 	cat etcfiles/cgioptions.cfg.DIST | sed -e 's!@XYMONHOME@!$(XYMONHOME)!g' >etcfiles/cgioptions.cfg
 
@@ -150,7 +151,7 @@ cfgfiles:
 
 clean:
 	rm -f $(PROGRAMS) *.o *~ client/*~ rrd/*~
-	rm -f etcfiles/xymon-apache.conf etcfiles/xymonserver.cfg etcfiles/hosts.cfg etcfiles/alerts.cfg etcfiles/tasks.cfg etcfiles/cgioptions.cfg
+	rm -f etcfiles/xymon-apache.conf etcfiles/xymonserver.cfg etcfiles/hosts.cfg etcfiles/alerts.cfg etcfiles/tasks.cfg etcfiles/cgioptions.cfg etcfiles/analysis.cfg etcfiles/combo.cfg etcfiles/graphs.cfg etcfiles/client-local.cfg etcfiles/rrddefinitions.cfg
 	(find etcfiles/ -name "*~"; find wwwfiles/ -name "*~"; find webfiles/ -name "*~") | xargs rm -f
 
 install: install-bin install-man install-cfg
@@ -194,6 +195,7 @@ install-cfg:
 	chmod 664 $(INSTALLROOT)$(INSTALLETCDIR)/critical.cfg $(INSTALLROOT)$(INSTALLETCDIR)/critical.cfg.bak
 	mkdir -p $(INSTALLROOT)$(XYMONLOGDIR); chmod 755 $(INSTALLROOT)$(XYMONLOGDIR)
 	mkdir -p $(INSTALLROOT)$(INSTALLETCDIR)/tasks.d; chmod 755 $(INSTALLROOT)$(INSTALLETCDIR)/tasks.d
+	for d in alerts.d analysis.d combo.d graphs.d client-local.d rrddefinitions.d hosts.d xymonserver.cfg.d; do mkdir -p $(INSTALLROOT)$(INSTALLETCDIR)/$$d; chmod 755 $(INSTALLROOT)$(INSTALLETCDIR)/$$d; done
 ifndef PKGBUILD
 	chown $(XYMONUSER) $(INSTALLROOT)$(XYMONLOGDIR) $(INSTALLROOT)$(XYMONHOME) $(INSTALLROOT)$(XYMONHOME)/* $(INSTALLROOT)$(INSTALLBINDIR)/* $(INSTALLROOT)$(INSTALLETCDIR)/* $(INSTALLROOT)$(INSTALLEXTDIR)/* $(INSTALLROOT)$(INSTALLWEBDIR)/* $(INSTALLROOT)$(INSTALLWWWDIR)/gifs $(INSTALLROOT)$(INSTALLWWWDIR)/gifs/* $(INSTALLROOT)$(INSTALLWWWDIR)/menu $(INSTALLROOT)$(INSTALLWWWDIR)/menu/* $(INSTALLROOT)$(INSTALLWWWDIR)/help $(INSTALLROOT)$(INSTALLWWWDIR)/notes $(INSTALLROOT)$(INSTALLWWWDIR)/html $(INSTALLROOT)$(INSTALLWWWDIR)/wml $(INSTALLROOT)$(XYMONVAR) $(INSTALLROOT)$(XYMONVAR)/*
 	chgrp `$(IDTOOL) -g $(XYMONUSER)` $(INSTALLROOT)$(XYMONLOGDIR) $(INSTALLROOT)$(XYMONHOME) $(INSTALLROOT)$(XYMONHOME)/* $(INSTALLROOT)$(INSTALLBINDIR)/* $(INSTALLROOT)$(INSTALLETCDIR)/* $(INSTALLROOT)$(INSTALLEXTDIR)/* $(INSTALLROOT)$(INSTALLWEBDIR)/* $(INSTALLROOT)$(INSTALLWWWDIR)/gifs $(INSTALLROOT)$(INSTALLWWWDIR)/gifs/* $(INSTALLROOT)$(INSTALLWWWDIR)/menu $(INSTALLROOT)$(INSTALLWWWDIR)/menu/* $(INSTALLROOT)$(INSTALLWWWDIR)/help $(INSTALLROOT)$(INSTALLWWWDIR)/notes $(INSTALLROOT)$(INSTALLWWWDIR)/html $(INSTALLROOT)$(INSTALLWWWDIR)/wml $(INSTALLROOT)$(XYMONVAR) $(INSTALLROOT)$(XYMONVAR)/*

--- a/xymond/etcfiles/alerts.cfg.DIST
+++ b/xymond/etcfiles/alerts.cfg.DIST
@@ -116,3 +116,6 @@
 #    DOWNSECS      - Number of seconds the service has been down.
 #    DOWNSECSMSG   - When recovered, holds the text "Event duration : N" where
 #                    N is the DOWNSECS value.
+
+# Local additions: any file dropped into the directory below is included
+optional directory @XYMONHOME@/etc/alerts.d

--- a/xymond/etcfiles/analysis.cfg.DIST
+++ b/xymond/etcfiles/analysis.cfg.DIST
@@ -389,3 +389,6 @@ DEFAULT
 	MEMSWAP 50 80
 	MEMACT  90 97
 
+
+# Local additions: any file dropped into the directory below is included
+optional directory @XYMONHOME@/etc/analysis.d

--- a/xymond/etcfiles/client-local.cfg.DIST
+++ b/xymond/etcfiles/client-local.cfg.DIST
@@ -129,3 +129,6 @@ log:/var/log/system.log:10240
 [sco_sv]
 log:/var/adm/syslog:10240
 
+
+# Local additions: any file dropped into the directory below is included
+optional directory @XYMONHOME@/etc/client-local.d

--- a/xymond/etcfiles/combo.cfg.DIST
+++ b/xymond/etcfiles/combo.cfg.DIST
@@ -12,3 +12,6 @@
 # See the combo.cfg(5) man-page for details on how you can
 # define tests.
 
+
+# Local additions: any file dropped into the directory below is included
+optional directory @XYMONHOME@/etc/combo.d

--- a/xymond/etcfiles/graphs.cfg.DIST
+++ b/xymond/etcfiles/graphs.cfg.DIST
@@ -2137,3 +2137,6 @@
 
 ########### end of ifmib graphs ###########
 
+
+# Local additions: any file dropped into the directory below is included
+optional directory @XYMONHOME@/etc/graphs.d

--- a/xymond/etcfiles/hosts.cfg.DIST
+++ b/xymond/etcfiles/hosts.cfg.DIST
@@ -14,3 +14,6 @@
 
 @XYMONHOSTIP@   @XYMONHOSTNAME@      # bbd http://@XYMONHOSTNAME@/
 
+
+# Local additions: any file dropped into the directory below is included
+optional directory @XYMONHOME@/etc/hosts.d

--- a/xymond/etcfiles/rrddefinitions.cfg.DIST
+++ b/xymond/etcfiles/rrddefinitions.cfg.DIST
@@ -35,3 +35,6 @@
 	# 576 datapoints w/ 288*5 minute averaged = 576 days @ 1 day avg.
 	RRA:AVERAGE:0.5:288:576
 
+
+# Local additions: any file dropped into the directory below is included
+optional directory @XYMONHOME@/etc/rrddefinitions.d

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -327,3 +327,6 @@ HOBBITLOGO="$XYMONLOGO"
 HOBBITCLIENTHOME="$XYMONCLIENTHOME"
 BBCLIENTLOGS="$XYMONSERVERLOGS"
 
+
+# Local additions: any file dropped into the directory below is included
+optional directory @XYMONHOME@/etc/xymonserver.cfg.d


### PR DESCRIPTION
## What

Generalizes the existing `tasks.d` drop-in directory to **all** the config files. Each shipped config now ends with:

```
optional directory @XYMONHOME@/etc/<name>.d
```

covering `alerts.d`, `analysis.d`, `combo.d`, `graphs.d`, `client-local.d`, `rrddefinitions.d`, `hosts.d`, `xymonserver.cfg.d`, and client-side `xymonclient.cfg.d` / `clientlaunch.d`.

Packagers and admins can drop config fragments into these directories without editing the shipped file — the same pattern `tasks.d` already provides, now everywhere.

## Mechanism (all pre-existing upstream)

- `directory` reads every file in the dir (as `tasks.cfg` does today); `optional` makes a missing dir silently ignored — both already implemented in `lib/stackio.c`.
- Five configs that shipped without a template step (`analysis`, `combo`, `graphs`, `client-local`, `rrddefinitions`) gain one so `@XYMONHOME@` is substituted, and are renamed to `.DIST` to match every other generated config.
- The install rule creates the new `.d` directories next to `tasks.d`.

## Origin / credits

Terabithia patches `5 xymon.breakout-directories` (server cfgs) and `6 xymon.envdirs` (env files), J.C. Cleaver — also on devel as `bff5b5ef5`, which uses the same `optional directory` form (adopted here). Closes the `.d defaults` item in #28; refs #29 (TBT 5/6), #106.

## Testing

- Full server build + `tests/testsuite`: 14/14.
- Generated configs carry the substituted absolute paths (verified for all 10).
- End-to-end: a host in `hosts.d/extra.cfg` is picked up by the parser; a missing `.d` directory produces no error.