### PR TITLE
xymond_rrd: make the drophost deletion unraceable, flush the cache before a rename

### DIFF
--- a/tests/server/xymond-rrd-drophost.sh
+++ b/tests/server/xymond-rrd-drophost.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-rrd-drophost.sh
+#
+# The drophost straggler race: @@drophost forks the host directory
+# deletion, but messages for that host already queued in the channel can
+# still arrive afterwards and recreate RRD files inside (or after) the
+# dying directory - leaving a half-resurrected host behind. The writer
+# now keeps a drop barrier that discards messages for a recently dropped
+# host and purges its cached updates before the deletion starts.
+#
+# The test forces the losing interleaving: the deletion completes, THEN
+# the straggler arrives - without the barrier the recreated directory
+# has nothing left to clean it up.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMOND_RRD "xymond/xymond_rrd"
+
+work=$(mktempdir)
+mkdir -p "$work/rrd" "$work/tmp"
+ts=$(date +%s)
+
+status_msg() {  # status_msg <statusts> -- one disk status for testhost
+	printf '@@status|%s|127.0.0.1|origin|testhost|disk|%s|green||green|%s|0||0||%s|0|linux|/\n' \
+		"$1" $(($1+1800)) "$ts" "$ts"
+	printf 'disk report\n'
+	printf '/dev/sda1 1000000 400000 600000 40%% /\n'
+	printf '@@\n'
+}
+
+{
+	status_msg "$ts"
+	printf '@@drophost|%s|127.0.0.1|testhost\n@@\n' "$ts"
+	# Give the forked deletion time to FINISH before the straggler
+	# arrives (without the delay the child's rm usually runs last and
+	# hides the recreation by timing luck).
+	sleep 2
+	status_msg $((ts+1))
+} | env XYMONHOME="$work" XYMONTMP="$work/tmp" \
+	"$XYMOND_RRD" --rrddir="$work/rrd" --no-cache 2>/dev/null
+sleep 1		# any still-running forked deletion
+[ -e "$work/rrd/testhost" ] \
+	&& fail "straggler recreated the dropped host directory: $(ls "$work/rrd/testhost")"
+
+# A host dropped longer ago than the barrier window resumes normally -
+# verified indirectly: a FRESH host (never dropped) is unaffected.
+{
+	printf '@@status|%s|127.0.0.1|origin|otherhost|disk|%s|green||green|%s|0||0||%s|0|linux|/\n' \
+		$((ts+2)) $((ts+1802)) "$ts" "$ts"
+	printf 'disk report\n'
+	printf '/dev/sda1 1000000 400000 600000 40%% /\n'
+	printf '@@\n'
+} | env XYMONHOME="$work" XYMONTMP="$work/tmp" \
+	"$XYMOND_RRD" --rrddir="$work/rrd" --no-cache 2>/dev/null
+[ -d "$work/rrd/otherhost" ] || fail "unrelated host's updates must not be barriered"
+
+# renamehost: pending CACHED updates must flush into the old-named files
+# before the rename moves them (rrdcacheflushhost cannot do this: it
+# expects "/host"-shaped keys and rate-limits; the old call was a no-op).
+rm -rf "$work/rrd"; mkdir -p "$work/rrd" "$work/tmp"
+{
+	status_msg "$ts"
+	printf '@@renamehost|%s|127.0.0.1|testhost|newhost\n@@\n' "$ts"
+} | env XYMONHOME="$work" XYMONTMP="$work/tmp" \
+	"$XYMOND_RRD" --rrddir="$work/rrd" --debug >"$work/dbg.log" 2>&1
+[ -d "$work/rrd/newhost" ] || fail "rename did not move the host directory"
+[ -e "$work/rrd/testhost" ] && fail "old directory survived the rename"
+grep -q "flushed and dropped 1 entries for host testhost" "$work/dbg.log" \
+	|| fail "pending update not flushed before the rename: $(grep -i updcache "$work/dbg.log")"
+
+echo "OK $(basename "$0")"

--- a/tests/server/xymond-rrd-drophost.sh
+++ b/tests/server/xymond-rrd-drophost.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-rrd-drophost.sh
+#
+# The drophost straggler race: @@drophost forks the host directory
+# deletion, but messages for that host already queued in the channel can
+# still arrive afterwards and recreate RRD files inside (or after) the
+# dying directory - leaving a half-resurrected host behind.
+#
+# The writer decides "straggler" by message time: a message at or before the
+# drop's own timestamp was already on its way, anything later means the name
+# is in use again. Every assertion here is therefore driven by the timestamps
+# in the messages, not by sleeping - the only sleep is the one that lets the
+# forked deletion finish, which is what makes the losing interleaving happen.
+#
+# The barrier table is process-local, so assertions about it have to be made
+# inside one worker lifetime: a second invocation starts with an empty table
+# and would accept anything.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMOND_RRD "xymond/xymond_rrd"
+
+work=$(mktempdir)
+ts=$(date +%s)
+
+status_msg() {  # status_msg <msg-timestamp> [hostname]
+	printf '@@status|%s|127.0.0.1|origin|%s|disk|%s|green||green|%s|0||0||%s|0|linux|/\n' \
+		"$1" "${2:-testhost}" $(($1+1800)) "$ts" "$ts"
+	printf 'disk report\n'
+	printf '/dev/sda1 1000000 400000 600000 40%% /\n'
+	printf '@@\n'
+}
+
+run_worker() {  # run_worker <rrddir> [extra args...]
+	local dir=$1; shift
+	env XYMONHOME="$work" XYMONTMP="$work/tmp" \
+		"$XYMOND_RRD" --rrddir="$dir" "$@"
+}
+
+mkdir -p "$work/tmp"
+
+# ---- the race itself: a message older than the drop must not resurrect it ----
+# Its own run: in the combined stream below a legitimate later message
+# recreates the directory, so "does it exist at the end" could not tell a held
+# barrier from a broken one.
+rrd1="$work/rrd1"; mkdir -p "$rrd1"
+{
+	status_msg "$ts"
+	printf '@@drophost|%s|127.0.0.1|testhost\n@@\n' $((ts+10))
+	# Let the forked deletion FINISH before the straggler arrives. Without
+	# it the child's rm usually runs last and hides the recreation by timing
+	# luck - the losing interleaving is the one worth pinning.
+	sleep 2
+	status_msg $((ts+5))		# generated before the drop: a straggler
+} | run_worker "$rrd1" --no-cache 2>/dev/null
+sleep 1
+[ -e "$rrd1/testhost" ] \
+	&& fail "a straggler older than the drop recreated the host directory: $(ls "$rrd1/testhost")"
+
+# ---- isolation and re-add, in one worker lifetime ----------------------------
+rrd2="$work/rrd2"; mkdir -p "$rrd2"
+{
+	status_msg "$ts"
+	printf '@@drophost|%s|127.0.0.1|testhost\n@@\n' $((ts+10))
+	sleep 2
+	status_msg $((ts+5))			# straggler: dropped
+	status_msg $((ts+11)) otherhost		# never dropped: must land
+	status_msg $((ts+20))			# host is back: must land
+} | run_worker "$rrd2" --no-cache 2>/dev/null
+sleep 1
+[ -d "$rrd2/otherhost" ] \
+	|| fail "an unrelated host's updates were dropped while another host was barriered"
+[ -d "$rrd2/testhost" ] \
+	|| fail "a message newer than the drop was refused - a re-added host stays blackholed"
+
+# ---- rename, then rename back ------------------------------------------------
+# The barrier is armed on the OLD name, which is a name that can be reused
+# immediately. A window-based barrier discards the returning host's data for
+# the length of the window; deciding by message time lets it resume at once.
+rrd3="$work/rrd3"; mkdir -p "$rrd3"
+{
+	status_msg "$ts"
+	printf '@@renamehost|%s|127.0.0.1|testhost|newhost\n@@\n' $((ts+10))
+	status_msg $((ts+20))			# testhost is a live name again
+} | run_worker "$rrd3" --no-cache 2>/dev/null
+[ -d "$rrd3/newhost" ]  || fail "rename did not move the host directory"
+[ -d "$rrd3/testhost" ] \
+	|| fail "the old name stayed barriered after it was legitimately reused"
+
+# ---- a rename must barrier the old name too ----------------------------------
+# The stock install runs one xymond_rrd per channel over a shared rrddir
+# (tasks.cfg.DIST [rrdstatus] and [rrddata]) and xymond posts the marker to
+# both, so the second worker to see it finds the directory already gone. It
+# still has its own queue of stragglers for the old name, and they must not
+# recreate it. Driving one worker, the equivalent is: rename, then a message
+# that predates the rename.
+rrd3b="$work/rrd3b"; mkdir -p "$rrd3b"
+{
+	status_msg "$ts"
+	printf '@@renamehost|%s|127.0.0.1|testhost|newhost\n@@\n' $((ts+10))
+	status_msg $((ts+5))			# predates the rename: a straggler
+} | run_worker "$rrd3b" --no-cache 2>/dev/null
+[ -d "$rrd3b/newhost" ] || fail "rename did not move the host directory"
+[ -e "$rrd3b/testhost" ] \
+	&& fail "a straggler older than the rename recreated the old host directory"
+
+# ---- a rename that FAILS must not blackhole the old host ---------------------
+# rename() fails on an occupied destination (and on a cross-device rrddir, and
+# on a permission problem). The files never moved, so the old host is still
+# live and must keep getting updates.
+rrd4="$work/rrd4"; mkdir -p "$rrd4/testhost" "$rrd4/newhost"
+printf 'occupied\n' >"$rrd4/newhost/occupied.rrd"
+{
+	printf '@@renamehost|%s|127.0.0.1|testhost|newhost\n@@\n' $((ts+10))
+	status_msg $((ts+20))
+} | run_worker "$rrd4" --no-cache 2>/dev/null
+[ -d "$rrd4/testhost" ] \
+	|| fail "the rename should have failed on an occupied destination, but the source is gone"
+[ -n "$(find "$rrd4/testhost" -name '*.rrd' 2>/dev/null)" ] \
+	|| fail "a failed rename blackholed the old host: its next update was discarded"
+
+# ---- the drop is barriered under the name that is actually deleted -----------
+# The hostname arrives as the admin typed it. dropdirectory() reduces it to a
+# basename, so if the barrier and the cache purge keep the unreduced form, a
+# straggler for the host that really was deleted walks straight past them.
+rrd4b="$work/rrd4b"; mkdir -p "$rrd4b"
+{
+	status_msg "$ts"
+	printf '@@drophost|%s|127.0.0.1|foo/testhost\n@@\n' $((ts+10))
+	sleep 2
+	status_msg $((ts+5))			# straggler for the deleted name
+} | run_worker "$rrd4b" --no-cache 2>/dev/null
+sleep 1
+[ -e "$rrd4b/testhost" ] \
+	&& fail "a slash-bearing drop deleted testhost but barriered another name, so the straggler recreated it"
+
+# ...and the cache purge uses that same name. Needs the cache on: with
+# --no-cache there is never a pending value for either name to match.
+rrd4c="$work/rrd4c"; mkdir -p "$rrd4c"
+{
+	status_msg "$ts"
+	printf '@@drophost|%s|127.0.0.1|foo/testhost\n@@\n' $((ts+10))
+} | run_worker "$rrd4c" --debug >"$work/slashdrop.log" 2>&1
+sleep 1
+grep -q "discarded 1 entries for host testhost" "$work/slashdrop.log" \
+	|| fail "a slash-bearing drop purged the cache under the unreduced name: $(grep -i updcache "$work/slashdrop.log")"
+
+# ---- the cache: flush on rename, discard on drop -----------------------------
+# Both need the cache ON. With --no-cache every reading is written immediately
+# and valcount is always 0, so rrdcache_drop_host() has nothing to act on and
+# neither branch is exercised at all.
+rrd5="$work/rrd5"; mkdir -p "$rrd5"
+{
+	status_msg "$ts"
+	printf '@@renamehost|%s|127.0.0.1|testhost|newhost\n@@\n' $((ts+10))
+} | run_worker "$rrd5" --debug >"$work/rename.log" 2>&1
+[ -d "$rrd5/newhost" ] || fail "rename did not move the host directory (cached run)"
+grep -q "flushed and dropped 1 entries for host testhost" "$work/rename.log" \
+	|| fail "pending update not flushed before the rename: $(grep -i updcache "$work/rename.log")"
+
+rrd6="$work/rrd6"; mkdir -p "$rrd6"
+{
+	status_msg "$ts"
+	printf '@@drophost|%s|127.0.0.1|testhost\n@@\n' $((ts+10))
+} | run_worker "$rrd6" --debug >"$work/drop.log" 2>&1
+sleep 1
+grep -q "discarded 1 entries for host testhost" "$work/drop.log" \
+	|| fail "the dropped host's cached update was not discarded: $(grep -i updcache "$work/drop.log")"
+
+pass "drophost discards stragglers by message time, leaves other hosts alone, lets a reused name resume, and survives a failed rename"

