### PR TITLE
xymonrrd: round split size up so graphs fill to maxgraphs

### DIFF
--- a/lib/xymonrrd.c
+++ b/lib/xymonrrd.c
@@ -269,8 +269,16 @@ static char *xymon_graph_text(char *hostname, char *dispname, char *service, int
 
 		step = (graphdef->maxgraphs ? graphdef->maxgraphs : 5);
 		if (itemcount) {
+			/* Spread itemcount instances evenly over the needed number of
+			 * graphs. gcount is the graph count (ceil); the per-graph step
+			 * must round UP too, otherwise a count that gcount does not
+			 * divide leaves every graph under-filled below maxgraphs and
+			 * spawns extra graphs - e.g. 25 items at maxgraphs=2 gives
+			 * gcount=13 but a floored step=1, so 25 single-item graphs
+			 * instead of 13. Rounding up yields step=2 (last graph holds
+			 * the remainder), never exceeding maxgraphs. */
 			int gcount = (itemcount / step); if ((gcount*step) != itemcount) gcount++;
-			step = (itemcount / gcount);
+			step = ((itemcount + gcount - 1) / gcount);
 		}
 
 		SBUF_MALLOC(rrdparturl, rrdparturlsize);


### PR DESCRIPTION
## Problem

When a service has more RRD instances than `maxgraphs` (the `::N` / `SPLITSIZE` cap), `xymon_graph_text()` splits them across several graphs. It first computes the graph count with a ceiling division, then re-divides the instances evenly over those graphs to avoid a stunted last graph — but that re-division used floor:

```c
step = itemcount / gcount;
```

Whenever `gcount` does not divide `itemcount` evenly, every graph is left under-filled below `maxgraphs` and the loop emits more graphs than `gcount` intended. Example: 25 disks with `disk::2` → `gcount = 13`, but the step floors to `25/13 = 1`, so the page renders 25 single-disk graphs instead of the intended ~13. Adding or removing one disk flips the layout, and a cap like `::5` can silently behave like `::4` (24 disks) or `::2` like `::1` (25 disks).

## Fix

Round the step up instead:

```c
step = (itemcount + gcount - 1) / gcount;
```

Each graph fills to the configured cap and only the last one carries the remainder. `ceil(itemcount / ceil(itemcount / maxgraphs))` is always ≤ `maxgraphs`, so the cap is still honoured, and the number of graphs emitted matches `gcount`.

## Verification

Checked exhaustively for item counts 1..200 and caps 1..8: the step never exceeds the cap, every instance is covered, and the graph count equals `gcount`.
