### PR TITLE
client: XYMONCLIENT_FS_EXCLUDE_MOUNTS drops mounts by glob (#170)

### DIFF
--- a/client/xymonclient-freebsd.sh
+++ b/client/xymonclient-freebsd.sh
@@ -57,6 +57,38 @@ case "$DFLOCALONLY" in
 	*) echo "xymonclient-freebsd: invalid XYMONCLIENT_FS_DF_LOCAL_ONLY '$DFLOCALONLY', using yes" >&2; DFLOCALONLY=yes ;;
 esac
 DFLOCAL=""; [ "$DFLOCALONLY" = yes ] && DFLOCAL="-l"
+# XYMONCLIENT_FS_EXCLUDE_MOUNTS: shell globs matched against the mount point
+# (last df column); matching filesystems are dropped from the disk and inode
+# reports entirely. Default: empty. (NORRDDISKS on the server keeps them
+# visible and only skips trending.)
+: "${XYMONCLIENT_FS_EXCLUDE_MOUNTS=}"
+# Header row always kept; shell builtins only; noglob as in fs_excl_opt.
+fs_filter_mounts() {
+	if [ -z "$XYMONCLIENT_FS_EXCLUDE_MOUNTS" ]; then
+		while IFS= read -r _fmline; do
+			printf '%s\n' "$_fmline"
+		done
+		return
+	fi
+	case $- in *f*) _fmrestoreglob=no ;; *) _fmrestoreglob=yes; set -f ;; esac
+	_fmheader=yes
+	while IFS= read -r _fmline; do
+		if [ "$_fmheader" = yes ]; then
+			_fmheader=no
+			printf '%s\n' "$_fmline"
+			continue
+		fi
+		_fmmnt=${_fmline##*[ 	]}
+		_fmkeep=yes
+		for _fmpat in $XYMONCLIENT_FS_EXCLUDE_MOUNTS; do
+			case "$_fmmnt" in
+				$_fmpat) _fmkeep=no; break ;;
+			esac
+		done
+		[ "$_fmkeep" = yes ] && printf '%s\n' "$_fmline"
+	done
+	[ "$_fmrestoreglob" = yes ] && set +f
+}
 # run_df FLAG [extra-excludes...]: df rows for one report behind the FS filter
 # and local-only flag. The seam where the remote-df sentinel will hook.
 run_df() {
@@ -84,7 +116,7 @@ if emit_df disk Disk -H; then
 	printf '%s\n' "$_out" | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
-}'
+}' | fs_filter_mounts
 fi
 echo "[inode]"
 # Same failure guard. Drop filesystems with no inode limit (df prints "-" in the
@@ -97,7 +129,7 @@ N
 s/[ 	]*\n[ 	]*/ /
 }' | awk '
 NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9}