--- a/tests/server/xymond-rrd-drophost.sh
+++ b/tests/server/xymond-rrd-drophost.sh
@@ -55,6 +55,30 @@ rrd1="$work/rrd1"; mkdir -p "$rrd1"
 [ -e "$rrd1/testhost" ] \
 	&& fail "the host directory survived the drop: $(ls "$rrd1/testhost")"
 
+# ---- the deletion must be finished when the worker is ------------------------
+# The assertion above passes either way: with a directory this small the forked
+# child wins the race long before the check runs, so it does not notice a
+# reverted barrier. Give the child real work instead -- enough files that a
+# background delete is still running when the parent exits -- and the two
+# behaviours separate: synchronously the directory is gone the moment the
+# worker returns, forked it is still being emptied.
+#
+# Timing-based, so sized with margin rather than tuned: ~50k files take the
+# order of 100ms to remove, against the microseconds the parent needs to finish
+# the drop and exit. A slower machine widens the gap rather than narrowing it.
+rrd3="$work/rrd3"; mkdir -p "$rrd3/testhost"
+( cd "$rrd3/testhost" && seq 1 50000 | sed 's/$/.rrd/' | xargs -n 500 touch )
+{
+	status_msg "$ts"
+	printf '@@drophost|%s|127.0.0.1|testhost\n@@\n' $((ts+10))
+} | run_worker "$rrd3" --no-cache 2>/dev/null
+if [ -e "$rrd3/testhost" ]; then
+	# Still there: with the barrier the delete finishes before the worker
+	# returns, so anything left means it was handed to a forked child again.
+	left=$(find "$rrd3/testhost" -type f 2>/dev/null | sed -n 1p || true)
+	fail "the drop was still in progress when the worker exited (${left:-directory still present}) -- the deletion is forked again"
+fi
+
 # ---- a drop deletes nothing but the host it names ---------------------------
 # basename("..") is "..", so appending it to rrddir named the parent of the
 # whole RRD tree and handed it to a recursive delete. safe_basename() refuses

--- a/tests/server/xymond-rrd-drophost.sh
+++ b/tests/server/xymond-rrd-drophost.sh
@@ -3,20 +3,20 @@
 #
 # tests/server/xymond-rrd-drophost.sh
 #
-# The drophost straggler race: @@drophost forks the host directory
-# deletion, but messages for that host already queued in the channel can
-# still arrive afterwards and recreate RRD files inside (or after) the
-# dying directory - leaving a half-resurrected host behind.
+# @@drophost and @@renamehost in the RRD writer.
 #
-# The writer decides "straggler" by message time: a message at or before the
-# drop's own timestamp was already on its way, anything later means the name
-# is in use again. Every assertion here is therefore driven by the timestamps
-# in the messages, not by sleeping - the only sleep is the one that lets the
-# forked deletion finish, which is what makes the losing interleaving happen.
+#   - the deletion is synchronous, so a message that follows the drop in the
+#     channel cannot land inside it and leave orphaned RRD files behind;
+#   - pending cached updates are discarded before the files are deleted and
+#     flushed before they are renamed (without the flush they are lost on
+#     every rename: the cache is keyed on the old path);
+#   - both names are confined to a single path component, so a "." or ".."
+#     cannot turn a recursive delete loose on the RRD tree or its parent.
 #
-# The barrier table is process-local, so assertions about it have to be made
-# inside one worker lifetime: a second invocation starts with an empty table
-# and would accept anything.
+# Message ordering here matches the real channel: xymond stamps metadata[1] at
+# post time and delivers in that order, so a status that follows a drop marker
+# is always stamped at or after it. Nothing here depends on a stream the
+# channel cannot produce.
 
 set -euo pipefail
 # shellcheck source=tests/lib/assert.sh
@@ -26,6 +26,7 @@ require_bin XYMOND_RRD "xymond/xymond_rrd"
 
 work=$(mktempdir)
 ts=$(date +%s)
