### PR TITLE
analysis.cfg: report the line of an invalid pattern, hint at whitespace truncation

### DIFF
--- a/lib/matching.c
+++ b/lib/matching.c
@@ -23,7 +23,13 @@ static char rcsid[] = "$Id$";
 
 #include "libxymon.h"
 
-pcre2_code *compileregex_opts(const char *pattern, uint32_t flags)
+/*
+ * As compileregex_opts(), but also hands back the pcre2 error code and offset
+ * so a caller can react to *why* a pattern failed - the message itself is
+ * still logged here, so callers only interested in that can keep using the
+ * simpler wrappers below. Both out-parameters are optional (pass NULL).
+ */
+pcre2_code *compileregex_ext(const char *pattern, uint32_t flags, int *errcode, PCRE2_SIZE *erroffset)
 {
 	pcre2_code *result;
 	char errmsg[120];
@@ -35,10 +41,20 @@ pcre2_code *compileregex_opts(const char *pattern, uint32_t flags)
 	if (result == NULL) {
 		pcre2_get_error_message(err, errmsg, sizeof(errmsg));
 		errprintf("pcre compile '%s' failed (offset %zu): %s\n", pattern, errofs, errmsg);
+		if (errcode) *errcode = err;
+		if (erroffset) *erroffset = errofs;
 		return NULL;
 	}
 
+	if (errcode) *errcode = 0;
+	if (erroffset) *erroffset = 0;
+
 	return result;
+}
+
+pcre2_code *compileregex_opts(const char *pattern, uint32_t flags)
+{
+	return compileregex_ext(pattern, flags, NULL, NULL);
 }
 
 pcre2_code *compileregex(const char *pattern)

--- a/lib/matching.h
+++ b/lib/matching.h
@@ -19,6 +19,7 @@
 
 extern pcre2_code *compileregex(const char *pattern);
 extern pcre2_code *compileregex_opts(const char *pattern, uint32_t flags);
+extern pcre2_code *compileregex_ext(const char *pattern, uint32_t flags, int *errcode, PCRE2_SIZE *erroffset);
 #ifdef PCRE_FIRSTLINE
 #define firstlineregex(P) compileregex_opts(P, PCRE_FIRSTLINE);
 #define firstlineregexnocase(P) compileregex_opts(P, PCRE_CASELESS|PCRE_FIRSTLINE);

