### PR TITLE
darwin: 'swap' status driven by the kernel's memory-pressure verdict

### DIFF
--- a/client/xymonclient-darwin.sh
+++ b/client/xymonclient-darwin.sh
@@ -54,6 +54,12 @@ echo "[mount]"
 mount
 echo "[meminfo]"
 vm_stat
+# The kernel's own memory-health verdict (1=normal, 2=warn, 4=critical)
+# drives a darwin-only "swap" status server-side. macOS swap capacity is
+# dynamic (the swapfile set grows on demand), so used/total percentages
+# carry no signal; vm.swapusage rides along as trend data only.
+sysctl kern.memorystatus_vm_pressure_level 2>/dev/null
+sysctl vm.swapusage 2>/dev/null
 echo "[ifconfig]"
 ifconfig -a
 echo "[route]"

--- a/client/xymonclient-darwin.sh
+++ b/client/xymonclient-darwin.sh
@@ -447,6 +447,12 @@ echo "[mount]"
 mount
 echo "[meminfo]"
 vm_stat
+# The kernel's own memory-health verdict (1=normal, 2=warn, 4=critical)
+# drives a darwin-only "swap" status server-side. macOS swap capacity is
+# dynamic (the swapfile set grows on demand), so used/total percentages
+# carry no signal; vm.swapusage rides along as trend data only.
+sysctl kern.memorystatus_vm_pressure_level 2>/dev/null
+sysctl vm.swapusage 2>/dev/null
 echo "[ifconfig]"
 ifconfig -a
 echo "[route]"