+mkdir -p "$work/tmp"
 
 status_msg() {  # status_msg <msg-timestamp> [hostname]
 	printf '@@status|%s|127.0.0.1|origin|%s|disk|%s|green||green|%s|0||0||%s|0|linux|/\n' \
@@ -41,134 +42,91 @@ run_worker() {  # run_worker <rrddir> [extra args...]
 		"$XYMOND_RRD" --rrddir="$dir" "$@"
 }
 
-mkdir -p "$work/tmp"
-
-# ---- the race itself: a message older than the drop must not resurrect it ----
-# Its own run: in the combined stream below a legitimate later message
-# recreates the directory, so "does it exist at the end" could not tell a held
-# barrier from a broken one.
+# ---- the drop removes the host's directory ---------------------------------
+# The deletion used to be forked, so a status read while the child was still
+# emptying the directory recreated it and the child's final rmdir() failed,
+# leaving orphaned RRD files for a host that no longer exists. A synchronous
+# delete completes before the next message is read.
 rrd1="$work/rrd1"; mkdir -p "$rrd1"
 {
 	status_msg "$ts"
 	printf '@@drophost|%s|127.0.0.1|testhost\n@@\n' $((ts+10))
-	# Let the forked deletion FINISH before the straggler arrives. Without
-	# it the child's rm usually runs last and hides the recreation by timing
-	# luck - the losing interleaving is the one worth pinning.
-	sleep 2
-	status_msg $((ts+5))		# generated before the drop: a straggler
 } | run_worker "$rrd1" --no-cache 2>/dev/null
-sleep 1
 [ -e "$rrd1/testhost" ] \
-	&& fail "a straggler older than the drop recreated the host directory: $(ls "$rrd1/testhost")"
+	&& fail "the host directory survived the drop: $(ls "$rrd1/testhost")"
 
-# ---- isolation and re-add, in one worker lifetime ----------------------------
-rrd2="$work/rrd2"; mkdir -p "$rrd2"
-{
-	status_msg "$ts"
-	printf '@@drophost|%s|127.0.0.1|testhost\n@@\n' $((ts+10))
-	sleep 2
-	status_msg $((ts+5))			# straggler: dropped
-	status_msg $((ts+11)) otherhost		# never dropped: must land
-	status_msg $((ts+20))			# host is back: must land
-} | run_worker "$rrd2" --no-cache 2>/dev/null
-sleep 1
-[ -d "$rrd2/otherhost" ] \
-	|| fail "an unrelated host's updates were dropped while another host was barriered"
-[ -d "$rrd2/testhost" ] \
-	|| fail "a message newer than the drop was refused - a re-added host stays blackholed"
+# ---- a drop deletes nothing but the host it names ---------------------------
+# basename("..") is "..", so appending it to rrddir named the parent of the
+# whole RRD tree and handed it to a recursive delete. safe_basename() refuses
+# these outright rather than reducing them.
+for name in "." ".." "/" "foo/testhost"; do
+	rrdx="$work/rrdx"; rm -rf "$rrdx"; mkdir -p "$rrdx/testhost" "$rrdx/otherhost"
+	printf 'canary\n'         >"$rrdx/otherhost/keep.rrd"
+	printf 'canary\n'         >"$rrdx/testhost/keep.rrd"
+	printf 'sibling canary\n' >"$work/SIBLING.txt"
+	printf '@@drophost|%s|127.0.0.1|%s\n@@\n' $((ts+10)) "$name" \
+		| run_worker "$rrdx" --no-cache 2>/dev/null
+	[ -f "$rrdx/otherhost/keep.rrd" ] \
+		|| fail "drop '$name' deleted an unrelated host's RRDs"
+	[ -f "$rrdx/testhost/keep.rrd" ] \
+		|| fail "drop '$name' deleted testhost, which it did not name"
+	[ -f "$work/SIBLING.txt" ] \
+		|| fail "drop '$name' escaped the RRD directory entirely"
+done
 
-# ---- rename, then rename back ------------------------------------------------
-# The barrier is armed on the OLD name, which is a name that can be reused
-# immediately. A window-based barrier discards the returning host's data for
-# the length of the window; deciding by message time lets it resume at once.
+# ---- rename moves the directory ---------------------------------------------
 rrd3="$work/rrd3"; mkdir -p "$rrd3"
 {
 	status_msg "$ts"
 	printf '@@renamehost|%s|127.0.0.1|testhost|newhost\n@@\n' $((ts+10))
-	status_msg $((ts+20))			# testhost is a live name again
 } | run_worker "$rrd3" --no-cache 2>/dev/null
 [ -d "$rrd3/newhost" ]  || fail "rename did not move the host directory"
-[ -d "$rrd3/testhost" ] \
-	|| fail "the old name stayed barriered after it was legitimately reused"
+[ -e "$rrd3/testhost" ] && fail "old directory survived the rename"
 
-# ---- a rename must barrier the old name too ----------------------------------
-# The stock install runs one xymond_rrd per channel over a shared rrddir
-# (tasks.cfg.DIST [rrdstatus] and [rrddata]) and xymond posts the marker to
-# both, so the second worker to see it finds the directory already gone. It
-# still has its own queue of stragglers for the old name, and they must not
-# recreate it. Driving one worker, the equivalent is: rename, then a message
-# that predates the rename.
-rrd3b="$work/rrd3b"; mkdir -p "$rrd3b"
+# ---- ...and confines both of its names --------------------------------------
+for pair in "..|newhost" "testhost|.." "foo/testhost|newhost" "testhost|foo/newhost"; do
+	rrdy="$work/rrdy"; rm -rf "$rrdy"; mkdir -p "$rrdy/testhost"
+	printf 'canary\n'         >"$rrdy/testhost/keep.rrd"
+	printf 'sibling canary\n' >"$work/SIBLING.txt"
+	printf '@@renamehost|%s|127.0.0.1|%s|%s\n@@\n' $((ts+10)) "${pair%|*}" "${pair#*|}" \
+		| run_worker "$rrdy" --no-cache 2>/dev/null
+	[ -f "$rrdy/testhost/keep.rrd" ] \
+		|| fail "rename '${pair%|*}' -> '${pair#*|}' moved a directory it did not name"
+	[ -f "$work/SIBLING.txt" ] \
+		|| fail "rename '${pair%|*}' -> '${pair#*|}' escaped the RRD directory"
+done
+
+# ---- the cache: flushed before a rename, discarded before a delete ----------
+# Both need the cache on. With --no-cache every reading is written immediately
+# and valcount stays 0, so rrdcache_drop_host() has nothing to act on and
+# neither branch runs at all.
+rrd4="$work/rrd4"; mkdir -p "$rrd4"
 {
 	status_msg "$ts"
 	printf '@@renamehost|%s|127.0.0.1|testhost|newhost\n@@\n' $((ts+10))
-	status_msg $((ts+5))			# predates the rename: a straggler
-} | run_worker "$rrd3b" --no-cache 2>/dev/null
-[ -d "$rrd3b/newhost" ] || fail "rename did not move the host directory"
-[ -e "$rrd3b/testhost" ] \
-	&& fail "a straggler older than the rename recreated the old host directory"
+} | run_worker "$rrd4" --debug >"$work/rename.log" 2>&1
+[ -d "$rrd4/newhost" ] || fail "rename did not move the host directory (cached run)"
+# The reading must be flushed BEFORE the rename, not swept up by the worker's
+# shutdown flush - by then the old path is gone and the write fails. Ordering
+# against the shutdown line is what separates the two: the "flushed and dropped
+# N entries" summary is printed from the match count whether or not anything
+# was written, and flush_cached_updates() logs the same line in both cases.
+fl=$(grep -n "Flushing '/testhost/" "$work/rename.log" | head -1 | cut -d: -f1)
+sd=$(grep -n "Shutting down, flushing cached updates" "$work/rename.log" | head -1 | cut -d: -f1)
+[ -n "$fl" ] || fail "the pending update was never flushed: $(grep -iE 'updcache|Flushing' "$work/rename.log")"
+[ -n "$sd" ] || fail "no shutdown-flush line to order against: $(cat "$work/rename.log")"
+[ "$fl" -lt "$sd" ] \
+	|| fail "the pending update was flushed at shutdown, after the rename moved its file, not before"
+[ -n "$(find "$rrd4/newhost" -name '*.rrd' 2>/dev/null)" ] \
+	|| fail "the flushed reading did not land in the renamed directory"
 
