### PR TITLE
init_tcp_services: copy the static cache at each call site, never free it

### DIFF
--- a/lib/xymonrrd.c
+++ b/lib/xymonrrd.c
@@ -85,7 +85,7 @@ static void rrd_setup(void)
 	rrd_destroy();
 
 	/* Get the tcp services, and count how many there are */
-	services = init_tcp_services();
+	services = strdup(init_tcp_services());
 	SBUF_MALLOC(tcptests, strlen(services)+1);
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 	#pragma GCC diagnostic push

--- a/xymonnet/xymonnet.c
+++ b/xymonnet/xymonnet.c
@@ -300,7 +300,7 @@ void load_services(void)
 	char *netsvcs;
 	char *p;
 
-	netsvcs = init_tcp_services();
+	netsvcs = strdup(init_tcp_services());
 
 	/* Keep the services db open. Don't close since we use it later in 
 	 * SSL handshake checking and URL parsing...


### PR DESCRIPTION
Two 2015 commits dropped the caller-side `strdup()` around `init_tcp_services()` while leaving the later `xfree()` in place. `init_tcp_services()` returns the module-static cache `xymonnetsvcs` (`lib/netservices.c`), so both callers end up freeing — and in xymonnet's case also `strtok()`-mangling — the shared cache:

- `9295f1a80` — `lib/xymonrrd.c` `rrd_setup()`: `services = init_tcp_services()` + `xfree(services)` at the end of setup.
- `53a0af40b` — `xymonnet.c`: `netsvcs = init_tcp_services()` + `strtok(netsvcs, " ")` + `xfree(netsvcs)`.

After the first free, `xymonnetsvcs` is left dangling non-NULL: the next `init_tcp_services()` call in the same process (`web/confreport.c:840`, `xymonnet/contest.c:1464`, or a `rrd_setup()` re-run) returns freed memory via the config-unchanged fast path, and a `protocols.cfg` reload frees the stale pointer a second time.

Both "leaks" the original commits addressed were false positives on the cached pointer — the caller-side copies were already freed locally. `main` is unaffected (it kept the `strdup()`/`xfree()` pair from the 4.3.0 merge); this restores the same form on `devel`, one commit per faulty commit.

Found while triaging TBT `519` for #29; do-not-port warnings for the two commits are recorded in #29 (TBT `519`, `213`) and #106.
