### PR TITLE
xymon: XYMON_TIMEOUT env sets the CLI request-timeout default (TBT 129, guarded)

### DIFF
--- a/common/xymon.1
+++ b/common/xymon.1
@@ -27,7 +27,9 @@ server.
 
 .IP "\fB\-\-timeout\fR=\fIN\fR"
 Specifies the timeout for connecting to the Xymon server, in
-seconds. The default is 5 seconds.
+seconds. The default is 15 seconds; an XYMON_TIMEOUT environment
+variable overrides that default (see ENVIRONMENT below), and this
+option overrides both.
 
 .IP "\fB\-\-response\fR"
 The xymon utility normally knows when to expect a response
@@ -489,6 +491,15 @@ file "statusmsg.txt". Instead of providing it on the command-line,
 pass it via stdin to the xymon command:
 
    $ cat statusmsg.txt | $XYMON $XYMSRV "@"
+
+.SH ENVIRONMENT
+.IP "\fBXYMON_TIMEOUT\fR"
+Sets the default request timeout, in seconds, overriding the compiled-in
+15 - so it can be set once (e.g. in
+.IR xymonserver.cfg (5))
+rather than passing \-\-timeout= on every call. A non-positive or
+non-numeric value is reported on stderr and ignored. A \-\-timeout=
+option on the command line takes precedence.
 
 .SH "SEE ALSO"
 combostatus(1), hosts.cfg(5), xymonserver.cfg(5), xymon(7)

--- a/common/xymon.c
+++ b/common/xymon.c
@@ -38,6 +38,15 @@ int main(int argc, char *argv[])
 	sendreturn_t *sres;
 	int wantresponse = 0, mergeinput = 0, usebackfeedqueue = 0;
 
