### PR TITLE
showgraph: make the RRD instance sort a total order

### DIFF
--- a/tests/web/showgraph-sort-total-order.sh
+++ b/tests/web/showgraph-sort-total-order.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/showgraph-sort-total-order.sh
+#
+# rrd_name_compare() must be a total order. The old per-pair mode choice
+# (numeric only when BOTH keys of a pair were numeric) was intransitive on
+# mixed key sets (9 < 10 < "1a" yet "1a" < 9), which is undefined behaviour
+# for qsort(3) - the sorted order depended on readdir() order. And distinct
+# keys must never compare equal ("007" vs "7"), or their order is unspecified.
+#
+# This extracts the REAL comparator (and its mode flag) from web/showgraph.c,
+# wraps it in a driver replicating the caller's all-numeric pre-scan, and
+# asserts: every input permutation of a mixed set sorts identically, and
+# numerically-equal distinct keys have one deterministic order.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SRC="$ROOT/web/showgraph.c"
+[ -f "$SRC" ] || skip "web/showgraph.c absent"
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# Extract the comparator and its mode flag from the real source.
+sed -n '/^static int rrd_keys_all_numeric/,/^}/p' "$SRC" > "$work/cmp.inc"
+grep -q "rrd_name_compare" "$work/cmp.inc" || fail "could not extract rrd_name_compare from showgraph.c"
+
+cat > "$work/driver.c" <<'DRIVER'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+typedef struct rrddb_t { char *key; char *rrdfn; char *rrdparam; } rrddb_t;
+#include "cmp.inc"
+/* Replicates the caller's set-wide pre-scan */
+static void set_mode(rrddb_t *r, int n) {
+	int i; char *endptr;
+	rrd_keys_all_numeric = (n > 0);
+	for (i = 0; (i < n) && rrd_keys_all_numeric; i++) {
+		strtol(r[i].key, &endptr, 10);
+		rrd_keys_all_numeric = ((endptr != r[i].key) && (*endptr == '\0'));
+	}
+}
+static void sortkeys(char **keys, int n, char *out) {
+	rrddb_t r[8]; int i;
+	for (i = 0; i < n; i++) { r[i].key = keys[i]; r[i].rrdfn = r[i].rrdparam = NULL; }
+	set_mode(r, n);
+	qsort(r, n, sizeof(rrddb_t), rrd_name_compare);
+	out[0] = '\0';
+	for (i = 0; i < n; i++) { strcat(out, r[i].key); strcat(out, " "); }
+}
+int main(void) {
+	/* mixed set: all 6 permutations must sort identically */
+	char *perms[6][3] = { {"9","10","1a"}, {"9","1a","10"}, {"10","9","1a"},
+			      {"10","1a","9"}, {"1a","9","10"}, {"1a","10","9"} };
+	char first[64], got[64]; int i, fails = 0;
+	sortkeys(perms[0], 3, first);
+	for (i = 1; i < 6; i++) {
+		sortkeys(perms[i], 3, got);
+		if (strcmp(first, got) != 0) { printf("FAIL permutation %d: '%s' vs '%s'\n", i, got, first); fails++; }
+	}
+	if (!fails) printf("ok   mixed set: all 6 permutations sort as '%s'\n", first);
+	/* all-numeric: numeric order, and 007 vs 7 deterministic (never equal) */
+	{ char *k[3] = {"10","7","007"};
+	  sortkeys(k, 3, got);
+	  if (strcmp(got, "007 7 10 ") != 0) { printf("FAIL numeric: got '%s' want '007 7 10 '\n", got); fails++; }
+	  else printf("ok   numeric set: '%s' (2-digit after 1-digit, 007 before 7)\n", got); }
+	/* plain numeric ordering unchanged: 2 before 10 */
+	{ char *k[2] = {"10","2"};
+	  sortkeys(k, 2, got);
+	  if (strcmp(got, "2 10 ") != 0) { printf("FAIL: got '%s' want '2 10 '\n", got); fails++; }
+	  else printf("ok   plain integers: '%s'\n", got); }
+	if (fails) { printf("%d check(s) FAILED\n", fails); return 1; }
+	printf("all sort-total-order checks ok\n");
+	return 0;
+}
+DRIVER
+"$CC" -g -O1 -fsanitize=address,undefined -I"$work" -o "$work/driver" "$work/driver.c" \
+	|| fail "driver failed to compile"
+"$work/driver" || fail "comparator total-order checks failed (see output above)"
+
+pass "rrd_name_compare is a total order (stable mixed sort, no phantom equality)"

