### PR TITLE
showgraph: pass exec-title arguments as literal shell words

### DIFF
--- a/tests/web/showgraph-exec-title.sh
+++ b/tests/web/showgraph-exec-title.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/showgraph-exec-title.sh
+#
+# A graphs.cfg "TITLE exec:<cmd>" runs <cmd> with the graph's displayname,
+# service and matched RRD filenames as arguments, and uses its first line
+# of output as the graph title. The displayname comes from the "disp="
+# CGI parameter, so those arguments must be passed to the script as
+# literal words, never interpreted by the shell. This test drives the
+# real showgraph CGI with values containing shell-active characters and
+# asserts they reach the script verbatim, with no shell evaluation.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+command -v make >/dev/null 2>&1 || skip "make not available"
+[ -f "$ROOT/web/showgraph.cgi" ] || skip "tree built without RRD support (no showgraph.cgi)"
+
+rrddef=$(sed -n 's/^RRDDEF *= *//p' "$ROOT/Makefile")
+rrdlibs=$(sed -n 's/^RRDLIBS *= *//p' "$ROOT/Makefile")
+[ -n "$rrdlibs" ] || rrdlibs="-lrrd"
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+
+pcre_libs=${PCRELIBS:-}
+if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+fi
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-showgraph-exec.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" $rrddef -o "$work/showgraph" \
+	"$ROOT/web/showgraph.c" "$ROOT/lib/libxymoncomm.a" \
+	$pcre_libs $rrdlibs $ssllibs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "showgraph does not compile"; }
+
+rrds="$work/rrd/testhost"
+mkdir -p "$rrds"
+touch "$rrds/tcp.conn.rrd"
+
+# The exec title script: record every argument it is handed (one per
+# line), and echo a fixed first line as the title.
+cat >"$work/titlescript.sh" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$@" >"$TITLE_ARGS_OUT"
+echo "the title"
+EOF
+chmod +x "$work/titlescript.sh"
+
+cp "$ROOT/xymond/etcfiles/graphs.cfg.DIST" "$work/graphs.cfg"
+cat >>"$work/graphs.cfg" <<EOF
+
+[exectitle]
+	FNPATTERN ^tcp\.conn\.rrd
+	TITLE exec:$work/titlescript.sh
+	YAXIS x
+	DEF:p@RRDIDX@=@RRDFN@:sec:AVERAGE
+	LINE2:p@RRDIDX@#@COLOR@:x
+EOF
+
+render() {  # render <disp-value>
+	rm -f "$work/SIDEEFFECT" "$work/args.out"
+	REQUEST_METHOD=GET \
+	QUERY_STRING="host=testhost&service=exectitle&graph=hourly&action=view&disp=$1" \
+	XYMONHOME="$work" TITLE_ARGS_OUT="$work/args.out" \
+		"$work/showgraph" --debug --config="$work/graphs.cfg" \
+		--rrddir="$rrds" >/dev/null 2>&1 || true
+}
+
+# A benign displayname is passed through verbatim as the first argument.
+render "myhost"
+[ -f "$work/args.out" ] || fail "exec title script did not run"
+grep -qx "myhost" "$work/args.out" || fail "benign displayname not passed literally: $(cat "$work/args.out")"
+
+# A "$(...)" value must be passed literally, not command-substituted:
+# the side-effect file must not appear, and the value must reach the
+# script as one argument, verbatim.
+val='x$(touch '"$work"'/SIDEEFFECT)y'
+render "$val"
+[ -e "$work/SIDEEFFECT" ] && fail "exec-title argument was shell-evaluated (\$() ran)"
+grep -qx "$val" "$work/args.out" \
+	|| fail "value with shell characters not passed as one literal argument: $(cat "$work/args.out")"
+
+# A value containing a double quote must not terminate an argument early.
+val2='a";touch '"$work"'/SIDEEFFECT;echo "b'
+render "$val2"
+[ -e "$work/SIDEEFFECT" ] && fail "exec-title argument was shell-evaluated (double quote)"
+grep -qx "$val2" "$work/args.out" || fail "value with a double quote not literal: $(cat "$work/args.out")"
+
+# A value containing backticks must not be command-substituted.
+val3='p`touch '"$work"'/SIDEEFFECT`q'
+render "$val3"
+[ -e "$work/SIDEEFFECT" ] && fail "exec-title argument was shell-evaluated (backticks)"
+grep -qx "$val3" "$work/args.out" || fail "value with backticks not literal: $(cat "$work/args.out")"
+
+echo "OK $(basename "$0")"

