### PR TITLE
tree: xtree lifecycle fixes - tsearch destroy leak + array-variant deleted-record iteration

### DIFF
--- a/lib/tree.c
+++ b/lib/tree.c
@@ -60,7 +60,19 @@ void *xtreeNew(int(*xtreeCompare)(const char *a, const char *b))
 
 void xtreeDestroy(void *treehandle)
 {
-	free(treehandle);
+	xtree_t *tree = treehandle;
+
+	if (!tree) return;
+	/* No tdestroy() outside glibc, so delete the root record until the
+	 * tree is empty (*(rec **)root is the POSIX-documented node layout):
+	 * tdelete frees the internal nodes, we free the record wrappers.
+	 * Keys and userdata belong to the caller, as always. */
+	while (tree->root) {
+		treerec_t *rec = *(treerec_t **)tree->root;
+		tdelete(rec, &tree->root, xtree_i_compare);
+		free(rec);
+	}
+	free(tree);
 }
 
 xtreeStatus_t xtreeAdd(void *treehandle, char *key, void *userdata)

--- a/lib/tree.c
+++ b/lib/tree.c
@@ -324,11 +324,15 @@ xtreePos_t xtreeFind(void *treehandle, char *key)
 xtreePos_t xtreeFirst(void *treehandle)
 {
 	xtree_t *mytree = (xtree_t *)treehandle;
+	xtreePos_t pos = 0;
 
 	/* Does tree exist ? Is it empty? */
 	if ((treehandle == NULL) || (mytree->treesz == 0)) return -1;
 
-	return 0;
+	/* Skip deleted records: their userdata is stale (usually freed) */
+	while ((pos < mytree->treesz) && mytree->entries[pos].deleted) pos++;
+
+	return (pos < mytree->treesz) ? pos : -1;
 }
 
 xtreePos_t xtreeNext(void *treehandle, xtreePos_t pos)
@@ -336,11 +340,12 @@ xtreePos_t xtreeNext(void *treehandle, xtreePos_t pos)
 	xtree_t *mytree = (xtree_t *)treehandle;
 
 	/* Does tree exist ? Is it empty? */
-	if ((treehandle == NULL) || (mytree->treesz == 0) || (pos >= (mytree->treesz - 1)) || (pos < 0)) return -1;
+	if ((treehandle == NULL) || (mytree->treesz == 0) || (pos < 0)) return -1;
 
+	/* Skip deleted records; bounds-check before touching an entry */
 	do {
 		pos++;
-	} while (mytree->entries[pos].deleted && (pos < mytree->treesz));
+	} while ((pos < mytree->treesz) && mytree->entries[pos].deleted);
 
 	return (pos < mytree->treesz) ? pos : -1;
 }

--- a/tests/server/xtree-destroy.sh
+++ b/tests/server/xtree-destroy.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xtree-destroy.sh
+#
+# xtreeDestroy must release everything the tree allocated. The tsearch
+# variant (HAVE_BINARY_TREE) used to free only the handle, leaking every
+# internal node and record wrapper of the destroyed tree - the fileset
+# index hits this on every drophost. Compile lib/tree.c BOTH ways - a
+# config.h shim per variant, so the test needs no built tree and is
+# independent of this platform's configure result - and run an
+# insert/find/delete/destroy workload under ASan's leak checker.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-xtree.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+# ASan with leak detection is the whole point; skip where unsupported.
+echo 'int main(void){return 0;}' >"$work/probe.c"
+"$CC" -fsanitize=address -o "$work/probe" "$work/probe.c" 2>/dev/null \
+	&& "$work/probe" 2>/dev/null \
+	|| skip "cc does not support -fsanitize=address"
+
+cat >"$work/harness.c" <<'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "config.h"	/* selects the tree variant - MUST match tree.c's */
+#include "tree.h"
+
+int main(void)
+{
+	char *keys[1000]; int *vals[1000];
+	void *tree = xtreeNew(strcmp);
+	xtreePos_t pos;
+	int i, seen = 0;
+
+	for (i = 0; i < 1000; i++) {
+		char buf[32];
+		sprintf(buf, "key%04d", i);
+		keys[i] = strdup(buf);
+		vals[i] = malloc(sizeof(int)); *vals[i] = i;
+		if (xtreeAdd(tree, keys[i], vals[i]) != XTREE_STATUS_OK) return 10;
+	}
+	if (xtreeFind(tree, "key0500") == xtreeEnd(tree)) return 11;
+	for (pos = xtreeFirst(tree); (pos != xtreeEnd(tree)); pos = xtreeNext(tree, pos)) seen++;
+	if (seen != 1000) return 12;
+	for (i = 0; i < 1000; i += 7) {
+		if (xtreeDelete(tree, keys[i]) != vals[i]) return 13;
+	}
+	xtreeDestroy(tree);
+	/* Keys and userdata stay caller-owned through delete AND destroy */
+	for (i = 0; i < 1000; i++) { free(keys[i]); free(vals[i]); }
+
+	/* Empty and NULL trees must be safe too */
+	xtreeDestroy(xtreeNew(strcmp));
+	xtreeDestroy(NULL);
+	return 0;
+}
+EOF
+
+# One config.h shim per variant: never the build's real config.h, so
+# (a) the suite's no-build lane can run this test, and (b) each compile
+# is guaranteed to be the variant it claims, whatever configure decided.
+mkdir -p "$work/shim-tsearch" "$work/shim-fallback"
+echo '#define HAVE_BINARY_TREE 1' >"$work/shim-tsearch/config.h"
+echo '#undef HAVE_BINARY_TREE' >"$work/shim-fallback/config.h"
+
+"$CC" -g -fsanitize=address -I"$work/shim-tsearch" -I"$ROOT/lib" \
+	-o "$work/t-tsearch" "$work/harness.c" "$ROOT/lib/tree.c" 2>"$work/cc1.log" \
+	|| { cat "$work/cc1.log" >&2; fail "tsearch-variant harness does not compile"; }
+"$work/t-tsearch" >"$work/out1" 2>&1 \
+	|| fail "tsearch variant leaks or fails (rc=$?): $(tail -15 "$work/out1")"
+
+"$CC" -g -fsanitize=address -I"$work/shim-fallback" -I"$ROOT/lib" \
+	-o "$work/t-fallback" "$work/harness.c" "$ROOT/lib/tree.c" 2>"$work/cc2.log" \
+	|| { cat "$work/cc2.log" >&2; fail "fallback-variant harness does not compile"; }
+"$work/t-fallback" >"$work/out2" 2>&1 \
+	|| fail "fallback variant leaks or fails (rc=$?): $(tail -15 "$work/out2")"
+
+echo "OK $(basename "$0")"

