### PR TITLE
Add HOSTDESCURL template to link the DESCR description on the info page

### DIFF
--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -290,6 +290,9 @@ text that will be shown on the "Info" column page; this can
 e.g. be used to store information about the physical location
 of the device, contact persons etc. If the text contain whitespace,
 you must enclose it in double-quotes, e.g.  DESCR:"switch:4th floor Marketing switch"
+The "Hosttype" and "Description" values can be turned into links on the
+info page by setting the HOSTTYPEURL and HOSTDESCURL formatting strings in
+.I xymonserver.cfg(5).
 
 .IP "CLASS:Classname"
 Force the host to belong to a specific class. Class-names are used

--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -290,9 +290,14 @@ text that will be shown on the "Info" column page; this can
 e.g. be used to store information about the physical location
 of the device, contact persons etc. If the text contain whitespace,
 you must enclose it in double-quotes, e.g.  DESCR:"switch:4th floor Marketing switch"
-The "Hosttype" and "Description" values can be turned into links on the
-info page by setting the HOSTTYPEURL and HOSTDESCURL formatting strings in
-.I xymonserver.cfg(5).
+"Hosttype" and "Description" are split at the \fBfirst\fR colon, so
+"Hosttype" must not itself contain a colon.
+HOSTTYPEURL and HOSTDESCURL in
+.I xymonserver.cfg(5)
+can turn these values into links on the info page. The info page renders
+this text unescaped, so raw HTML placed directly in "Description" (e.g.
+an \fB<a href=...>\fR link) is also rendered as a link, independently of
+HOSTDESCURL, and can be used to link different hosts to different targets.
 
 .IP "CLASS:Classname"
 Force the host to belong to a specific class. Class-names are used

--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -292,9 +292,9 @@ of the device, contact persons etc. If the text contain whitespace,
 you must enclose it in double-quotes, e.g.  DESCR:"switch:4th floor Marketing switch"
 "Hosttype" and "Description" are split at the \fBfirst\fR colon, so
 "Hosttype" must not itself contain a colon.
-HOSTTYPEURL and HOSTDESCURL in
+HOSTDESCURL in
 .I xymonserver.cfg(5)
-can turn these values into links on the info page. The info page renders
+can turn the description into a link on the info page. The info page renders
 this text unescaped, so raw HTML placed directly in "Description" (e.g.
 an \fB<a href=...>\fR link) is also rendered as a link, independently of
 HOSTDESCURL, and can be used to link different hosts to different targets.

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -347,6 +347,24 @@ becomes a formatting string for the documentation URL. E.g. for the host
 Default: Not set, so host documentation will be retrieved from the
 XYMONNOTES directory.
 
+.IP HOSTTYPEURL
+Format string used to build a link for the host-type part of a
+.I hosts.cfg(5)
+"DESCR:Hosttype:Description" tag, shown on the host's info page. If set,
+this string becomes a formatting string for the link URL, e.g.
+HOSTTYPEURL="https://wiki.example.com/systems/%s" will turn a host-type of
+"linux" into a link to "https://wiki.example.com/systems/linux".
+Default: Not set, so the host-type is shown as plain text.
+
+.IP HOSTDESCURL
+Format string used to build a link for the description part of a
+.I hosts.cfg(5)
+"DESCR:Hosttype:Description" tag, shown on the host's info page. If set,
+this string becomes a formatting string for the link URL, e.g.
+HOSTDESCURL="https://cmdb.example.com/ci/%s" will turn a description of
+"CIID1234" into a link to "https://cmdb.example.com/ci/CIID1234".
+Default: Not set, so the description is shown as plain text.
+
 
 .SH SETTINGS FOR SENDING MESSAGES TO XYMON
 .IP XYMSRV

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -347,15 +347,6 @@ becomes a formatting string for the documentation URL. E.g. for the host
 Default: Not set, so host documentation will be retrieved from the
 XYMONNOTES directory.
 
