### PR TITLE
stackio: accept 'source FILE' and '. FILE' as aliases for 'include' (TBT 59)

### DIFF
--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -52,8 +52,18 @@ filename (if it begins with a '/'), or a relative filename -
 relative file names are prefixed with the directory where
 the main hosts.cfg file is located (usually $XYMONHOME/etc/).
 
-You can nest include tags, i.e. a file that is included 
+You can nest include tags, i.e. a file that is included
 from the main hosts.cfg file can itself include other files.
+
+The directives "source filename" and ". filename" (dot, space,
+filename) are accepted as aliases for "include". They exist so a
+configuration file written in shell syntax \- e.g.
+.I xymonserver.cfg(5)
+\- can use the shell's own include directives and be followed both
+by a shell sourcing the file and by the Xymon config parser. Note
+that the aliases are recognised in every Xymon configuration file
+read through this parser, not only shell\-syntax ones: a line whose
+first word is "source" or "." is always treated as an include.
 
 .IP "dispinclude filename"
 Acts like the "include" tag, but only for the xymongen tool.
@@ -74,9 +84,10 @@ files ending in ".dpkg\-new" or ".dpkg\-orig", and all special
 files (devices, sockets, pipes etc).
 
 .IP "optional include/directory"
-Both "include" and "directory" can be prefixed with the tag
-"optional", which will prevent an error message being logged if
-the file or directory is not present on a system.
+Both "include" (and its "source" / "." aliases) and "directory"
+can be prefixed with the tag "optional", which will prevent an
+error message being logged if the file or directory is not
+present on a system.
 
 
 .SH GENERAL PER-HOST OPTIONS

--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -73,6 +73,16 @@ the main hosts.cfg file is located (usually $XYMONHOME/etc/).
 You can nest include tags, i.e. a file that is included
 from the main hosts.cfg file can itself include other files.
 
+The directives "source filename" and ". filename" (dot, space,
+filename) are accepted as aliases for "include". They exist so a
+configuration file written in shell syntax \- e.g.
+.I xymonserver.cfg(5)
+\- can use the shell's own include directives and be followed both
+by a shell sourcing the file and by the Xymon config parser. Note
+that the aliases are recognised in every Xymon configuration file
+read through this parser, not only shell\-syntax ones: a line whose
+first word is "source" or "." is always treated as an include.
+
 .IP "\fBdispinclude\fR \fIfilename\fR"
 Acts like the "include" tag, but only for the xymongen tool.
 Can be used e.g. to put a group of hosts on multiple sub-pages,
@@ -92,9 +102,10 @@ files ending in ".dpkg\-new" or ".dpkg\-orig", and all special
 files (devices, sockets, pipes etc).
 
 .IP "\fBoptional include/directory\fR"
-Both "include" and "directory" can be prefixed with the tag
-"optional", which will prevent an error message being logged if
-the file or directory is not present on a system.
+Both "include" (and its "source" / "." aliases) and "directory"
+can be prefixed with the tag "optional", which will prevent an
+error message being logged if the file or directory is not
+present on a system.
 
 
 .SH GENERAL PER-HOST OPTIONS

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -14,6 +14,16 @@ syntax \fBNAME+=VALUE\fR. VALUE is then appended to the existing
 value of the NAME variable. If NAME has not been defined, then
 this acts as if it were a normal definition.
 
+Other files can be pulled in with \fBinclude FILENAME\fR. Because
+this file uses shell syntax and may also be sourced directly by
+shell scripts, the shell's own include directives \fBsource
+FILENAME\fR and \fB. FILENAME\fR are accepted as aliases for
+"include" \- the same reference is then followed both by a shell
+sourcing the file and by the Xymon tools reading it. Any of them
+can be prefixed with \fBoptional\fR to silence the error when the
+file does not exist \- but note a shell does not understand that
+prefix, so use it only in files read exclusively by Xymon.
+
 .SH ENVIRONMENT AREAS
 In some cases it may be useful to have different values for an environment
 variable, depending on where it is used. This is possible by defining

--- a/docs/manpages/man5/hosts.cfg.5.html
+++ b/docs/manpages/man5/hosts.cfg.5.html
@@ -91,6 +91,15 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
         is located (usually $XYMONHOME/etc/).</p>
     <p class="Pp">You can nest include tags, i.e. a file that is included from
         the main hosts.cfg file can itself include other files.</p>
+    <p class="Pp">The directives &quot;source filename&quot; and &quot;.
+        filename&quot; (dot, space, filename) are accepted as aliases for
+        &quot;include&quot;. They exist so a configuration file written in shell
+        syntax - e.g. <i><a href="../man5/xymonserver.cfg.5.html">xymonserver.cfg</a>(5)</i> - can use the shell's own
+        include directives and be followed both by a shell sourcing the file and
+        by the Xymon config parser. Note that the aliases are recognised in
+        every Xymon configuration file read through this parser, not only
+        shell-syntax ones: a line whose first word is &quot;source&quot; or
+        &quot;.&quot; is always treated as an include.</p>
     <p class="Pp"></p>
   </dd>
   <dt id="dispinclude"><a class="permalink" href="#dispinclude"><b>dispinclude</b>