-# ---- a rename that FAILS must not blackhole the old host ---------------------
-# rename() fails on an occupied destination (and on a cross-device rrddir, and
-# on a permission problem). The files never moved, so the old host is still
-# live and must keep getting updates.
-rrd4="$work/rrd4"; mkdir -p "$rrd4/testhost" "$rrd4/newhost"
-printf 'occupied\n' >"$rrd4/newhost/occupied.rrd"
-{
-	printf '@@renamehost|%s|127.0.0.1|testhost|newhost\n@@\n' $((ts+10))
-	status_msg $((ts+20))
-} | run_worker "$rrd4" --no-cache 2>/dev/null
-[ -d "$rrd4/testhost" ] \
-	|| fail "the rename should have failed on an occupied destination, but the source is gone"
-[ -n "$(find "$rrd4/testhost" -name '*.rrd' 2>/dev/null)" ] \
-	|| fail "a failed rename blackholed the old host: its next update was discarded"
-
-# ---- the drop is barriered under the name that is actually deleted -----------
-# The hostname arrives as the admin typed it. dropdirectory() reduces it to a
-# basename, so if the barrier and the cache purge keep the unreduced form, a
-# straggler for the host that really was deleted walks straight past them.
-rrd4b="$work/rrd4b"; mkdir -p "$rrd4b"
-{
-	status_msg "$ts"
-	printf '@@drophost|%s|127.0.0.1|foo/testhost\n@@\n' $((ts+10))
-	sleep 2
-	status_msg $((ts+5))			# straggler for the deleted name
-} | run_worker "$rrd4b" --no-cache 2>/dev/null
-sleep 1
-[ -e "$rrd4b/testhost" ] \
-	&& fail "a slash-bearing drop deleted testhost but barriered another name, so the straggler recreated it"
-
-# ...and the cache purge uses that same name. Needs the cache on: with
-# --no-cache there is never a pending value for either name to match.
-rrd4c="$work/rrd4c"; mkdir -p "$rrd4c"
-{
-	status_msg "$ts"
-	printf '@@drophost|%s|127.0.0.1|foo/testhost\n@@\n' $((ts+10))
-} | run_worker "$rrd4c" --debug >"$work/slashdrop.log" 2>&1
-sleep 1
-grep -q "discarded 1 entries for host testhost" "$work/slashdrop.log" \
-	|| fail "a slash-bearing drop purged the cache under the unreduced name: $(grep -i updcache "$work/slashdrop.log")"
-
-# ---- the cache: flush on rename, discard on drop -----------------------------
-# Both need the cache ON. With --no-cache every reading is written immediately
-# and valcount is always 0, so rrdcache_drop_host() has nothing to act on and
-# neither branch is exercised at all.
 rrd5="$work/rrd5"; mkdir -p "$rrd5"
 {
 	status_msg "$ts"
-	printf '@@renamehost|%s|127.0.0.1|testhost|newhost\n@@\n' $((ts+10))
-} | run_worker "$rrd5" --debug >"$work/rename.log" 2>&1
-[ -d "$rrd5/newhost" ] || fail "rename did not move the host directory (cached run)"
-grep -q "flushed and dropped 1 entries for host testhost" "$work/rename.log" \
-	|| fail "pending update not flushed before the rename: $(grep -i updcache "$work/rename.log")"
-
-rrd6="$work/rrd6"; mkdir -p "$rrd6"
-{
-	status_msg "$ts"
 	printf '@@drophost|%s|127.0.0.1|testhost\n@@\n' $((ts+10))
-} | run_worker "$rrd6" --debug >"$work/drop.log" 2>&1
-sleep 1
+} | run_worker "$rrd5" --debug >"$work/drop.log" 2>&1
 grep -q "discarded 1 entries for host testhost" "$work/drop.log" \
 	|| fail "the dropped host's cached update was not discarded: $(grep -i updcache "$work/drop.log")"
+[ -e "$rrd5/testhost" ] && fail "the dropped host's directory survived (cached run)"
 
-pass "drophost discards stragglers by message time, leaves other hosts alone, lets a reused name resume, and survives a failed rename"
+pass "drophost deletes only the host it names and cannot be raced; renamehost flushes the cache and confines both names"

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -514,6 +514,54 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	return 0;
 }
 
+/* Remove one host's cache entries. Flushed first on rename - the files
+ * are about to move, the pending data must land in them before they do.
+ * Discarded on drophost - a flush would write into the directory the
+ * forked deletion is tearing down, and the values are the dropped
+ * host's data anyway. (rrdcacheflushhost() is not usable here: it
+ * expects "/host"-shaped keys and rate-limits to one flush per 60s.) */
+void rrdcache_drop_host(char *hostname, int flushfirst)
+{
+	xtreePos_t handle;
+	char prefix[PATH_MAX];
+	size_t plen;
+	char **keys = NULL;
+	int nkeys = 0, i;
+
+	if ((updcache_keyofs == -1) || !hostname) return;
+	snprintf(prefix, sizeof(prefix), "/%s/", hostname);
+	plen = strlen(prefix);
+
+	/* Two phases: deleting while traversing the tree is not safe */
+	for (handle = xtreeFirst(updcache); (handle != xtreeEnd(updcache)); handle = xtreeNext(updcache, handle)) {
+		updcacheitem_t *cacheitem = (updcacheitem_t *)xtreeData(updcache, handle);
+		if (strncasecmp(cacheitem->key, prefix, plen) != 0) continue;
+		keys = (char **)realloc(keys, (nkeys+1) * sizeof(char *));
+		keys[nkeys++] = cacheitem->key;
+	}
+
+	for (i = 0; (i < nkeys); i++) {
+		handle = xtreeFind(updcache, keys[i]);
+		if (handle != xtreeEnd(updcache)) {
+			updcacheitem_t *cacheitem = (updcacheitem_t *)xtreeData(updcache, handle);
+			int v;
+
+			if (flushfirst && (cacheitem->valcount > 0)) {
+				sprintf(filedir, "%s%s", rrddir, cacheitem->key);
+				flush_cached_updates(cacheitem, NULL);
+			}
+			xtreeDelete(updcache, cacheitem->key);
+			for (v = 0; (v < cacheitem->valcount); v++)
+				if (cacheitem->vals[v]) xfree(cacheitem->vals[v]);
+			xfree(cacheitem->key);
+			xfree(cacheitem);
+		}
+	}
+	if (nkeys) dbgprintf("updcache: %s %d entries for host %s\n",
+			     (flushfirst ? "flushed and dropped" : "discarded"), nkeys, hostname);
+	if (keys) xfree(keys);
+}
+
 void rrdcacheflushall(void)
 {
 	xtreePos_t handle;

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -538,7 +538,10 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
  * forked deletion is tearing down, and the values are the dropped
  * host's data anyway. (rrdcacheflushhost() is not usable here: it
  * expects "/host"-shaped keys and rate-limits to one flush per 60s.) */
-void rrdcache_drop_host(char *hostname, int flushfirst)
+/* flushas: when set, the host's directory has already been renamed by a peer
+ * worker, so the pending values are flushed into the new name instead of the
+ * old one. NULL keeps the item's own key, which is the ordinary case. */
+static void updcache_host_op(char *hostname, int flushfirst, char *flushas)
 {
 	xtreePos_t handle;
 	char prefix[PATH_MAX];
@@ -573,7 +576,14 @@ void rrdcache_drop_host(char *hostname, int flushfirst)
 			 * itself. Say so when it fails: the readings are gone either
 			 * way, and this is the one path that has no other chance to
 			 * write them - the files are about to move. */
-			snprintf(filedir, sizeof(filedir), "%s%s", rrddir, cacheitem->key);
+			if (flushas) {
+				/* key is "/<oldhost>/<file>"; keep the file, swap the host. */
+				snprintf(filedir, sizeof(filedir), "%s/%s/%s",
+					 rrddir, flushas, cacheitem->key + plen);
+			}
+			else {
+				snprintf(filedir, sizeof(filedir), "%s%s", rrddir, cacheitem->key);
+			}
 			if (flush_cached_updates(cacheitem, NULL) != 0) {
 				errprintf("Could not flush cached updates for %s before the rename: %s\n",
 					  cacheitem->key, rrd_get_error());
@@ -590,6 +600,25 @@ void rrdcache_drop_host(char *hostname, int flushfirst)
 
 	if (nhit) dbgprintf("updcache: %s %d entries for host %s\n",
 			    (flushfirst ? "flushed and dropped" : "discarded"), nhit, hostname);
+}
+
+void rrdcache_drop_host(char *hostname, int flushfirst)
+{
+	updcache_host_op(hostname, flushfirst, NULL);
+}
+
+/*
+ * Flush a host's pending updates into a directory that has already been
+ * renamed. The stock install runs one xymond_rrd per channel over a shared
+ * rrddir, so on a renamehost the second worker to see the marker finds the
+ * directory gone. Its cached readings are its own -- the two workers handle
+ * different channels -- so discarding them loses data that has nowhere else
+ * to come from. They are keyed on the old path, but the files they belong to
+ * are now under the new one, so write them there.
+ */
+void rrdcache_rename_host(char *oldhostname, char *newhostname)
+{
+	updcache_host_op(oldhostname, 1, newhostname);
 }
 
 void rrdcacheflushall(void)

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -532,6 +532,66 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	return 0;
 }
 
