### PR TITLE
docs: clarify RRD graph settings in xymonserver.cfg (GRAPHS ::N split size, GRAPHS_<column> scope, legacy disk filters)

### DIFF
--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -540,19 +540,27 @@ The graph names must match graph definitions from
 or instance names handled by those definitions.
 
 .IP GRAPHS
-List of graph names that should be shown on the "trends" column,
-in display order. The matching RRD files are selected by the
-corresponding graph definition in
+List of graph names known to the graph display code. On the
+"trends" column, this list also defines which graphs are shown
+and in what order. The matching RRD files are selected by the
+corresponding graph definitions in
 .I graphs.cfg(5).
 Each entry is either "name" or "name::N": "name" is the graph name,
 and N is the maximum number of RRD files drawn per graph image after
 the graph has been split; the default is 5 per image. The double colon
 is literal, so "mrtg::1" draws one file per image.
+N counts RRD files, not lines: each RRD file may hold several data sets
+(DS), each drawn as its own curve, so an image showing N files can
+contain several times N lines. Choose N with the per-file DS count in
+mind - a 2-DS graph at "::2" draws 4 lines, while a 1-DS graph at "::5"
+draws 5.
 A legacy middle field is accepted by the parser for compatibility, but
 it is ignored and should not be used in new configurations.
-The N value belongs in GRAPHS, not in GRAPHS_<COLUMNNAME>. Status
-page GRAPHS_<COLUMNNAME> entries inherit N when they name the same
-graph definition. If a graph is used only from GRAPHS_<COLUMNNAME>
+The N value belongs in GRAPHS, not in GRAPHS_<COLUMNNAME>, and is
+used whenever graph links are generated for that graph. This includes
+the "trends" page, a test column's default status-page graph from
+TEST2RRD, and status-page GRAPHS_<COLUMNNAME> entries that name the
+same graph definition. If a graph is used only from GRAPHS_<COLUMNNAME>
 and has no matching entry in GRAPHS, it uses the default split size.
 On the "trends" page, the RRD file count is known automatically.
 On status pages, splitting only happens when

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -521,7 +521,19 @@ include a graph.
 
 .IP GRAPHS
 List of the RRD databases, that should be shown as a graph on
-the "trends" column.
+the "trends" column. Each entry is "name[::N]": N is the maximum
+number of RRD files drawn per graph image before the graph is
+split into multiple images (default: 5). E.g. "mrtg::1" draws one
+file per image. N governs the graph wherever it is rendered: on
+the "trends" page, on the test's own status page, and for
+GRAPHS_<column> entries. On status pages the split only happens
+for columns listed in the "\-\-multigraphs" option of
+.I svcstatus.cgi(1);
+a column not listed there shows all its curves in one image.
+Note: a "DISK filesystem IGNORE" rule in
+.I analysis.cfg(5)
+removes a filesystem from the status, the alerts and the graphs;
+NORRDDISKS below removes only the graph.
 
 .IP NORRDDISKS
 This is used to disable the tracking of certain filesystems. By default

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -498,49 +498,79 @@ the service is provided in the BBSVCNUM variable.
 
 
 .SH XYMOND_RRD SETTINGS
+The RRD graph settings have three separate roles. TEST2RRD maps
+status- and data-message column names to the RRD graph name used
+for storing data and for the column's default status-page graph.
+GRAPHS_<COLUMNNAME> changes only what graphs are shown on that
+column's status page. GRAPHS defines the graph list and order on
+the "trends" page, and also stores graph-display metadata such
+as the per-image split size.
 
 .IP TEST2RRD
-List of "COLUMNNAME[=RRDSERVICE]" settings, that define which
-status- and data-messages have a corresponding RRD graph. You will 
-normally not need to modify this, unless you have added a
-custom TCP-based test to the protocols.cfg file, and want to collect data about
-the response-time, OR if you are using the
+List of "COLUMNNAME[=RRDSERVICE]" settings. This tells
+.I xymond_rrd(8)
+which status- and data-messages have RRD data, and which RRD
+graph name should be used for that column. If "=RRDSERVICE" is
+omitted, the RRD graph name is the same as the column name. For
+example, "cpu=la" stores the "cpu" column in the "la" RRD graph,
+while "disk" uses "disk" for both names.
+The same mapping is also used by
+.I svcstatus.cgi(1)
+as the default graph to show on the detailed status page for
+that column.
+You will normally not need to modify this, unless you have added
+a custom TCP-based test to the protocols.cfg file and want to
+collect response-time data, or if you are using the
 .I xymond_rrd(8)
 external script mechanism to collect data from custom tests.
 Note: All TCP tests are automatically added.
 