--- a/tests/server/analysis-pattern-error-context.sh
+++ b/tests/server/analysis-pattern-error-context.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/analysis-pattern-error-context.sh
+#
+# Regression guard for the diagnostics emitted when a %pattern in analysis.cfg
+# fails to compile (#253).
+#
+# Two things are pinned here.
+#
+# 1. Location. The pcre error alone printed only the (possibly truncated)
+#    pattern, so an operator saw the same context-free line in clientdata.log,
+#    rrd-data.log and rrd-status.log with nothing saying which config line
+#    produced it. The parser now adds "at line N", following the convention
+#    already used by the neighbouring syntax errors.
+#
+# 2. The whitespace hint, and its gate. analysis.cfg is tokenized on
+#    whitespace, so a pattern written with a literal space is silently cut at
+#    the space; when the cut lands inside a group or a character class the
+#    remnant fails to compile. That specific cause gets a hint pointing at
+#    [[:space:]]. The gate is pcre2's own error code -- MISSING_CLOSING_
+#    PARENTHESIS / MISSING_SQUARE_BRACKET -- not a scan of the pattern text,
+#    because counting delimiters cannot tell a group from a class literal.
+#
+# The fixture is four PROC rules, one per line, so the asserted line numbers
+# are also a check that the parser reports the right one:
+#
+#   line 1  %(Synchronization Failed        truncated at the space -> hint
+#   line 2  %bad{2,1}proc                   invalid on its own merits -> no hint
+#   line 3  %[(]{2,1}                       '(' is a class literal, and the
+#                                           failure is the quantifier -> no hint
+#   line 4  %Synchronization[[:space:]]...  the supported spelling -> silent
+#
+# Line 3 is the case a delimiter-counting scanner gets wrong: it sees one
+# unmatched '(' and offers the whitespace hint for a pattern that contains no
+# whitespace at all. Line 4 keeps the whole thing honest -- without it, a
+# parser that rejected every pattern would still pass lines 1-3.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+# Drives the built server-side client-data processor. Skips if unbuilt; a
+# CMake/autopkgtest caller that exports XYMOND_CLIENT to a real path makes a
+# dangling path a failure rather than a skip (see require_bin).
+require_bin XYMOND_CLIENT xymond/xymond_client
+
+work=$(mktempdir)
+
+# No comment or blank lines: the parser counts every physical line, so the
+# fixture's own numbering is what the assertions below expect.
+cat >"$work/analysis.cfg" <<'EOF'
+PROC %(Synchronization Failed 1 99 red
+PROC %bad{2,1}proc 1 99 red
+PROC %[(]{2,1} 1 99 red
+PROC %Synchronization[[:space:]]Failed 1 99 red
+EOF
+
+# Diagnostics go to stderr (errprintf); the dump itself goes to stdout and is
+# not what this test is about.
+"$XYMOND_CLIENT" --config="$work/analysis.cfg" --dump-config >/dev/null 2>"$work/err" \
+	|| fail "xymond_client --dump-config exited non-zero: $(cat "$work/err")"
+
+errs=$(cat "$work/err")
+
+trunc_line=$(printf '%s\n' "$errs" | grep -F "Invalid pattern '%(Synchronization'") || true
+quant_line=$(printf '%s\n' "$errs" | grep -F "Invalid pattern '%bad{2,1}proc'")     || true
+class_line=$(printf '%s\n' "$errs" | grep -F "Invalid pattern '%[(]{2,1}'")         || true
+
+[ -n "$trunc_line" ] || fail "no diagnostic for the space-truncated pattern: $errs"
+[ -n "$quant_line" ] || fail "no diagnostic for the invalid quantifier pattern: $errs"
+[ -n "$class_line" ] || fail "no diagnostic for the class-literal pattern: $errs"
+
+# (1) Every diagnostic names the config line it came from -- the point of #253.
+assert_contains "at line 1" "$trunc_line" \
+	"invalid pattern on line 1 is not reported with its config line"
+assert_contains "at line 2" "$quant_line" \
+	"invalid pattern on line 2 is not reported with its config line"
+assert_contains "at line 3" "$class_line" \
+	"invalid pattern on line 3 is not reported with its config line"
+
+# (2) The hint fires for a pattern actually truncated at a space.
+assert_contains "[[:space:]]" "$trunc_line" \
+	"a pattern truncated at a space no longer suggests [[:space:]]"
+
+# (3) ...and only then. A pattern that is invalid for an unrelated reason gets
+# the location and nothing else.
+assert_not_contains "hint" "$quant_line" \
+	"whitespace hint offered for '%bad{2,1}proc', which contains no whitespace"
+
+# (4) The regression the delimiter-counting version had: '(' inside a class is
+# a literal, and this pattern fails on its quantifier, not on an open group.
+assert_not_contains "hint" "$class_line" \
+	"whitespace hint offered for '%[(]{2,1}' -- '(' inside [] counted as an unclosed group"
+
+# (5) The supported spelling compiles, so nothing at all is reported for it.
+# This also proves (1)-(4) are not passing because every pattern is rejected.
+assert_not_contains "Synchronization[[:space:]]Failed" "$errs" \
+	"a valid [[:space:]] pattern produced a diagnostic"
+
+count=$(printf '%s\n' "$errs" | grep -c "Invalid pattern" || true)
+assert_equal "3" "$count" \
+	"expected exactly 3 invalid-pattern diagnostics from a 4-line config, got $count"
+
+pass "invalid analysis.cfg patterns report their config line, and the whitespace hint is gated on pcre2's error code (#253)"

--- a/xymond/client_config.c
+++ b/xymond/client_config.c
@@ -405,6 +405,10 @@ static ruleset_t *ruleset(char *hostname, char *pagename, char *classname)
 	return head;
 }
 
+/* Line currently being parsed by load_client_config(), so pattern-compile
+ * errors can report where the bad pattern came from. */
+static int curparseline = 0;
+
 static exprlist_t *setup_expr(char *ptn, int multiline)
 {
 	exprlist_t *newitem = (exprlist_t *)calloc(1, sizeof(exprlist_t));
@@ -415,6 +419,26 @@ static exprlist_t *setup_expr(char *ptn, int multiline)
 			newitem->exp = multilineregex(ptn+1);
 		else
 			newitem->exp = compileregex(ptn+1);
+		if (newitem->exp == NULL) {
+			/* compileregex() logged the pcre error, but without saying
+			 * where the pattern came from. A common cause is a pattern
+			 * containing a space: the config is tokenized on whitespace,
+			 * so the pattern gets truncated mid-way - which usually
+			 * shows up as unbalanced parentheses or brackets. */
+			int i, parens = 0, brackets = 0;
+			for (i = 0; ptn[i]; i++) {
+				switch (ptn[i]) {
+				  case '\\': if (ptn[i+1]) i++; break;
+				  case '(': parens++; break;
+				  case ')': parens--; break;
+				  case '[': brackets++; break;
+				  case ']': brackets--; break;
+				}
+			}
+			errprintf("Invalid pattern '%s' at line %d%s\n", ptn, curparseline,
+				  ((parens != 0) || (brackets != 0)) ?
+				  " (hint: if the pattern contains a space, the config splits tokens on whitespace - write [[:space:]] instead)" : "");
+		}
 	}
 	newitem->next = exprhead;
 	exprhead = newitem;
@@ -626,7 +650,7 @@ int load_client_config(char *configfn)
 		char *newtime, *newextime, *newtext, *newgroup;
 		int unknowntok = 0;
 
-		cfid++;
+		cfid++; curparseline = cfid;
 		sanitize_input(inbuf, 1, 0); if (STRBUFLEN(inbuf) == 0) continue;
 
 		newhost = newpage = newexhost = newexpage = newclass = newexclass = newdg = newexdg = NULL;

--- a/xymond/client_config.c
+++ b/xymond/client_config.c
@@ -405,16 +405,39 @@ static ruleset_t *ruleset(char *hostname, char *pagename, char *classname)
 	return head;
 }
 