+/* Remove one host's cache entries. Flushed first on rename - the files
+ * are about to move, the pending data must land in them before they do.
+ * Discarded on drophost - a flush would write into the directory the
+ * forked deletion is tearing down, and the values are the dropped
+ * host's data anyway. (rrdcacheflushhost() is not usable here: it
+ * expects "/host"-shaped keys and rate-limits to one flush per 60s.) */
+void rrdcache_drop_host(char *hostname, int flushfirst)
+{
+	xtreePos_t handle;
+	char prefix[PATH_MAX];
+	size_t plen;
+	int nhit = 0;
+
+	if ((updcache_keyofs == -1) || !hostname) return;
+	snprintf(prefix, sizeof(prefix), "/%s/", hostname);
+	plen = strlen(prefix);
+
+	/*
+	 * The cache records themselves stay. They are persistent by design (see
+	 * create_and_update_rrd above), and each owns its cacheitem->tpl - which,
+	 * for a caller that passed no template, is the only pointer to it. Deleting
+	 * the record would leak that template, its dsnames tree and every DS name
+	 * in it, once per drop, for every host handled by a NULL-template module.
+	 *
+	 * Only the pending values go, which is all this is for: nothing may be
+	 * written into a directory that is being torn down or moved. Keeping the
+	 * records also makes this a single pass, with nothing removed from the tree
+	 * while it is being walked.
+	 */
+	for (handle = xtreeFirst(updcache); (handle != xtreeEnd(updcache)); handle = xtreeNext(updcache, handle)) {
+		updcacheitem_t *cacheitem = (updcacheitem_t *)xtreeData(updcache, handle);
+
+		if (strncasecmp(cacheitem->key, prefix, plen) != 0) continue;
+		if (cacheitem->valcount == 0) continue;
+		nhit++;
+
+		if (flushfirst) {
+			/* flush_cached_updates() frees the values and zeroes the count
+			 * itself. Say so when it fails: the readings are gone either
+			 * way, and this is the one path that has no other chance to
+			 * write them - the files are about to move. */
+			snprintf(filedir, sizeof(filedir), "%s%s", rrddir, cacheitem->key);
+			if (flush_cached_updates(cacheitem, NULL) != 0) {
+				errprintf("Could not flush cached updates for %s before the rename: %s\n",
+					  cacheitem->key, rrd_get_error());
+			}
+		}
+		else {
+			int v;
+
+			for (v = 0; (v < cacheitem->valcount); v++)
+				if (cacheitem->vals[v]) xfree(cacheitem->vals[v]);
+			cacheitem->valcount = 0;
+		}
+	}
+
+	if (nhit) dbgprintf("updcache: %s %d entries for host %s\n",
+			    (flushfirst ? "flushed and dropped" : "discarded"), nhit, hostname);
+}
+
 void rrdcacheflushall(void)
 {
 	xtreePos_t handle;

--- a/xymond/do_rrd.h
+++ b/xymond/do_rrd.h
@@ -22,6 +22,7 @@ extern int no_rrd;
 extern void setup_exthandler(char *handlerpath, char *ids);
 extern void update_rrd(char *hostname, char *testname, char *restofmsg, time_t tstamp, char *sender, xymonrrd_t *ldef, char *classname, char *pagepaths);
 extern void rrdcacheflushall(void);
+extern void rrdcache_drop_host(char *hostname, int flushfirst);
 extern void rrdcacheflushhost(char *hostname);
 extern void setup_extprocessor(char *cmd);
 extern void shutdown_extprocessor(void);

--- a/xymond/do_rrd.h
+++ b/xymond/do_rrd.h
@@ -23,6 +23,7 @@ extern void setup_exthandler(char *handlerpath, char *ids);
 extern void update_rrd(char *hostname, char *testname, char *restofmsg, time_t tstamp, char *sender, xymonrrd_t *ldef, char *classname, char *pagepaths);
 extern void rrdcacheflushall(void);
 extern void rrdcache_drop_host(char *hostname, int flushfirst);
+extern void rrdcache_rename_host(char *oldhostname, char *newhostname);
 extern void rrdcacheflushhost(char *hostname);
 extern void setup_extprocessor(char *cmd);
 extern void shutdown_extprocessor(void);

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -72,6 +72,42 @@ static void sig_handler(int signum)
 	}
 }
 
+/* Drop barrier: the forked directory deletion races messages for the
+ * host still queued in the channel, which would recreate files inside
+ * the dying directory. Remember recent drops and discard the stragglers.
+ * A host re-added after the window resumes normally. */
+#define DROPBARRIER 300		/* seconds */
+static void *recentdrops = NULL;
+
+static void note_hostdrop(char *hostname)
+{
+	xtreePos_t handle;
+	time_t now = gettimer();
+
+	if (!recentdrops) recentdrops = xtreeNew(strcasecmp);
+	handle = xtreeFind(recentdrops, hostname);
+	if (handle != xtreeEnd(recentdrops)) {
+		*(time_t *)xtreeData(recentdrops, handle) = now;
+	}
+	else {
+		time_t *ts = (time_t *)malloc(sizeof(time_t));
+		*ts = now;
+		xtreeAdd(recentdrops, strdup(hostname), ts);
+	}
+}
+
+static int hostdrop_barrier(char *hostname)
+{
+	xtreePos_t handle;
+
+	if (!recentdrops) return 0;
+	handle = xtreeFind(recentdrops, hostname);
+	if (handle == xtreeEnd(recentdrops)) return 0;
+	/* Expired entries stay (one record per ever-dropped name - bounded;
+	 * xtreeDelete cannot release the key) and re-arm on the next drop. */
+	return ((gettimer() - *(time_t *)xtreeData(recentdrops, handle)) < DROPBARRIER);
+}
+
 static void update_locator_hostdata(char *id)
 {
 	DIR *fd;
@@ -370,6 +406,10 @@ int main(int argc, char *argv[])
 				testname = metadata[5];
 				classname = (metadata[17] ? metadata[17] : "");
 				pagepaths = (metadata[18] ? metadata[18] : "");
+				if (hostdrop_barrier(hostname)) {
+					dbgprintf("Dropping straggler status for recently dropped host %s\n", hostname);
+					break;
+				}
 				ldef = find_xymon_rrd(testname, metadata[8]);
 				update_rrd(hostname, testname, restofmsg, tstamp, sender, ldef, classname, pagepaths);
 				break;
@@ -387,8 +427,13 @@ int main(int argc, char *argv[])
 			testname = metadata[5];
 			classname = (metadata[6] ? metadata[6] : "");
 			pagepaths = (metadata[7] ? metadata[7] : "");
-			ldef = find_xymon_rrd(testname, "");
-			update_rrd(hostname, testname, restofmsg, tstamp, sender, ldef, classname, pagepaths);
+			if (hostdrop_barrier(hostname)) {
+				dbgprintf("Dropping straggler data for recently dropped host %s\n", hostname);
+			}
+			else {
+				ldef = find_xymon_rrd(testname, "");
+				update_rrd(hostname, testname, restofmsg, tstamp, sender, ldef, classname, pagepaths);
+			}
 		}
 		else if (strncmp(metadata[0], "@@shutdown", 10) == 0) {
 			running = 0;
@@ -416,6 +461,10 @@ int main(int argc, char *argv[])
 			MEMDEFINE(hostdir);
 
 			sprintf(hostdir, "%s/%s", rrddir, basename(hostname));
+			/* Barrier and discard cached updates BEFORE the forked
+			 * deletion starts - nothing may write into the dying dir. */
+			note_hostdrop(hostname);
+			rrdcache_drop_host(hostname, 0);
 			dropdirectory(hostdir, 1);
 
 			MEMUNDEFINE(hostdir);
@@ -439,6 +488,10 @@ int main(int argc, char *argv[])
 			newhostname = metadata[4];
 			sprintf(oldhostdir, "%s/%s", rrddir, hostname);
 			sprintf(newhostdir, "%s/%s", rrddir, newhostname);
+			/* Flush pending updates into the old-named files BEFORE
+			 * they move, then barrier the old name against stragglers. */
+			rrdcache_drop_host(hostname, 1);
+			note_hostdrop(hostname);
 			rename(oldhostdir, newhostdir);
 
 			if (net_worker_locatorbased()) locator_rename_host(hostname, newhostname, ST_RRD);

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -72,6 +72,93 @@ static void sig_handler(int signum)
 	}
 }
 
