### PR TITLE
docs: delayred shows the status as yellow while the red is deferred

### DIFF
--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -123,9 +123,17 @@ with \fBdelayred=disk:10,cpu:30\fR, a red disk-status will not appear
 on the Xymon webpages until it has been red for at least 10 minutes.
 Note: Since most tests only execute once every 5 minutes, it will
 usually not make sense to set N to anything but a multiple of 5. The
-exception is network tests, since 
+exception is network tests, since
 .I xymonnet\-again.sh(1)
 will re-run failed network tests once a minute for up to 30 minutes.
+
+Note: while the change to red is deferred, the status is shown as
+yellow - it does not stay green - so alert rules matching a yellow
+status will still trigger. To keep the status unchanged during the
+delay, list the status column in both \fBdelayred\fR and
+\fBdelayyellow\fR. A status that has gone purple (no data) is an
+exception: the first report that arrives after the data gap takes
+effect immediately, without any delay.
 
 .IP delayyellow=STATUSCOLUMN:DELAY[,STATUSCOLUMN:DELAY...]
 Same as \fBdelayred\fR, but defers the change to a yellow status.

--- a/xymond/xymond.8
+++ b/xymond/xymond.8
@@ -124,6 +124,11 @@ but these options allow you to set a default value for the delays.
 The value N is in minutes. Default: 0 minutes (no delay).
 Note: Since most tests only execute once every 5 minutes, it will
 usually not make sense to set N to anything but a multiple of 5.
+.br
+While the change to red is deferred the status is shown as yellow, not
+green; use both delays to keep the status unchanged. A status
+recovering from purple (no data) is updated immediately, without any
+delay.
 
 .IP "\-\-env=FILENAME"
 Loads the content of FILENAME as environment settings before starting


### PR DESCRIPTION
Summary
Docs-only change. Neither man page mentioned that a status inside its delayred window is displayed as yellow rather than staying green. In fact, hosts.cfg(5) says a delayed red "will not appear on the Xymon webpages" — implying nothing changes — when in reality the status degrades to yellow immediately, so alert rules matching yellow still fire during the window.

The behavior comes from xymond's changedelay() handling in handle_status(): while the red delay hasn't elapsed, the status falls through to yellow unless a delayyellow window also covers the column. Two consequences worth knowing:

To keep a status fully unchanged during the delay, the column must be listed in both delayred and delayyellow.
A status recovering from purple (no data) is updated immediately — changedelay() skips all delays when the current color is purple, so the first report after a data gap takes effect at once.
Adds a note covering all of this to the delayred entry in hosts.cfg(5) and, in brief, to the --delay-red/--delay-yellow options in xymond(8).

Why document it
This has been a recurring source of confusion on the mailing list for over a decade, and the answer has only ever existed as list folklore:

["Please clarify: http yellow when delayred is set?"](https://lists.xymon.com/archive/2012-June/034764.html) (2012) — user set delayred=http:10 and asked exactly this question after watching the test turn yellow; went unanswered long enough to warrant a ["Please help" repost](https://lists.xymon.com/archive/2012-June/034907.html).
["Red alert delay"](https://lists.xymon.com/archive/2015-April/041524.html) (2015) — same observation; the suggested workaround was exactly what these docs now say (add delayyellow).
["delayred on conn"](https://lists.xymon.com/archive/2016-March/043236.html) (2016) — user surprised by the intermediate yellow again.
No GitHub issue or PR has ever covered it.

Notes
No behavior change — wording only. Both pages pass groff -man -z cleanly; testsuite green.