-.IP GRAPHS_<COLUMNAME>
-List of GRAPHs that should be displayed on the corresponding column page. Note
-this will override the default, so to add multiple graphs you should include
-the original one (e.g. GRAPHS_cpu="la,vmstat1").
-
-These are used together by the 
-.I svcstatus.cgi(1) 
-script to determine if the detailed status view of a test should 
-include a graph.
+.IP GRAPHS_<COLUMNNAME>
+Comma-separated list of graph names to display on the detailed
+status page for COLUMNNAME. This is a display setting only; it
+does not cause
+.I xymond_rrd(8)
+to collect new data.
+If GRAPHS_<COLUMNNAME> is set, it replaces the default status-page
+graph from TEST2RRD, so include the original graph too if you still
+want it. For example, GRAPHS_cpu="la,vmstat1" shows both graphs on
+the cpu status page.
+The graph names must match graph definitions from
+.I graphs.cfg(5)
+or instance names handled by those definitions.
 
 .IP GRAPHS
-List of the RRD databases, that should be shown as a graph on
-the "trends" column. Each entry is "name[::N]": at most N RRD
-files are drawn per graph image, and a graph with more files is
-split into multiple images (default: 5 per image). E.g.
-"mrtg::1" draws one file per image. The full syntax is
-"name[:partname][:N]" where the middle field is a rarely used
-graph part name from
+List of graph names that should be shown on the "trends" column,
+in display order. The matching RRD files are selected by the
+corresponding graph definition in
+.I graphs.cfg(5).
+Each entry uses the syntax
+"name[:partname][:N]": "name" is the graph name, "partname" is a
+rarely used graph part name from
 .I graphs.cfg(5)
-\- hence the double colon when only N is given.
-N follows the graph definition wherever it is used: on the
-"trends" page, on the test's own status page, and for
-GRAPHS_<column> entries. Exception: entries with an explicit
-graph list in a host's TRENDS tag (e.g. "disk:disk1|disk2", see
+\- hence the double colon when only N is given, e.g. "mrtg::1".
+N is the maximum number of RRD files drawn per graph image after
+the graph has been split; the default is 5 per image. For example,
+"mrtg::1" draws one file per image.
+The N value belongs in GRAPHS, not in GRAPHS_<COLUMNNAME>. Status
+page GRAPHS_<COLUMNNAME> entries inherit N when they name the same
+graph definition. If a graph is used only from GRAPHS_<COLUMNNAME>
+and has no matching entry in GRAPHS, it uses the default split size.
+On the "trends" page, the RRD file count is known automatically.
+On status pages, splitting only happens when
+.I svcstatus.cgi(1)
+has an instance count for the graph. A status message can provide
+this explicitly with a "<!-- linecount=N -->" marker. If no marker
+is present,
+.I svcstatus.cgi(1)
+computes the count automatically only for columns listed in the
+"\-\-multigraphs" option (built-in default: disk, inode, qtree,
+quotas, snapshot, TblSpace, if_load); any other column draws all
+matching RRD files in one image.
+Exception: entries with an explicit graph list in a host's TRENDS
+tag (e.g. "disk:disk1|disk2", see
 .I hosts.cfg(5))
 ignore N and use the default of 5.