--- a/tests/web/showgraph-exec-title.sh
+++ b/tests/web/showgraph-exec-title.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/showgraph-exec-title.sh
+#
+# A graphs.cfg "TITLE exec:<cmd>" runs <cmd> with the graph's displayname,
+# service and matched RRD filenames as arguments, and uses its first line
+# of output as the graph title. The displayname comes from the "disp="
+# CGI parameter, so those arguments must be passed to the script as
+# literal words, never interpreted by the shell. This test drives the
+# real showgraph CGI with values containing shell-active characters and
+# asserts they reach the script verbatim, with no shell evaluation.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+command -v make >/dev/null 2>&1 || skip "make not available"
+[ -f "$ROOT/web/showgraph.cgi" ] || skip "tree built without RRD support (no showgraph.cgi)"
+
+rrddef=$(sed -n 's/^RRDDEF *= *//p' "$ROOT/Makefile")
+rrdlibs=$(sed -n 's/^RRDLIBS *= *//p' "$ROOT/Makefile")
+[ -n "$rrdlibs" ] || rrdlibs="-lrrd"
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+
+pcre_libs=${PCRELIBS:-}
+if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+fi
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-showgraph-exec.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" $rrddef -o "$work/showgraph" \
+	"$ROOT/web/showgraph.c" "$ROOT/lib/libxymoncomm.a" \
+	$pcre_libs $rrdlibs $ssllibs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "showgraph does not compile"; }
+
+rrds="$work/rrd/testhost"
+mkdir -p "$rrds"
+touch "$rrds/tcp.conn.rrd"
+
+# The exec title script: record every argument it is handed (one per
+# line), and echo a fixed first line as the title.
+cat >"$work/titlescript.sh" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$@" >"$TITLE_ARGS_OUT"
+echo "the title"
+EOF
+chmod +x "$work/titlescript.sh"
+
+cp "$ROOT/xymond/etcfiles/graphs.cfg.DIST" "$work/graphs.cfg"
+cat >>"$work/graphs.cfg" <<EOF
+
+[exectitle]
+	FNPATTERN ^tcp\.conn\.rrd
+	TITLE exec:$work/titlescript.sh
+	YAXIS x
+	DEF:p@RRDIDX@=@RRDFN@:sec:AVERAGE
+	LINE2:p@RRDIDX@#@COLOR@:x
+EOF
+
+render() {  # render <disp-value>
+	rm -f "$work/SIDEEFFECT" "$work/args.out"
+	REQUEST_METHOD=GET \
+	QUERY_STRING="host=testhost&service=exectitle&graph=hourly&action=view&disp=$1" \
+	XYMONHOME="$work" TITLE_ARGS_OUT="$work/args.out" \
+		"$work/showgraph" --debug --config="$work/graphs.cfg" \
+		--rrddir="$rrds" >/dev/null 2>&1 || true
+}
+
+# A benign displayname is passed through verbatim as the first argument.
+render "myhost"
+[ -f "$work/args.out" ] || fail "exec title script did not run"
+grep -qxF -- "myhost" "$work/args.out" || fail "benign displayname not passed literally: $(cat "$work/args.out")"
+
+# A "$(...)" value must be passed literally, not command-substituted:
+# the side-effect file must not appear, and the value must reach the
+# script as one argument, verbatim.
+val='x$(touch '"$work"'/SIDEEFFECT)y'
+render "$val"
+[ -e "$work/SIDEEFFECT" ] && fail "exec-title argument was shell-evaluated (\$() ran)"
+grep -qxF -- "$val" "$work/args.out" \
+	|| fail "value with shell characters not passed as one literal argument: $(cat "$work/args.out")"
+
+# A value containing a double quote must not terminate an argument early.
+val2='a";touch '"$work"'/SIDEEFFECT;echo "b'
+render "$val2"
+[ -e "$work/SIDEEFFECT" ] && fail "exec-title argument was shell-evaluated (double quote)"
+grep -qxF -- "$val2" "$work/args.out" || fail "value with a double quote not literal: $(cat "$work/args.out")"
+
+# A value containing backticks must not be command-substituted.
+val3='p`touch '"$work"'/SIDEEFFECT`q'
+render "$val3"
+[ -e "$work/SIDEEFFECT" ] && fail "exec-title argument was shell-evaluated (backticks)"
+grep -qxF -- "$val3" "$work/args.out" || fail "value with backticks not literal: $(cat "$work/args.out")"
+
+# A single quote must not close the quoting placed around the value. The
+# embedded $(...) keeps this observable: an escaping bug that lets the
+# quote out leaves the command substitution live, so the failure shows up
+# as the side-effect file rather than only as a shell syntax error.
+val4='a'\''$(touch '"$work"'/SIDEEFFECT)'\''b'
+render "$val4"
+[ -e "$work/SIDEEFFECT" ] && fail "exec-title argument was shell-evaluated (single quote)"
+[ -f "$work/args.out" ] || fail "value with a single quote broke the command line (script did not run)"
+grep -qxF -- "$val4" "$work/args.out" || fail "value with a single quote not literal: $(cat "$work/args.out")"
+
+echo "OK $(basename "$0")"

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -104,6 +104,29 @@ int firstidx = -1;
 int idxcount = -1;
 int lastidx = 0;
 