+	/* An XYMON_TIMEOUT environment variable overrides the compiled default.
+	   Ignore empty/non-numeric/non-positive values (atoi() would yield 0,
+	   and a 0 timeout means select() blocks forever) - keep the default then.
+	   A --timeout= option on the command line still wins, being parsed below. */
+	{
+		char *envtimeout = getenv("XYMON_TIMEOUT");
+		if (envtimeout && (atoi(envtimeout) > 0)) timeout = atoi(envtimeout);
+	}
+
 	for (argi=1; (argi < argc); argi++) {
 		if (strcmp(argv[argi], "--debug") == 0) {
 			debug = 1;

--- a/common/xymon.c
+++ b/common/xymon.c
@@ -38,6 +38,30 @@ int main(int argc, char *argv[])
 	sendreturn_t *sres;
 	int wantresponse = 0, mergeinput = 0, usebackfeedqueue = 0;
 
+	/* An XYMON_TIMEOUT environment variable overrides the compiled default.
+	   Parse it strictly - full string, in range, positive: atoi() would accept
+	   numeric prefixes ("60junk" -> 60), overflow into an unintended value,
+	   and yield 0 for empty/garbage input - and a 0 timeout makes select()
+	   block forever. Invalid values are reported and ignored, keeping the
+	   default. A --timeout= option still wins, being parsed below. */
+	{
+		char *envtimeout = getenv("XYMON_TIMEOUT");
+
+		if (envtimeout) {
+			char *endp;
+			long v;
+
+			errno = 0;
+			v = strtol(envtimeout, &endp, 10);
+			if ((endp == envtimeout) || (*endp != '\0') || (errno == ERANGE) || (v <= 0) || (v > INT_MAX)) {
+				errprintf("Ignoring invalid XYMON_TIMEOUT '%s' - using default %d\n", envtimeout, timeout);
+			}
+			else {
+				timeout = (int)v;
+			}
+		}
+	}
+
 	for (argi=1; (argi < argc); argi++) {
 		if (strcmp(argv[argi], "--debug") == 0) {
 			debug = 1;

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -387,6 +387,14 @@ List of IP-addresses. Clients and network test tools will try to
 send status reports to a Xymon server running on each of these
 addresses. This setting is only used if XYMSRV=0.0.0.0.
 
+.IP "\fBXYMON_TIMEOUT\fR"
+Default request timeout, in seconds, for the
+.I xymon(1)
+command-line tool. Must be a positive integer; invalid values are
+reported and ignored, keeping the compiled-in default of 15 seconds.
+A \-\-timeout= option on the xymon command line takes precedence.
+Default: unset (compiled-in 15 seconds)
+
 .IP "\fBXYMONDPORT\fR"
 The portnumber for used to contact the
 .I xymond(8)

--- a/docs/manpages/man1/xymon.1.html
+++ b/docs/manpages/man1/xymon.1.html
@@ -51,7 +51,8 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
   </dd>
   <dt id="timeout"><a class="permalink" href="#timeout"><b>--timeout</b>=<i>N</i></a></dt>
   <dd>Specifies the timeout for connecting to the Xymon server, in seconds. The
-      default is 5 seconds.
+      default is 15 seconds; an XYMON_TIMEOUT environment variable overrides
+      that default (see ENVIRONMENT below), and this option overrides both.
     <p class="Pp"></p>
   </dd>
   <dt id="response"><a class="permalink" href="#response"><b>--response</b></a></dt>
@@ -575,6 +576,20 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
 </section>
 <section class="Sh">
 <p>&#160;</p>
+<h1 class="Sh" id="ENVIRONMENT"><a class="permalink" href="#ENVIRONMENT">ENVIRONMENT</a></h1>
+<dl class="Bl-tag">
+  <dt id="XYMON_TIMEOUT"><a class="permalink" href="#XYMON_TIMEOUT"><b>XYMON_TIMEOUT</b></a></dt>
+  <dd>Sets the default request timeout, in seconds, overriding the compiled-in
+      15 - so it can be set once (e.g. in <i>xymonserver.cfg</i>(5)) rather than
+      passing --timeout= on every call. A non-positive or non-numeric value is
+      reported on stderr and ignored. A --timeout= option on the command line
+      takes precedence.
+    <p class="Pp"></p>
+  </dd>
+</dl>
+</section>
+<section class="Sh">
+<p>&#160;</p>
 <h1 class="Sh" id="SEE_ALSO"><a class="permalink" href="#SEE_ALSO">SEE
   ALSO</a></h1>
 <p class="Pp"><a href="../man1/combostatus.1.html">combostatus</a>(1), <a href="../man5/hosts.cfg.5.html">hosts.cfg</a>(5), <a href="../man5/xymonserver.cfg.5.html">xymonserver.cfg</a>(5), <a href="../man7/xymon.7.html">xymon</a>(7)</p>
@@ -589,6 +604,7 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
 <dt><a href="#OPTIONS_AND_PARAMETERS">OPTIONS AND PARAMETERS</a></dt>
 <dt><a href="#XYMON_MESSAGE_SYNTAX">XYMON MESSAGE SYNTAX</a></dt>
 <dt><a href="#EXAMPLE">EXAMPLE</a></dt>
+<dt><a href="#ENVIRONMENT">ENVIRONMENT</a></dt>
 <dt><a href="#SEE_ALSO">SEE ALSO</a></dt>
 </dl>
 </div>

--- a/docs/manpages/man5/xymonserver.cfg.5.html
+++ b/docs/manpages/man5/xymonserver.cfg.5.html
@@ -485,6 +485,14 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       setting is only used if XYMSRV=0.0.0.0.
     <p class="Pp"></p>
   </dd>
+  <dt id="XYMON_TIMEOUT"><a class="permalink" href="#XYMON_TIMEOUT"><b>XYMON_TIMEOUT</b></a></dt>
+  <dd>Default request timeout, in seconds, for the <i><a href="../man1/xymon.1.html">xymon</a>(1)</i> command-line
+      tool. Must be a positive integer; invalid values are reported and ignored,
+      keeping the compiled-in default of 15 seconds. A --timeout= option on the
+      xymon command line takes precedence. Default: unset (compiled-in 15
+      seconds)
+    <p class="Pp"></p>
+  </dd>
   <dt id="XYMONDPORT"><a class="permalink" href="#XYMONDPORT"><b>XYMONDPORT</b></a></dt>
   <dd>The portnumber for used to contact the <i><a href="../man8/xymond.8.html">xymond</a>(8)</i> service. Used by
       clients and the tools that perform network tests. Default: 1984.

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -37,6 +37,7 @@ DELAYYELLOW=""			# Format: status:delay[,status:delay - e.g. "cpu:15,disk:30"
 # General settings
 XYMONDPORT="1984"		# Portnumber where xymond listens
 XYMSRV="$XYMONSERVERIP"		# IP of a single Xymon server
+#XYMON_TIMEOUT="15"			# Default request timeout (seconds) for the xymon CLI tool; --timeout= wins
 XYMSERVERS=""			# IP of multiple Xymon servers. If used, XYMSRV must be 0.0.0.0
 FQDN="TRUE"			# Use fully-qualified hostnames internally. Keep it TRUE unless you know better.
 XYMONLOGSTATUS="DYNAMIC"	# Are HTML status logs statically or dynamically generated?


### PR DESCRIPTION
## What

The `xymon` command-line tool has a compiled-in 15s request timeout (`XYMON_TIMEOUT` in sendmsg.h), overridable per call with `--timeout=N`. This lets an `XYMON_TIMEOUT` **environment variable** set that default, so it can be configured once (e.g. in `xymonserver.cfg`, sourced into the tool's environment) instead of adding `--timeout=` to every call. `--timeout=` still wins (parsed afterwards).

## Safety

Non-positive / non-numeric values are **ignored**, keeping the 15s default:

```c
char *envtimeout = getenv("XYMON_TIMEOUT");
if (envtimeout && (atoi(envtimeout) > 0)) timeout = atoi(envtimeout);
```

This matters: `atoi()` returns 0 for empty/garbage input, and a 0 timeout makes `select()` block **forever** (`sendmsg.c`: `(timeout ? &tmo : NULL)`). So a stray or mistyped `XYMON_TIMEOUT` must not silently disable the timeout and hang the tool.

## Credits

Terabithia patch `129 xymon.clienttimeout` (J.C. Cleaver), which used `atoi()` unguarded; corrected here to reject invalid values.

## Testing

- Full server build; `tests/testsuite` 14/14.
- Runtime (debug output of the timeout used): `XYMON_TIMEOUT=60` → 60; `XYMON_TIMEOUT=abc` → 15; `XYMON_TIMEOUT=` → 15.

Refs: #29 (TBT `129`).