-On status pages the split only happens for columns listed in
-the "\-\-multigraphs" option of
-.I svcstatus.cgi(1)
-(built-in default: disk, inode, qtree, quotas, snapshot,
-TblSpace, if_load); any other column draws all its RRD files in
-a single image.
 Note: a "DISK filesystem IGNORE" rule in
 .I analysis.cfg(5)
 removes a filesystem from the status, the alerts and the graphs;

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -571,27 +571,30 @@ tag (e.g. "disk:disk1|disk2", see
 ignore N and use the default of 5.
 Note: a "DISK filesystem IGNORE" rule in
 .I analysis.cfg(5)
-removes a filesystem from the status, the alerts and the graphs;
-NORRDDISKS below removes only the graph.
+removes a filesystem from the status, the alerts and the graphs.
+This is usually the preferred replacement for the deprecated
+NORRDDISKS/RRDDISKS settings below.
 
 .IP NORRDDISKS
-This is used to disable the tracking of certain filesystems. By default
-all filesystems reported by a client are tracked. In some cases you may want 
-to disable this for certain filesystems, e.g. database filesystems since they
-are always completely full. This setting is a regular expression that is matched
-against the filesystem name (the Unix mount-point, or the Windows disk-letter) -
-if the filesystem name matches this expression, then it will not be tracked
-by Xymon.
+Deprecated legacy setting. It is retained for compatibility with old
+configurations, but should be considered unsupported for new use.
+Use
+.I analysis.cfg(5)
+rules such as "DISK filesystem IGNORE" or "INODE filesystem IGNORE"
+instead whenever the filesystem should be removed from status, alerts
+and graphs.
+NORRDDISKS only disables RRD graph tracking for matching filesystems.
+The value is a regular expression matched against the filesystem name
+(the Unix mount-point, or the Windows disk-letter).
 .br
 Note: Setting this does not affect filesystems that are already being tracked
 by Xymon - to remove them, you must remove the RRD files for the unwanted filesystems
 from the ~xymon/data/rrd/HOSTNAME/ directory.
 
 .IP RRDDISKS
-This is used to enable tracking of only selected filesystems (see the NORRDDISKS
-setting above). By default all filesystems are being tracked, setting this changes 
-that default so that only those filesystems that match this pattern will be 
-tracked.
+Deprecated legacy setting, with the same compatibility-only status as
+NORRDDISKS. It changes the default so that only filesystems matching
+this regular expression are tracked for RRD graphs.
 
 
 .SH XYMONNET NETWORK TEST SETTINGS

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -544,14 +544,12 @@ List of graph names that should be shown on the "trends" column,
 in display order. The matching RRD files are selected by the
 corresponding graph definition in
 .I graphs.cfg(5).
-Each entry uses the syntax
-"name[:partname][:N]": "name" is the graph name, "partname" is a
-rarely used graph part name from
-.I graphs.cfg(5)
-\- hence the double colon when only N is given, e.g. "mrtg::1".
-N is the maximum number of RRD files drawn per graph image after
-the graph has been split; the default is 5 per image. For example,
-"mrtg::1" draws one file per image.
+Each entry is either "name" or "name::N": "name" is the graph name,
+and N is the maximum number of RRD files drawn per graph image after
+the graph has been split; the default is 5 per image. The double colon
+is literal, so "mrtg::1" draws one file per image.
+A legacy middle field is accepted by the parser for compatibility, but
+it is ignored and should not be used in new configurations.
 The N value belongs in GRAPHS, not in GRAPHS_<COLUMNNAME>. Status
 page GRAPHS_<COLUMNNAME> entries inherit N when they name the same
 graph definition. If a graph is used only from GRAPHS_<COLUMNNAME>
@@ -822,4 +820,3 @@ the options you normally used when building Xymon webpages.
 
 .SH "SEE ALSO"
 xymon(7)
-

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -521,15 +521,26 @@ include a graph.
 
 .IP GRAPHS
 List of the RRD databases, that should be shown as a graph on
-the "trends" column. Each entry is "name[::N]": N is the maximum
-number of RRD files drawn per graph image before the graph is
-split into multiple images (default: 5). E.g. "mrtg::1" draws one
-file per image. N governs the graph wherever it is rendered: on
-the "trends" page, on the test's own status page, and for
-GRAPHS_<column> entries. On status pages the split only happens
-for columns listed in the "\-\-multigraphs" option of
-.I svcstatus.cgi(1);
-a column not listed there shows all its curves in one image.
+the "trends" column. Each entry is "name[::N]": at most N RRD
+files are drawn per graph image, and a graph with more files is
+split into multiple images (default: 5 per image). E.g.
+"mrtg::1" draws one file per image. The full syntax is
+"name[:partname][:N]" where the middle field is a rarely used
+graph part name from
+.I graphs.cfg(5)
+\- hence the double colon when only N is given.
+N follows the graph definition wherever it is used: on the
+"trends" page, on the test's own status page, and for
+GRAPHS_<column> entries. Exception: entries with an explicit
+graph list in a host's TRENDS tag (e.g. "disk:disk1|disk2", see
+.I hosts.cfg(5))
+ignore N and use the default of 5.
+On status pages the split only happens for columns listed in
+the "\-\-multigraphs" option of
+.I svcstatus.cgi(1)
+(built-in default: disk, inode, qtree, quotas, snapshot,
+TblSpace, if_load); any other column draws all its RRD files in
+a single image.
 Note: a "DISK filesystem IGNORE" rule in
 .I analysis.cfg(5)
 removes a filesystem from the status, the alerts and the graphs;

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -182,15 +182,18 @@ TEST2RRD="cpu=la,disk,inode,qtree,memory,$PINGCOLUMN=tcp,http=tcp,dns=tcp,dig=tc
 
 GRAPHS_ntp="ntp.offset"
 