-(NR>=2 && $8 != "-"){printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
+(NR>=2 && $8 != "-"){printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}' | fs_filter_mounts
 fi
 echo "[mount]"
 mount

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -113,6 +113,43 @@ case "$DFLOCALONLY" in
 		DFLOCALONLY=yes
 		;;
 esac
+# XYMONCLIENT_FS_EXCLUDE_MOUNTS: shell globs matched against the mount point
+# (last df column); matching filesystems are dropped from the disk and inode
+# reports entirely. Default: empty. (NORRDDISKS on the server keeps them
+# visible and only skips trending.)
+: "${XYMONCLIENT_FS_EXCLUDE_MOUNTS=}"
+# Header row always kept; shell builtins only (no new external commands);
+# noglob so a '*' pattern stays a pattern.
+fs_filter_mounts()
+{
+	if [ -z "$XYMONCLIENT_FS_EXCLUDE_MOUNTS" ]; then
+		while IFS= read -r fmline; do
+			printf '%s\n' "$fmline"
+		done
+		return
+	fi
+	case $- in
+		*f*) FMRESTOREGLOB=no ;;
+		*) FMRESTOREGLOB=yes; set -f ;;
+	esac
+	fmheader=yes
+	while IFS= read -r fmline; do
+		if [ "$fmheader" = yes ]; then
+			fmheader=no
+			printf '%s\n' "$fmline"
+			continue
+		fi
+		fmmnt=${fmline##*[ 	]}
+		fmkeep=yes
+		for fmpat in $XYMONCLIENT_FS_EXCLUDE_MOUNTS; do
+			case "$fmmnt" in
+				$fmpat) fmkeep=no; break ;;
+			esac
+		done
+		[ "$fmkeep" = yes ] && printf '%s\n' "$fmline"
+	done
+	[ "$FMRESTOREGLOB" = yes ] && set +f
+}
 run_df()
 {
 	DFINODES="$1"
@@ -158,7 +195,8 @@ emit_df()
 N
 s/[ 	]*\n[ 	]*/ /
 }' -e "s&^rootfs&${ROOTFS}&" \
-	| awk -v ino="$1" 'NR == 1 || ino != "yes" || $5 != "-"'
+	| awk -v ino="$1" 'NR == 1 || ino != "yes" || $5 != "-"' \
+	| fs_filter_mounts
 }
 ROOTFS=`readlink -m /dev/root`
 emit_df no Disk

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -63,9 +63,15 @@ LOGFETCHOPTS=""
 #    not silently reported green. This does not cover the hang above: a
 #    wedged df never exits.
 #
+# XYMONCLIENT_FS_EXCLUDE_MOUNTS: shell glob patterns matched against the
+#    mount point; matching filesystems are dropped from the disk and inode
+#    reports entirely (high-churn mounts: poudriere, docker). NORRDDISKS on
+#    the server keeps them visible and only skips trending. Default: empty.
+#
 # XYMONCLIENT_FS_INCLUDE_TYPES="zfs virtiofs tmpfs"
 # XYMONCLIENT_FS_EXCLUDE_TYPES="iso9660 squashfs fuse.snapfuse"
 # XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
+# XYMONCLIENT_FS_EXCLUDE_MOUNTS="/poudriere/* /var/lib/docker/*"
 
 
 # Local Mode (Only) Options

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -81,6 +81,17 @@ is marked failed (yellow) rather than left empty, so a failed filesystem
 probe is not silently reported green. This does not cover the hang
 above: a wedged df never exits.
 
