### PR TITLE
docs: name the GRAPHS ::N setting by its unit - instances per image

### DIFF
--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -523,7 +523,7 @@ for storing data and for the column's default status-page graph.
 GRAPHS_<COLUMNNAME> changes only what graphs are shown on that
 column's status page. GRAPHS defines the graph list and order on
 the "trends" page, and also stores graph-display metadata such
-as the per-image split size.
+as the maximum number of instances (RRD files) shown per graph image.
 
 .IP TEST2RRD
 List of "COLUMNNAME[=RRDSERVICE]" settings. This tells
@@ -565,10 +565,10 @@ and in what order. The matching RRD files are selected by the
 corresponding graph definitions in
 .I graphs.cfg(5).
 Each entry is either "name" or "name::N": "name" is the graph name,
-and N is the maximum number of RRD files drawn per graph image after
+and N is the maximum number of instances (RRD files) drawn per graph image after
 the graph has been split; the default is 5 per image. The double colon
 is literal, so "mrtg::1" draws one file per image.
-N counts RRD files, not lines: each RRD file may hold several data sets
+N counts instances (RRD files), not lines: each RRD file may hold several data sets
 (DS), each drawn as its own curve, so an image showing N files can
 contain several times N lines. Choose N with the per-file DS count in
 mind - a 2-DS graph at "::2" draws 4 lines, while a 1-DS graph at "::5"
@@ -580,7 +580,8 @@ used whenever graph links are generated for that graph. This includes
 the "trends" page, a test column's default status-page graph from
 TEST2RRD, and status-page GRAPHS_<COLUMNNAME> entries that name the
 same graph definition. If a graph is used only from GRAPHS_<COLUMNNAME>
-and has no matching entry in GRAPHS, it uses the default split size.
+and has no matching entry in GRAPHS, it uses the default limit of
+instances per image.
 On the "trends" page, the RRD file count is known automatically.
 On status pages, splitting only happens when
 .I svcstatus.cgi(1)

--- a/lib/htmllog.c
+++ b/lib/htmllog.c
@@ -528,13 +528,13 @@ void generate_html_log(char *hostname, char *displayname, char *service, char *i
 					 * (a prefix-matched table entry would rewrite it to its
 					 * base name) and leaves the shared table unwritten - the
 					 * legacy strdup() into it leaked and corrupted later
-					 * lookups. maxgraphs: the entry's own GRAPHS record, else
+					 * lookups. maxinstancesperimage: the entry's own GRAPHS record, else
 					 * the service's default graph.
 					 */
 					owngdef = find_xymon_graph(graphsptr);
 					memset(&localgraph, 0, sizeof(localgraph));
 					localgraph.xymonrrdname = graphsptr;
-					localgraph.maxgraphs = (owngdef ? owngdef->maxgraphs : (graph ? graph->maxgraphs : 0));
+					localgraph.maxinstancesperimage = (owngdef ? owngdef->maxinstancesperimage : (graph ? graph->maxinstancesperimage : 0));
 					fprintf(output, "%s\n", xymon_graph_data(hostname, displayname, graphsptr, color, &localgraph, linecount, HG_WITHOUT_STALE_RRDS, HG_PLAIN_LINK, locatorbased, now-graphtime, now));
 					graphsptr = strtok(NULL,",");
 				}

