### PR TITLE
xymond_rrd: env-tunable buffering for the external RRD processor (devel f1682a661 = TBT 513, corrected)

### DIFF
--- a/docs/manpages/man8/xymond_rrd.8.html
+++ b/docs/manpages/man8/xymond_rrd.8.html
@@ -352,6 +352,25 @@ Section: Maintenance Commands (8)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a
     nearly suitable for injection using <i>rrdupdate(1)</i> and easily
     transformable to other formats. If the process exits, xymond_rrd will
     re-launch it automatically.</p>
+<p class="Pp">The stream is fully buffered, so an update is normally written to
+    the processor only once the buffer fills. On a busy server that is
+    invisible; on a quiet one an update may wait a long time before it is
+    written. Set <b>RRD_EXTPROC_DOFLUSH</b> in <i><a href="../man5/xymonserver.cfg.5.html">xymonserver.cfg</a>(5)</i> to
+    flush after every update instead, at the cost of one write per update -- use
+    it when the processor forwards to something that expects a live stream.
+    <b>RRD_EXTPROC_BUFSIZ</b> sets the size of the buffer, in bytes; the default
+    is the system's BUFSIZ.</p>
+<p class="Pp">The buffer reaches the processor only if the processor is still
+    running when the stream is closed. That holds on an orderly stop: xymond_rrd
+    flushes the stream to the processor before exiting, so a normal shutdown
+    loses nothing.</p>
+<p class="Pp">If the processor exits first, everything still buffered is lost.
+    xymond_rrd notices only on its next write to the stream -- which, with the
+    stream buffered, is the write that fills the buffer -- and it is that late
+    in re-launching the processor as well. Up to <b>RRD_EXTPROC_BUFSIZ</b> bytes
+    of updates can go to a processor that is already gone; with
+    <b>RRD_EXTPROC_DOFLUSH</b> set the same failure costs at most a single
+    update.</p>
 <p class="Pp"></p>
 <p class="Pp"></p>
 </section>

--- a/tests/rrd/extproc-doflush.sh
+++ b/tests/rrd/extproc-doflush.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/rrd/extproc-doflush.sh
+#
+# RRD_EXTPROC_DOFLUSH must make --processor data arrive as it is produced,
+# not when the buffer fills or the processor is torn down.
+#
+# The default is a buffered stream, so on a quiet server an update can sit
+# unwritten for a long time -- fine for feeding an RRD store, not fine for a
+# processor forwarding to something that expects a live stream. DOFLUSH is
+# the documented escape hatch (xymond_rrd.8), and it is worth a guard: it is
+# one boolean in setup_extprocessor(), and losing it would be invisible
+# until an operator noticed their feed had gone quiet.
+#
+# The assertion is made while xymond_rrd is still running -- stdin is held
+# open through a fifo -- because at teardown the buffered stream is flushed
+# too (tests/rrd/extproc-teardown-flush.sh covers that path), so a run that
+# waits for exit cannot tell the two modes apart.
+#
+# Deliberately only the positive direction. Asserting that the *default*
+# has not delivered yet means asserting the absence of an event, which on a
+# loaded runner is a wall-clock race, and a flaky test is worse than none
+# (tests/README.md).
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMOND_RRD xymond/xymond_rrd
+
+work=$(mktempdir)
+mkdir -p "$work/home/etc" "$work/tmp" "$work/rrd"
+: > "$work/home/etc/analysis.cfg"
+: > "$work/hosts.cfg"
+
+cat > "$work/processor" <<EOF
+#!/bin/sh
+while IFS= read -r line; do printf '%s\n' "\$line" >> "$work/received.txt"; done
+EOF
+chmod +x "$work/processor"
+
+mkfifo "$work/feed"
+
+ts=$(date +%s)
+
+# The buffer is forced far above one update, so nothing can reach the
+# processor by filling it: only a flush can, which is the point.
+env \
+	XYMONHOME="$work/home" \
+	XYMONVAR="$work" \
+	XYMONTMP="$work/tmp" \
+	XYMONRRDS="$work/rrd" \
+	HOSTSCFG="$work/hosts.cfg" \
+	TEST2RRD="inode" \
+	GRAPHS="inode" \
+	RRD_EXTPROC_BUFSIZ=65536 \
+	RRD_EXTPROC_DOFLUSH=1 \
+	"$XYMOND_RRD" --no-cache --no-rrd --rrddir="$work/rrd" \
+	--processor="$work/processor" \
+	<"$work/feed" >"$work/xymond_rrd.log" 2>&1 &
+worker=$!
+register_cleanup "kill $worker 2>/dev/null || true"
+
+# Hold the write end open so the worker keeps reading after the message.
+exec {feed}>"$work/feed"
+register_cleanup "exec {feed}>&- 2>/dev/null || true"
+
+printf '@@status|%s|127.0.0.1||unix.test|inode|%s|green||||||||||unix|\n' "$ts" "$((ts + 1800))" >&$feed
+printf 'status unix.test.inode green %s - Filesystems ok\n' "$ts" >&$feed
+printf 'Filesystem itotal iused ifree %%%%iused Mounted on\n' >&$feed
+printf '/dev/ld0a 259070 41020 218050 15%%%% /\n@@\n' >&$feed
+
+# Wait for the condition, not for a duration: poll until the processor has
+# recorded something, with a ceiling so a broken build fails instead of
+# hanging the suite.
+delivered=no
+for _ in $(seq 1 100); do
+	if [ -s "$work/received.txt" ]; then delivered=yes; break; fi
+	sleep 0.1
+done
+
+if [ "$delivered" != yes ]; then
+	exec {feed}>&-
+	wait "$worker" 2>/dev/null || true
+	cat "$work/xymond_rrd.log" >&2
+	fail "RRD_EXTPROC_DOFLUSH did not deliver the update while xymond_rrd was still running"
+fi
+
+received=$(cat "$work/received.txt")
+
+exec {feed}>&-
+wait "$worker" 2>/dev/null || true
+
+assert_contains "unix.test inode" "$received" \
+	"the flushed update names the host and test"
+
+pass "RRD_EXTPROC_DOFLUSH delivers --processor data while xymond_rrd is still running"