--- a/tests/server/xtree-iterate-deleted.sh
+++ b/tests/server/xtree-iterate-deleted.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xtree-iterate-deleted.sh
+#
+# Iterating a tree after xtreeDelete must never visit a deleted record.
+# The fallback (array) variant only tombstones on delete: xtreeFirst used
+# to return slot 0 without checking the tombstone flag, handing back
+# userdata the caller had already freed - xymond_rrd's update-cache
+# eviction hit this on every full-tree walk once the first-sorting entry
+# was evicted. xtreeNext also read one slot past the array when the
+# trailing entries were tombstones. Compile lib/tree.c BOTH ways - a
+# config.h shim per variant, same scheme as xtree-destroy.sh - and walk
+# a tree with deleted head/middle/tail entries under ASan, dereferencing
+# every visited record so a stale pointer trips the sanitizer.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-xtree-iter.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+# ASan catches the use-after-free/overread; skip where unsupported.
+echo 'int main(void){return 0;}' >"$work/probe.c"
+"$CC" -fsanitize=address -o "$work/probe" "$work/probe.c" 2>/dev/null \
+	&& "$work/probe" 2>/dev/null \
+	|| skip "cc does not support -fsanitize=address"
+
+cat >"$work/harness.c" <<'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "config.h"	/* selects the tree variant - MUST match tree.c's */
+#include "tree.h"
+
+#define N 100
+
+static int deleted_idx(int i)
+{
+	/* head, a middle run, and the tail - the tail run is what made the
+	 * old fallback xtreeNext read past the end of the entry array */
+	return (i == 0) || ((i >= 10) && (i < 20)) || (i >= N-3);
+}
+
+int main(void)
+{
+	char *keys[N]; int *vals[N];
+	void *tree = xtreeNew(strcmp);
+	xtreePos_t pos;
+	int i, seen = 0, ndeleted = 0;
+
+	for (i = 0; i < N; i++) {
+		char buf[32];
+		sprintf(buf, "key%04d", i);
+		keys[i] = strdup(buf);
+		vals[i] = malloc(sizeof(int)); *vals[i] = i;
+		if (xtreeAdd(tree, keys[i], vals[i]) != XTREE_STATUS_OK) return 10;
+	}
+
+	/* Delete and free like the updcache eviction does: the record's
+	 * userdata (and the caller's key copy) die with the delete. */
+	for (i = 0; i < N; i++) {
+		if (!deleted_idx(i)) continue;
+		if (xtreeDelete(tree, keys[i]) != vals[i]) return 11;
+		free(vals[i]); vals[i] = NULL;
+		free(keys[i]); keys[i] = NULL;
+		ndeleted++;
+	}
+
+	for (pos = xtreeFirst(tree); (pos != xtreeEnd(tree)); pos = xtreeNext(tree, pos)) {
+		int *v = (int *)xtreeData(tree, pos);
+		if (deleted_idx(*v)) return 12;	/* visited a deleted record (ASan usually fires first) */
+		seen++;
+	}
+	if (seen != N - ndeleted) return 13;
+
+	xtreeDestroy(tree);
+	for (i = 0; i < N; i++) { free(keys[i]); free(vals[i]); }
+
+	/* All-deleted tree: xtreeFirst must return end, not slot 0 */
+	{
+		char *k[3]; int *v[3];
+		tree = xtreeNew(strcmp);
+		for (i = 0; i < 3; i++) {
+			char buf[8];
+			sprintf(buf, "k%d", i);
+			k[i] = strdup(buf);
+			v[i] = malloc(sizeof(int)); *v[i] = i;
+			if (xtreeAdd(tree, k[i], v[i]) != XTREE_STATUS_OK) return 20;
+		}
+		for (i = 0; i < 3; i++) {
+			if (xtreeDelete(tree, k[i]) != v[i]) return 21;
+			free(v[i]); free(k[i]);
+		}
+		if (xtreeFirst(tree) != xtreeEnd(tree)) return 22;
+		xtreeDestroy(tree);
+	}
+
+	return 0;
+}
+EOF
+
+# One config.h shim per variant, never the build's real config.h - each
+# compile is guaranteed to be the variant it claims.
+mkdir -p "$work/shim-tsearch" "$work/shim-fallback"
+echo '#define HAVE_BINARY_TREE 1' >"$work/shim-tsearch/config.h"
+echo '#undef HAVE_BINARY_TREE' >"$work/shim-fallback/config.h"
+
+"$CC" -g -fsanitize=address -I"$work/shim-tsearch" -I"$ROOT/lib" \
+	-o "$work/t-tsearch" "$work/harness.c" "$ROOT/lib/tree.c" 2>"$work/cc1.log" \
+	|| { cat "$work/cc1.log" >&2; fail "tsearch-variant harness does not compile"; }
+"$work/t-tsearch" >"$work/out1" 2>&1 \
+	|| fail "tsearch variant visits deleted records (rc=$?): $(tail -15 "$work/out1")"
+
+"$CC" -g -fsanitize=address -I"$work/shim-fallback" -I"$ROOT/lib" \
+	-o "$work/t-fallback" "$work/harness.c" "$ROOT/lib/tree.c" 2>"$work/cc2.log" \
+	|| { cat "$work/cc2.log" >&2; fail "fallback-variant harness does not compile"; }
+"$work/t-fallback" >"$work/out2" 2>&1 \
+	|| fail "fallback variant visits deleted records (rc=$?): $(tail -15 "$work/out2")"
+
+echo "OK $(basename "$0")"