-# This defines which graph names to include on the "trends" column webpage,
-# and the order in which they appear. The matching RRD files are selected by
-# graphs.cfg. Entries use name or name::N; N caps the RRD files per graph image
-# once a graph is split, so "mrtg::1" means one file per image. A legacy middle
-# field is accepted by the parser but ignored; use name::N for new settings.
-# Put ::N here, not in GRAPHS_<columnname>; status page entries inherit N when
-# they name the same graph definition. If a graph is used only from
-# GRAPHS_<columnname> and has no matching entry here, it uses the default split
-# size.
+# This defines graph names known to the graph display code. On the "trends"
+# column, it also defines which graphs are shown and in what order. The matching
+# RRD files are selected by graphs.cfg. Entries use name or name::N; N caps the
+# RRD files per graph image once a graph is split, so "mrtg::1" means one file
+# per image. N counts files, not lines: one RRD file can hold several DS, each
+# drawn as its own curve, so N files may show several times N lines (a 2-DS
+# graph at ::2 draws 4 lines). A legacy middle field is accepted but ignored; use
+# name::N for new settings. Put ::N here, not in GRAPHS_<columnname>; it applies
+# on the trends page, on a test column's default status-page graph, and on
+# GRAPHS_<columnname> entries that name the same graph definition. If a graph is
+# used only from GRAPHS_<columnname> and has no matching entry here, it uses the
+# default split size.
 # On status pages, splitting also needs an instance count: either the status
 # message includes "<!-- linecount=N -->", or svcstatus.cgi computes it
 # automatically for columns listed in its --multigraphs option.

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -184,11 +184,13 @@ GRAPHS_ntp="ntp.offset"
 
 # This defines which graph names to include on the "trends" column webpage,
 # and the order in which they appear. The matching RRD files are selected by
-# graphs.cfg. Entries use name[:partname][:N]; N caps the RRD files per graph
-# image once a graph is split, so "mrtg::1" means one file per image. Put ::N
-# here, not in GRAPHS_<columnname>; status page entries inherit N when they name
-# the same graph definition. If a graph is used only from GRAPHS_<columnname>
-# and has no matching entry here, it uses the default split size.
+# graphs.cfg. Entries use name or name::N; N caps the RRD files per graph image
+# once a graph is split, so "mrtg::1" means one file per image. A legacy middle
+# field is accepted by the parser but ignored; use name::N for new settings.
+# Put ::N here, not in GRAPHS_<columnname>; status page entries inherit N when
+# they name the same graph definition. If a graph is used only from
+# GRAPHS_<columnname> and has no matching entry here, it uses the default split
+# size.
 # On status pages, splitting also needs an instance count: either the status
 # message includes "<!-- linecount=N -->", or svcstatus.cgi computes it
 # automatically for columns listed in its --multigraphs option.

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -154,31 +154,44 @@ XYMONRRDS="$XYMONVAR/rrd"
 RRDHEIGHT="120"
 RRDWIDTH="576"		# The RRD's contain 576 data points, so this is a good value
 