-.IP HOSTTYPEURL
-Format string used to build a link for the host-type part of a
-.I hosts.cfg(5)
-"DESCR:Hosttype:Description" tag, shown on the host's info page. If set,
-this string becomes a formatting string for the link URL, e.g.
-HOSTTYPEURL="https://wiki.example.com/systems/%s" will turn a host-type of
-"linux" into a link to "https://wiki.example.com/systems/linux".
-Default: Not set, so the host-type is shown as plain text.
-
 .IP HOSTDESCURL
 Format string used to build a link for the description part of a
 .I hosts.cfg(5)
@@ -367,7 +358,7 @@ Default: Not set, so the description is shown as plain text.
 
 Note: if a host's DESCR value contains "<" (see the raw-HTML case in
 .I hosts.cfg(5)
-), HOSTTYPEURL/HOSTDESCURL leaves it as-is rather than urlencoding it into
+), HOSTDESCURL leaves it as-is rather than urlencoding it into
 the link template, so no link is added for that host.
 
 

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -365,6 +365,11 @@ HOSTDESCURL="https://cmdb.example.com/ci/%s" will turn a description of
 "CIID1234" into a link to "https://cmdb.example.com/ci/CIID1234".
 Default: Not set, so the description is shown as plain text.
 
+Note: if a host's DESCR value contains "<" (see the raw-HTML case in
+.I hosts.cfg(5)
+), HOSTTYPEURL/HOSTDESCURL leaves it as-is rather than urlencoding it into
+the link template, so no link is added for that host.
+
 
 .SH SETTINGS FOR SENDING MESSAGES TO XYMON
 .IP XYMSRV