--- a/tests/web/showgraph-sort-total-order.sh
+++ b/tests/web/showgraph-sort-total-order.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/showgraph-sort-total-order.sh
+#
+# rrd_name_compare() must be a total order. The old per-pair mode choice
+# (numeric only when BOTH keys of a pair were numeric) was intransitive on
+# mixed key sets (9 < 10 < "1a" yet "1a" < 9), which is undefined behaviour
+# for qsort(3) - the sorted order depended on readdir() order. And distinct
+# keys must never compare equal ("007" vs "7"), or their order is unspecified.
+#
+# This extracts the REAL comparator AND the real mode-selection function from
+# web/showgraph.c and drives both, rather than replicating the pre-scan here: a
+# replica keeps passing after production goes back to pairwise or lexical-only,
+# which is precisely the regression this guards. It asserts that every input
+# permutation of a mixed set sorts identically, and that numerically-equal
+# distinct keys have one deterministic order.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SRC="$ROOT/web/showgraph.c"
+[ -f "$SRC" ] || skip "web/showgraph.c absent"
+
+require_cc
+
+work=$(mktempdir)
+
+# Extract the comparator, its mode flag, and the mode-selection function from
+# the real source. Both must be there: silently missing one would leave the
+# driver testing nothing.
+sed -n '/^static int rrd_keys_all_numeric/,/^}/p'  "$SRC" >  "$work/cmp.inc"
+sed -n '/^static void rrd_set_sort_mode/,/^}/p'    "$SRC" >> "$work/cmp.inc"
+grep -q "rrd_name_compare"   "$work/cmp.inc" || fail "could not extract rrd_name_compare from showgraph.c"
+grep -q "rrd_set_sort_mode"  "$work/cmp.inc" || fail "could not extract rrd_set_sort_mode from showgraph.c"
+
+cat > "$work/driver.c" <<'DRIVER'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+typedef struct rrddb_t { char *key; char *rrdfn; char *rrdparam; } rrddb_t;
+#include "cmp.inc"
+static void sortkeys(char **keys, int n, char *out) {
+	rrddb_t r[8]; int i;
+	for (i = 0; i < n; i++) { r[i].key = keys[i]; r[i].rrdfn = r[i].rrdparam = NULL; }
+	rrd_set_sort_mode(r, n);
+	qsort(r, n, sizeof(rrddb_t), rrd_name_compare);
+	out[0] = '\0';
+	for (i = 0; i < n; i++) { strcat(out, r[i].key); strcat(out, " "); }
+}
+int main(void) {
+	/* mixed set: all 6 permutations must sort identically */
+	char *perms[6][3] = { {"9","10","1a"}, {"9","1a","10"}, {"10","9","1a"},
+			      {"10","1a","9"}, {"1a","9","10"}, {"1a","10","9"} };
+	char first[64], got[64]; int i, fails = 0;
+	sortkeys(perms[0], 3, first);
+	for (i = 1; i < 6; i++) {
+		sortkeys(perms[i], 3, got);
+		if (strcmp(first, got) != 0) { printf("FAIL permutation %d: '%s' vs '%s'\n", i, got, first); fails++; }
+	}
+	if (!fails) printf("ok   mixed set: all 6 permutations sort as '%s'\n", first);
+	/* all-numeric: numeric order, and 007 vs 7 deterministic (never equal) */
+	{ char *k[3] = {"10","7","007"};
+	  sortkeys(k, 3, got);
+	  if (strcmp(got, "007 7 10 ") != 0) { printf("FAIL numeric: got '%s' want '007 7 10 '\n", got); fails++; }
+	  else printf("ok   numeric set: '%s' (2-digit after 1-digit, 007 before 7)\n", got); }
+	/* plain numeric ordering unchanged: 2 before 10 */
+	{ char *k[2] = {"10","2"};
+	  sortkeys(k, 2, got);
+	  if (strcmp(got, "2 10 ") != 0) { printf("FAIL: got '%s' want '2 10 '\n", got); fails++; }
+	  else printf("ok   plain integers: '%s'\n", got); }
+	if (fails) { printf("%d check(s) FAILED\n", fails); return 1; }
+	printf("all sort-total-order checks ok\n");
+	return 0;
+}
+DRIVER
+# Sanitizers when the runtime is actually there: several distros ship libasan
+# in its own package, and linking -fsanitize= without it fails outright, which
+# took the whole suite down with it. asan_usable() builds and RUNS a probe.
+san=""
+asan_usable && san="-fsanitize=address,undefined"
+# shellcheck disable=SC2086
+"$CC" -g -O1 $san -I"$work" -o "$work/driver" "$work/driver.c" \
+	|| fail "driver failed to compile"
+"$work/driver" || fail "comparator total-order checks failed (see output above)"
+
+pass "rrd_name_compare is a total order (stable mixed sort, no phantom equality)"

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -625,22 +625,26 @@ char *expand_tokens(char *tpl)
 	return STRBUF(result);
 }
 