-# TEST2RRD defines the status- and data-messages you want to collect RRD data
-# about. You will normally not need to modify this, unless you have added a
-# script to pick up RRD data from custom tests (the xymond_rrd --extra-script
-# and --extra-tests options).
-# Note that network tests defined in the protocols.cfg file are automatically
-# included.
-# The format here is "COLUMN=RRDSERVICE". If you leave out the "=RRDSERVICE"
-# part, it is assumed to be the same as the COLUMN value.
+# These settings have separate roles:
+# - TEST2RRD maps status/data columns to the RRD graph name used for storing
+#   data and for the column's default status-page graph.
+# - GRAPHS_<columnname> changes only what graphs are shown on that column's
+#   status page; it does not make xymond_rrd collect new data.
+# - GRAPHS defines the graph list and order on the trends page, and also stores
+#   graph-display metadata such as the per-image split size.
 
-# GRAPHS_<columnname> entries define what graphs to display on COLUMNs, if not the 
-# default ones indicated above. This can allow you to display additional graphs on
-# a status page, even if xymond_rrd is not using the TEST2RRD data above.
-# If present, overrides the column RRD value above for display purposes, so be sure
-# to include the that, if desired
-# eg, GRAPHS_cpu="la,vmstat1"
+# TEST2RRD format: COLUMN[=RRDSERVICE]. If "=RRDSERVICE" is omitted, the
+# RRD graph name is the same as the COLUMN value. You will normally not need to
+# modify this, unless you have added a script to pick up RRD data from custom
+# tests (the xymond_rrd --extra-script and --extra-tests options). Network
+# tests defined in protocols.cfg are automatically included.
+
+# GRAPHS_<columnname> entries define what graphs to display on COLUMNs, instead
+# of the default graph named by TEST2RRD. This can display additional graphs on a
+# status page, even when xymond_rrd is not using TEST2RRD for those graphs.
+# If present, this overrides the default column graph for display purposes, so
+# include the original graph too if you still want it.
+# Example: GRAPHS_cpu="la,vmstat1"
 
 #
-# TEST2RRD and GRAPHS_* are used by the svcstatus.cgi script to determine if the detailed
+# TEST2RRD and GRAPHS_* are used by svcstatus.cgi to determine if the detailed
 # status view of a test should include a graph.
 TEST2RRD="cpu=la,disk,inode,qtree,memory,$PINGCOLUMN=tcp,http=tcp,dns=tcp,dig=tcp,time=ntpstat,ntp=tcp,vmstat,iostat,netstat,temperature,apache,bind,sendmail,mailq,nmailq=mailq,socks,bea,iishealth,citrix,bbgen,bbtest,bbproxy,hobbitd,files,procs=processes,ports,clock,lines,deltalines,ops,stats,cifs,JVM,JMS,HitCache,Session,JDBCConn,ExecQueue,JTA,TblSpace,RollBack,MemReq,InvObj,snapmirr,snaplist,snapshot,if_load=devmon,temp=devmon,paging,mdc,mdchitpct,cics,dsa,getvis,maxuser,nparts,xymongen,xymonnet,xymonproxy,xymond"
 
 GRAPHS_ntp="ntp.offset"
 
