### PR TITLE
xymonnet: remove the legacy SNTP/SNTPOPTS external call-out (#199)

### DIFF
--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -1019,7 +1019,8 @@ test to end up with a green status, all lookups must succeed.
 Check for a running NTP (Network Time Protocol) server on this
 host. By default this uses a built-in SNTP probe and needs no external
 program. Set NTPDATE to the ntpdate program (on ntpsec, "ntpdig") to use
-that instead.
+that instead, and adapt NTPDATEOPTS to the chosen client (its default is
+ntpdate syntax).
 
 .IP "\fBrpc\fR[=\fIrpcservice1\fR,\fIrpcservice2\fR,...]"
 Check for one or more available RPC services. This check is indirect

--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -712,8 +712,10 @@ no external program. On ntpsec, where ntpdate is unavailable, set this to "ntpdi
 Default: "" (built-in probe)
 
 .IP "\fBNTPDATEOPTS\fR"
-Options for the ntpdate program (used only when NTPDATE is set).
+Options for the NTPDATE program (used only when NTPDATE is set).
 Default: "\-u \-q"
+The default is ntpdate syntax; when NTPDATE is set to a different client
+(such as "ntpdig"), clear or adapt these options to ones that client accepts.
 
 .IP "\fBRPCINFO\fR"
 Defines the

--- a/docs/manpages/man1/xymonnet.1.html
+++ b/docs/manpages/man1/xymonnet.1.html
@@ -82,10 +82,10 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
   </dd>
   <dt id="cmdtimeout"><a class="permalink" href="#cmdtimeout"><b>--cmdtimeout</b>=<i>N</i></a></dt>
   <dd>This option sets a timeout for the external commands used by the RPC and
-      traceroute tests and by the external NTP backends (ntpdate/sntp). The
-      built-in NTP probe is not governed by it: the probe bounds itself with a
-      short, fixed retransmission budget (a few attempts), so it can never hang
-      and does not need an external kill timer.
+      traceroute tests and by the external NTP backend (NTPDATE). The built-in
+      NTP probe is not governed by it: the probe bounds itself with a short,
+      fixed retransmission budget (a few attempts), so it can never hang and
+      does not need an external kill timer.
     <p class="Pp"></p>
   </dd>
   <dt id="concurrency"><a class="permalink" href="#concurrency"><b>--concurrency</b>=<i>N</i></a></dt>
@@ -619,22 +619,25 @@ Example:
     <p class="Pp"></p>
   </dd>
   <dt id="NTPDATE"><a class="permalink" href="#NTPDATE"><b>NTPDATE</b></a></dt>
-  <dd>Path to the external ntpdate program for the &quot;ntp&quot; service; the
-      target IP is appended. Empty (the default) selects the built-in SNTP
-      probe. On ntpsec, where ntpdate is unavailable, set this to
-      &quot;ntpdig&quot;.</dd>
+  <dd>Path to an external NTP client for the &quot;ntp&quot; service; the target
+      IP is appended. Empty (the default) selects the built-in SNTP probe. On
+      ntpsec, where ntpdate is unavailable, set this to &quot;ntpdig&quot;.</dd>
   <dt id="NTPDATEOPTS"><a class="permalink" href="#NTPDATEOPTS"><b>NTPDATEOPTS</b></a></dt>
-  <dd>Options passed to the ntpdate program (used only when NTPDATE is set).
-      Default: &quot;-u -q&quot;.
-    <p class="Pp"></p>
-  </dd>
-  <dt id="SNTP"><a class="permalink" href="#SNTP"><b>SNTP</b></a></dt>
-  <dd>Location of the <i>sntp(1)</i> utility. A legacy, explicitly-set SNTP
-      forces sntp for the &quot;ntp&quot; service.</dd>
-  <dt id="SNTPOPTS"><a class="permalink" href="#SNTPOPTS"><b>SNTPOPTS</b></a></dt>
-  <dd>Options passed to the <i>sntp(1)</i> utility. Default: &quot;-u&quot;.
-    <p class="Pp"></p>
-  </dd>
+  <dd>Options passed to the NTPDATE program (used only when NTPDATE is set).
+      Default: &quot;-u -q&quot;. The default is ntpdate syntax; when NTPDATE is
+      set to a different client (such as &quot;ntpdig&quot;), clear or adapt
+      these options to ones that client accepts.</dd>
+</dl>
+<p class="Pp">Note: the legacy SNTP and SNTPOPTS variables (an external
+    msntp/sntp call-out for the &quot;ntp&quot; service) have been removed; the
+    invocation predated current sntp implementations and no longer worked with
+    any of them. Use the built-in probe (the default), or set NTPDATE to an
+    external client such as &quot;ntpdig&quot;, &quot;sntp&quot; or
+    &quot;msntp&quot;, adjusting NTPDATEOPTS to options that client accepts.
+    Only the built-in probe and ntpdate-style &quot;offset&quot; output feed the
+    ntp graph; other clients' output is not parsed (see <a href="../man8/xymond_rrd.8.html">xymond_rrd</a>(8)).</p>
+<p class="Pp"></p>
+<dl class="Bl-tag">
   <dt id="RPCINFO"><a class="permalink" href="#RPCINFO"><b>RPCINFO</b></a></dt>
   <dd>Location of the <i>rpcinfo(8)</i> utility. Used by xymonnet for the
       &quot;rpc&quot; service checks.

--- a/docs/manpages/man5/hosts.cfg.5.html
+++ b/docs/manpages/man5/hosts.cfg.5.html
@@ -1108,7 +1108,8 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
   <dd>Check for a running NTP (Network Time Protocol) server on this host. By
       default this uses a built-in SNTP probe and needs no external program. Set
       NTPDATE to the ntpdate program (on ntpsec, &quot;ntpdig&quot;) to use that
-      instead.
+      instead, and adapt NTPDATEOPTS to the chosen client (its default is
+      ntpdate syntax).
     <p class="Pp"></p>
   </dd>
   <dt id="rpc"><a class="permalink" href="#rpc"><b>rpc</b>[=<i>rpcservice1</i>,<i>rpcservice2</i>,...]</a></dt>

--- a/docs/manpages/man5/xymonserver.cfg.5.html
+++ b/docs/manpages/man5/xymonserver.cfg.5.html
@@ -827,8 +827,10 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <p class="Pp"></p>
   </dd>
   <dt id="NTPDATEOPTS"><a class="permalink" href="#NTPDATEOPTS"><b>NTPDATEOPTS</b></a></dt>
-  <dd>Options for the ntpdate program (used only when NTPDATE is set). Default:
-      &quot;-u -q&quot;
+  <dd>Options for the NTPDATE program (used only when NTPDATE is set). Default:
+      &quot;-u -q&quot; The default is ntpdate syntax; when NTPDATE is set to a
+      different client (such as &quot;ntpdig&quot;), clear or adapt these
+      options to ones that client accepts.
     <p class="Pp"></p>
   </dd>
   <dt id="RPCINFO"><a class="permalink" href="#RPCINFO"><b>RPCINFO</b></a></dt>

--- a/docs/manpages/man8/xymond_rrd.8.html
+++ b/docs/manpages/man8/xymond_rrd.8.html
@@ -238,9 +238,10 @@ Section: Maintenance Commands (8)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a
   <dt id="ntp"><a class="permalink" href="#ntp"><b>ntp</b></a></dt>
   <dd>Tracks the clock offset between the local system and an NTP server,
       together with the RFC 5905 root distance (the &quot;+/-&quot; accuracy
-      bound), as measured by the built-in SNTP probe in xymonnet (or by an
-      external &quot;ntpdate&quot;/&quot;sntp&quot; command). The graph plots
-      the offset with the root distance as an error band.
+      bound), as measured by the built-in SNTP probe in xymonnet or by an
+      external ntpdate command (NTPDATE). Output from other external NTP clients
+      (sntp, ntpdig) is not parsed, so no ntp data is recorded when they are
+      used. The graph plots the offset with the root distance as an error band.
     <p class="Pp"></p>
   </dd>
   <dt id="citrix"><a class="permalink" href="#citrix"><b>citrix</b></a></dt>