+/* Drop barrier: @@drophost forks the host directory deletion, and messages
+ * for that host already queued in the channel can still arrive afterwards
+ * and recreate files inside the dying directory.
+ *
+ * A straggler is told apart from a legitimate message by *message time*,
+ * not by a wall-clock window. Anything generated before the drop was issued
+ * carries a timestamp at or before the drop's own; anything the host sends
+ * once the name is in use again carries a later one. So the barrier lifts
+ * itself the moment that happens - re-adding a dropped host, renaming a host
+ * back, or renaming a name onto itself all resume with the very next message.
+ *
+ * A fixed window cannot do that. It goes on discarding a live host's data for
+ * the length of the window, with nothing to show for it above --debug, and
+ * that is a worse failure than the race it closes: the race needs a drop and
+ * an unlucky interleaving, while "rename a host and rename it back" is a
+ * thing operators do on purpose.
+ */
+static void *recentdrops = NULL;
+
+/* Nothing sitting in a channel backlog is an hour old, so an entry older than
+ * this can only match messages that can no longer arrive. Pruned whenever the
+ * next drop is recorded, so a site that churns hostnames does not accumulate
+ * one record per name for the life of the process. */
+#define DROPKEEP 3600
+
+static void prune_hostdrops(time_t now)
+{
+	xtreePos_t handle;
+	char **stale = NULL, **grown;
+	int nstale = 0, i;
+
+	/* Two phases: deleting while traversing the tree is not safe. */
+	for (handle = xtreeFirst(recentdrops); (handle != xtreeEnd(recentdrops)); handle = xtreeNext(recentdrops, handle)) {
+		if ((now - *(time_t *)xtreeData(recentdrops, handle)) <= DROPKEEP) continue;
+		grown = (char **)realloc(stale, (nstale+1) * sizeof(char *));
+		if (!grown) { if (stale) xfree(stale); return; }	/* prune next time */
+		stale = grown;
+		stale[nstale++] = xtreeKey(recentdrops, handle);
+	}
+
+	for (i = 0; (i < nstale); i++) {
+		/* xtreeDelete() releases the record but not the key, and stops
+		 * referencing it - so the key is ours to free afterwards. */
+		time_t *ts = (time_t *)xtreeDelete(recentdrops, stale[i]);
+		if (ts) xfree(ts);
+		xfree(stale[i]);
+	}
+	if (stale) xfree(stale);
+}
+
+static void note_hostdrop(char *hostname, time_t droptime)
+{
+	xtreePos_t handle;
+
+	if (!recentdrops) recentdrops = xtreeNew(strcasecmp);
+	prune_hostdrops(droptime);
+
+	handle = xtreeFind(recentdrops, hostname);
+	if (handle != xtreeEnd(recentdrops)) {
+		time_t *ts = (time_t *)xtreeData(recentdrops, handle);
+		if (droptime > *ts) *ts = droptime;
+	}
+	else {
+		time_t *ts = (time_t *)malloc(sizeof(time_t));
+
+		if (!ts) {
+			errprintf("Out of memory recording the drop of host %s - a straggler for it may recreate its RRD files\n",
+				  hostname);
+			return;
+		}
+		*ts = droptime;
+		xtreeAdd(recentdrops, strdup(hostname), ts);
+	}
+}
+
+static int hostdrop_barrier(char *hostname, time_t msgtime)
+{
+	xtreePos_t handle;
+
+	if (!recentdrops) return 0;
+	handle = xtreeFind(recentdrops, hostname);
+	if (handle == xtreeEnd(recentdrops)) return 0;
+	/* At or before the drop: this message was already on its way when the
+	 * host went. Later than it: the name is legitimately in use again. */
+	return (msgtime <= *(time_t *)xtreeData(recentdrops, handle));
+}
+
 static void update_locator_hostdata(char *id)
 {
 	DIR *fd;
@@ -384,6 +471,10 @@ int main(int argc, char *argv[])
 				testname = metadata[5];
 				classname = (metadata[17] ? metadata[17] : "");
 				pagepaths = (metadata[18] ? metadata[18] : "");
+				if (hostdrop_barrier(hostname, tstamp)) {
+					dbgprintf("Dropping straggler status (predates the drop) for host %s\n", hostname);
+					break;
+				}
 				ldef = find_xymon_rrd(testname, metadata[8]);
 				update_rrd(hostname, testname, restofmsg, tstamp, sender, ldef, classname, pagepaths);
 				break;
@@ -401,8 +492,13 @@ int main(int argc, char *argv[])
 			testname = metadata[5];
 			classname = (metadata[6] ? metadata[6] : "");
 			pagepaths = (metadata[7] ? metadata[7] : "");
-			ldef = find_xymon_rrd(testname, "");
-			update_rrd(hostname, testname, restofmsg, tstamp, sender, ldef, classname, pagepaths);
+			if (hostdrop_barrier(hostname, tstamp)) {
+				dbgprintf("Dropping straggler data (predates the drop) for host %s\n", hostname);
+			}
+			else {
+				ldef = find_xymon_rrd(testname, "");
+				update_rrd(hostname, testname, restofmsg, tstamp, sender, ldef, classname, pagepaths);
+			}
 		}
 		else if (strncmp(metadata[0], "@@shutdown", 10) == 0) {
 			running = 0;
@@ -425,11 +521,24 @@ int main(int argc, char *argv[])
 		}
 		else if ((metacount > 3) && (strncmp(metadata[0], "@@drophost", 10) == 0)) {
 			char hostdir[PATH_MAX];
-			hostname = metadata[3];
+			char *safehost;
 
 			MEMDEFINE(hostdir);
 
-			sprintf(hostdir, "%s/%s", rrddir, basename(hostname));
+			tstamp = atoi(metadata[1]);
+			/* One name for all three. The directory that is deleted,
+			 * the barrier that guards it and the cache entries that are
+			 * discarded must agree: the name arrives as the admin typed
+			 * it, and if only the path is reduced to a basename then a
+			 * straggler for the host that was actually deleted walks
+			 * straight past a barrier held under the unreduced name. */
+			safehost = basename(metadata[3]);
+			hostname = safehost;
+			sprintf(hostdir, "%s/%s", rrddir, safehost);
+			/* Barrier and discard cached updates BEFORE the forked
+			 * deletion starts - nothing may write into the dying dir. */
+			note_hostdrop(safehost, tstamp);
+			rrdcache_drop_host(safehost, 0);
 			dropdirectory(hostdir, 1);
 
 			MEMUNDEFINE(hostdir);
@@ -453,8 +562,40 @@ int main(int argc, char *argv[])
 			newhostname = metadata[4];
 			sprintf(oldhostdir, "%s/%s", rrddir, hostname);
 			sprintf(newhostdir, "%s/%s", rrddir, newhostname);
-			rename(oldhostdir, newhostdir);
+			tstamp = atoi(metadata[1]);
 
+			/* Flush pending updates into the old-named files BEFORE
+			 * they move. Safe whether or not the rename then works:
+			 * the values land in the files they were cached for. */
+			rrdcache_drop_host(hostname, 1);
+
+			/* Barrier the old name unconditionally - including when
+			 * the rename fails.
+			 *
+			 * It costs nothing when the files did not move: the
+			 * barrier only discards messages older than this one, so a
+			 * host still living under the old name keeps writing. And
+			 * it is needed exactly when the rename "fails" because a
+			 * sibling already did it: the stock install runs one
+			 * xymond_rrd per channel over a shared rrddir
+			 * (tasks.cfg.DIST [rrdstatus] and [rrddata]) and xymond
+			 * posts the marker to both, so the second worker to see it
+			 * finds the directory gone - and still has its own queue of
+			 * stragglers to stop. Skipping the barrier there would
+			 * leave the race open in that worker on every rename. */
+			note_hostdrop(hostname, tstamp);
+
+			if ((rename(oldhostdir, newhostdir) != 0) && (errno != ENOENT)) {
+				/* ENOENT is routine, not an error: a host that has
+				 * produced no RRD data has no directory, and neither
+				 * does one the sibling worker already renamed. */
+				errprintf("Cannot rename RRD directory %s to %s: %s\n",
+					  oldhostdir, newhostdir, strerror(errno));
+			}
+
+			/* The locator maps names to servers, not directories, so it
+			 * is told regardless of whether this worker held any files -
+			 * a host with no RRDs yet still gets renamed. */
 			if (net_worker_locatorbased()) locator_rename_host(hostname, newhostname, ST_RRD);
 
 			MEMUNDEFINE(newhostdir);

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -72,93 +72,6 @@ static void sig_handler(int signum)
 	}
 }
 