--- a/xymond/client/darwin.c
+++ b/xymond/client/darwin.c
@@ -70,9 +70,69 @@ void handle_darwin_client(char *hostname, char *clienttype, enum ostype_t os,
 
 	if (meminfostr) {
 		unsigned long pagesfree, pagesactive, pagesinactive, pageswireddown, pgsize;
+		long memswaptotal, memswapused;
 		char *p;
 
 		pagesfree = pagesactive = pagesinactive = pageswireddown = pgsize = -1;
+		memswaptotal = memswapused = -1;
+
+		/*
+		 * "vm.swapusage: total = 2048.00M  used = 1189.19M  free = 858.81M"
+		 * Converted to MB. Trend data for the "swap" status below only - it is
+		 * deliberately NOT fed to the memory report: macOS swap is dynamic, so
+		 * a used/total percentage would false-alarm on healthy machines.
+		 */
+		p = strstr(meminfostr, "vm.swapusage:");
+		if (p) {
+			double swt, swu;
+			char unt, unu;
+
+			if (sscanf(p, "vm.swapusage: total = %lf%c used = %lf%c", &swt, &unt, &swu, &unu) == 4) {
+				if (unt == 'K') swt /= 1024; else if (unt == 'G') swt *= 1024;
+				if (unu == 'K') swu /= 1024; else if (unu == 'G') swu *= 1024;
+				memswaptotal = (long)swt;
+				memswapused  = (long)swu;
+			}
+		}
+
+		/*
+		 * Darwin-only "swap" status, driven by the kernel's memory-pressure
+		 * verdict (kern.memorystatus_vm_pressure_level: 1=normal, 2=warn,
+		 * 4=critical) - the signal Apple provides precisely because swap
+		 * capacity numbers stopped meaning anything. The swap growth ceiling
+		 * (container free space) is already covered by the disk report.
+		 * Body lines are NCV-formatted, so graphing needs no new code. Use the
+		 * split variant - one RRD per metric, so mixed units graph separately
+		 * and future metrics need no DS surgery:
+		 * TEST2RRD+=",swap=ncv" SPLITNCV_swap="Pressure:GAUGE,SwapUsedMB:GAUGE"
+		 */
+		p = strstr(meminfostr, "kern.memorystatus_vm_pressure_level:");
+		if (p) {
+			long presslevel = -1;
+			int presscolor;
+			char *pressname;
+			char msgline[1024];
+
+			sscanf(p, "kern.memorystatus_vm_pressure_level: %ld", &presslevel);
+			if (presslevel == 1)      { presscolor = COL_GREEN;  pressname = "normal"; }
+			else if (presslevel == 2) { presscolor = COL_YELLOW; pressname = "warn"; }
+			else if (presslevel >= 4) { presscolor = COL_RED;    pressname = "critical"; }
+			else                      { presscolor = COL_YELLOW; pressname = "unknown"; }
+
+			init_status(presscolor);
+			sprintf(msgline, "status %s.swap %s %s - Memory pressure %s\n",
+				commafy(hostname), colorname(presscolor),
+				(timestr ? timestr : "<no timestamp data>"), pressname);
+			addtostatus(msgline);
+			sprintf(msgline, "\nPressure : %ld\n", presslevel);
+			addtostatus(msgline);
+			if (memswapused != -1) {
+				sprintf(msgline, "SwapUsedMB : %ld\nSwapTotalMB : %ld\n", memswapused, memswaptotal);
+				addtostatus(msgline);
+			}
+			if (fromline && !localmode) addtostatus(fromline);
+			finish_status();
+		}
 
 		p = strstr(meminfostr, "page size of");
 		if (p && (sscanf(p, "page size of %lu bytes", &pgsize) == 1)) pgsize /= 1024;


### PR DESCRIPTION
## Why not swap percentages

macOS swap capacity is **dynamic** - the swapfile set grows and shrinks on demand - so a used/total percentage false-alarms on healthy machines (they chronically sit at 50-90% by design) and can *improve* while things worsen (total grows under pressure). Its only hard ceiling, container free space, is already the disk report (#178). What Apple provides instead, precisely because those numbers stopped meaning anything, is the kernel's own verdict: `kern.memorystatus_vm_pressure_level` (1=normal, 2=warn, 4=critical).

## What this adds

- **Client** (`xymonclient-darwin.sh`): `[meminfo]` sends the pressure level and `vm.swapusage` next to `vm_stat`.
- **Server** (`xymond/client/darwin.c`): a darwin-only **`swap` status** maps the verdict straight to green/yellow/red - no thresholds to misconfigure, the kernel already judged. Swap used/total MB ride along as trend data only, deliberately NOT fed to the memory report's percentage thresholds. Unexpected level values show as yellow "unknown", never silence; old macOS without the sysctl sends nothing and the column never appears.

## Graphing (pure site config, no new code)

The body is NCV-formatted; use the **split** variant so the mixed units (a 1-4 level vs MB) chart separately and future metrics need no DS surgery:

```sh
# xymonserver.cfg
TEST2RRD+=",swap=ncv"
SPLITNCV_swap="Pressure:GAUGE,SwapUsedMB:GAUGE"
GRAPHS_swap="swappressure,swapused"   # graphs on the swap status page
GRAPHS+=",swappressure,swapused"      # and on the trends page
```

```
# graphs.cfg
[swappressure]
        FNPATTERN ^swap,(Pressure).rrd
        TITLE Memory pressure level
        YAXIS level
        DEF:p@RRDIDX@=@RRDFN@:lambda:AVERAGE
        LINE2:p@RRDIDX@#00CCCC:@RRDPARAM@

[swapused]
        FNPATTERN ^swap,(SwapUsedMB).rrd
        TITLE Swap used
        YAXIS MB
        DEF:s@RRDIDX@=@RRDFN@:lambda:AVERAGE
        AREA:s@RRDIDX@#00CC00:@RRDPARAM@
```

Status-page rendering of `GRAPHS_swap` on a column without a default graph works since #206; single-file FNPATTERN selection since #139. Shipping the two gdefs in `graphs.cfg.DIST` is deferred until the feature proves itself.

## Testing

Tree builds; suite 18/18. Parse logic unit-checked against the measured `vm.swapusage` format (M/K/G suffixes, zero-swap, missing line). On-platform: `sysctl kern.memorystatus_vm_pressure_level` and `vm.swapusage` output formats measured on a real Apple-silicon Mac mini; end-to-end column rendering needs a server pointed at a mac client.