--- a/tests/rrd/extproc-teardown-flush.sh
+++ b/tests/rrd/extproc-teardown-flush.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/rrd/extproc-teardown-flush.sh
+#
+# Regression guard: everything written to the --processor stream must reach
+# the external processor, including whatever is still sitting in the stdio
+# buffer when xymond_rrd shuts the processor down.
+#
+# xymond_rrd buffers that stream (RRD_EXTPROC_BUFSIZ, default BUFSIZ), so on
+# a quiet server an update can sit unwritten indefinitely. Teardown is what
+# gets it out: shutdown_extprocessor() runs on exit and whenever the
+# processor is restarted after a SIGPIPE. It used to close(2) the raw fd and
+# NULL the FILE* without fclose(), so the buffer was discarded rather than
+# flushed -- silently, since close() succeeds. Every update since the last
+# buffer-fill was lost on each restart and on every shutdown.
+#
+# The buffer size is forced well above one update so the line cannot reach
+# the processor by filling the buffer; only the teardown flush can deliver
+# it, which is exactly the behaviour under test.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMOND_RRD xymond/xymond_rrd
+
+work=$(mktempdir)
+mkdir -p "$work/home/etc" "$work/tmp" "$work/rrd"
+: > "$work/home/etc/analysis.cfg"
+: > "$work/hosts.cfg"
+
+# The processor records each line as it arrives, so "what got through" is
+# readable after the run. Line-buffered by read/printf, not by stdio, so a
+# partial delivery would still show up.
+cat > "$work/processor" <<EOF
+#!/bin/sh
+while IFS= read -r line; do printf '%s\n' "\$line" >> "$work/received.txt"; done
+EOF
+chmod +x "$work/processor"
+
+ts=$(date +%s)
+message="@@status|$ts|127.0.0.1||unix.test|inode|$((ts + 1800))|green||||||||||unix|
+status unix.test.inode green $ts - Filesystems ok
+Filesystem itotal iused ifree %iused Mounted on
+/dev/ld0a 259070 41020 218050 15% /
+@@
+"
+
+# --no-rrd: this test is about the processor stream, not the RRD files.
+printf '%s' "$message" | env \
+	XYMONHOME="$work/home" \
+	XYMONVAR="$work" \
+	XYMONTMP="$work/tmp" \
+	XYMONRRDS="$work/rrd" \
+	HOSTSCFG="$work/hosts.cfg" \
+	TEST2RRD="inode" \
+	GRAPHS="inode" \
+	RRD_EXTPROC_BUFSIZ=65536 \
+	"$XYMOND_RRD" --no-cache --no-rrd --rrddir="$work/rrd" \
+	--processor="$work/processor" \
+	>"$work/xymond_rrd.log" 2>&1 \
+	|| { cat "$work/xymond_rrd.log" >&2; fail "xymond_rrd exited non-zero"; }
+
+# Distinguish "the update never reached the stream" from "it reached the
+# stream and teardown dropped it" -- without this the assertion below could
+# pass vacuously if the message stopped being parsed at all.
+grep -q "External processor '$work/processor' started" "$work/xymond_rrd.log" \
+	|| { cat "$work/xymond_rrd.log" >&2; fail "the external processor was never started"; }
+
+# The processor is forked by xymond_rrd, not by this shell, so there is no
+# handle to wait on: when xymond_rrd exits, the flushed bytes are in the pipe
+# but the processor may not have been scheduled to read them yet. Wait for the
+# condition, not for a duration -- with the fclose() reverted the file never
+# appears, so the ceiling only bounds the failing run.
+delivered=no
+for _ in $(seq 1 100); do
+	if [ -s "$work/received.txt" ]; then delivered=yes; break; fi
+	sleep 0.1
+done
+
+if [ "$delivered" != yes ]; then
+	cat "$work/xymond_rrd.log" >&2
+	fail "the external processor received nothing: the buffered update was discarded at teardown instead of flushed"
+fi
+
+received=$(cat "$work/received.txt")
+assert_contains "unix.test inode" "$received" \
+	"the update that reached the external processor names the host and test"
+
+pass "buffered --processor data is flushed to the processor at teardown"

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -45,6 +45,7 @@ int no_rrd = 0;                /* Write to rrd by default */
 
 static int  processorfd = 0;
 static FILE *processorstream = NULL;