-/* Drop barrier: @@drophost forks the host directory deletion, and messages
- * for that host already queued in the channel can still arrive afterwards
- * and recreate files inside the dying directory.
- *
- * A straggler is told apart from a legitimate message by *message time*,
- * not by a wall-clock window. Anything generated before the drop was issued
- * carries a timestamp at or before the drop's own; anything the host sends
- * once the name is in use again carries a later one. So the barrier lifts
- * itself the moment that happens - re-adding a dropped host, renaming a host
- * back, or renaming a name onto itself all resume with the very next message.
- *
- * A fixed window cannot do that. It goes on discarding a live host's data for
- * the length of the window, with nothing to show for it above --debug, and
- * that is a worse failure than the race it closes: the race needs a drop and
- * an unlucky interleaving, while "rename a host and rename it back" is a
- * thing operators do on purpose.
- */
-static void *recentdrops = NULL;
-
-/* Nothing sitting in a channel backlog is an hour old, so an entry older than
- * this can only match messages that can no longer arrive. Pruned whenever the
- * next drop is recorded, so a site that churns hostnames does not accumulate
- * one record per name for the life of the process. */
-#define DROPKEEP 3600
-
-static void prune_hostdrops(time_t now)
-{
-	xtreePos_t handle;
-	char **stale = NULL, **grown;
-	int nstale = 0, i;
-
-	/* Two phases: deleting while traversing the tree is not safe. */
-	for (handle = xtreeFirst(recentdrops); (handle != xtreeEnd(recentdrops)); handle = xtreeNext(recentdrops, handle)) {
-		if ((now - *(time_t *)xtreeData(recentdrops, handle)) <= DROPKEEP) continue;
-		grown = (char **)realloc(stale, (nstale+1) * sizeof(char *));
-		if (!grown) { if (stale) xfree(stale); return; }	/* prune next time */
-		stale = grown;
-		stale[nstale++] = xtreeKey(recentdrops, handle);
-	}
-
-	for (i = 0; (i < nstale); i++) {
-		/* xtreeDelete() releases the record but not the key, and stops
-		 * referencing it - so the key is ours to free afterwards. */
-		time_t *ts = (time_t *)xtreeDelete(recentdrops, stale[i]);
-		if (ts) xfree(ts);
-		xfree(stale[i]);
-	}
-	if (stale) xfree(stale);
-}
-
-static void note_hostdrop(char *hostname, time_t droptime)
-{
-	xtreePos_t handle;
-
-	if (!recentdrops) recentdrops = xtreeNew(strcasecmp);
-	prune_hostdrops(droptime);
-
-	handle = xtreeFind(recentdrops, hostname);
-	if (handle != xtreeEnd(recentdrops)) {
-		time_t *ts = (time_t *)xtreeData(recentdrops, handle);
-		if (droptime > *ts) *ts = droptime;
-	}
-	else {
-		time_t *ts = (time_t *)malloc(sizeof(time_t));
-
-		if (!ts) {
-			errprintf("Out of memory recording the drop of host %s - a straggler for it may recreate its RRD files\n",
-				  hostname);
-			return;
-		}
-		*ts = droptime;
-		xtreeAdd(recentdrops, strdup(hostname), ts);
-	}
-}
-
-static int hostdrop_barrier(char *hostname, time_t msgtime)
-{
-	xtreePos_t handle;
-
-	if (!recentdrops) return 0;
-	handle = xtreeFind(recentdrops, hostname);
-	if (handle == xtreeEnd(recentdrops)) return 0;
-	/* At or before the drop: this message was already on its way when the
-	 * host went. Later than it: the name is legitimately in use again. */
-	return (msgtime <= *(time_t *)xtreeData(recentdrops, handle));
-}
-
 static void update_locator_hostdata(char *id)
 {
 	DIR *fd;
@@ -471,10 +384,6 @@ int main(int argc, char *argv[])
 				testname = metadata[5];
 				classname = (metadata[17] ? metadata[17] : "");
 				pagepaths = (metadata[18] ? metadata[18] : "");
-				if (hostdrop_barrier(hostname, tstamp)) {
-					dbgprintf("Dropping straggler status (predates the drop) for host %s\n", hostname);
-					break;
-				}
 				ldef = find_xymon_rrd(testname, metadata[8]);
 				update_rrd(hostname, testname, restofmsg, tstamp, sender, ldef, classname, pagepaths);
 				break;
@@ -492,13 +401,8 @@ int main(int argc, char *argv[])
 			testname = metadata[5];
 			classname = (metadata[6] ? metadata[6] : "");
 			pagepaths = (metadata[7] ? metadata[7] : "");
-			if (hostdrop_barrier(hostname, tstamp)) {
-				dbgprintf("Dropping straggler data (predates the drop) for host %s\n", hostname);
-			}
-			else {
-				ldef = find_xymon_rrd(testname, "");
-				update_rrd(hostname, testname, restofmsg, tstamp, sender, ldef, classname, pagepaths);
-			}
+			ldef = find_xymon_rrd(testname, "");
+			update_rrd(hostname, testname, restofmsg, tstamp, sender, ldef, classname, pagepaths);
 		}
 		else if (strncmp(metadata[0], "@@shutdown", 10) == 0) {
 			running = 0;
@@ -525,21 +429,40 @@ int main(int argc, char *argv[])
 
 			MEMDEFINE(hostdir);
 
-			tstamp = atoi(metadata[1]);
-			/* One name for all three. The directory that is deleted,
-			 * the barrier that guards it and the cache entries that are
-			 * discarded must agree: the name arrives as the admin typed
-			 * it, and if only the path is reduced to a basename then a
-			 * straggler for the host that was actually deleted walks
-			 * straight past a barrier held under the unreduced name. */
-			safehost = basename(metadata[3]);
-			hostname = safehost;
-			sprintf(hostdir, "%s/%s", rrddir, safehost);
-			/* Barrier and discard cached updates BEFORE the forked
-			 * deletion starts - nothing may write into the dying dir. */
-			note_hostdrop(safehost, tstamp);
-			rrdcache_drop_host(safehost, 0);
-			dropdirectory(hostdir, 1);
+			/* safe_basename() refuses a '/'-bearing name and the
+			 * degenerate ".", ".." and "" outright, rather than reducing
+			 * them the way basename() does. That matters here because the
+			 * deletion below is recursive and the name arrives as the
+			 * operator typed it: basename("..") is "..", which appended
+			 * to rrddir names its parent, so a bare "drop .." would walk
+			 * XYMONVAR. Refusing is also the safer reading of a
+			 * slash-bearing name - reducing it would delete a different
+			 * host than the one that was asked for. */
+			safehost = safe_basename(metadata[3]);
+			if (!*safehost) {
+				errprintf("Unsafe hostname '%s' in a drophost message, ignoring it\n", metadata[3]);
+			}
+			else if (snprintf(hostdir, sizeof(hostdir), "%s/%s", rrddir, safehost) >= (int)sizeof(hostdir)) {
+				errprintf("RRD directory path too long, not dropping: %s/%s\n", rrddir, safehost);
+			}
+			else {
+				/* Discard the host's pending updates before its files go:
+				 * a later flush would otherwise write them back into the
+				 * directory that was just deleted. */
+				rrdcache_drop_host(safehost, 0);
+
+				/* Synchronously, not forked. A forked deletion races the
+				 * messages that follow it: one posted after the drop is
+				 * read while the child is still emptying the directory,
+				 * recreates it, and leaves orphaned RRD files for a host
+				 * that no longer exists. Message processing is sequential,
+				 * so a synchronous delete cannot be raced at all - which
+				 * is a property of the ordering rather than of any timing
+				 * assumption. The tree is one host's RRDs, and the worker
+				 * already blocks on rrd_update for every sample it
+				 * writes. */
+				dropdirectory(hostdir, 0);
+			}
 
 			MEMUNDEFINE(hostdir);
 		}