--- a/lib/environ.c
+++ b/lib/environ.c
@@ -103,8 +103,6 @@ const static struct {
 	{ "NONETPAGE", "" },
 	{ "FPING", "xymonping" },
 	{ "FPINGOPTS", "-Ae" },
-	{ "SNTP", "sntp" },
-	{ "SNTPOPTS", "-u" },
 	{ "NTPDATE", "" },		/* ntpdate program; empty = built-in SNTP probe */
 	{ "NTPDATEOPTS", "-u -q" },
 	{ "TRACEROUTE", "traceroute" },

--- a/tests/rrd/ntp-offset-parse-harness.c
+++ b/tests/rrd/ntp-offset-parse-harness.c
@@ -6,11 +6,13 @@
  * and do_ntpstat.c - the same way xymond/do_rrd.c #includes them, with the RRD
  * plumbing stubbed so the values that WOULD be written to ntp.rrd are captured.
  *
- * Pins, across all three backends, that the clock offset is parsed and stored in
+ * Pins, across both backends, that the clock offset is parsed and stored in
  * milliseconds (seconds x 1000):
  *   - the built-in SNTP probe banner  ("... offset +0.001234 +/- 0.005678 sec ...")
  *   - ntpdate                          ("... offset -0.040324, delay ...")
- *   - sntp                             ("... + 0.038766 +/- 0.052900 secs")
+ * and that standalone sntp/ntpdig output records nothing (the external sntp
+ * call-out and its " secs" parser were removed - issue #199; the parser never
+ * matched any real tool output anyway),
  * plus that the probe's "+/-" root distance is recorded as the 2nd DS ("U" when a
  * backend omits it), and that do_ntpstat parses "offset=" even at the very start
  * of the message (the #183 out-of-bounds-read case) without scaling its ms value.
@@ -76,12 +78,12 @@ int main(void)
 	check("ntpdate",
 	      record_ntp("server 1.2.3.4, stratum 3, offset -0.040324, delay 0.02568\n"),
 	      -40.324);
-	/* sntp: "<date> <time> <sign> <offset> +/- <err> secs" (the parser reads the
-	 * date/time as the first two whitespace tokens and requires "secs" as the last,
-	 * so an ISO date stays one token and there is no trailing newline). */
-	check("sntp",
-	      record_ntp("2009-11-13 11:29:10.000313 + 0.038766 +/- 0.052900 secs"),
-	      38.766);
+	/* The external sntp call-out was removed (#199): its " secs" output style,
+	 * old or modern, must not be recorded as an offset. */
+	check("legacy msntp-style output -> nothing recorded",
+	      record_ntp("2009 Nov 13 11:29:10.000313 + 0.038766 +/- 0.052900 secs") == NO_RECORD ? 0.0 : 1.0, 0.0);
+	check("modern sntp/ntpdig output -> nothing recorded",
+	      record_ntp("2026-07-16 21:00:00.123456 (+0000) +0.591 +/- 0.902 h1 192.0.2.1 s2 no-leap") == NO_RECORD ? 0.0 : 1.0, 0.0);
 	check("no offset -> nothing recorded",
 	      record_ntp("server 1.2.3.4 is unreachable\n") == NO_RECORD ? 0.0 : 1.0, 0.0);
 	/* A non-numeric "offset" token must be skipped, not silently recorded as 0:

--- a/tests/rrd/ntp-offset-parse.sh
+++ b/tests/rrd/ntp-offset-parse.sh
@@ -4,8 +4,8 @@
 # tests/rrd/ntp-offset-parse.sh
 #
 # Compiles and runs ntp-offset-parse-harness.c, which drives the real do_net.c +
-# do_ntpstat.c offset parsing for the "ntp" test across the three backends
-# (built-in probe banner, ntpdate, sntp) and the do_ntpstat "offset=" path, with
+# do_ntpstat.c offset parsing for the "ntp" test across both backends
+# (built-in probe banner, ntpdate) and the do_ntpstat "offset=" path, with
 # the RRD plumbing stubbed. Fails if any offset is parsed or scaled wrongly.
 
 set -euo pipefail

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -138,7 +138,7 @@ FPINGOPTS="-Ae"					# Standard options to fping/xymonping
 # is appended); empty selects the built-in probe. On ntpsec, where ntpdate is
 # unavailable, set NTPDATE="ntpdig".
 #NTPDATE="ntpdate"				# ntpdate program; empty = built-in probe
-NTPDATEOPTS="-u -q"				# Options for ntpdate (-p deprecated)
+NTPDATEOPTS="-u -q"				# ntpdate syntax; clear/adapt if NTPDATE is another client (e.g. ntpdig)
 TRACEROUTE="traceroute"                         # How to do traceroute on failing ping tests. Requires "trace" in hosts.cfg .
 TRACEROUTEOPTS="-n -q 2 -w 2 -m 15"		# Standard options to traceroute
 XYMONROUTERTEXT="router"			# What to call a failing intermediate network device.

--- a/xymond/rrd/do_net.c
+++ b/xymond/rrd/do_net.c
@@ -87,9 +87,7 @@ int do_net_rrd(char *hostname, char *testname, char *classname, char *pagepaths,
 	}
 	else if (strcmp(testname, "ntp") == 0) {
 		/*
-		 * sntp output: 
-		 *    2009 Nov 13 11:29:10.000313 + 0.038766 +/- 0.052900 secs
-		 * ntpdate output: 
+		 * ntpdate output:
 		 *    server 172.16.10.2, stratum 3, offset -0.040324, delay 0.02568
 		 *    13 Nov 11:29:06 ntpdate[7038]: adjust time server 172.16.10.2 offset -0.040324 sec
 		 * built-in SNTP probe banner:
@@ -101,7 +99,6 @@ int do_net_rrd(char *hostname, char *testname, char *classname, char *pagepaths,
 		static void *ntp_tpl = NULL;
 
 		char *offsetval = NULL;
-		char offsetbuf[40];
 		char rdbuf[24];
 		double rootdist_ms = -1.0;
 		char *msgcopy = strdup(msg);
@@ -112,28 +109,7 @@ int do_net_rrd(char *hostname, char *testname, char *classname, char *pagepaths,
 			/* ntpdate and the built-in SNTP probe both report "offset <seconds>". */
 			offsetval = strtok(p + 7, " \r\n\t");
 		}