+/* Sort mode for rrd_name_compare, decided ONCE for the whole set before
+ * qsort. Deciding per pair (numeric only when BOTH keys of that pair were
+ * numeric) made the comparator intransitive on mixed sets - 9 < 10 < "1a"
+ * yet "1a" < 9 - which is undefined behaviour for qsort(3): the resulting
+ * display (and paging) order depended on readdir() order. */
+static int rrd_keys_all_numeric = 0;
+
 int rrd_name_compare(const void *v1, const void *v2)
 {
 	rrddb_t *r1 = (rrddb_t *)v1;
 	rrddb_t *r2 = (rrddb_t *)v2;
-	char *endptr;
-	long numkey1, numkey2;
-	int key1isnumber, key2isnumber;
 
-	/* See if the keys are all numeric; if yes, then do a numeric sort */
-	numkey1 = strtol(r1->key, &endptr, 10); key1isnumber = (*endptr == '\0');
-	numkey2 = strtol(r2->key, &endptr, 10); key2isnumber = (*endptr == '\0');
+	if (rrd_keys_all_numeric) {
+		long numkey1 = atol(r1->key);
+		long numkey2 = atol(r2->key);
 
-	if (key1isnumber && key2isnumber) {
 		if (numkey1 < numkey2) return -1;
 		else if (numkey1 > numkey2) return 1;
-		else return 0;
+		/* Distinct keys must never compare equal ("007" vs "7"), or
+		 * their relative order is unspecified: break ties on the text. */
 	}
 
 	return strcmp(r1->key, r2->key);
@@ -1074,7 +1078,20 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 			errprintf("showgraph: no RRD file matched service '%s'\n", service);
 	}
 
-	/* Sort them so the display looks prettier */
+	/* Sort them so the display looks prettier. Numeric sort only when ALL
+	 * keys are numeric (what the comparator always intended), so the
+	 * comparison mode cannot change from pair to pair. */
+	{
+		int i;
+
+		rrd_keys_all_numeric = (rrddbcount > 0);
+		for (i = 0; (i < rrddbcount) && rrd_keys_all_numeric; i++) {
+			char *endptr;
+
+			strtol(rrddbs[i].key, &endptr, 10);
+			rrd_keys_all_numeric = ((endptr != rrddbs[i].key) && (*endptr == '\0'));
+		}
+	}
 	qsort(&rrddbs[0], rrddbcount, sizeof(rrddb_t), rrd_name_compare);
 
 	/* Setup the title */

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -648,25 +648,47 @@ char *expand_tokens(char *tpl)
 	return STRBUF(result);
 }
 