+/* Quote a value for safe inclusion as a single word in a /bin/sh command
+ * line: wrap it in single quotes and render each embedded single quote as
+ * '\'' (close, escaped quote, reopen). The result contains no shell-active
+ * character outside the admin's own command, so a CGI-supplied value
+ * cannot break out. Caller frees. */
+static char *shellquote(const char *s)
+{
+	strbuffer_t *b = newstrbuffer(0);
+	const char *p;
+	char *result;
+
+	addtobuffer(b, "'");
+	for (p = (s ? s : ""); (*p); p++) {
+		if (*p == '\'') addtobuffer(b, "'\\''");
+		else addtobufferraw(b, (char *)p, 1);
+	}
+	addtobuffer(b, "'");
+	result = strdup(STRBUF(b));
+	freestrbuffer(b);
+
+	return result;
+}
+
 void errormsg(char *msg)
 {
 	printf("Content-type: %s\n\n", xgetenv("HTMLCONTENTTYPE"));
@@ -1080,27 +1103,35 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	/* Setup the title */
 	if (!gdef->title) gdef->title = strdup("");
 	if (strncmp(gdef->title, "exec:", 5) == 0) {
-		char *pcmd;
-		int i, pcmdlen = 7;
+		strbuffer_t *cmd = newstrbuffer(0);
 		FILE *pfd;
 		char *p;
-		char *param_str = "%s \"%s\" %s \"%s\"";
+		int i;
 
-		pcmdlen += (strlen(gdef->title+5) + strlen(displayname) + strlen(service) + strlen(glegend));
-		for (i=0; (i<rrddbcount); i++) pcmdlen += (strlen(rrddbs[i].rrdfn) + 3);
-
-		p = pcmd = (char *)malloc(pcmdlen+1);
-		p += snprintf(p, pcmdlen+1, param_str, gdef->title+5, displayname, service, glegend);
+		/* The admin's command line (gdef->title+5, from graphs.cfg)
+		 * runs verbatim - it is trusted and may carry its own options
+		 * or pipes on purpose. Every value appended after it, however,
+		 * is CGI- or filename-derived (displayname from the "disp="
+		 * parameter, the matched RRD filenames), so each is shell-quoted
+		 * and reaches the command as one literal argument, whatever
+		 * characters it contains. */
+		addtobuffer(cmd, gdef->title+5);
+		p = shellquote(displayname); addtobuffer(cmd, " "); addtobuffer(cmd, p); xfree(p);
+		p = shellquote(service);     addtobuffer(cmd, " "); addtobuffer(cmd, p); xfree(p);
+		p = shellquote(glegend);     addtobuffer(cmd, " "); addtobuffer(cmd, p); xfree(p);
 		for (i=0; (i<rrddbcount); i++) {
 			if ((firstidx == -1) || ((i >= firstidx) && (i <= lastidx))) {
-				p += snprintf(p, (pcmdlen - (p - pcmd) + 1), " \"%s\"", rrddbs[i].rrdfn);
+				p = shellquote(rrddbs[i].rrdfn);
+				addtobuffer(cmd, " "); addtobuffer(cmd, p); xfree(p);
 			}
 		}
-		pfd = popen(pcmd, "r");
+
+		pfd = popen(STRBUF(cmd), "r");
 		if (pfd) {
 			if (fgets(graphtitle, sizeof(graphtitle), pfd) == NULL) *graphtitle = '\0';
 			pclose(pfd);
 		}
+		freestrbuffer(cmd);
 
 		/* Drop any newline at end of the title */
 		p = strchr(graphtitle, '\n'); if (p) *p = '\0';


### PR DESCRIPTION
## What

`showgraph.cgi` supports dynamic graph titles via a graphs.cfg
`TITLE exec:<command>` directive: the command runs and its first output
line becomes the graph title. The command line is assembled for `popen()`
from the admin's command plus several request- and filename-derived
values — the graph's `displayname` (the `disp=` CGI parameter), the
service name, the legend, and the matched RRD filenames.

Those values were interpolated without quoting, so shell-active
characters in them were interpreted by the shell rather than passed
through as data.

## Change

Every value appended after the admin's (trusted) command is now
single-quote-escaped, so each reaches the exec-title script as one
literal argument regardless of its contents. The command from graphs.cfg
still runs verbatim, so legitimate exec titles behave exactly as before.

## Test

Adds `tests/web/showgraph-exec-title.sh`, which drives the real CGI with
values containing `$(...)`, double quotes and backticks and asserts each
is delivered to the script verbatim with no shell evaluation. Full suite
green on this branch.