@@ -119,9 +128,10 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
   </dd>
   <dt id="optional"><a class="permalink" href="#optional"><b>optional
     include/directory</b></a></dt>
-  <dd>Both &quot;include&quot; and &quot;directory&quot; can be prefixed with
-      the tag &quot;optional&quot;, which will prevent an error message being
-      logged if the file or directory is not present on a system.
+  <dd>Both &quot;include&quot; (and its &quot;source&quot; / &quot;.&quot;
+      aliases) and &quot;directory&quot; can be prefixed with the tag
+      &quot;optional&quot;, which will prevent an error message being logged if
+      the file or directory is not present on a system.
     <p class="Pp"></p>
     <p class="Pp"></p>
   </dd>

--- a/docs/manpages/man5/xymonserver.cfg.5.html
+++ b/docs/manpages/man5/xymonserver.cfg.5.html
@@ -30,6 +30,15 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <b>NAME+=VALUE</b>. VALUE is then appended to the existing value of the NAME
     variable. If NAME has not been defined, then this acts as if it were a
     normal definition.</p>
+<p class="Pp">Other files can be pulled in with <b>include FILENAME</b>. Because
+    this file uses shell syntax and may also be sourced directly by shell
+    scripts, the shell's own include directives <b>source</b> <b>FILENAME</b>
+    and <b>. FILENAME</b> are accepted as aliases for &quot;include&quot; - the
+    same reference is then followed both by a shell sourcing the file and by the
+    Xymon tools reading it. Any of them can be prefixed with <b>optional</b> to
+    silence the error when the file does not exist - but note a shell does not
+    understand that prefix, so use it only in files read exclusively by
+  Xymon.</p>
 <p class="Pp"></p>
 </section>
 <section class="Sh">

--- a/lib/stackio.c
+++ b/lib/stackio.c
@@ -439,7 +439,8 @@ char *stackfgets(strbuffer_t *buffer, char *extraincl)
 		        Note: there is no shell equivalent for the "directory" directive. */
 		     (strncmp(bufpastwhitespace, "source ", 7) == 0) || (strncmp(bufpastwhitespace, "source\t", 7) == 0) ||
 		     (strncmp(bufpastwhitespace, ". ", 2) == 0) || (strncmp(bufpastwhitespace, ".\t", 2) == 0) ||
