### PR TITLE
xymonnet: keep only interface flags from net-snmp-config

### DIFF
--- a/xymonnet/Makefile
+++ b/xymonnet/Makefile
@@ -85,11 +85,29 @@ contest: contest.c httptest.o dns.o dns2.o httpcookies.o $(XYMONCOMMLIB) $(XYMON
 	$(CC) $(CFLAGS) -o contest -I../include $(CARESINC) -DSTANDALONE contest.c httptest.o dns.o dns2.o httpcookies.o $(CARESLIBS) $(XYMONCOMMLIBS) $(XYMONTIMELIBS)
 
 
+# net-snmp-config exports the distro's full build policy along with the
+# interface: -Werror=declaration-after-statement (newer net-snmp), the EL9
+# hardened-ld -specs (forces PIE links against our non-PIC objects), LTO,
+# fortify options, and more. Keep only what we actually need from it:
+# for compiling, include dirs and defines; for linking, library names,
+# dirs and runtime paths.
+SNMPCFLAGS := $(shell for flag in `net-snmp-config --cflags 2>/dev/null`; do \
+		case $$flag in \
+			(-I*|-D*|-U*|-pthread) echo $$flag ;; \
+		esac; \
+	done)
+
+SNMPLIBS := $(shell for flag in `net-snmp-config --libs 2>/dev/null`; do \
+		case $$flag in \
+			(-l*|-L*|-Wl,-rpath*|-Wl,-R*|-pthread) echo $$flag ;; \
+		esac; \
+	done)
+
 xymon-snmpcollect: xymon-snmpcollect.o $(XYMONCOMMLIB) $(XYMONTIMELIB)
-	$(CC) $(LDFLAGS) -o $@ xymon-snmpcollect.o `net-snmp-config --libs` ../lib/libxymon.a $(XYMONCOMMLIBS) $(XYMONTIMELIBS)
+	$(CC) $(LDFLAGS) -o $@ xymon-snmpcollect.o $(SNMPLIBS) ../lib/libxymon.a $(XYMONCOMMLIBS) $(XYMONTIMELIBS)
 
 xymon-snmpcollect.o: xymon-snmpcollect.c
-	$(CC) $(CFLAGS) -I. `net-snmp-config --cflags` -c -o $@ xymon-snmpcollect.c
+	$(CC) $(CFLAGS) -I. $(SNMPCFLAGS) -c -o $@ xymon-snmpcollect.c
 
 ################################################
 # Default compilation rules


### PR DESCRIPTION
## Problem

The SNMP collector's build consumes `net-snmp-config --cflags` and `--libs` verbatim. That script exports each distro's build **policy** along with the interface - and two of those policies now break SNMP-enabled builds. The design is Henrik's original from 2008 and was correct for 15 years; the world moved underneath it.

## Impacted OS (observed in a 30-platform pipeline run, make build, SNMP enabled)

| OS | leak | failure |
|---|---|---|
| Rocky Linux 9, AlmaLinux 9, Oracle Linux 9 | `--libs` carries the redhat-hardened-ld `-specs` (forces PIE link) | ❌ `relocation R_X86_64_32 ... can not be used when making a PIE object; recompile with -fPIE` against every non-PIC object |
| Arch Linux (net-snmp 5.9.5.2), Alpine 3.23, openSUSE Tumbleweed, FreeBSD 13.5/14.3/15.0 | `--cflags` carries `-Werror=declaration-after-statement` | ❌ C90 errors in xymon-snmpcollect.c (macro trap fixed separately in #239) |
| Debian, Ubuntu, Fedora, EL8, Alpine ≤3.22/edge, NetBSD, OpenBSD, EL10 | flags not (yet) exported there | ✅ |

Both leaks are version-dependent - Alpine edge passes while 3.23 fails - so green today means nothing tomorrow.

## Fix

Filter the script's output to the interface we actually consume:

- compile: `-I` / `-D` / `-U` (+ `-pthread`)
- link: `-l` / `-L` / `-Wl,-rpath` / `-Wl,-R` (+ `-pthread`)

Everything else (`-Werror=*`, `-specs=*`, LTO, fortify, optimization overrides) is dropped, making the build immune to whatever any distro exports next. This mirrors what the CMake side already does for `--cflags` on macOS (Homebrew leak) - same distrust, now applied consistently.

Complements #239: that PR fixes the latent macro bug the `-Werror` leak exposed; this one stops foreign policy reaching our compiler at all.

## Testing

Built with `DOSNMP=yes` against a real net-snmp (5.9.1): collector compiles, links against libnetsnmp, and runs. Full suite 16/16. The EL9 case is only reproducible on an EL9 toolchain - the pipeline lanes that caught it are the verification vehicle.