-		else if (strstr(msgcopy, " secs") != NULL) {
-			/* Probably new "sntp" output */
-			char *year, *tm, *offsetdirection, *offset, *plusminus, *errorbound, *secs;
 
-			tm = offsetdirection = plusminus = errorbound = secs = NULL;
-			year = strtok(msgcopy, " ");
-			tm = year ? strtok(NULL, " ") : NULL;
-			offsetdirection = tm ? strtok(NULL, " ") : NULL;
-			offset = offsetdirection ? strtok(NULL, " ") : NULL;
-			plusminus = offset ? strtok(NULL, " ") : NULL;
-			errorbound = plusminus ? strtok(NULL, " ") : NULL;
-			secs = errorbound ? strtok(NULL, " ") : NULL;
-
-			if ( offsetdirection && ((strcmp(offsetdirection, "+") == 0) || (strcmp(offsetdirection, "-") == 0)) &&
-			     plusminus && (strcmp(plusminus, "+/-") == 0) && 
-			     secs && (strcmp(secs, "secs") == 0) ) {
-				/* Looks sane */
-				snprintf(offsetbuf, sizeof(offsetbuf), "%s%s", offsetdirection, offset);
-				offsetval = offsetbuf;
-			}
-		}
-		
 		/* The built-in probe banner also carries the "+/-" root distance - the RFC
 		 * 5905 accuracy bound (which folds in root dispersion). Record it next to
 		 * the offset so the graph can draw offset +/- rootdist. ntpdate omits it, so

--- a/xymond/xymond_rrd.8
+++ b/xymond/xymond_rrd.8
@@ -182,8 +182,10 @@ Xymon contrib/ directory.
 .IP "\fBntp\fR"
 Tracks the clock offset between the local system and an NTP server,
 together with the RFC 5905 root distance (the "+/\-" accuracy bound),
-as measured by the built\-in SNTP probe in xymonnet (or by an external
-"ntpdate"/"sntp" command). The graph plots the offset with the root
+as measured by the built\-in SNTP probe in xymonnet or by an external
+ntpdate command (NTPDATE). Output from other external NTP clients
+(sntp, ntpdig) is not parsed, so no ntp data is recorded when they are
+used. The graph plots the offset with the root
 distance as an error band.
 
 .IP "\fBcitrix\fR"

--- a/xymonnet/xymonnet.1
+++ b/xymonnet/xymonnet.1
@@ -67,7 +67,7 @@ This option is deprecated, and will be ignored. Use the
 
 .IP \-\-cmdtimeout=N
 This option sets a timeout for the external commands used by the RPC and
-traceroute tests and by the external NTP backends (ntpdate/sntp). The
+traceroute tests and by the external NTP backend (NTPDATE). The
 built-in NTP probe is not governed by it: the probe bounds itself with a
 short, fixed retransmission budget (a few attempts), so it can never hang
 and does not need an external kill timer.
@@ -556,21 +556,18 @@ Optionally used when a connectivity test fails to pinpoint the
 network location that is causing the failure.
 
 .IP NTPDATE
-Path to the external ntpdate program for the "ntp" service; the target IP is
+Path to an external NTP client for the "ntp" service; the target IP is
 appended. Empty (the default) selects the built-in SNTP probe. On ntpsec, where
 ntpdate is unavailable, set this to "ntpdig".
 .IP NTPDATEOPTS
-Options passed to the ntpdate program (used only when NTPDATE is set).
+Options passed to the NTPDATE program (used only when NTPDATE is set).
 Default: "\-u \-q".
-
-.IP SNTP
-Location of the
-.I sntp(1)
-utility. A legacy, explicitly-set SNTP forces sntp for the "ntp" service.
-.IP SNTPOPTS
-Options passed to the
-.I sntp(1)
-utility. Default: "\-u".
+.PP
+Note: the legacy SNTP and SNTPOPTS variables (an external msntp/sntp call-out
+for the "ntp" service) have been removed; the invocation predated current sntp
+implementations and no longer worked with any of them. Use the built-in probe
+(the default), or set NTPDATE to an external client such as "ntpdig", "sntp"
+or "msntp".
 
 .IP RPCINFO
 Location of the 

--- a/xymonnet/xymonnet.1
+++ b/xymonnet/xymonnet.1
@@ -67,7 +67,7 @@ This option is deprecated, and will be ignored. Use the
 
 .IP "\fB\-\-cmdtimeout\fR=\fIN\fR"
 This option sets a timeout for the external commands used by the RPC and
-traceroute tests and by the external NTP backends (ntpdate/sntp). The
+traceroute tests and by the external NTP backend (NTPDATE). The
 built-in NTP probe is not governed by it: the probe bounds itself with a
 short, fixed retransmission budget (a few attempts), so it can never hang
 and does not need an external kill timer.
@@ -556,21 +556,22 @@ Optionally used when a connectivity test fails to pinpoint the
 network location that is causing the failure.
 
 .IP "\fBNTPDATE\fR"
-Path to the external ntpdate program for the "ntp" service; the target IP is
+Path to an external NTP client for the "ntp" service; the target IP is
 appended. Empty (the default) selects the built-in SNTP probe. On ntpsec, where
 ntpdate is unavailable, set this to "ntpdig".
 .IP "\fBNTPDATEOPTS\fR"
-Options passed to the ntpdate program (used only when NTPDATE is set).
+Options passed to the NTPDATE program (used only when NTPDATE is set).
 Default: "\-u \-q".
-
-.IP "\fBSNTP\fR"
-Location of the
-.I sntp(1)
-utility. A legacy, explicitly-set SNTP forces sntp for the "ntp" service.
-.IP "\fBSNTPOPTS\fR"
-Options passed to the
-.I sntp(1)
-utility. Default: "\-u".
+The default is ntpdate syntax; when NTPDATE is set to a different client
+(such as "ntpdig"), clear or adapt these options to ones that client accepts.
+.PP
+Note: the legacy SNTP and SNTPOPTS variables (an external msntp/sntp call-out
+for the "ntp" service) have been removed; the invocation predated current sntp
+implementations and no longer worked with any of them. Use the built-in probe
+(the default), or set NTPDATE to an external client such as "ntpdig", "sntp"
+or "msntp", adjusting NTPDATEOPTS to options that client accepts. Only the
+built-in probe and ntpdate-style "offset" output feed the ntp graph; other
+clients' output is not parsed (see xymond_rrd(8)).
 
 .IP "\fBRPCINFO\fR"
 Location of the

--- a/xymonnet/xymonnet.c
+++ b/xymonnet/xymonnet.c
@@ -1070,13 +1070,12 @@ void run_nslookup_service(service_t *service)
 #include "ntpprobe.c"	/* in-process SNTP probe (the default) */
 
 /* The "ntp" test uses the built-in SNTP probe by default; a non-empty NTPDATE
- * (the ntpdate program) or a legacy, explicitly-set SNTP selects an external tool. */
+ * (an external NTP client such as ntpdate or ntpdig) selects an external tool. */
 void run_ntp_service(service_t *service)
 {
 	testitem_t	*t;
 	char		*ntpcmd  = xgetenv("NTPDATE");
-	int		use_sntp = (getenv("SNTP") != NULL);	/* getenv, not xgetenv: only an explicit SNTP (not its default) forces sntp */
-	int		use_external = use_sntp || (ntpcmd && *ntpcmd);
+	int		use_external = (ntpcmd && *ntpcmd);
 
 	if (!use_external) {
 		/* Built-in probe: bounds itself with NTP_PROBE_TRIES short attempts, so it
@@ -1092,24 +1091,19 @@ void run_ntp_service(service_t *service)
 		return;
 	}
 
-	/* External tool (sntp wins over ntpdate, above); the command buffers are scoped
-	 * here so the internal path never carries them. */
+	/* External tool; the command buffers are scoped here so the internal path
+	 * never carries them. */
 	{
 		char	cmd[PATH_MAX+1024];
 		char	cmdpath[PATH_MAX];
 
-		strncpy(cmdpath, (use_sntp ? xgetenv("SNTP") : ntpcmd), sizeof(cmdpath));
+		strncpy(cmdpath, ntpcmd, sizeof(cmdpath));
 		cmdpath[sizeof(cmdpath)-1] = '\0';
 
 		for (t=service->items; (t); t = t->next) {
 			/* Do not run NTP test if host does not resolve in DNS or is down */
 			if (!t->host->dnserror && !t->host->pingerror) {
-				if (use_sntp) {
-					snprintf(cmd, sizeof(cmd), "%s %s -d %d %s 2>&1", cmdpath, xgetenv("SNTPOPTS"), extcmdtimeout-1, ip_to_test(t->host));
-				}
-				else {
-					snprintf(cmd, sizeof(cmd), "%s %s %s 2>&1", cmdpath, xgetenv("NTPDATEOPTS"), ip_to_test(t->host));
-				}
+				snprintf(cmd, sizeof(cmd), "%s %s %s 2>&1", cmdpath, xgetenv("NTPDATEOPTS"), ip_to_test(t->host));
 
 				t->open = (run_command(cmd, "no server suitable for synchronization", t->banner, 1, extcmdtimeout) == 0);
 			}
@@ -2287,7 +2281,7 @@ int main(int argc, char *argv[])
 			printf("Usage: %s [options] [host1 host2 host3 ...]\n", argv[0]);
 			printf("General options:\n");
 			printf("    --timeout=N                 : Timeout (in seconds) for service tests\n");
-			printf("    --cmdtimeout=N              : Timeout for the external RPC, traceroute and ntpdate/sntp commands (the built-in NTP probe self-bounds)\n");
+			printf("    --cmdtimeout=N              : Timeout for the external RPC, traceroute and ntpdate commands (the built-in NTP probe self-bounds)\n");
 			printf("    --concurrency=N             : Number of tests run in parallel\n");
 			printf("    --dns-timeout=N             : DNS lookups timeout and fail after N seconds [30]\n");
 			printf("    --dns=[only|ip|standard]    : How IP's are decided\n");


### PR DESCRIPTION
Closes #199.

Removes the legacy `SNTP` / `SNTPOPTS` external call-out from the `ntp` test. Full analysis with sources in #199; the short version:

- The invocation (`sntp $SNTPOPTS -d <timeout> <host>`) is **msntp syntax**. On ntp classic 4.2.8, `-d` is `--debug-level` (no argument — the timeout leaks through as a bogus host) and `-u` (the `SNTPOPTS` default) now takes an argument and swallows the following `-d`; on ntpsec's `ntpdig`, `-u` doesn't exist. **The command fails outright on every current implementation.**
- The offset side **never worked at all**: the `" secs"` parser branch in `do_net.c` expects a 7-token line no tool ever printed, and in a status message it tokenizes the leading `green <date> ...` line first. Verified empirically against msntp, sntp 4.2.6, sntp 4.2.8 and ntpdig output, framed and bare: zero matches. Dead code since inception.
- No capability is lost: the built-in SNTP probe (#181) is the default, and `NTPDATE` remains the escape hatch to any external client (`ntpdig`, `sntp`, or `msntp` for a genuine holdout).

## Change

- `xymonnet/xymonnet.c`: drop the `SNTP` branch from `run_ntp_service()`; drop "sntp" from the `--cmdtimeout` help text.
- `lib/environ.c`: drop the `SNTP`/`SNTPOPTS` defaults.
- `xymond/rrd/do_net.c`: remove the dead `" secs"` parser branch (the `"offset "` branch serving the built-in probe and ntpdate is untouched).
- `xymonnet.1`: replace the `SNTP`/`SNTPOPTS` entries with a removal note pointing at the built-in probe / `NTPDATE`.
- `tests/rrd/ntp-offset-parse-harness.c`: the old sntp positive case (which only passed with a synthetic single-token date no tool prints) becomes two negative cases — legacy and modern sntp-style output must record nothing.

Net: −33 lines.

## Validation

- `tests/rrd/ntp-offset-parse.sh` passes (11 checks, ASan/UBSan): probe banner and ntpdate offsets still recorded in ms, root distance still recorded/`U`, sntp-style output records nothing, #183 `offset=` regression case intact.
- Full `./configure --server && make` build clean; `xymonnet --help` shows the updated text; `strings` on both binaries confirms no `SNTPOPTS` residue.
