### PR TITLE
htmllog: mirror NORRDDISKS/RRDDISKS when sizing disk graph paging (#234)

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -57,6 +57,9 @@ $(XYMONCLIENTCOMMLIB): $(XYMONCLIENTCOMMLIBOBJS)
 loadhosts.o: loadhosts.c loadhosts_file.c loadhosts_net.c
 	$(CC) $(CFLAGS) -c -o $@ loadhosts.c
 
+htmllog.o: htmllog.c
+	$(CC) $(CFLAGS) $(PCREINCDIR) -c -o $@ $<
+
 eventlog.o: eventlog.c
 	$(CC) $(CFLAGS) $(PCREINCDIR) -c -o $@ $<
 

--- a/lib/htmllog.c
+++ b/lib/htmllog.c
@@ -23,6 +23,9 @@ static char rcsid[] = "$Id$";
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
 #include "libxymon.h"
 #include "version.h"
 
@@ -165,6 +168,75 @@ static void textwithcolorimg(char *msg, FILE *output)
 			restofmsg = NULL;
 		}
 	} while (restofmsg);
+}
+
+/*
+ * Mirror do_disk.c's NORRDDISKS/RRDDISKS filtering when counting the status
+ * lines that size the graph paging (issue #234). Filesystems held back by
+ * those patterns keep their status line but never get an RRD file, so
+ * counting their lines pages into graph images with nothing behind them.
+ * Same patterns, same subject (the mount point - the line's last field, as
+ * do_disk extracts it), same precedence (exclude wins; when an include
+ * pattern is set, only matching filesystems count). Lines whose last field
+ * does not start with '/' (df header, decorations) are never filtered.
+ * Caveat: assumes the rendering host shares the RRD host's xymonserver.cfg
+ * settings, which is the case everywhere the RRD directory is local.
+ */
+static int rrd_skips_fs(char *bol, char *eoln)
+{
+	static int ptnsetup = 0;
+	static pcre2_code *inclpattern = NULL;
+	static pcre2_code *exclpattern = NULL;
+	pcre2_match_data *ovector;
+	char *mnt, *end;
+	int result;
+
+	if (!ptnsetup) {
+		char errmsg[120];
+		int err;
+		PCRE2_SIZE errofs;
+		char *ptn;
+
+		ptnsetup = 1;
+		ptn = getenv("RRDDISKS");
+		if (ptn && strlen(ptn)) {
+			inclpattern = pcre2_compile((PCRE2_SPTR)ptn, strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
+			if (!inclpattern) {
+				pcre2_get_error_message(err, (PCRE2_UCHAR *)errmsg, sizeof(errmsg));
+				errprintf("PCRE compile of RRDDISKS='%s' failed, error %s, offset %zu\n", ptn, errmsg, errofs);
+			}
+		}
+		ptn = getenv("NORRDDISKS");
+		if (ptn && strlen(ptn)) {
+			exclpattern = pcre2_compile((PCRE2_SPTR)ptn, strlen(ptn), PCRE2_CASELESS, &err, &errofs, NULL);
+			if (!exclpattern) {
+				pcre2_get_error_message(err, (PCRE2_UCHAR *)errmsg, sizeof(errmsg));
+				errprintf("PCRE compile of NORRDDISKS='%s' failed, error %s, offset %zu\n", ptn, errmsg, errofs);
+			}
+		}
+	}
+	if (!inclpattern && !exclpattern) return 0;
+
+	/* The mount point is the line's last whitespace-separated field */
+	end = eoln;
+	while ((end > bol) && isspace((int)*(end-1))) end--;
+	mnt = end;
+	while ((mnt > bol) && !isspace((int)*(mnt-1))) mnt--;
+	if ((mnt >= end) || (*mnt != '/')) return 0;
+
+	if (exclpattern) {
+		ovector = pcre2_match_data_create_from_pattern(exclpattern, NULL);
+		result = pcre2_match(exclpattern, (PCRE2_SPTR)mnt, (end - mnt), 0, 0, ovector, NULL);
+		pcre2_match_data_free(ovector);
+		if (result >= 0) return 1;
+	}
+	if (inclpattern) {
+		ovector = pcre2_match_data_create_from_pattern(inclpattern, NULL);
+		result = pcre2_match(inclpattern, (PCRE2_SPTR)mnt, (end - mnt), 0, 0, ovector, NULL);
+		pcre2_match_data_free(ovector);
+		if (result < 0) return 1;
+	}
+	return 0;
 }
 
 
@@ -465,6 +537,10 @@ void generate_html_log(char *hostname, char *displayname, char *service, char *i
 			SBUF_MALLOC(multikey, strlen(service) + 3);
 			snprintf(multikey, multikey_buflen, ",%s,", service);
 			if (strstr(multigraphs, multikey)) {
+				/* Columns whose RRDs come from do_disk, where the
+				 * NORRDDISKS/RRDDISKS filters apply (issue #234) */
+				int diskfamily = (strstr(",disk,inode,qtree,quotas,snapshot,TblSpace,", multikey) != NULL);
+
 				/* The "disk" report from the NetWare client puts a "warning light" on all entries */
 				int netwarediskreport = (strstr(firstline, "NetWare Volumes") != NULL);
 
@@ -486,7 +562,12 @@ void generate_html_log(char *hostname, char *displayname, char *service, char *i
 						}
 						else {
 							/* We found something that is not blank, so one more line */
-							if (!netwarediskreport) linecount++;
+							char *eoln = strchr(p, '\n');
+
+							if (!eoln) eoln = p + strlen(p);
+							/* ...unless its RRD is filtered by NORRDDISKS/RRDDISKS:
+							 * counting it would page into a graph with no data (#234) */
+							if (!netwarediskreport && !(diskfamily && rrd_skips_fs(p, eoln))) linecount++;
 						}
 
 						if (strlen(p) > 10 &&  *p == '<' ) {

--- a/tests/web/html-log-norrd-linecount-harness.c
+++ b/tests/web/html-log-norrd-linecount-harness.c
@@ -1,0 +1,113 @@
+/* Regression test for issue #234: the graph paging on a disk-family status
+ * page sized itself by counting status-text lines, ignoring that
+ * NORRDDISKS/RRDDISKS hold some of those filesystems out of the RRDs - so
+ * the page requested graph slices with no files behind them (dead images).
+ * htmllog must mirror the do_disk filter when counting: same patterns, same
+ * subject (the mount point, the line's last field), same precedence. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libxymon.h"
+
+static int failures = 0;
+
+static void expect_contains(const char *label, const char *text, const char *needle)
+{
+	if (!text || !strstr(text, needle)) {
+		fprintf(stderr, "%s: missing '%s'\n", label, needle);
+		failures++;
+	}
+}
+
+static void expect_not_contains(const char *label, const char *text, const char *needle)
+{
+	if (text && strstr(text, needle)) {
+		fprintf(stderr, "%s: unexpected '%s'\n", label, needle);
+		failures++;
+	}
+}
+
+static char *render(const char *service, const char *restofmsg)
+{
+	char *html = NULL;
+	size_t htmlsz = 0;
+	FILE *out;
+
+	out = open_memstream(&html, &htmlsz);
+	if (!out) { perror("open_memstream"); exit(2); }
+
+	generate_html_log("testhost", "Test Host", (char *)service, "127.0.0.1",
+			  COL_GREEN, 0, "tester", "",
+			  0, "0 minutes", "green status ok", (char *)restofmsg,
+			  NULL, 0, NULL, NULL, 0, NULL,
+			  0, 1, 0, 0, NULL, NULL,
+			  NULL, NULL, NULL, 3600, out);
+
+	fclose(out);
+	return html;
+}
+
+int main(int argc, char **argv)
+{
+	char dfmsg[4096];
+	char *html;
+	int i;
+
+	histlocation = HIST_NONE;
+
+	/* df report: header + 15 kept filesystems + 5 poudriere ones that
+	 * NORRDDISKS (set by the wrapper script) holds out of the RRDs. */
+	snprintf(dfmsg, sizeof(dfmsg), "Filesystem 1024-blocks Used Avail Capacity Mounted on\n");
+	for (i = 1; i <= 15; i++)
+		snprintf(dfmsg + strlen(dfmsg), sizeof(dfmsg) - strlen(dfmsg),
+			 "zdata/fs%d 1000 500 500 50%% /zdata/fs%d\n", i, i);
+	for (i = 1; i <= 5; i++)
+		snprintf(dfmsg + strlen(dfmsg), sizeof(dfmsg) - strlen(dfmsg),
+			 "zdata/p%d 1000 500 500 50%% /poudriere/data%d\n", i, i);
+
+	/* The RRDDISKS/NORRDDISKS patterns are compiled once per process, so the
+	 * wrapper runs this harness once per scenario; argv[1] picks the
+	 * expectations matching the environment the wrapper set. */
+	{
+		const char *mode = "none";
+		char lc[64];
+
+		if (argc > 1) mode = argv[1];
+		html = render("disk", dfmsg);
+
+		if (strcmp(mode, "none") == 0) {
+			/* No filters: all 20 lines count (header subtracted) */
+			expect_contains(mode, html, "<!-- linecount=20 -->");
+			expect_contains(mode, html, "first=16&amp;count=5");
+			expect_not_contains(mode, html, "first=21");
+		}
+		else if (strcmp(mode, "excl") == 0) {
+			/* NORRDDISKS=^/poudriere: 5 lines uncounted -> 15 */
+			expect_contains(mode, html, "<!-- linecount=15 -->");
+			expect_contains(mode, html, "first=11&amp;count=5");
+			expect_not_contains(mode, html, "first=16");
+		}
+		else if (strcmp(mode, "incl") == 0) {
+			/* RRDDISKS=^/zdata/fs: only matching lines count -> 15 */
+			expect_contains(mode, html, "<!-- linecount=15 -->");
+			expect_not_contains(mode, html, "first=16");
+		}
+		else if (strcmp(mode, "both") == 0) {
+			/* include ^/ (everything), exclude one: exclude wins -> 19.
+			 * 19 lines page as 4 groups of 4 (rebalanced), firsts 1,5,9,13,17 */
+			expect_contains(mode, html, "<!-- linecount=19 -->");
+			expect_contains(mode, html, "first=17&amp;count=4");
+			expect_not_contains(mode, html, "first=21");
+		}
+		else {
+			fprintf(stderr, "unknown mode '%s'\n", mode);
+			failures++;
+		}
+		(void)lc;
+		free(html);
+	}
+
+	printf(failures ? "FAILED\n" : "ALL OK\n");
+	return failures ? 1 : 0;
+}

--- a/tests/web/html-log-norrd-linecount.sh
+++ b/tests/web/html-log-norrd-linecount.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/html-log-norrd-linecount.sh
+#
+# Regression guard for issue #234: the disk-page graph paging must not count
+# status lines whose filesystems NORRDDISKS/RRDDISKS hold out of the RRDs -
+# those slots would render as broken images. htmllog mirrors the do_disk
+# filter when counting; the patterns are compiled once per process, so the
+# harness runs once per scenario.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+here=$(dirname "$0")
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+command -v make >/dev/null 2>&1 || skip "make not available"
+
+pcre_libs=${PCRELIBS:-}
+if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+fi
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile" 2>/dev/null || true)
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-norrd-lc.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+	"$here/html-log-norrd-linecount-harness.c" "$ROOT/lib/libxymoncomm.a" \
+	$pcre_libs $ssllibs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+common_env() {
+	env XYMONHOME="$work" CGIBINURL="/xymon-cgi" RRDWIDTH=576 RRDHEIGHT=120 \
+	    XYMONSKIN="/xymon/gifs" XYMONWEB="/xymon" IMAGEFILETYPE="gif" \
+	    TEST2RRD="disk" GRAPHS="la,disk" \
+	    INFOCOLUMN="info" TRENDSCOLUMN="trends" ACKUNTILMSG="until %H:%M" "$@"
+}
+
+run_case() {  # run_case <mode> [ENV=val...]
+	mode=$1; shift
+	common_env "$@" "$work/harness" "$mode" >"$work/out.log" 2>"$work/err.log" \
+		|| fail "scenario '$mode' failed: $(cat "$work/err.log")"
+}
+
+run_case none
+run_case excl NORRDDISKS='^/poudriere'
+run_case incl RRDDISKS='^/zdata/fs'
+run_case both RRDDISKS='^/' NORRDDISKS='^/zdata/fs1$'
+
+pass "disk-page graph paging mirrors the NORRDDISKS/RRDDISKS filters"


### PR DESCRIPTION
## Problem

A disk-family status page sizes its graph paging by counting status lines, but `NORRDDISKS`/`RRDDISKS` filter those filesystems at RRD-write time only - the counter never knew, so the page requested trailing graph slices with no files behind them: permanently broken images for every visible-but-untrended filesystem.

Field case (#234, verified numbers): 110 lines counted, ~11 held back by `NORRDDISKS="^(.*poudriere.*)"`, 99 RRD files - 2-4 dead slots on every page view. Closes #234 for the reported configuration.

## Fix

Apply the same filters in the counter - no filesystem access, pure in-memory string work: same patterns (compiled once, as in `do_disk.c`), same subject (the mount point - the line's last field, only when it starts with '/', so the df header and decorations are never touched), same precedence (exclude wins; with an include pattern set, only matching filesystems count). Gated to the do_disk column family (disk, inode, qtree, quotas, snapshot, TblSpace); other multigraph columns untouched.

Counter and writer now derive from one truth - the property that already makes `analysis.cfg` `DISK ... IGNORE` self-consistent. No new state, no reconciliation channel, byte-identical behavior when the variables are unset.

Caveat (in the code comment): assumes the rendering host shares the RRD host's `xymonserver.cfg` settings - true wherever the RRD directory is local.

## Testing

Harness drives the real `generate_html_log()` once per pattern scenario (patterns are process-cached): unfiltered (20 lines -> 4x5 slots), NORRDDISKS (15), RRDDISKS-only (15), both with exclude-wins (19 -> rebalanced 4-per-slot). Fails on unpatched code at exactly the filtered-count assertions. Full suite 19/19.