### PR TITLE
lib: SBUF_DEFINE must not end in a semicolon (C90 empty-statement trap)

### DIFF
--- a/lib/htmllog.c
+++ b/lib/htmllog.c
@@ -96,8 +96,8 @@ static void hostsvc_setup(void)
 static void historybutton(char *cgibinurl, char *hostname, char *service, char *ip, char *displayname, char *btntxt, FILE *output) 
 {
 	SBUF_DEFINE(tmp1);
-	SBUF_DEFINE(tmp2)
-		
+	SBUF_DEFINE(tmp2);
+
 	SBUF_MALLOC(tmp2, strlen(service)+3);
 
 	getenv_default("NONHISTS", "info,trends", NULL);

--- a/lib/strfunc.h
+++ b/lib/strfunc.h
@@ -29,8 +29,8 @@ extern char *htmlquoted(char *s);
 extern char *prehtmlquoted(char *s);
 extern strbuffer_t *replacetext(char *original, char *oldtext, char *newtext);
 
-#define SBUF_DEFINE(NAME) char *NAME = NULL; size_t NAME##_buflen = 0;
-#define STATIC_SBUF_DEFINE(NAME) static char *NAME = NULL; static size_t NAME##_buflen = 0;
+#define SBUF_DEFINE(NAME) char *NAME = NULL; size_t NAME##_buflen = 0
+#define STATIC_SBUF_DEFINE(NAME) static char *NAME = NULL; static size_t NAME##_buflen = 0
 #define SBUF_MALLOC(NAME, LEN) { NAME##_buflen = (LEN); NAME = (char *)malloc((LEN)+1); }
 #define SBUF_CALLOC(NAME, NMEMB, LEN) { NAME##_buflen = (LEN); NAME = (char *)calloc(NMEMB, (LEN)+1); }
 #define SBUF_REALLOC(NAME, LEN) { NAME##_buflen = (LEN); NAME = (char *)realloc(NAME, (LEN)+1); }

--- a/tests/server/sbuf-define-c90.sh
+++ b/tests/server/sbuf-define-c90.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/sbuf-define-c90.sh
+#
+# The SBUF_DEFINE/STATIC_SBUF_DEFINE macros must not end in a semicolon:
+# every call site writes its own, and a doubled ';' is an empty STATEMENT,
+# turning any following declaration into a C90 constraint violation. That
+# stays invisible until something compiles with
+# -Werror=declaration-after-statement - which newer net-snmp packages leak
+# through `net-snmp-config --cflags`, breaking xymon-snmpcollect.c on
+# Arch, Alpine 3.23, openSUSE Tumbleweed and FreeBSD 13.5-15.0.
+#
+# Guard: compile a snippet that uses the macro followed by a declaration,
+# with that -Werror flag, against the real lib/strfunc.h.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+
+work=$(mktempdir)
+
+cat >"$work/sbuf-c90.c" <<'EOF'
+#include <stdlib.h>
+
+/* strfunc.h only names strbuffer_t through pointers in prototypes */
+typedef struct strbuffer_t strbuffer_t;
+#include "strfunc.h"
+
+int check(void);
+int check(void)
+{
+	SBUF_DEFINE(buf);
+	int used = 0;	/* must still be a legal declaration after SBUF_DEFINE(...); */
+
+	SBUF_MALLOC(buf, 8);
+	used = (buf != NULL);
+	free(buf);
+	return used + (int)buf_buflen;
+}
+EOF
+
+"$CC" -fsyntax-only -Wall -Werror=declaration-after-statement \
+	-I"$ROOT/lib" "$work/sbuf-c90.c" 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; \
+	     fail "SBUF_DEFINE followed by a declaration trips -Werror=declaration-after-statement (macro ends in ';'?)"; }
+
+pass "SBUF_DEFINE call sites stay C90-clean under -Werror=declaration-after-statement"


### PR DESCRIPTION
## Problem

`SBUF_DEFINE`/`STATIC_SBUF_DEFINE` in `lib/strfunc.h` end with a semicolon, and every call site writes its own. The doubled `;` is an empty **statement**, so any declaration following a `SBUF_DEFINE(x);` line is a C90 declaration-after-statement violation - at 100+ call sites tree-wide, latent since the macro was introduced in the 2019 CVE sweep (`484edeb26`), because nothing ever compiled those files with the strict flag.

Newer net-snmp packages changed that: they leak `-Werror=declaration-after-statement` through `net-snmp-config --cflags`, so any SNMP-enabled build of `xymon-snmpcollect.c` now fails at its two such sites (lines 773, 1061).

## Impacted OS (observed in a 30-platform pipeline run, make build, SNMP enabled)

| OS | toolchain | result |
|---|---|---|
| Arch Linux (base + latest, net-snmp 5.9.5.2) | gcc | ❌ `ISO C90 forbids mixed declarations and code` |
| Alpine 3.23 | gcc | ❌ same |
| openSUSE Tumbleweed | gcc | ❌ same |
| FreeBSD 13.5 / 14.3 / 15.0 | clang | ❌ `mixing declarations and code is incompatible with standards before C99` |
| Alpine ≤3.22/edge, Debian, Ubuntu, Fedora, EL8/9*, NetBSD, OpenBSD | | ✅ their net-snmp doesn't (yet) export the flag |

*EL9 fails differently (`net-snmp-config --libs` leaking the hardened-ld spec) - separate PR.

## Fix

Drop the trailing semicolon from both macros; add the one missing call-site semicolon that relied on it (`lib/htmllog.c:99` - all other sites verified to carry their own). No behavior change anywhere.

## Regression coverage

`tests/server/sbuf-define-c90.sh` compiles a snippet using `SBUF_DEFINE` followed by a declaration with `-Werror=declaration-after-statement` against the real header - the exact mechanism that fires in the field. Fails on the previous macro, passes now; needs a compiler but no built tree. Full suite: 17 passed, 0 failed.