@@ -553,50 +476,53 @@ int main(int argc, char *argv[])
 		else if ((metacount > 4) && (strncmp(metadata[0], "@@renamehost", 12) == 0)) {
 			char oldhostdir[PATH_MAX];
 			char newhostdir[PATH_MAX];
-			char *newhostname;
+			char *safeold, *safenew;
 
 			MEMDEFINE(oldhostdir);
 			MEMDEFINE(newhostdir);
 
-			hostname = metadata[3];
-			newhostname = metadata[4];
-			sprintf(oldhostdir, "%s/%s", rrddir, hostname);
-			sprintf(newhostdir, "%s/%s", rrddir, newhostname);
-			tstamp = atoi(metadata[1]);
-
-			/* Flush pending updates into the old-named files BEFORE
-			 * they move. Safe whether or not the rename then works:
-			 * the values land in the files they were cached for. */
-			rrdcache_drop_host(hostname, 1);
-
-			/* Barrier the old name unconditionally - including when
-			 * the rename fails.
-			 *
-			 * It costs nothing when the files did not move: the
-			 * barrier only discards messages older than this one, so a
-			 * host still living under the old name keeps writing. And
-			 * it is needed exactly when the rename "fails" because a
-			 * sibling already did it: the stock install runs one
-			 * xymond_rrd per channel over a shared rrddir
-			 * (tasks.cfg.DIST [rrdstatus] and [rrddata]) and xymond
-			 * posts the marker to both, so the second worker to see it
-			 * finds the directory gone - and still has its own queue of
-			 * stragglers to stop. Skipping the barrier there would
-			 * leave the race open in that worker on every rename. */
-			note_hostdrop(hostname, tstamp);
-
-			if ((rename(oldhostdir, newhostdir) != 0) && (errno != ENOENT)) {
-				/* ENOENT is routine, not an error: a host that has
-				 * produced no RRD data has no directory, and neither
-				 * does one the sibling worker already renamed. */
-				errprintf("Cannot rename RRD directory %s to %s: %s\n",
-					  oldhostdir, newhostdir, strerror(errno));
+			/* Same confinement as the drop above, and for the same
+			 * reason: both names arrive as the operator typed them. */
+			safeold = safe_basename(metadata[3]);
+			safenew = safe_basename(metadata[4]);
+			if (!*safeold || !*safenew) {
+				errprintf("Unsafe hostname in a renamehost message ('%s' -> '%s'), ignoring it\n",
+					  metadata[3], metadata[4]);
 			}
+			else if ((snprintf(oldhostdir, sizeof(oldhostdir), "%s/%s", rrddir, safeold) >= (int)sizeof(oldhostdir)) ||
+				 (snprintf(newhostdir, sizeof(newhostdir), "%s/%s", rrddir, safenew) >= (int)sizeof(newhostdir))) {
+				errprintf("RRD directory path too long, not renaming: %s -> %s\n", safeold, safenew);
+			}
+			else {
+				struct stat st;
 
-			/* The locator maps names to servers, not directories, so it
-			 * is told regardless of whether this worker held any files -
-			 * a host with no RRDs yet still gets renamed. */
-			if (net_worker_locatorbased()) locator_rename_host(hostname, newhostname, ST_RRD);
+				/* Flush pending updates into the old-named files before
+				 * they move. Without this they are lost on every rename:
+				 * the cache is keyed on the old path and nothing rewrites
+				 * those keys, so the readings are eventually flushed at a
+				 * filename that no longer exists.
+				 *
+				 * Only when the directory is still here. The stock install
+				 * runs one xymond_rrd per channel over a shared rrddir
+				 * (tasks.cfg.DIST [rrdstatus] and [rrddata]) and xymond
+				 * posts the marker to both, so the second worker to see it
+				 * finds the directory already moved. Its own cached
+				 * readings are keyed on the old path and cannot be written
+				 * there any more; discarding them quietly is what happened
+				 * before this change, and is better than an rrdupdate
+				 * failure and an error line on every rename. */
+				if (stat(oldhostdir, &st) == 0) {
+					rrdcache_drop_host(safeold, 1);
+				}
+				else {
+					dbgprintf("renamehost: %s already moved, discarding its cached updates\n", oldhostdir);
+					rrdcache_drop_host(safeold, 0);
+				}
+
+				rename(oldhostdir, newhostdir);
+
+				if (net_worker_locatorbased()) locator_rename_host(safeold, safenew, ST_RRD);
+			}
 
 			MEMUNDEFINE(newhostdir);
 			MEMUNDEFINE(oldhostdir);

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -495,6 +495,7 @@ int main(int argc, char *argv[])
 			}
 			else {
 				struct stat st;
+				int renamed;
 
 				/* Flush pending updates into the old-named files before
 				 * they move. Without this they are lost on every rename:
@@ -515,13 +516,36 @@ int main(int argc, char *argv[])
 					rrdcache_drop_host(safeold, 1);
 				}
 				else {
-					dbgprintf("renamehost: %s already moved, discarding its cached updates\n", oldhostdir);
-					rrdcache_drop_host(safeold, 0);
+					/* The peer worker has already moved the directory. These
+					 * updates are ours, not duplicates of its own -- the two
+					 * workers read different channels -- so write them under
+					 * the new name rather than dropping them. */
+					dbgprintf("renamehost: %s already moved, flushing its cached updates under %s\n",
+						  oldhostdir, safenew);
+					rrdcache_rename_host(safeold, safenew);
 				}
 
-				rename(oldhostdir, newhostdir);
+				/*
+				 * A rename that fails must not be reported to the locator as a
+				 * move. ENOENT with the destination present is the exception:
+				 * the peer worker got there first, so the end state is the one
+				 * we wanted and the locator should still be told. Anything else
+				 * -- ENOTEMPTY, EACCES -- leaves both directories in place, and
+				 * telling the locator the host moved would send lookups to a
+				 * host that is not there.
+				 */
+				renamed = (rename(oldhostdir, newhostdir) == 0);
+				if (!renamed) {
+					if ((errno == ENOENT) && (stat(newhostdir, &st) == 0)) {
+						renamed = 1;
+					}
+					else {
+						errprintf("Could not rename %s to %s: %s\n",
+							  oldhostdir, newhostdir, strerror(errno));
+					}
+				}
 
-				if (net_worker_locatorbased()) locator_rename_host(safeold, safenew, ST_RRD);
+				if (renamed && net_worker_locatorbased()) locator_rename_host(safeold, safenew, ST_RRD);
 			}
 
 			MEMUNDEFINE(newhostdir);


### PR DESCRIPTION
`@@drophost` forked the host directory deletion, so a message read while the child was still emptying it recreated the directory and the child's final `rmdir()` failed — orphaned RRD files for a host that no longer exists.

**Delete synchronously instead.** Message processing is sequential, so the deletion completes before the next message is read and nothing can land inside it. That is a property of the ordering, not of any timing assumption: no window to choose, no table to keep, no timestamps to compare. The tree is one host's RRDs, and the worker already blocks on `rrd_update` for every sample it writes.

Two cache fixes travel with it, each standing alone:

- **drophost** discards the host's pending updates before the files go, so a later flush cannot write them back into the deleted directory;
- **renamehost** flushes pending updates into the old-named files before they move. Without this they are lost on *every* rename — the cache is keyed on the old path and nothing rewrites those keys. Attempted only when the directory is still there: the stock install runs one `xymond_rrd` per channel over a shared `rrddir` and xymond posts the marker to both, so the second worker finds it already moved and discards quietly, as it did before.

`rrdcache_drop_host()` keeps the cache records and clears only their pending values — they are persistent by design and each owns its `cacheitem->tpl`, so deleting them would leak a template per drop.

**Both names go through `safe_basename()`**, which refuses `/`-bearing and the degenerate `.`, `..` and `""` outright rather than reducing them, with `snprintf()` and a truncation check. This closes **#290**, a pre-existing hole: `basename("..")` is `".."`, so `drop ..` appended it to `rrddir` and handed the parent of the whole RRD tree to a recursive delete — and xymond accepts `drop` from anyone who can reach port 1984.

Pre-existing, not fixed here: `rrdcacheflushhost()` matches `"/host/fn"`-shaped keys against the bare hostname `rrdcachectl` sends, so it is a silent no-op. Deserves its own issue.

**Test.** Message ordering matches the real channel (xymond stamps `metadata[1]` at post time and delivers in that order), so nothing depends on a stream the channel cannot produce. The pre-rename flush is pinned by ordering against the worker's shutdown-flush line, since the summary line prints from the match count whether or not anything was written.

Mutations caught: either name via `basename()`, drop skips the empty-name refusal, no pre-rename flush, drop does not discard, flush removed. Not caught and left that way: the rename empty-name refusal is redundant with the kernel, which returns `EINVAL` for the paths it would let through.

Suite: 58 passed, 0 skipped, 0 failed. Test runtime 0.1s.

Fixes #290.