+/* Sort mode for rrd_name_compare, decided ONCE for the whole set before
+ * qsort. Deciding per pair (numeric only when BOTH keys of that pair were
+ * numeric) made the comparator intransitive on mixed sets - 9 < 10 < "1a"
+ * yet "1a" < 9 - which is undefined behaviour for qsort(3): the resulting
+ * display (and paging) order depended on readdir() order. */
+static int rrd_keys_all_numeric = 0;
+
 int rrd_name_compare(const void *v1, const void *v2)
 {
 	rrddb_t *r1 = (rrddb_t *)v1;
 	rrddb_t *r2 = (rrddb_t *)v2;
-	char *endptr;
-	long numkey1, numkey2;
-	int key1isnumber, key2isnumber;
 
-	/* See if the keys are all numeric; if yes, then do a numeric sort */
-	numkey1 = strtol(r1->key, &endptr, 10); key1isnumber = (*endptr == '\0');
-	numkey2 = strtol(r2->key, &endptr, 10); key2isnumber = (*endptr == '\0');
+	if (rrd_keys_all_numeric) {
+		long numkey1 = atol(r1->key);
+		long numkey2 = atol(r2->key);
 
-	if (key1isnumber && key2isnumber) {
 		if (numkey1 < numkey2) return -1;
 		else if (numkey1 > numkey2) return 1;
-		else return 0;
+		/* Distinct keys must never compare equal ("007" vs "7"), or
+		 * their relative order is unspecified: break ties on the text. */
 	}
 
 	return strcmp(r1->key, r2->key);
+}
+
+/* Decide the sort mode ONCE for the whole set, before qsort. Numeric only when
+ * every key is numeric, which is what the comparator always intended. A named
+ * function rather than a block inside the caller so that the regression test
+ * drives this decision instead of a copy of it: a copy keeps passing after the
+ * real one goes back to pairwise or lexical-only. */
+static void rrd_set_sort_mode(rrddb_t *dbs, int count)
+{
+	int i;
+
+	rrd_keys_all_numeric = (count > 0);
+	for (i = 0; (i < count) && rrd_keys_all_numeric; i++) {
+		char *endptr;
+
+		strtol(dbs[i].key, &endptr, 10);
+		rrd_keys_all_numeric = ((endptr != dbs[i].key) && (*endptr == '\0'));
+	}
 }
 
 static int rrd_param_matches_service(const char *param, const char *svc)
@@ -1097,7 +1119,8 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 			errprintf("showgraph: no RRD file matched service '%s'\n", service);
 	}
 
-	/* Sort them so the display looks prettier */
+	/* Sort them so the display looks prettier. */
+	rrd_set_sort_mode(rrddbs, rrddbcount);
 	qsort(&rrddbs[0], rrddbcount, sizeof(rrddb_t), rrd_name_compare);
 
 	/* Setup the title */


### PR DESCRIPTION
`rrd_name_compare()` picked its mode per pair — numeric when both keys of that pair parsed as integers, `strcmp` otherwise. On a mixed set that is intransitive, which is undefined behaviour for `qsort(3)`.

Measured: the three permutations of `{9, 10, 1a}` produced three different "sorted" orders.

| | before | after |
|---|---|---|
| `9 < 10` | numeric | — |
| `"10" < "1a"` | text | — |
| `"1a" < "9"` | text | — |
| result | three orders for one set | one deterministic order |
| `007` vs `7` | compared equal, order unspecified | tie broken on the text form |

Mixed sets are real: interface instances can be `0`, `1`, `eth0` on the same host. Display order and the first/count graph paging built on it depended on `readdir()` order.

The mode is now decided once for the whole set — which is what the comparator's own comment ("See if the keys are all numeric") always promised. Homogeneous sets sort exactly as before.

**Test:** all six permutations of a mixed set must sort identically, numerically-equal distinct keys must have one order, plain integers unchanged. It drives the real `rrd_set_sort_mode()` rather than a copy of it — @SoundGoof showed the earlier version kept passing with the production pre-scan replaced by `rrd_keys_all_numeric = 0`; that mutation now fails two of the three checks.
