### PR TITLE
xymond_rrd: refuse an overlong XYMONTMP instead of overflowing sun_path (#236)

### DIFF
--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -181,6 +181,14 @@ Default: $XYMONSERVERROOT/server/ .
 
 .IP XYMONTMP
 Directory used for temporary files. Default: $XYMONHOME/tmp/
+.br
+Note:
+.I xymond_rrd(8)
+creates its cache-control Unix socket ("rrdctl.<pid>") in this
+directory, and Unix socket paths have a small, platform-dependent
+length limit (around 92 to 107 bytes for the complete path, depending
+on the OS). xymond_rrd refuses to start when XYMONTMP is too deep for
+the socket path to fit, so keep this directory path short.
 
 .IP XYMONWWWDIR
 Directory for Xymon webfiles. The $XYMONWEB URL must map to this directory.

--- a/tests/server/xymond-rrd-ctlsocket-path.sh
+++ b/tests/server/xymond-rrd-ctlsocket-path.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-rrd-ctlsocket-path.sh
+#
+# Regression guard for issue #236: xymond_rrd composed its cache-control
+# socket path with an unchecked sprintf into sun_path (~108 bytes), so any
+# XYMONTMP longer than ~92 characters overflowed the buffer and aborted the
+# daemon at startup ("*** buffer overflow detected ***") with no logged
+# cause. It must instead refuse to start with a clear error naming the
+# problem - and keep starting normally with an ordinary XYMONTMP.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMOND_RRD "xymond/xymond_rrd"
+
+work=$(mktempdir)
+
+# A path safely past sun_path (108 bytes on Linux, as small as 92 elsewhere)
+longtmp="$work/$(printf 'x%.0s' $(seq 1 120))"
+mkdir -p "$longtmp" "$work/rrd" "$work/tmp"
+
+# Overlong XYMONTMP: a clean refusal (exit 1 + message), not a SIGABRT (134)
+rc=0
+out=$(echo -n | XYMONTMP="$longtmp" XYMONHOME="$work" \
+	"$XYMOND_RRD" --rrddir="$work/rrd" --no-cache 2>&1) || rc=$?
+[ "$rc" -eq 1 ] || fail "expected clean exit 1 on overlong XYMONTMP, got $rc: $out"
+assert_contains "XYMONTMP is too long" "$out" "overlong XYMONTMP refused with a clear error"
+
+# An ordinary XYMONTMP still starts and shuts down cleanly on EOF
+rc=0
+out=$(echo -n | XYMONTMP="$work/tmp" XYMONHOME="$work" \
+	"$XYMOND_RRD" --rrddir="$work/rrd" --no-cache 2>&1) || rc=$?
+[ "$rc" -eq 0 ] || fail "expected clean exit 0 with short XYMONTMP, got $rc: $out"
+
+pass "xymond_rrd refuses an overlong XYMONTMP instead of aborting"

--- a/xymond/xymond_rrd.8
+++ b/xymond/xymond_rrd.8
@@ -82,6 +82,14 @@ file.
 .IP XYMONRRDS
 Default directory where RRD files are stored.
 
+.IP XYMONTMP
+Directory where xymond_rrd creates the cache-control Unix socket
+("rrdctl.<pid>") used to flush cached updates when a graph is shown.
+Unix socket paths have a small, platform-dependent length limit
+(around 92 to 107 bytes for the complete path), so xymond_rrd refuses
+to start - with an error stating the actual limit - when XYMONTMP is
+too deep for the socket path to fit.
+
 .IP NCV_testname
 Defines the types of data collected by the "ncv" module in xymond_rrd.
 See below for more information.

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -253,7 +253,18 @@ int main(int argc, char *argv[])
 
 	/* Setup the control socket that receives cache-flush commands */
 	memset(&ctlsockaddr, 0, sizeof(ctlsockaddr));
-	sprintf(ctlsockaddr.sun_path, "%s/rrdctl.%lu", xgetenv("XYMONTMP"), (unsigned long)getpid());
+	{
+		/* sun_path is tiny (~108 bytes); an unchecked sprintf of a deep XYMONTMP
+		 * overflows it and aborts the daemon at startup with no logged cause.
+		 * showgraph guards the sender side of this socket the same way. */
+		int n = snprintf(ctlsockaddr.sun_path, sizeof(ctlsockaddr.sun_path),
+				 "%s/rrdctl.%lu", xgetenv("XYMONTMP"), (unsigned long)getpid());
+		if ((n < 0) || (n >= (int)sizeof(ctlsockaddr.sun_path))) {
+			errprintf("Cannot set up cache-control socket: XYMONTMP is too long for a socket path (max %d characters)\n",
+				  (int)(sizeof(ctlsockaddr.sun_path) - 1));
+			return 1;
+		}
+	}
 	unlink(ctlsockaddr.sun_path);     /* In case it was accidentally left behind */
 	ctlsockaddr.sun_family = AF_UNIX;
 	ctlsocket = socket(AF_UNIX, SOCK_DGRAM, 0);

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -253,7 +253,21 @@ int main(int argc, char *argv[])
 
 	/* Setup the control socket that receives cache-flush commands */
 	memset(&ctlsockaddr, 0, sizeof(ctlsockaddr));
-	sprintf(ctlsockaddr.sun_path, "%s/rrdctl.%lu", xgetenv("XYMONTMP"), (unsigned long)getpid());
+	{
+		/* sun_path is tiny (~108 bytes); refuse an XYMONTMP that cannot
+		 * fit rather than overflow (showgraph guards the sender side). */
+		char *xymontmp = xgetenv("XYMONTMP");
+		int n = snprintf(ctlsockaddr.sun_path, sizeof(ctlsockaddr.sun_path),
+				 "%s/rrdctl.%lu", xymontmp, (unsigned long)getpid());
+		if ((n < 0) || (n >= (int)sizeof(ctlsockaddr.sun_path))) {
+			/* Report the limit on XYMONTMP itself: sun_path minus the suffix. */
+			int maxtmp = (int)sizeof(ctlsockaddr.sun_path) - 1
+				   - snprintf(NULL, 0, "/rrdctl.%lu", (unsigned long)getpid());
+			errprintf("Cannot set up cache-control socket: XYMONTMP is too long for a socket path (%d characters; max %d with this process ID)\n",
+				  (int)strlen(xymontmp), maxtmp);
+			return 1;
+		}
+	}
 	unlink(ctlsockaddr.sun_path);     /* In case it was accidentally left behind */
 	ctlsockaddr.sun_family = AF_UNIX;
 	ctlsocket = socket(AF_UNIX, SOCK_DGRAM, 0);


### PR DESCRIPTION
## Problem

`xymond_rrd` composes its cache-control socket path (`$XYMONTMP/rrdctl.<pid>`) with an unchecked `sprintf` into `sun_path`, which is only ~108 bytes on Linux (as small as 92 on other platforms). A deep `XYMONTMP` — containers, CI sandboxes, per-user tmpdirs — overflows it: with `_FORTIFY_SOURCE` the daemon aborts at startup with no logged cause; without it, the overflow silently smashes the neighbouring sockaddr fields and the daemon keeps running (observed: failed `chmod()`, exit 0). Every trend stops updating either way.

Closes #236.

## Fix (single commit)

- Bound the composition with `snprintf`; on overflow, exit through the same path as the adjacent `socket()`/`bind()` failures, mirroring the sender-side guard in `web/showgraph.c`.
- The diagnostic reports the offending `XYMONTMP`'s length and the **actual** limit for it — `sun_path` minus the `/rrdctl.<pid>` suffix, which shifts with the pid's digit count (e.g. `237 characters; max 94 with this process ID`) — not the raw `sun_path` size, so an admin shortens to a length that actually fits.
- Documented the constraint (platform-dependent, ~92–107 bytes for the complete path) in `xymonserver.cfg.5` (XYMONTMP entry) and `xymond_rrd.8` (ENVIRONMENT).

## Regression coverage

`tests/server/xymond-rrd-ctlsocket-path.sh` drives the built worker with a 120-character `XYMONTMP` (asserts clean exit 1 naming XYMONTMP; the pre-fix binary dies on SIGABRT or corrupts silently) and with an ordinary one (clean start, EOF shutdown). Skips on the bare-tree lane, executes post-build. Full suite: 16 passed, 0 failed.