+static int  processorflush = 0;   /* fflush the external processor after every write? (RRD_EXTPROC_DOFLUSH) */
 
 static char *exthandler = NULL;
 static char **extids = NULL;
@@ -105,12 +106,18 @@ void setup_extprocessor(char *cmd)
 {
 
 	int n;
+	size_t processorbufsz;
 	int pfd[2];
 	pid_t childpid;
 
 	if (!cmd) return;
 
 	processorfd = 0;
+	/* Default: rely on the stdio buffer (flushed when it fills and on teardown),
+	   which cuts a write syscall per RRD update. Set RRD_EXTPROC_DOFLUSH to flush
+	   after every write instead; RRD_EXTPROC_BUFSIZ tunes the buffer size. */
+	processorflush = (getenv("RRD_EXTPROC_DOFLUSH") != NULL);
+	processorbufsz = getenv("RRD_EXTPROC_BUFSIZ") ? atol(getenv("RRD_EXTPROC_BUFSIZ")) : BUFSIZ;
 
 	n = pipe(pfd);
 	if (n == -1) {
@@ -141,6 +148,12 @@ void setup_extprocessor(char *cmd)
 			close(pfd[0]);
 			processorfd = pfd[1];
 			processorstream = fdopen(processorfd, "w");
+			if (processorstream) {
+				/* NB: arg order matches the format (n, cmd, size) - the
+				   original had cmd/n swapped, crashing on setvbuf failure. */
+				n = setvbuf(processorstream, (char *)NULL, _IOFBF, processorbufsz);
+				if (n) errprintf("setvbuf() returned %d on processor '%s' for %lu bytes: %s\n", n, cmd, (unsigned long)processorbufsz, strerror(errno));
+			}
 			errprintf("External processor '%s' started\n", cmd);
 		}
 	}
