### PR TITLE
xymond_rrd: link libm for isfinite() (#232)

### DIFF
--- a/xymond/Makefile
+++ b/xymond/Makefile
@@ -58,8 +58,10 @@ xymond_history: $(HISTORYOBJS) $(XYMONCOMMLIB) $(XYMONTIMELIB)
 xymond_alert: $(ALERTOBJS) $(XYMONCOMMLIB)
 	$(CC) $(LDFLAGS) -o $@ $(RPATHOPT) $(ALERTOBJS) $(XYMONTIMELIBS) $(XYMONCOMMLIBS) $(PCRELIBS)
 
+# -lm: do_net.c uses isfinite(), which glibc inlines as a compiler builtin but
+# the BSDs resolve to __isfinite in libm (issue #232). Harmless where unneeded.
 xymond_rrd: $(RRDOBJS) $(XYMONCOMMLIB)
-	$(CC) $(LDFLAGS) -o $@ $(RPATHOPT) $(RRDOBJS) $(XYMONTIMELIBS) $(XYMONCOMMLIBS) $(RRDLIBS) $(PCRELIBS)
+	$(CC) $(LDFLAGS) -o $@ $(RPATHOPT) $(RRDOBJS) $(XYMONTIMELIBS) $(XYMONCOMMLIBS) $(RRDLIBS) $(PCRELIBS) -lm
 
 xymond.o: xymond.c
 	$(CC) $(CFLAGS) $(SSLFLAGS) -c -o $@ xymond.c


### PR DESCRIPTION
## Problem

`fa805be26` (PR #181) added `isfinite()` guards to `do_net.c`'s NTP offset parsing. glibc inlines `isfinite()` as a compiler builtin, so Linux CI never noticed — but the BSDs resolve it to `__isfinite` in `libm.so`, and `xymond_rrd`'s link line had no `-lm`:

```
ld: error: undefined symbol: __isfinite
```

The FreeBSD port currently only builds with a manual `LDFLAGS+=-lm` workaround.

Closes #232.

## Fix

Add `-lm` to the `xymond_rrd` link line, unconditionally — the flag is identical on every supported platform and harmless where the symbol is inlined or libm is folded into libc. This follows the tree's existing convention for the same situation: `web/Makefile` links `perfdata.cgi` with a literal `-lm` and a comment (`# Need -lm on perfdata because it refers to isnan()`); probed, system-dependent libraries stay in configure variables (`RRDLIBS`, `PCRELIBS`, ...), fixed self-evident ones go on the line.

No regression test: the failure is only observable when linking on a BSD, which the Linux-only CI cannot exercise. Verified to build and link unchanged on Linux; on-platform confirmation is the FreeBSD port building without the `LDFLAGS` workaround.