+.IP XYMONCLIENT_FS_EXCLUDE_MOUNTS
+Whitespace-separated shell glob patterns matched against the mount
+point; matching filesystems are dropped from the disk and inode reports
+entirely \(em no status line, no trending, no alerts. Use for high-churn
+mounts that should not be monitored at all, e.g.
+"/poudriere/* /var/lib/docker/*". This complements the server-side
+NORRDDISKS/RRDDISKS settings in
+.I xymonserver.cfg(5),
+which keep the filesystem visible on the status page and only skip
+trending it. Default: empty (no mounts excluded).
+
 .IP XYMON
 Full path to the 
 .I xymon(1)

--- a/tests/client/fs-filter-freebsd.sh
+++ b/tests/client/fs-filter-freebsd.sh
@@ -38,10 +38,14 @@ if [[ " \$* " =~ " -i " ]]; then
 	printf 'Filesystem Size Used Avail Capacity iused ifree %%iused Mounted on\n'
 	printf '/dev/ada0p2 100 50 50 50%% 1000 9000 10%% /\n'
 	printf 'tank 200 1 199 1%% 0 0 - /tank\n'
+	printf 'zdata/poudriere 200 1 199 1%% 5 95 5%% /poudriere/data\n'
 else
 	echo "\$*" >> "$DF_LOG"
 	printf 'Filesystem Size Used Avail Capacity Mounted on\n'
 	printf '/dev/ada0p2 100G 50G 50G 50%% /\n'
+	printf 'zdata/photos 200G 10G 190G 5%% /zdata/photos\n'
+	printf 'zdata/poudriere 200G 10G 190G 5%% /poudriere/data\n'
+	printf 'zdata/poudriere2 200G 10G 190G 5%% /poudriere/jails\n'
 fi
 EOF
 chmod +x "$STUB/df"
@@ -125,6 +129,29 @@ inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
 assert_not_contains "/tank" "$inode_section" \
 	"inode report drops the no-inode-limit filesystem (%iused '-')"
 
+# --- XYMONCLIENT_FS_EXCLUDE_MOUNTS: drop mounts by glob pattern --------------
+# Output-level cases (the type filters assert on df argv; this filter runs on
+# df's OUTPUT): the stub emits /, /zdata/photos, /poudriere/data and
+# /poudriere/jails in [df], and /, /tank, /poudriere/data in [inode].
+out=$( cd "$TMP"; /bin/sh "$SNIPPET" 2>/dev/null )
+assert_contains "/poudriere/data" "$out" "default: no mounts are excluded"
+
+out=$( cd "$TMP"; XYMONCLIENT_FS_EXCLUDE_MOUNTS='/poudriere/*' /bin/sh "$SNIPPET" 2>/dev/null )
+disk_section=$(printf '%s\n' "$out" | sed -n '1,/^\[inode\]/p')
+inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
+assert_contains     "Mounted on"        "$disk_section" "header row survives the mount filter"
+assert_contains     "/zdata/photos"     "$disk_section" "non-matching mounts are kept"
+assert_not_contains "/poudriere/data"   "$disk_section" "glob excludes a matching mount from [df]"
+assert_not_contains "/poudriere/jails"  "$disk_section" "glob excludes every matching mount"
+assert_not_contains "/poudriere/data"   "$inode_section" "glob excludes the mount from [inode] too"
+assert_contains     "/dev/ada0p2"       "$inode_section" "non-matching inode rows are kept"
+
+# A bare '*' must act as a match-everything pattern (noglob: it must not
+# expand against the decoy files in the working directory) and keep headers.
+out=$( cd "$TMP"; XYMONCLIENT_FS_EXCLUDE_MOUNTS='*' /bin/sh "$SNIPPET" 2>/dev/null )
+assert_contains     "Mounted on"  "$out" "header rows survive even a '*' pattern"
+assert_not_contains "/dev/ada0p2" "$out" "'*' drops every mount row"
+
 # --- false-green guard: df fails with no output -> marker, not empty section --
 out=$( cd "$TMP"; DF_FAIL=1 /bin/sh "$SNIPPET" 2>/dev/null )
 assert_contains "Disk report collection failed" "$out" \
@@ -134,4 +161,4 @@ assert_contains "Inode report collection failed" "$out" \
 assert_not_contains "Filesystem" "$out" \
 	"failure marker carries no df header (server reads a header-less section as yellow)"
 
-pass "xymonclient-freebsd.sh FS filter: types, local-only, inode zfs/tmpfs+'-' drop, df-failure marker"
+pass "xymonclient-freebsd.sh FS filter: types, mounts, local-only, inode zfs/tmpfs+'-' drop, df-failure marker"

--- a/tests/client/fs-filter-linux.sh
+++ b/tests/client/fs-filter-linux.sh
@@ -88,6 +88,9 @@ else
 fi
 printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
 printf '/dev/sda1 1000000 500000 500000 50%% /\n'
+printf 'zdata/photos 2000000 100000 1900000 5%% /zdata/photos\n'
+printf 'zdata/poudriere 2000000 100000 1900000 5%% /poudriere/data\n'
+printf 'zdata/poudriere2 2000000 100000 1900000 5%% /poudriere/jails\n'
 EOF
 chmod +x "$STUB/df"
 
@@ -326,3 +329,38 @@ assert_not_contains "dynfs" "$inode_section" \
 	"inode report drops a no-inode-limit filesystem (IUse% '-')"
 assert_contains "dynfs" "$inode_out" \
 	"the same filesystem still appears in [df] (it has a real disk %)"
+
+# --- XYMONCLIENT_FS_EXCLUDE_MOUNTS: drop mounts by glob pattern -------------
+# Output-level cases (the type filters above assert on df argv; this filter
+# runs on df's OUTPUT): the stub df emits /, /zdata/photos, /poudriere/data
+# and /poudriere/jails.
+
+run_df_output() {
+	: > "$DF_LOG"
+	: > "$INODE_LOG"
+	: > "$STDERR_LOG"
+	(
+		cd "$TMP"
+		/bin/sh "$SNIPPET" 2>"$STDERR_LOG"
+	)
+}
+
+out=$(run_df_output)
+assert_contains "/poudriere/data" "$out" "default: no mounts are excluded"
+
+out=$(XYMONCLIENT_FS_EXCLUDE_MOUNTS='/poudriere/*' run_df_output)
+assert_contains     "Mounted on"       "$out" "header row survives the mount filter"
+assert_contains     "/dev/sda1"        "$out" "the root filesystem is kept"
+assert_contains     "/zdata/photos"    "$out" "non-matching mounts are kept"
+assert_not_contains "/poudriere/data"  "$out" "glob excludes a matching mount"
+assert_not_contains "/poudriere/jails" "$out" "glob excludes every matching mount"
+
+out=$(XYMONCLIENT_FS_EXCLUDE_MOUNTS='/poudriere/jails /zdata/*' run_df_output)
+assert_contains     "/poudriere/data" "$out" "an exact pattern excludes only its own mount"
+assert_not_contains "/zdata/photos"   "$out" "every listed pattern applies"
+
+# A bare '*' must act as a match-everything pattern (noglob: it must not
+# expand against files in the working directory) and never eat the header.
+out=$(XYMONCLIENT_FS_EXCLUDE_MOUNTS='*' run_df_output)
+assert_contains     "Mounted on" "$out" "header row survives even a '*' pattern"
+assert_not_contains "/dev/sda1"  "$out" "'*' drops every mount row"


### PR DESCRIPTION
## What

A new client-side filter in the #170 family: `XYMONCLIENT_FS_EXCLUDE_MOUNTS` takes whitespace-separated shell glob patterns matched against the **mount point**; matching filesystems are dropped from the disk and inode reports entirely - no status line, no trending, no alerts. Default empty: output is byte-identical unless set.

```sh
XYMONCLIENT_FS_EXCLUDE_MOUNTS="/poudriere/* /var/lib/docker/*"
```

## Why

The existing type filters cannot express "exclude these ZFS datasets, keep those" - on a ZFS host every mount shares one type, so high-churn build mounts (poudriere, docker) cannot be filtered by type at all (surfaced while diagnosing #234). The server-side `NORRDDISKS` covers the *other* semantic - visible on the status page but untrended - and is documented as the contrast in every doc this PR touches.

## Implementation

- Linux and FreeBSD clients (the two with the fs-filter base on main); NetBSD/OpenBSD/Darwin adopt the variable when their #170 type-filter PRs land.
- Final stage of each report, after the split-line join (and the inode reformat on FreeBSD), so the mount point is always the last field; the header row is unconditionally kept.
- `case` glob matching under noglob (a `*` pattern never expands against the working directory), shell builtins only - the restricted-PATH regression scenario fails on any new external command, and did exactly that to an early `cat`-based draft.
- Documented in `xymonclient.cfg.DIST` and `xymonclient.cfg.5`.

## Testing

Per-OS regression cases in `fs-filter-linux.sh` / `fs-filter-freebsd.sh`: default-off, single and multiple patterns, both reports, non-matching rows kept, header survival (including under a bare `*`), noglob behavior. Full suite: 17 passed, 0 failed.