@@ -460,7 +473,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		n = fprintf(processorstream, "%s %s %s", ((rrdtpldata_t *)template)->template, rrdvalues, hostname);
 		for (i=0; ((n >= 0) && fnparams[i]); i++) n = fprintf(processorstream, " %s", fnparams[i]);
 		if (n >= 0) n = fprintf(processorstream, "\n");
-		if (n >= 0) fflush(processorstream);
+		if (processorflush && (n >= 0)) fflush(processorstream);
 
 		if (n == -1) {
 			errprintf("Ext-processor write failed: %s\n", strerror(errno));

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -150,7 +150,12 @@ void shutdown_extprocessor(void)
 {
 	if (!processorfd) return;
 
-	close(processorfd);
+	/* Close via the stdio stream so any buffered data is flushed to the
+	   external processor and the FILE is freed. A bare close() on the fd
+	   would leak the FILE and, if the stream is buffered, silently discard
+	   un-flushed data. Fall back to close() if fdopen() had failed. */
+	if (processorstream) fclose(processorstream);
+	else close(processorfd);
 	processorfd = 0;
 	processorstream = NULL;
 

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -45,7 +45,7 @@ int no_rrd = 0;                /* Write to rrd by default */
 
 static int  processorfd = 0;
 static FILE *processorstream = NULL;
-static int  processorflush = 0;
+static int  processorflush = 0;   /* fflush the external processor after every write? (RRD_EXTPROC_DOFLUSH) */
 
 static char *exthandler = NULL;
 static char **extids = NULL;
@@ -113,6 +113,9 @@ void setup_extprocessor(char *cmd)
 	if (!cmd) return;
 
 	processorfd = 0;
+	/* Default: rely on the stdio buffer (flushed when it fills and on teardown),
+	   which cuts a write syscall per RRD update. Set RRD_EXTPROC_DOFLUSH to flush
+	   after every write instead; RRD_EXTPROC_BUFSIZ tunes the buffer size. */
 	processorflush = (getenv("RRD_EXTPROC_DOFLUSH") != NULL);
 	processorbufsz = getenv("RRD_EXTPROC_BUFSIZ") ? atol(getenv("RRD_EXTPROC_BUFSIZ")) : BUFSIZ;
 
@@ -145,9 +148,13 @@ void setup_extprocessor(char *cmd)
 			close(pfd[0]);
 			processorfd = pfd[1];
 			processorstream = fdopen(processorfd, "w");
-			n = setvbuf( processorstream, (char *)NULL, _IOFBF, processorbufsz );
-			if (n) errprintf("setvbuf() returned %d on processor '%s' for %lu bytes: %s\n", cmd, n, processorbufsz, strerror(errno));
-			logprintf("External processor '%s' started\n", cmd);
+			if (processorstream) {
+				/* NB: arg order matches the format (n, cmd, size) - the
+				   original had cmd/n swapped, crashing on setvbuf failure. */
+				n = setvbuf(processorstream, (char *)NULL, _IOFBF, processorbufsz);
+				if (n) errprintf("setvbuf() returned %d on processor '%s' for %lu bytes: %s\n", n, cmd, (unsigned long)processorbufsz, strerror(errno));
+			}
+			errprintf("External processor '%s' started\n", cmd);
 		}
 	}
 }