-# This defines which RRD files to include on the "trends" column webpage,
-# and the order in which they appear.
+# This defines which graph names to include on the "trends" column webpage,
+# and the order in which they appear. The matching RRD files are selected by
+# graphs.cfg. Entries use name[:partname][:N]; N caps the RRD files per graph
+# image once a graph is split, so "mrtg::1" means one file per image. Put ::N
+# here, not in GRAPHS_<columnname>; status page entries inherit N when they name
+# the same graph definition. If a graph is used only from GRAPHS_<columnname>
+# and has no matching entry here, it uses the default split size.
+# On status pages, splitting also needs an instance count: either the status
+# message includes "<!-- linecount=N -->", or svcstatus.cgi computes it
+# automatically for columns listed in its --multigraphs option.
 GRAPHS="la,disk,inode,qtree,files,processes,memory,users,vmstat,iostat,tcp.http,tcp,ncv,netstat,ifstat,mrtg::1,ports,temperature,ntpstat,apache,bind,sendmail,mailq,socks,bea,iishealth,citrix,bbgen,bbtest,bbproxy,hobbitd,clock,lines,deltalines,ops,stats,cifs,JVM,JMS,HitCache,Session,JDBCConn,ExecQueue,JTA,TblSpace,RollBack,MemReq,InvObj,snapmirr,snaplist,snapshot,devmon::1,if_load::1,temp,paging,mdc,mdchitpct,cics,dsa,getvis,maxuser,nparts,xymongen,xymonnet,xymonproxy,xymond"
 
 # These two settings can be used to restrict what filesystems are being

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -196,10 +196,12 @@ GRAPHS_ntp="ntp.offset"
 # automatically for columns listed in its --multigraphs option.
 GRAPHS="la,disk,inode,qtree,files,processes,memory,users,vmstat,iostat,tcp.http,tcp,ncv,netstat,ifstat,mrtg::1,ports,temperature,ntpstat,apache,bind,sendmail,mailq,socks,bea,iishealth,citrix,bbgen,bbtest,bbproxy,hobbitd,clock,lines,deltalines,ops,stats,cifs,JVM,JMS,HitCache,Session,JDBCConn,ExecQueue,JTA,TblSpace,RollBack,MemReq,InvObj,snapmirr,snaplist,snapshot,devmon::1,if_load::1,temp,paging,mdc,mdchitpct,cics,dsa,getvis,maxuser,nparts,xymongen,xymonnet,xymonproxy,xymond"
 
-# These two settings can be used to restrict what filesystems are being
-# tracked (i.e. have their utilisation graphed) by Xymon.
-# NORRDDISKS=""		# Filesystems that will NOT be tracked
-# RRDDISKS=""		# Only track these filesystems
+# Deprecated legacy filesystem graph filters. Prefer DISK/INODE filesystem
+# IGNORE rules in analysis.cfg when a filesystem should be removed from status,
+# alerts and graphs. These settings are retained only for old configurations and
+# affect RRD graph tracking only.
+# NORRDDISKS=""		# Filesystems that will NOT be tracked for graphs
+# RRDDISKS=""		# Only graph these filesystems
 
 
 ###############################################################


### PR DESCRIPTION
Documentation only, no behaviour change. The RRD graph settings in `xymonserver.cfg.5` and the matching comments in `xymonserver.cfg.DIST` were terse and easy to misread — especially the `GRAPHS` `::N` split size, which setting owns it, and the status of `NORRDDISKS`/`RRDDISKS`.

**Three roles, now stated up front:**

- `TEST2RRD` — maps a column to the RRD graph name used for storing data and for the column's default status-page graph.
- `GRAPHS_<COLUMNNAME>` — display only; it collects no data and replaces the column's default graph, so the original must be re-listed if still wanted.
- `GRAPHS` — graph list and order on the trends page, plus graph-display metadata such as the split size.

**`::N` split size (belongs in `GRAPHS`):**

- `name::N` caps the number of RRD **files** drawn per image once a graph is split (default 5). Files can hold several DS, each drawn as a curve, so an image may show more than N lines — a 2-DS graph at `::2` draws 4.
- It applies wherever links for that graph are generated: trends page, the column's `TEST2RRD` default graph, and `GRAPHS_<COLUMNNAME>` entries naming the same graph.
- Status pages split only when an instance count is available: a `<!-- linecount=N -->` marker in the status message, or automatic counting for `--multigraphs` columns (built-in default: disk, inode, qtree, quotas, snapshot, TblSpace, if_load).
- The legacy middle field (`name:x:N`) is documented as parsed-but-ignored; a host `TRENDS` tag with an explicit graph list (e.g. `disk:disk1|disk2`) ignores N and uses the default of 5.

**`NORRDDISKS`/`RRDDISKS`** are now documented as deprecated legacy settings, retained for old configurations: they affect RRD graph tracking only and do not remove already-tracked RRD files. The usual replacement is a `DISK`/`INODE ... IGNORE` rule in `analysis.cfg(5)` when a filesystem should be dropped from status, alerts and graphs.

Man page and DIST comments were updated together so they stay consistent; the man page renders cleanly with `groff`.