+/* Line currently being parsed by load_client_config(), so pattern-compile
+ * errors can report where the bad pattern came from. */
+static int curparseline = 0;
+
 static exprlist_t *setup_expr(char *ptn, int multiline)
 {
 	exprlist_t *newitem = (exprlist_t *)calloc(1, sizeof(exprlist_t));
 
 	newitem->pattern = strdup(ptn);
 	if (*ptn == '%') {
-		if (multiline)
-			newitem->exp = multilineregex(ptn+1);
-		else
-			newitem->exp = compileregex(ptn+1);
+		/* Same flags as compileregex()/multilineregex(), but we ask for the
+		 * pcre2 error code so a truncated pattern can be told apart from one
+		 * that is simply wrong. */
+		int errcode = 0;
+		int truncated;
+
+		newitem->exp = compileregex_ext(ptn+1, PCRE2_CASELESS | (multiline ? PCRE2_MULTILINE : 0),
+						&errcode, NULL);
+		if (newitem->exp == NULL) {
+			/* compileregex_ext() logged the pcre error, but without saying
+			 * where the pattern came from. A common cause is a pattern
+			 * containing a space: the config is tokenized on whitespace, so
+			 * the pattern is silently truncated at the space - and when the
+			 * cut lands inside a group or a character class, pcre2 reports
+			 * exactly one of these two errors. Any other failure is the
+			 * pattern's own doing, so it gets the location only. */
+			truncated = ((errcode == PCRE2_ERROR_MISSING_CLOSING_PARENTHESIS) ||
+				     (errcode == PCRE2_ERROR_MISSING_SQUARE_BRACKET));
+
+			errprintf("Invalid pattern '%s' at line %d%s\n", ptn, curparseline,
+				  (truncated ?
+				   " (hint: if the pattern contains a space, the config splits tokens on whitespace - write [[:space:]] instead)" : ""));
+		}
 	}
 	newitem->next = exprhead;
 	exprhead = newitem;
@@ -627,6 +650,7 @@ int load_client_config(char *configfn)
 		int unknowntok = 0;
 
 		cfid++;
+		curparseline = cfid;
 		sanitize_input(inbuf, 1, 0); if (STRBUFLEN(inbuf) == 0) continue;
 
 		newhost = newpage = newexhost = newexpage = newclass = newexclass = newdg = newexdg = NULL;


### PR DESCRIPTION
Follow-up to #253 (resolved by hand there, but the errors were un-diagnosable for days): make pattern-compile failures self-locating. The whitespace-truncation grammar limitation behind it is tracked in #256; the DS-only-parsing question in #254 stays open (recommended home: #218).

When a `%pattern` in analysis.cfg fails to compile, the pcre error printed only the (possibly truncated) pattern — no file, no line. And because every process that loads analysis.cfg compiles all patterns, the same error lands in `clientdata.log`, `rrd-data.log` and `rrd-status.log`, which made #253 look like an RRD problem.

This PR:

- **`lib/matching.c`** — adds `compileregex_ext()`, which is `compileregex_opts()` plus optional out-parameters for the pcre2 error code and offset; `compileregex_opts()` becomes a call through it. Both out-parameters take NULL, so no existing caller changes and the message is still formatted in one place. (`xymond/rrd/do_disk.c` and `web/showgraph.c` currently call `pcre2_compile()` directly for the same reason — not converted here.)
- **`xymond/client_config.c`** — prints the config line next to the pcre error (`Invalid pattern '%(Synchronization' at line 2 ...`), following the parser's existing "at line %d" convention; and when pcre2 reports `MISSING_CLOSING_PARENTHESIS` or `MISSING_SQUARE_BRACKET`, adds a hint about the usual cause — the config tokenizes on whitespace, so a pattern written with a literal space is silently truncated, and `[[:space:]]` is the supported spelling. Any other compile error gets the location only.

Gating on pcre2's own error code rather than scanning the pattern text is what @SoundGoof's review asked for, and the counterexample is real: `%[(]{2,1}` contains no whitespace and fails on its quantifier, but a delimiter-counting scan sees one unmatched `(` (it is a class literal) and offers the whitespace hint. Verified against pcre2 directly:

```
FAIL  (Synchronization   err=114  missing closing parenthesis
FAIL  bad{2,1}proc       err=104  numbers out of order in {} quantifier
FAIL  [(]{2,1}           err=104  numbers out of order in {} quantifier
FAIL  foo[a-z            err=106  missing terminating ] for character class
OK    [[:space:]]foo
```

With this, the #253 scenario is self-diagnosing:

```
pcre compile '(Synchronization' failed (offset 16): missing closing parenthesis
Invalid pattern '%(Synchronization' at line 1 (hint: if the pattern contains a space, the config splits tokens on whitespace - write [[:space:]] instead)
pcre compile 'bad{2,1}proc' failed (offset 7): numbers out of order in {} quantifier
Invalid pattern '%bad{2,1}proc' at line 2
pcre compile '[(]{2,1}' failed (offset 7): numbers out of order in {} quantifier
Invalid pattern '%[(]{2,1}' at line 3
```

(line 4 of that fixture is `%Synchronization[[:space:]]Failed` — the supported spelling — and is silent.)

`tests/server/analysis-pattern-error-context.sh` pins all four cases through `xymond_client --dump-config`. It fails against `main` (no location at all) and against the first revision of this PR (false hint on `%[(]{2,1}`). Full suite: 51 passed, 3 skipped, 0 failed.

Two caveats worth stating rather than hiding:

- The reported number is the parser's running line count, and `stackfgets()` follows `include` transparently, so with an included analysis.cfg it spans files instead of restarting per file. That is the same caveat the neighbouring `Syntax error line %d` / `Unknown token ... at line %d` messages already carry; giving `stackio` a current-filename accessor is a separate change.
- A `LOG ... match=%pattern` rule calls `setup_expr()` twice (multiline + single-line), so a bad pattern there is reported twice. Pre-existing — the pcre error was already doubled — and untouched here.

The architectural point in #254 (rrd modules loading all rule types) is left alone deliberately — that belongs to the unified-rule-engine work in #218 rather than a DS-only parse path.