@@ -156,7 +163,12 @@ void shutdown_extprocessor(void)
 {
 	if (!processorfd) return;
 
-	close(processorfd);
+	/* Close via the stdio stream so any buffered data is flushed to the
+	   external processor and the FILE is freed. A bare close() on the fd
+	   would leak the FILE and, if the stream is buffered, silently discard
+	   un-flushed data. Fall back to close() if fdopen() had failed. */
+	if (processorstream) fclose(processorstream);
+	else close(processorfd);
 	processorfd = 0;
 	processorstream = NULL;
 

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -45,6 +45,7 @@ int no_rrd = 0;                /* Write to rrd by default */
 
 static int  processorfd = 0;
 static FILE *processorstream = NULL;
+static int  processorflush = 0;
 
 static char *exthandler = NULL;
 static char **extids = NULL;
@@ -105,12 +106,15 @@ void setup_extprocessor(char *cmd)
 {
 
 	int n;
+	size_t processorbufsz;
 	int pfd[2];
 	pid_t childpid;
 
 	if (!cmd) return;
 
 	processorfd = 0;
+	processorflush = (getenv("RRD_EXTPROC_DOFLUSH") != NULL);
+	processorbufsz = getenv("RRD_EXTPROC_BUFSIZ") ? atol(getenv("RRD_EXTPROC_BUFSIZ")) : BUFSIZ;
 
 	n = pipe(pfd);
 	if (n == -1) {
@@ -141,7 +145,9 @@ void setup_extprocessor(char *cmd)
 			close(pfd[0]);
 			processorfd = pfd[1];
 			processorstream = fdopen(processorfd, "w");
-			errprintf("External processor '%s' started\n", cmd);
+			n = setvbuf( processorstream, (char *)NULL, _IOFBF, processorbufsz );
+			if (n) errprintf("setvbuf() returned %d on processor '%s' for %lu bytes: %s\n", cmd, n, processorbufsz, strerror(errno));
+			logprintf("External processor '%s' started\n", cmd);
 		}
 	}
 }
@@ -473,7 +479,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 		n = fprintf(processorstream, "%s %s %s", ((rrdtpldata_t *)template)->template, rrdvalues, hostname);
 		for (i=0; ((n >= 0) && fnparams[i]); i++) n = fprintf(processorstream, " %s", fnparams[i]);
 		if (n >= 0) n = fprintf(processorstream, "\n");