--- a/lib/environ.c
+++ b/lib/environ.c
@@ -125,7 +125,6 @@ const static struct {
 	{ "RRDWIDTH", "576" },
 	{ "COLUMNDOCURL", "$CGIBINURL/columndoc.sh?%s" },
 	{ "HOSTDOCURL", "" },
-	{ "HOSTTYPEURL", "" },
 	{ "HOSTDESCURL", "" },
 	{ "XYMONLOGO", "Xymon" },
 	{ "XYMONPAGELOCAL", "<B><I>Pages Hosted Locally</I></B>" },

--- a/lib/environ.c
+++ b/lib/environ.c
@@ -125,6 +125,8 @@ const static struct {
 	{ "RRDWIDTH", "576" },
 	{ "COLUMNDOCURL", "$CGIBINURL/columndoc.sh?%s" },
 	{ "HOSTDOCURL", "" },
+	{ "HOSTTYPEURL", "" },
+	{ "HOSTDESCURL", "" },
 	{ "XYMONLOGO", "Xymon" },
 	{ "XYMONPAGELOCAL", "<B><I>Pages Hosted Locally</I></B>" },
 	{ "XYMONPAGEREMOTE", "<B><I>Remote Status Display</I></B>" },

--- a/web/svcstatus-info.c
+++ b/web/svcstatus-info.c
@@ -1036,7 +1036,8 @@ char *generate_info(char *hostname, char *critconfigfn)
 
 		delim = strchr(val, ':'); if (delim) *delim = '\0';
 		addtobuffer(infobuf, "<tr><th align=left>Host type:</th><td align=left>");
-		if (typeurl) {
+		/* Value may already contain raw HTML (e.g. a link) - don't urlencode/wrap it. */
+		if (typeurl && !strchr(val, '<')) {
 			snprintf(linkurl, sizeof(linkurl), typeurl, urlencode(val));
 			addtobuffer(infobuf, "<a href=\"");
 			addtobuffer(infobuf, linkurl);
@@ -1050,7 +1051,8 @@ char *generate_info(char *hostname, char *critconfigfn)
 			*delim = ':'; 
 			delim++;
 			addtobuffer(infobuf, "<tr><th align=left>Description:</th><td align=left>");
-			if (descrurl) {
+			/* Same guard as above. */
+			if (descrurl && !strchr(delim, '<')) {
 				snprintf(linkurl, sizeof(linkurl), descrurl, urlencode(delim));
 				addtobuffer(infobuf, "<a href=\"");
 				addtobuffer(infobuf, linkurl);

--- a/web/svcstatus-info.c
+++ b/web/svcstatus-info.c
@@ -1028,17 +1028,37 @@ char *generate_info(char *hostname, char *critconfigfn)
 
 	val = xmh_item(hostwalk, XMH_DESCRIPTION);
 	if (val) {
-		char *delim;
+		char *delim, *typeurl, *descrurl;
+		char linkurl[PATH_MAX];
+
+		typeurl = xgetenv("HOSTTYPEURL"); if (typeurl && !*typeurl) typeurl = NULL;
+		descrurl = xgetenv("HOSTDESCURL"); if (descrurl && !*descrurl) descrurl = NULL;
 
 		delim = strchr(val, ':'); if (delim) *delim = '\0';
 		addtobuffer(infobuf, "<tr><th align=left>Host type:</th><td align=left>");
-		addtobuffer(infobuf, val);
+		if (typeurl) {
+			snprintf(linkurl, sizeof(linkurl), typeurl, urlencode(val));
+			addtobuffer(infobuf, "<a href=\"");
+			addtobuffer(infobuf, linkurl);
+			addtobuffer(infobuf, "\">");
+			addtobuffer(infobuf, val);
+			addtobuffer(infobuf, "</a>");
+		}
+		else addtobuffer(infobuf, val);
 		addtobuffer(infobuf, "</td></tr>\n");
 		if (delim) { 
 			*delim = ':'; 
 			delim++;
 			addtobuffer(infobuf, "<tr><th align=left>Description:</th><td align=left>");
-			addtobuffer(infobuf, delim);
+			if (descrurl) {
+				snprintf(linkurl, sizeof(linkurl), descrurl, urlencode(delim));
+				addtobuffer(infobuf, "<a href=\"");
+				addtobuffer(infobuf, linkurl);
+				addtobuffer(infobuf, "\">");
+				addtobuffer(infobuf, delim);
+				addtobuffer(infobuf, "</a>");
+			}
+			else addtobuffer(infobuf, delim);
 			addtobuffer(infobuf, "</td></tr>\n");
 		}
 		addtobuffer(infobuf, "<tr><td colspan=2>&nbsp;</td></tr>\n");

--- a/web/svcstatus-info.c
+++ b/web/svcstatus-info.c
@@ -1028,30 +1028,20 @@ char *generate_info(char *hostname, char *critconfigfn)
 
 	val = xmh_item(hostwalk, XMH_DESCRIPTION);
 	if (val) {
-		char *delim, *typeurl, *descrurl;
+		char *delim, *descrurl;
 		char linkurl[PATH_MAX];
 
-		typeurl = xgetenv("HOSTTYPEURL"); if (typeurl && !*typeurl) typeurl = NULL;
 		descrurl = xgetenv("HOSTDESCURL"); if (descrurl && !*descrurl) descrurl = NULL;
 
 		delim = strchr(val, ':'); if (delim) *delim = '\0';
 		addtobuffer(infobuf, "<tr><th align=left>Host type:</th><td align=left>");
-		/* Value may already contain raw HTML (e.g. a link) - don't urlencode/wrap it. */
-		if (typeurl && !strchr(val, '<')) {
-			snprintf(linkurl, sizeof(linkurl), typeurl, urlencode(val));
-			addtobuffer(infobuf, "<a href=\"");
-			addtobuffer(infobuf, linkurl);
-			addtobuffer(infobuf, "\">");
-			addtobuffer(infobuf, val);
-			addtobuffer(infobuf, "</a>");
-		}
-		else addtobuffer(infobuf, val);
+		addtobuffer(infobuf, val);
 		addtobuffer(infobuf, "</td></tr>\n");
 		if (delim) { 
 			*delim = ':'; 
 			delim++;
 			addtobuffer(infobuf, "<tr><th align=left>Description:</th><td align=left>");
-			/* Same guard as above. */
+			/* Value may already contain raw HTML (e.g. a link) - don't urlencode/wrap it. */
 			if (descrurl && !strchr(delim, '<')) {
 				snprintf(linkurl, sizeof(linkurl), descrurl, urlencode(delim));
 				addtobuffer(infobuf, "<a href=\"");

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -203,6 +203,13 @@ COLUMNDOCURL="$CGIBINURL/columndoc.sh?%s"	# URL formatting string for column-lin
 #
 # HOSTDOCURL="$XYMONNOTESSKIN/%s.html"
 
+# HOSTTYPEURL and HOSTDESCURL are formatting strings for turning the two parts of a
+# hosts.cfg "DESCR:Hosttype:Description" tag into links on the info page. If NOT set
+# (the default), the values are shown as plain text.
+#
+# HOSTTYPEURL="https://wiki.example.com/systems/%s"   # Makes the DESCR host-type a link on the info page
+# HOSTDESCURL="https://cmdb.example.com/ci/%s"           # Makes the DESCR description a link on the info page
+
 
 # HTML content
 HTMLCONTENTTYPE="text/html"                     # You can add charset options here.

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -203,11 +203,10 @@ COLUMNDOCURL="$CGIBINURL/columndoc.sh?%s"	# URL formatting string for column-lin
 #
 # HOSTDOCURL="$XYMONNOTESSKIN/%s.html"
 
-# HOSTTYPEURL and HOSTDESCURL are formatting strings for turning the two parts of a
-# hosts.cfg "DESCR:Hosttype:Description" tag into links on the info page. If NOT set
-# (the default), the values are shown as plain text.
+# HOSTDESCURL is a formatting string for turning the description part of a
+# hosts.cfg "DESCR:Hosttype:Description" tag into a link on the info page. If NOT set
+# (the default), the value is shown as plain text.
 #
-# HOSTTYPEURL="https://wiki.example.com/systems/%s"   # Makes the DESCR host-type a link on the info page
 # HOSTDESCURL="https://cmdb.example.com/ci/%s"           # Makes the DESCR description a link on the info page
 
 


### PR DESCRIPTION
Adds one optional xymonserver.cfg template to turn the description part of a hosts.cfg `DESCR:Hosttype:Description` tag into a link on the host's info page.

**Problem**
`DESCR:linux:CIID1234` renders as plain-text rows on the info page, with no way to make the description a clickable link (CMDB entry, wiki page, inventory system) short of embedding raw HTML in every host line.

**Solution**
`HOSTDESCURL`, following the existing COLUMNDOCURL/HOSTDOCURL convention: a printf-style `%s` format string, unset/empty (the default) = no link, output byte-for-byte identical to today.

```
HOSTDESCURL="https://cmdb.example.com/ci/%s"
```

The substituted value is urlencode()d since DESCR text is free-form. Values already containing raw HTML (`<`) are left untouched, so the existing per-host raw-HTML passthrough — now documented in hosts.cfg.5 along with the first-colon split rule — keeps working and takes precedence per host.

**Changes**
- environ.c: register the HOSTDESCURL default (empty).
- svcstatus-info.c: wrap the description in a link when the template is set and the value carries no raw HTML.
- xymonserver.cfg.DIST, xymonserver.cfg.5, hosts.cfg.5: documentation.

**Testing** (by the author)
Clean build; testsuite 14/14; `groff -man -z` clean on both man pages; manual rendering of the info page with template set / unset / raw-HTML DESCR / DESCR without a description part.

**Review history**: the PR originally added a second template (`HOSTTYPEURL`) for the host-type part; it was dropped during review as having no concrete use case — the type is a category, not an identifier. See the review thread.