### PR DESCRIPTION
Two xtree lifecycle bugs in the fallback (array) variant and the POSIX
binary-tree (tsearch) variant. Both are pre-existing on `main`, found
during unrelated review work; neither has another PR upstream.

## 1. tsearch `xtreeDestroy` leaks the whole tree

The `HAVE_BINARY_TREE` variant of `xtreeDestroy()` frees only the tree handle, leaking every internal tsearch node and record wrapper of the destroyed tree.

**Why now, when no default build compiles that variant:** the genconfig probe for the POSIX binary-tree path is commented out on `main`, so today this is latent. But it is **not** hypothetical:

- **devel runs it live** — its probe is enabled, so any glibc/BSD devel build uses the tsearch variant as the running code.
- **#106 tracks bringing that to main** (the portability items `d56377dc`/`1c93aea9`), and TBT patch `61` (issue #29) is the same enablement. The moment that lands, this leak fires on every `xtreeDestroy` call site.

**The fix:** the canonical POSIX teardown — delete the root record until the tree is empty (the `*(rec **)root` node access POSIX documents): `tdelete` frees the internal nodes, we free the record wrappers. No allocation during teardown, no scratch state. Keys and userdata stay caller-owned, unchanged.

Compared to devel's answer (`tdestroy(tree->root, free)` **plus a probe guard** that disables the whole tsearch path on platforms without GNU `tdestroy`), this is pure POSIX: enabling the binary-tree path needs **no platform gate**, and the site-specific teardown patch tracked as TBT `235` (flagged in #29 as messy: GNU-only, valgrind residue, risky `free(zombie->key)`) becomes unnecessary.

## 2. array variant visits deleted records (second commit)

`xtreeDelete` only tombstones a slot in the fallback (array) variant, and the iterators did not all honor that — this one bites the DEFAULT build, today:

- **`xtreeFirst`** returned slot 0 unconditionally, handing back userdata the caller had already freed when the first-sorting entry was a tombstone. `xymond_rrd`'s update-cache eviction walks the whole tree and hits this once the lowest-keyed entry is evicted.
- **`xtreeNext`** read `entries[pos].deleted` **before** its bounds check — an out-of-bounds slot read when the trailing entries are all tombstones.

Both now skip tombstones with the bounds check first.

## Tests

- `tests/server/xtree-destroy.sh`: compiles `lib/tree.c` **both ways** (one config.h shim per variant, so no built tree is needed) and runs an insert/find/delete/destroy workload under AddressSanitizer's leak checker. With the destroy fix reverted the tsearch variant reports ~48 kB leaked from a 1000-record tree.
- `tests/server/xtree-iterate-deleted.sh`: same both-ways scheme, walks a tree with deleted head/middle/tail entries under ASan and dereferences every visited record so a stale pointer trips the sanitizer. With the iteration fix reverted the array variant aborts.

Both variants run clean with the fixes. Full suite: 20/20 on this branch.

Refs #106 (portability cluster), #29 (TBT `61`/`235`/`240`).
