### PR TITLE
Document undocumented hosts.cfg tags (DOC:, WARNSTOPS:) and fix .default. host tag list

### DIFF
--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -299,6 +299,25 @@ this text unescaped, so raw HTML placed directly in "Description" (e.g.
 an \fB<a href=...>\fR link) is also rendered as a link, independently of
 HOSTDESCURL, and can be used to link different hosts to different targets.
 
+.IP "DOC:URL"
+Define a URL with documentation for the host, shown as a "Documentation:"
+row on the host's "Info" column page. The URL may contain a \fB%s\fR
+conversion, which is replaced with the hostname, e.g.
+DOC:"https://cmdb.example.com/host/%s". A literal "%" in the URL must be
+escaped as "%%".
+DOC: can be set on the ".default." host (see the
+.B DEFAULT HOST
+section below) to provide a fleet-wide default documentation link, with a
+per-host DOC: tag taking precedence. It is also exported to alert scripts
+as XMH_DOCURL (see
+.I xymon\-xmh(5)
+).
+HOSTDOCURL in
+.I xymonserver.cfg(5)
+is a global hostname-keyed template for a "Notes:" row. E.g.
+with HOSTDOCURL="/docs/%s.php" set in xymonserver.cfg, a host "myhost"
+gets a "Notes:" link to "/docs/myhost.php".
+
 .IP "CLASS:Classname"
 Force the host to belong to a specific class. Class-names are used
 when configuring log-file monitoring (they can be used as references in
@@ -554,6 +573,18 @@ basis, instead of using a global setting for all hosts. The
 threshold is defined as the percentage of the time that the host
 must be available, e.g. "WARNPCT:98.5" if you want the threshold to
 be at 98.5%
+
+.IP WARNSTOPS:count
+Sets a threshold on the number of separate down-periods ("stops" - i.e.
+times the status went above yellow) allowed within the reporting
+interval. If the number of down-periods exceeds "count", the report is
+shown as red - even if WARNPCT's availability-percentage threshold
+would otherwise show green or yellow. This catches hosts that flap
+frequently (many short outages) but still have a high overall
+availability percentage.
+E.g. "WARNSTOPS:5" turns the report red once a 6th outage occurs in
+the reporting interval.
+Default: -1 (disabled - no limit on the number of down-periods).
 
 .IP "noflap[=test1,test2,...]"
 Disable flap detection for this host, or for specific tests on this
@@ -1411,10 +1442,10 @@ per-host definitions will override the default ones. To apply to all hosts
 this should be listed FIRST in your file.
 
 \fBNOTE:\fR The ".default." host entry will only accept the following
-tags - others are silently ignored: delayyellow, delayred, NOCOLUMNS, 
-COMMENT, DESCR, CLASS, dialup, testip, nonongreen, nodisp, noinfo, 
+tags - others are silently ignored: delayred, delayyellow, NOCOLUMNS, 
+COMMENT, DESCR, DOC, CLASS, dialup, nonongreen, nodisp, noinfo, 
 notrends, noclient, TRENDS, NOPROPRED, NOPROPYELLOW, NOPROPPURPLE, NOPROPACK, 
-REPORTTIME, WARNPCT, NET, noclear, nosslcert, ssldays, DOWNTIME, depends, 
+REPORTTIME, WARNPCT, WARNSTOPS, testip, NET, noclear, nosslcert, ssldays, DOWNTIME, depends, 
 noping, noconn, trace, notrace, HIDEHTTP, browser, pulldata. Specifically, 
 note that network tests, "badTEST" settings, and alternate pageset 
 relations cannot be listed on the ".default." host.

--- a/common/xymon-xmh.5
+++ b/common/xymon-xmh.5
@@ -62,7 +62,8 @@ in which the host is defined.
 Value of the NAME tag.
 
 .IP XMH_DOCURL
-Value of the DOC tag.
+Value of the DOC tag, with any %s conversion already substituted with
+the hostname.
 
 .IP XMH_DOWNTIME
 Value of the DOWNTIME tag.

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -347,6 +347,11 @@ becomes a formatting string for the documentation URL. E.g. for the host
 Default: Not set, so host documentation will be retrieved from the
 XYMONNOTES directory.
 
+Note: for a per-host, overridable link (shown on its own "Documentation:"
+row), use the DOC: tag in
+.I hosts.cfg(5)
+instead.
+
 .IP HOSTDESCURL
 Format string used to build a link for the description part of a
 .I hosts.cfg(5)


### PR DESCRIPTION
Document the DOC: hosts.cfg tag
Problem
DOC: is a fully-functional per-host documentation-link tag (loadhosts.c) — it supports %s→hostname substitution, inherits through the .default. host, and is exported to alert scripts as XMH_DOCURL — but it was completely absent from every man page. It was flagged as an undocumented mechanism during review of #230.

While auditing the .default. host's accepted-tag list for this, I also found WARNSTOPS: (an availability-report tag) was undocumented in hosts.cfg.5, and two entries in that list were out of order (delayyellow/delayred reversed, testip misplaced relative to where it's actually documented).

Solution
hosts.cfg.5:
Add a DOC: entry describing the tag, its %s substitution, .default. inheritance, and XMH_DOCURL export, cross-referencing HOSTDOCURL in xymonserver.cfg.5.
Add DOC and WARNSTOPS to the .default. host's accepted-tag list.
Fix delayred/delayyellow ordering and move testip next to NET, matching the order tags are documented elsewhere in the file.
Add a WARNSTOPS:count entry (previously entirely undocumented) describing the outage-count threshold.
xymon-xmh.5: note that XMH_DOCURL already has %s substituted.
xymonserver.cfg.5: cross-reference DOC: from HOSTDOCURL, global hostname-keyed template for the "Notes:" row.
No code changes — documentation only.

Testing
Clean build; testsuite 18/18; groff -man -z clean on all three edited man pages.