### PR TITLE
docs: clear damping documentation debt (issue #229, step 1)

### DIFF
--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -815,6 +815,9 @@ The default method is "best" - so it will report green if
 just one of the IP's respond to ping.
 
 .IP badconn[\-weekdays\-starttime\-endtime]:x:y:z
+NOTE: This has been deprecated, use the \fBdelayred\fR and
+\fBdelayyellow\fR settings instead.
+
 This is taken directly from the "fping.sh" connectivity-
 testing script, and is used by xymonnet when it runs
 with ping testing enabled (the default). See the description

--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -870,6 +870,9 @@ The default method is "best" - so it will report green if
 just one of the IP's respond to ping.
 
 .IP "\fBbadconn[\-weekdays\-starttime\-endtime]:x:y:z\fR"
+NOTE: This has been deprecated, use the \fBdelayred\fR and
+\fBdelayyellow\fR settings instead.
+
 This is taken directly from the "fping.sh" connectivity-
 testing script, and is used by xymonnet when it runs
 with ping testing enabled (the default). See the description

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -410,9 +410,21 @@ The default is "green,clear,blue".
 
 .IP ALERTREPEAT
 How often alerts get repeated while a status is in an alert state.
-This is the default setting, which may be changed in the 
+This is the default setting, which may be changed in the
 .I alerts.cfg(5)
 file.
+
+.IP DELAYRED
+Default setting for the \fBdelayred\fR tag in
+.I hosts.cfg(5)
+applied to hosts that do not have the tag. The format is the same
+as the tag: "STATUSCOLUMN:DELAY[,STATUSCOLUMN:DELAY...]" with DELAY
+in minutes, e.g. "cpu:15,disk:30". Note: a \fBdelayred\fR tag on a
+host replaces this default entirely for that host - per-test values
+are not merged. Default: empty (no delay).
+
+.IP DELAYYELLOW
+Same as DELAYRED, but the default for the \fBdelayyellow\fR tag.
 
 .IP MAXMSG_STATUS
 The maximum size of a "status" message in kB, default: 256.

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -430,6 +430,18 @@ This is the default setting, which may be changed in the
 .I alerts.cfg(5)
 file.
 
+.IP "\fBDELAYRED\fR"
+Default setting for the \fBdelayred\fR tag in
+.I hosts.cfg(5)
+applied to hosts that do not have the tag. The format is the same
+as the tag: "STATUSCOLUMN:DELAY[,STATUSCOLUMN:DELAY...]" with DELAY
+in minutes, e.g. "cpu:15,disk:30". Note: a \fBdelayred\fR tag on a
+host replaces this default entirely for that host - per-test values
+are not merged. Default: empty (no delay).
+
+.IP "\fBDELAYYELLOW\fR"
+Same as DELAYRED, but the default for the \fBdelayyellow\fR tag.
+
 .IP "\fBMAXMSG_STATUS\fR"
 The maximum size of a "status" message in kB, default: 256.
 Status messages are the ones that end up as columns on the

--- a/docs/manpages/man5/hosts.cfg.5.html
+++ b/docs/manpages/man5/hosts.cfg.5.html
@@ -945,9 +945,12 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <p class="Pp"></p>
   </dd>
   <dt id="badconn[-weekdays-starttime-endtime]:x:y:z"><a class="permalink" href="#badconn[-weekdays-starttime-endtime]:x:y:z"><b>badconn[-weekdays-starttime-endtime]:x:y:z</b></a></dt>
-  <dd>This is taken directly from the &quot;fping.sh&quot; connectivity- testing
-      script, and is used by xymonnet when it runs with ping testing enabled
-      (the default). See the description of the &quot;badTEST&quot; tag.
+  <dd>NOTE: This has been deprecated, use the <b>delayred</b> and
+      <b>delayyellow</b> settings instead.
+    <p class="Pp">This is taken directly from the &quot;fping.sh&quot;
+        connectivity- testing script, and is used by xymonnet when it runs with
+        ping testing enabled (the default). See the description of the
+        &quot;badTEST&quot; tag.</p>
     <p class="Pp"></p>
   </dd>
   <dt id="route:router1,router2"><a class="permalink" href="#route:router1,router2"><b>route:router1,router2,....</b></a></dt>

--- a/docs/manpages/man5/xymonserver.cfg.5.html
+++ b/docs/manpages/man5/xymonserver.cfg.5.html
@@ -535,6 +535,19 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       file.
     <p class="Pp"></p>
   </dd>
+  <dt id="DELAYRED"><a class="permalink" href="#DELAYRED"><b>DELAYRED</b></a></dt>
+  <dd>Default setting for the <b>delayred</b> tag in <i><a href="../man5/hosts.cfg.5.html">hosts.cfg</a>(5)</i> applied
+      to hosts that do not have the tag. The format is the same as the tag:
+      &quot;STATUSCOLUMN:DELAY[,STATUSCOLUMN:DELAY...]&quot; with DELAY in
+      minutes, e.g. &quot;cpu:15,disk:30&quot;. Note: a <b>delayred</b> tag on a
+      host replaces this default entirely for that host - per-test values are
+      not merged. Default: empty (no delay).
+    <p class="Pp"></p>
+  </dd>
+  <dt id="DELAYYELLOW"><a class="permalink" href="#DELAYYELLOW"><b>DELAYYELLOW</b></a></dt>
+  <dd>Same as DELAYRED, but the default for the <b>delayyellow</b> tag.
+    <p class="Pp"></p>
+  </dd>
   <dt id="MAXMSG_STATUS"><a class="permalink" href="#MAXMSG_STATUS"><b>MAXMSG_STATUS</b></a></dt>
   <dd>The maximum size of a &quot;status&quot; message in kB, default: 256.
       Status messages are the ones that end up as columns on the web display.

--- a/xymond/xymond.8
+++ b/xymond/xymond.8
@@ -114,22 +114,6 @@ at least (N/300)\-1, e.g. if you set flap\-seconds to 3600 (1 hour), then
 flap\-count should be at least (3600/300)\-1, i.e. 11.
 Default: 1800 seconds (30 minutes).
 
-.IP "\-\-delay\-red=N"
-.IP "\-\-delay\-yellow=N"
-Sets the delay before a red/yellow status causes a change in the web
-page display. Is usually controlled on a per-host basis via the
-\fBdelayred\fR and \fBdelayyellow\fR settings in
-.I hosts.cfg(5)
-but these options allow you to set a default value for the delays.
-The value N is in minutes. Default: 0 minutes (no delay).
-Note: Since most tests only execute once every 5 minutes, it will
-usually not make sense to set N to anything but a multiple of 5.
-.br
-While the change to red is deferred the status is shown as yellow, not
-green; use both delays to keep the status unchanged. A status
-recovering from purple (no data) is updated immediately, without any
-delay.
-
 .IP "\-\-env=FILENAME"
 Loads the content of FILENAME as environment settings before starting
 xymond. This is mostly used when running as a stand-alone daemon; if


### PR DESCRIPTION
Step 1 of the rollout plan in #229 — documentation only, no behavior change.

- **xymond.8**: remove the `--delay-red`/`--delay-yellow` option entries. These options are implemented nowhere — xymond takes the defaults from the `DELAYRED`/`DELAYYELLOW` environment settings (`xymond.c:5279`), not from command-line options. The per-host tags remain documented in hosts.cfg(5), where the interim-yellow note from #228 already lives, so nothing is lost.
- **xymonserver.cfg.5**: document `DELAYRED`/`DELAYYELLOW`, shipped in xymonserver.cfg since 2011 but absent from the man page, including the current replace-not-merge behavior when a host also carries the tag.
- **hosts.cfg.5**: add to `badconn` the same deprecation note `badTEST` has carried since 2011.

Refs #229.
