### PR TITLE
lib/url.c: fix off-by-one truncating the last char of .netrc passwords

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -223,7 +223,7 @@ static void load_netrc(void)
 
 					item->host = host;
 					item->auth = (char *) malloc(login_len + 1);
-					snprintf(item->auth, login_len, "%s:%s", login, password);
+					snprintf(item->auth, login_len + 1, "%s:%s", login, password);
 					item->next = loginhead;
 					loginhead = item;
 					host = login = password = NULL;


### PR DESCRIPTION
Summary
load_netrc() in lib/url.c drops the last character of every .netrc password:


unsigned int login_len = strlen(login) + strlen(password) + 1;   // len("login:password")
item->auth = (char *) malloc(login_len + 1);                      // correctly sized
snprintf(item->auth, login_len, "%s:%s", login, password);         // size passed is 1 byte short
snprintf's size includes the null terminator, so it writes at most size - 1 bytes. Passing login_len instead of login_len + 1 truncates the final character every time (e.g. hunter2 → hunter).

Introduced in 484edeb26 (2019 CVE-2019-1345x sprintf→snprintf hardening pass) — the malloc was sized correctly but the snprintf size wasn't updated to match. Still present on every upstream branch; no existing issue/PR mentions it.

Fix
Pass login_len + 1 to snprintf, matching the allocated buffer.