### PR TITLE
build/rrd.sh: explain the NetBSD no-X11 RRDtool link failure (#70)

### DIFF
--- a/build/rrd.sh
+++ b/build/rrd.sh
@@ -170,6 +170,18 @@ PROBE
 		fi
 	else
 		echo "ERROR: Linking with RRDtool fails"
+		if test "`uname -s`" = "NetBSD" -a ! -f /usr/X11R7/lib/libfontconfig.so.2
+		then
+			echo ""
+			echo "NOTE: On NetBSD, the pre-built rrdtool package links against the base"
+			echo "X11 sets in /usr/X11R7 (e.g. libfontconfig.so.2). These are not present"
+			echo "on systems installed without X11, and pkg_add cannot provide them."
+			echo "Install the xbase set - no reinstall needed:"
+			echo "  ftp https://cdn.netbsd.org/pub/NetBSD/NetBSD-`uname -r`/`uname -m`/binary/sets/xbase.tar.xz"
+			echo "  tar -xJpf xbase.tar.xz -C /"
+			echo "See https://github.com/xymon-monitoring/xymon/issues/70 for details."
+			echo ""
+		fi
 		RRDOK="NO"
 	fi
 	OS=`uname -s | sed -e's@/@_@g'` $MAKE -f Makefile.test-rrd clean

--- a/docs/install.html.DIST
+++ b/docs/install.html.DIST
@@ -88,7 +88,16 @@ files installed as well. Often these are in packages called "something<em>-dev</
 	use one of these - many Linux- and *BSD-systems have pre-packaged
 	versions of it.<br>
 	Note that RRDtool requires various graphics-libraries. RRDtool 1.2.x uses
-	libpng, newer versions rely on the Cairo graphics library.</li>
+	libpng, newer versions rely on the Cairo graphics library.<br>
+	<em>NetBSD:</em> the pre-built rrdtool package links against the base X11
+	sets in <tt>/usr/X11R7</tt> (e.g. <tt>libfontconfig.so.2</tt>). These are
+	not present on systems installed without X11, and cannot be added with
+	pkg_add. Install the xbase set - no reinstall needed (adjust release and
+	architecture):<br>
+	<tt>ftp https://cdn.netbsd.org/pub/NetBSD/NetBSD-10.1/amd64/binary/sets/xbase.tar.xz</tt><br>
+	<tt>tar -xJpf xbase.tar.xz -C /</tt><br>
+	Without it, the RRDtool link test fails and Xymon builds with trend-graph
+	support disabled.</li>
 
 	<li>OpenSSL is a library for communicating with network services, that
 	use SSL encryption - e.g. secure websites. Although this library is


### PR DESCRIPTION
Closes #70.

On NetBSD, the pre-built `rrdtool` package is compiled against the base X11 sets (`X11_TYPE=native`), so librrd's dependency chain references `/usr/X11R7/lib` libraries such as `libfontconfig.so.2`. On systems installed without X11 those libraries do not exist and cannot be added with `pkg_add` (pkgsrc's fontconfig deliberately ships a different soname, `libfontconfig.so.1`). The RRDtool link probe then fails and Xymon silently builds with trend-graph support disabled — the failure mode Roland documented in #70.

## Change

- **`build/rrd.sh`**: when the link test fails on NetBSD and `/usr/X11R7/lib/libfontconfig.so.2` is missing, print why and the exact fix — fetch the `xbase.tar.xz` set for the running release/arch (URL built from `uname -r`/`uname -m`) and extract it over `/`. No reinstall needed. Other platforms are unaffected; the hint is gated on `uname -s` = NetBSD plus the missing file.
- **`docs/install.html.DIST`**: document the same prerequisite in the install guide's RRDtool bullet.

## Validation

Reproduced and fixed end-to-end on a NetBSD 10.1 x86-64 VM in CI ([run](https://github.com/bonomani/xymon/actions/runs/29530091021), one-off workflow kept out of this PR):

1. Baseline: the VM image ships `/usr/X11R7/lib/libfontconfig.so.2`.
2. `rm -rf /usr/X11R7` (simulates an X11-less server install), then `sh build/rrd.sh`: `Compiling with RRDtool works OK` + `ERROR: Linking with RRDtool fails` — the exact #70 symptom — followed by the new NOTE with the resolved URL `https://cdn.netbsd.org/pub/NetBSD/NetBSD-10.1/amd64/binary/sets/xbase.tar.xz`.
3. Applied the hint verbatim (`ftp` + `tar -xJpf xbase.tar.xz -C /`).
4. Re-ran the probe: `Linking with RRDtool works OK`.

Also: `sh -n build/rrd.sh` clean; the hint block verified suppressed on non-NetBSD systems.