-		if (n >= 0) fflush(processorstream);
+		if (processorflush && (n >= 0)) fflush(processorstream);
 
 		if (n == -1) {
 			errprintf("Ext-processor write failed: %s\n", strerror(errno));

--- a/xymond/xymond_rrd.8
+++ b/xymond/xymond_rrd.8
@@ -306,6 +306,29 @@ in a format nearly suitable for injection using
 and easily transformable to other formats. If the process exits,
 xymond_rrd will re-launch it automatically.
 
+The stream is fully buffered, so an update is normally written to the
+processor only once the buffer fills. On a busy server that is invisible;
+on a quiet one an update may wait a long time before it is written. Set
+\fBRRD_EXTPROC_DOFLUSH\fR in
+.I xymonserver.cfg(5)
+to flush after every update instead, at the cost of one write per update
+\-\- use it when the processor forwards to something that expects a live
+stream. \fBRRD_EXTPROC_BUFSIZ\fR sets the size of the buffer, in bytes;
+the default is the system's BUFSIZ.
+
+The buffer reaches the processor only if the processor is still running
+when the stream is closed. That holds on an orderly stop: xymond_rrd
+flushes the stream to the processor before exiting, so a normal shutdown
+loses nothing.
+
+If the processor exits first, everything still buffered is lost.
+xymond_rrd notices only on its next write to the stream \-\- which, with
+the stream buffered, is the write that fills the buffer \-\- and it is
+that late in re\-launching the processor as well. Up to
+\fBRRD_EXTPROC_BUFSIZ\fR bytes of updates can go to a processor that is
+already gone; with \fBRRD_EXTPROC_DOFLUSH\fR set the same failure costs
+at most a single update.
+
 
 .SH CUSTOM RRD DATA VIA SCRIPTS
 xymond_rrd provides a simple mechanism for adding custom graphs


### PR DESCRIPTION
Ports the external-RRD-processor buffering feature (devel `f1682a661` = #29 TBT `513`)
to `main`, with the bugs it ships with on devel/4.4 and in the Terabithia RPMs fixed.

| | |
| --- | --- |
| `d3c5d6e3` | the original, unmodified — Japheth "J.C." Cleaver, 2015-11-22, with `cherry picked from` provenance |
| `534a7b9b` | everything we changed — fixes, manpage, tests |

## Feature

`xymond_rrd` `fflush`es the `--processor` stream after every line — a write syscall per
RRD update. Two env vars let you buffer instead: `RRD_EXTPROC_BUFSIZ` (stdio buffer size,
default the system `BUFSIZ`) and `RRD_EXTPROC_DOFLUSH` (flush every write, today's
behaviour).

## Fixes

1. **Teardown discarded the buffer.** `shutdown_extprocessor()` closed the raw fd and
   NULLed the `FILE*` without `fclose()` — leaking the FILE and, once the stream is
   buffered, dropping unwritten data on every restart and on exit. Now `fclose()`, with
   `close()` as fallback if `fdopen()` failed. This is what makes the feature safe to
   enable.
2. **The `setvbuf`-failure diagnostic was itself a crash** — `cmd` and `n` swapped against
   the format, so `%d` took a `char*` and `%s` an `int`. Reordered, size cast for `%lu`.
3. **`setvbuf()` ran on an unchecked `fdopen()` result.** Guarded.
4. **Port decision:** the original moved the "External processor started" line to
   `logprintf`, which on `main` is `#define logprintf(...) printf(__VA_ARGS__)` — a bare
   stdout write. It stays on `errprintf` with the rest of the file's diagnostics.

The original's `Changes` entry targeted devel's 4.4-alpha section; `main` has had no
unreleased section since 4.3.30, so there is nowhere for it to land.

## Behaviour change

The default flips from flush-per-line to buffered, matching `f1682a661`:

- **Clean shutdown loses nothing** — SIGTERM/SIGINT reach `shutdown_extprocessor()`, whose
  `fclose()` flushes. That is fix 1 working.
- **Processor death loses the buffer.** Measured on a pipe mimicking this code (SIGPIPE
  caught, 20 buffered updates, reader gone): `fclose` returns `-1`, versus `0` with nothing
  pending under flush-per-line. Previously at most one line was in flight; now up to
  `RRD_EXTPROC_BUFSIZ`.
- **Delivery is no longer prompt.** At ~50 bytes per update, ~160 accumulate before a
  flush — immaterial for RRD graphing, material if the processor feeds a live consumer.

`RRD_EXTPROC_DOFLUSH` restores per-line flushing. **Whether buffered should be the default
on `main` is worth deciding deliberately** rather than inheriting from devel.

`RRD_EXTPROC_BUFSIZ` is unvalidated — `atol()` gives `0` for `yes`, `64` for `64K`,
`SIZE_MAX` for `-1`, and glibc's `setvbuf` accepts all of them silently. Left alone here;
validating it is a behaviour change, not a port fix.

## Documentation and tests

`main` already carries most of devel's `4ec669eb`; the gap was the paragraph describing the
two variables. Written fresh, not ported — devel calls `RRD_EXTPROC_BUFSIZ` the *"pipe
buffer size (on systems which allow this)"*, and it is the stdio buffer set by `setvbuf` on
a stream this process owns. The new text adds what devel omits: that buffering delays
delivery, and what is lost when the processor dies. HTML regenerated, `mandoc -T lint`
clean.

Two tests in `tests/rrd/`, each proven to fail on the defect it guards:

| test | defect reintroduced |
| --- | --- |
| `extproc-teardown-flush.sh` | `FAIL: the external processor received nothing: the buffered update was discarded at teardown` |
| `extproc-doflush.sh` | `FAIL: RRD_EXTPROC_DOFLUSH did not deliver the update while xymond_rrd was still running` |

Both drive the real `xymond_rrd` with `--no-rrd` and a recording processor, forcing
`RRD_EXTPROC_BUFSIZ=65536` so nothing can arrive by the buffer filling. Neither asserts the
negative direction (that the default has *not* delivered yet) — that is the absence of an
event, and bounding it with a wall clock is a race.

## Verified

- Suite 55 passed / 0 skipped / 0 failed on a built server tree (53 before).
- SIGPIPE is caught in `xymond_rrd`, so the new `fclose()` into a broken pipe returns EOF
  rather than killing the worker; the reload path clears its flag *after*
  `setup_extprocessor()`, so a SIGPIPE from the teardown flush is swallowed, not looped.
- Rebased onto current `main` and rebuilt. The branch had been cut from `6f5f87861`, before
  this file gained its path-truncation hardening, so it had never compiled against the code
  it merges into.

Refs: #29 (TBT `513` = `f1682a661`)