--- a/lib/xymonrrd.c
+++ b/lib/xymonrrd.c
@@ -137,7 +137,7 @@ static void rrd_setup(void)
 			p = strchr(grec->xymonpartname, ':');
 			if (p) {
 				*p = '\0';
-				grec->maxgraphs = atoi(p+1);
+				grec->maxinstancesperimage = atoi(p+1);
 				if (strlen(grec->xymonpartname) == 0) {
 					xfree(grec->xymonpartname);
 					grec->xymonpartname = NULL;
@@ -227,9 +227,9 @@ static char *xymon_graph_text(char *hostname, char *dispname, char *service, int
 		gheight = atoi(xgetenv("RRDHEIGHT"));
 	}
 
-	dbgprintf("rrdlink_url: host %s, rrd %s (partname:%s, maxgraphs:%d, count=%d)\n", 
+	dbgprintf("rrdlink_url: host %s, rrd %s (partname:%s, maxinstancesperimage:%d, count=%d)\n", 
 		hostname, 
-		graphdef->xymonrrdname, textornull(graphdef->xymonpartname), graphdef->maxgraphs, itemcount);
+		graphdef->xymonrrdname, textornull(graphdef->xymonpartname), graphdef->maxinstancesperimage, itemcount);
 
 	if ((service != NULL) && (strcmp(graphdef->xymonrrdname, "tcp") == 0)) {
 		snprintf(rrdservicename, sizeof(rrdservicename), "tcp:%s", service);
@@ -267,16 +267,16 @@ static char *xymon_graph_text(char *hostname, char *dispname, char *service, int
 		int first = 1;
 		int step;
 
-		step = (graphdef->maxgraphs ? graphdef->maxgraphs : 5);
+		step = (graphdef->maxinstancesperimage ? graphdef->maxinstancesperimage : 5);
 		if (itemcount) {
 			/* Spread itemcount instances evenly over the needed number of
 			 * graphs. gcount is the graph count (ceil); the per-graph step
 			 * must round UP too, otherwise a count that gcount does not
-			 * divide leaves every graph under-filled below maxgraphs and
-			 * spawns extra graphs - e.g. 25 items at maxgraphs=2 gives
+			 * divide leaves every graph under-filled below maxinstancesperimage and
+			 * spawns extra graphs - e.g. 25 items at maxinstancesperimage=2 gives
 			 * gcount=13 but a floored step=1, so 25 single-item graphs
 			 * instead of 13. Rounding up yields step=2 (last graph holds
-			 * the remainder), never exceeding maxgraphs. */
+			 * the remainder), never exceeding maxinstancesperimage. */
 			int gcount = (itemcount / step); if ((gcount*step) != itemcount) gcount++;
 			step = ((itemcount + gcount - 1) / gcount);
 		}

--- a/lib/xymonrrd.h
+++ b/lib/xymonrrd.h
@@ -23,7 +23,7 @@ typedef struct {
 typedef struct {
    char *xymonrrdname;
    char *xymonpartname;
-   int  maxgraphs;
+   int  maxinstancesperimage;
 } xymongraph_t;
 
 typedef enum {

--- a/web/svcstatus-trends.c
+++ b/web/svcstatus-trends.c
@@ -204,7 +204,7 @@ static char *rrdlink_text(void *host, graph_t *rrd, hg_link_t wantmeta, time_t s
 
 			myrrd->gdef->xymonrrdname = graphdef;
 			myrrd->gdef->xymonpartname = NULL;
-			myrrd->gdef->maxgraphs = 0;
+			myrrd->gdef->maxinstancesperimage = 0;
 			myrrd->count = rrd->count;
 			myrrd->next = NULL;
 			partlink = xymon_graph_data(xmh_item(host, XMH_HOSTNAME), hostdisplayname, NULL, -1, myrrd->gdef, myrrd->count, 

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -160,7 +160,8 @@ RRDWIDTH="576"		# The RRD's contain 576 data points, so this is a good value
 # - GRAPHS_<columnname> changes only what graphs are shown on that column's
 #   status page; it does not make xymond_rrd collect new data.
 # - GRAPHS defines the graph list and order on the trends page, and also stores
-#   graph-display metadata such as the per-image split size.
+#   graph-display metadata such as the maximum number of instances (RRD
+#   files) shown per graph image.
 
 # TEST2RRD format: COLUMN[=RRDSERVICE]. If "=RRDSERVICE" is omitted, the
 # RRD graph name is the same as the COLUMN value. You will normally not need to
@@ -185,15 +186,15 @@ GRAPHS_ntp="ntp.offset"
 # This defines graph names known to the graph display code. On the "trends"
 # column, it also defines which graphs are shown and in what order. The matching
 # RRD files are selected by graphs.cfg. Entries use name or name::N; N caps the
-# RRD files per graph image once a graph is split, so "mrtg::1" means one file
-# per image. N counts files, not lines: one RRD file can hold several DS, each
+# instances (RRD files) per graph image once a graph is split, so "mrtg::1" means one file
+# per image. N counts instances (files), not lines: one RRD file can hold several DS, each
 # drawn as its own curve, so N files may show several times N lines (a 2-DS
 # graph at ::2 draws 4 lines). A legacy middle field is accepted but ignored; use
 # name::N for new settings. Put ::N here, not in GRAPHS_<columnname>; it applies
 # on the trends page, on a test column's default status-page graph, and on
 # GRAPHS_<columnname> entries that name the same graph definition. If a graph is
 # used only from GRAPHS_<columnname> and has no matching entry here, it uses the
-# default split size.
+# default limit of instances per image.
 # On status pages, splitting also needs an instance count: either the status
 # message includes "<!-- linecount=N -->", or svcstatus.cgi computes it
 # automatically for columns listed in its --multigraphs option.


### PR DESCRIPTION
Follow-up coherence fix to #243, in two commits:

**1. docs** — the new xymonserver.cfg documentation called the third `GRAPHS` field the "per-image split size". "Split size" names the operation rather than the unit; say what the value counts: **the maximum number of instances (RRD files) shown per graph image**. The two sentences that said only "RRD files"/"files" now use "instances (RRD files)" consistently. The `::N` syntax is unchanged; "splitting" as a verb stays.

**2. lib,web** — rename the `xymongraph_t.maxgraphs` field to `maxinstancesperimage`. The identifier has never been public (no config file, man page or DIST comment ever says "maxgraphs" — users only write the anonymous third `GRAPHS` field), and the name is wrong: it does not cap graphs — the number of images is derived and unbounded — it caps instances per image. Pure mechanical rename (11 occurrences, 4 files), no behaviour change; verified with a full `./configure --server && make`.