-		     (extraincl && (strncmp(bufpastwhitespace, extraincl, strlen(extraincl)) == 0)) ) {
+		     (extraincl && (strncmp(bufpastwhitespace, extraincl, strlen(extraincl)) == 0) &&
+		      ((*(bufpastwhitespace+strlen(extraincl)) == ' ') || (*(bufpastwhitespace+strlen(extraincl)) == '\t'))) ) {
 			char *newfn, *eol, eolchar = '\0';
 
 			eol = bufpastwhitespace + strcspn(bufpastwhitespace, "\r\n"); if (eol) { eolchar = *eol; *eol = '\0'; }

--- a/lib/stackio.c
+++ b/lib/stackio.c
@@ -433,6 +433,12 @@ char *stackfgets(strbuffer_t *buffer, char *extraincl)
 		if (strncmp(bufpastwhitespace, "optional", 8) == 0) { optional = 1; bufpastwhitespace += 8 + strspn(bufpastwhitespace+8, " \t"); }
 
 		if ( (strncmp(bufpastwhitespace, "include ", 8) == 0) || (strncmp(bufpastwhitespace, "include\t", 8) == 0) ||
+		     /* "source FILE" and ". FILE" are accepted as aliases for "include",
+		        so a shell-syntax config file (e.g. xymonserver.cfg) can use the
+		        shell's own include directives and still be followed by xymon.
+		        Note: there is no shell equivalent for the "directory" directive. */
+		     (strncmp(bufpastwhitespace, "source ", 7) == 0) || (strncmp(bufpastwhitespace, "source\t", 7) == 0) ||
+		     (strncmp(bufpastwhitespace, ". ", 2) == 0) || (strncmp(bufpastwhitespace, ".\t", 2) == 0) ||
 		     (extraincl && (strncmp(bufpastwhitespace, extraincl, strlen(extraincl)) == 0)) ) {
 			char *newfn, *eol, eolchar = '\0';
 

--- a/lib/stackio.c
+++ b/lib/stackio.c
@@ -436,7 +436,14 @@ char *stackfgets(strbuffer_t *buffer, char *extraincl)
 		if (strncmp(bufpastwhitespace, "optional", 8) == 0) { optional = 1; bufpastwhitespace += 8 + strspn(bufpastwhitespace+8, " \t"); }
 
 		if ( (strncmp(bufpastwhitespace, "include ", 8) == 0) || (strncmp(bufpastwhitespace, "include\t", 8) == 0) ||
-		     (extraincl && (strncmp(bufpastwhitespace, extraincl, strlen(extraincl)) == 0)) ) {
+		     /* "source FILE" and ". FILE" are accepted as aliases for "include",
+		        so a shell-syntax config file (e.g. xymonserver.cfg) can use the
+		        shell's own include directives and still be followed by xymon.
+		        Note: there is no shell equivalent for the "directory" directive. */
+		     (strncmp(bufpastwhitespace, "source ", 7) == 0) || (strncmp(bufpastwhitespace, "source\t", 7) == 0) ||
+		     (strncmp(bufpastwhitespace, ". ", 2) == 0) || (strncmp(bufpastwhitespace, ".\t", 2) == 0) ||
+		     (extraincl && (strncmp(bufpastwhitespace, extraincl, strlen(extraincl)) == 0) &&
+		      ((*(bufpastwhitespace+strlen(extraincl)) == ' ') || (*(bufpastwhitespace+strlen(extraincl)) == '\t'))) ) {
 			char *newfn, *eol, eolchar = '\0';
 
 			eol = bufpastwhitespace + strcspn(bufpastwhitespace, "\r\n"); if (eol) { eolchar = *eol; *eol = '\0'; }

--- a/tests/server/xymongrep-filter.sh
+++ b/tests/server/xymongrep-filter.sh
@@ -85,4 +85,31 @@ assert_not_contains "db.example.com" "$out" \
 out=$("$XYMONGREP" --noextras --hosts="$work/hosts.cfg" 'http*')
 assert_not_contains "dialup" "$out" "--noextras must drop the dialup flag"
 
-pass "xymongrep tag selection contract holds (exact, prefix-*, echoed tags, dialup flag)"
+# "source FILE" and ". FILE" are include aliases (PR #223, TBT 59), so a
+# shell-syntax config sourced by both a shell and xymon follows the same
+# reference. "optional" composes with them; a word merely *starting* with
+# a directive ("sourcehost") is not an include. Exercised through the same
+# real load_hostnames()/stackfgets() path as the rest of this test.
+cat >"$work/fragment.cfg" <<'EOF'
+7.7.7.7		frag-src.example.com	# conn
+EOF
+cat >"$work/fragment2.cfg" <<'EOF'
+8.8.8.8		frag-dot.example.com	# conn
+EOF
+printf '2.3.4.5\t\tinctest.example.com\t# conn\nsource %s\n. %s\nsource\t%s\noptional source %s\noptional . %s\nsourcehost 9.9.9.9\n' \
+	"$work/fragment.cfg" "$work/fragment2.cfg" "$work/fragment.cfg" \
+	"$work/missing.cfg" "$work/missing2.cfg" >"$work/hosts-src.cfg"
+
+out=$("$XYMONGREP" --hosts="$work/hosts-src.cfg" conn 2>"$work/stderr.log")
+assert_contains "frag-src.example.com # conn" "$out" "'source FILE' must include the fragment"
+assert_contains "frag-dot.example.com # conn" "$out" "'. FILE' must include the fragment"
+assert_contains "inctest.example.com # conn" "$out" "host lines around the includes must survive"
+# The optional-source lines reference missing files, and the "sourcehost..."
+# line only *starts* with the directive word (the alias needs a separator).
+# Neither may be parsed as an include: the parse must stay silent - the
+# pre-#223 downstream patch would log "Cannot open include file" for the
+# sourcehost line, and a non-optional misparse would for the missing ones.
+assert_not_contains "Cannot open include file" "$(cat "$work/stderr.log")" \
+	"no line may be misparsed as a failed include"
+
+pass "xymongrep tag selection contract holds (exact, prefix-*, echoed tags, dialup flag, source/. includes)"


### PR DESCRIPTION
Shell-syntax config files (`xymonserver.cfg`, `xymonclient.cfg`) are read both by xymon and by shell scripts that source them. Shell's own include directives are `source FILE` and `. FILE`; accepting them as aliases for xymon's `include` lets one such file pull in another and have *both* loaders follow it.

| line | before | after |
|---|---|---|
| `source FILE` / `. FILE` | ignored by xymon | followed, like `include` |
| `sourcehost ...` at line start | — | not an include (separator required) |
| `netincludes ...` | **followed as an include** (bare prefix compare) | not an include |
| `directory` | unchanged | unchanged — no shell equivalent |

The `netinclude`/`dispinclude` match was the pre-existing half: it compared a bare prefix, so `netincludes` was followed. It now requires the same trailing space or tab as every other keyword.

**Docs:** `hosts.cfg.5`, where the include directives already live, plus the point worth stating plainly — the aliases work in *every* file read through the stacked parser, not only shell-syntax ones. `xymonserver.cfg.5` carries the use case and the warning that the `optional` prefix is Xymon-only and would break a shell sourcing the same file.

**Test:** the xymongrep contract test, through the real `load_hostnames()`/`stackfgets()` path — `source FILE`, `. FILE`, `source<TAB>FILE`, `optional source` of a missing file staying silent, and `sourcehost ...` asserted on stderr staying free of `Cannot open include file`, which is what the original bare-prefix patch would have logged.

From Terabithia patch 59 (J.C. Cleaver, `xymon.shellinclude`), with the match tightened. TBT 59 is an RPM patch with no upstream commit, so there is no original to place first. Tracked in #29.
