### PR TITLE
xymond_history: do not write a closing hist record with an empty color

### DIFF
--- a/tests/server/history-tail-resync.sh
+++ b/tests/server/history-tail-resync.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/history-tail-resync.sh
+#
+# Guard for the hist-file tail recovery in xymond_history
+# (xymon-monitoring/xymon#269).
+#
+# When the tail of a hist file holds a valid open record followed by a
+# malformed suffix (torn write, partial copy), xymond_history seeks back to
+# the open record and rewrites it closed. The rewrite must also TRUNCATE the
+# file after the newly written open record: without that, the stale suffix
+# survives past the (shorter) rewrite, ends up glued to the new open record,
+# and is carried forward onto every subsequent status change - the file never
+# re-synchronizes.
+#
+# Drives the real worker over a hist file seeded with an open record plus a
+# 300-byte garbage suffix (inside the 512-byte tail scan window) and two
+# consecutive status changes, then asserts the suffix is gone and every
+# record is well-formed. Skips when the worker binary has not been built.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+BIN="$ROOT/xymond/xymond_history"
+
+[ -x "$BIN" ] || skip "xymond/xymond_history not built"
+
+WORK=$(mktempdir)
+mkdir -p "$WORK/hist" "$WORK/logs" "$WORK/histlogs"
+HISTFILE="$WORK/hist/junk,host.disk"
+
+# Valid open record, then a malformed suffix shorter than the scan window.
+printf 'Mon Apr  6 22:37:31 2020 green 1586205451\n' > "$HISTFILE"
+head -c 300 /dev/zero | tr '\0' 'G' >> "$HISTFILE"
+
+# Two consecutive status changes: green->red, then red->yellow.
+printf '@@stachg#1|1586206051.00000|127.0.0.1|xymond|junk.host|disk|1586206351|red|green|1586205451|0||0|0|\nbody\n@@\n@@stachg#2|1586209651.00000|127.0.0.1|xymond|junk.host|disk|1586209951|yellow|red|1586206051|0||0|0|\nbody\n@@\n' \
+	> "$WORK/msg2x"
+
+env XYMONSERVERLOGS="$WORK/logs" XYMONHISTLOGS="$WORK/histlogs" \
+	"$BIN" --histdir="$WORK/hist" < "$WORK/msg2x" > /dev/null 2>&1
+
+result=$(cat "$HISTFILE")
+
+# The stale suffix must not survive - not glued to a record, not anywhere.
+assert_not_contains "G" "$result" \
+	"stale tail bytes survived the seek-back rewrite (#269): file did not re-sync"
+
+# Exactly the three expected records: two closed (with the durations fixed by
+# the message timestamps, so timezone-independent) and the final open record.
+# The open record must be the last thing in the file - nothing after it.
+assert_match " green 1586205451 600
+.* red 1586206051 3600
+.* yellow 1586209651$" "$result" \
+	"hist file does not hold the two closed records plus a clean final open record (#269)"
+
+pass "xymond_history truncates a stale tail after seek-back rewrite (#269)"

--- a/xymond/xymond_history.c
+++ b/xymond/xymond_history.c
@@ -299,6 +299,7 @@ int main(int argc, char *argv[])
 					 */
 					off_t pos = -1;
 					char l[1024];
+					char scancol[100];
 					int gotit;
 
 					MEMDEFINE(l);
@@ -323,14 +324,15 @@ int main(int argc, char *argv[])
 						if (fgets(l, sizeof(l)-1, statuslogfd)) {
 							/* Sun Oct 10 06:49:42 2004 red   1097383782 602 */
 
-							if ((strlen(l) > 24) && 
-							    (sscanf(l+24, " %s %d %d", oldcol, &lastchg_i, &dur_i) == 2) &&
-							    (parse_color(oldcol) != -1)) {
-								/* 
+							if ((strlen(l) > 24) &&
+							    (sscanf(l+24, " %s %d %d", scancol, &lastchg_i, &dur_i) == 2) &&
+							    (parse_color(scancol) != -1)) {
+								/*
 								 * Record the start location of the line
 								 */
 								pos = tmppos;
 								lastchg = lastchg_i;
+								strncpy(oldcol, scancol, sizeof(oldcol));
 							}
 						}
 						else {
@@ -339,13 +341,27 @@ int main(int argc, char *argv[])
 					}
 
 					if (pos == -1) {
-						/* 
+						/*
 						 * Couldnt find anything in the log.
 						 * Take lastchg from the timestamp of the logfile,
 						 * and just append the data.
 						 */
 						lastchg = st.st_mtime;
 						fseeko(statuslogfd, 0, SEEK_END);
+						if (st.st_size > 0) {
+							char lastbyte;
+
+							/*
+							 * If the last line is unterminated garbage, terminate it
+							 * so the record we append below starts on a line of its own.
+							 */
+							fseeko(statuslogfd, -1, SEEK_END);
+							if ((fread(&lastbyte, 1, 1, statuslogfd) == 1) && (lastbyte != '\n')) {
+								fseeko(statuslogfd, 0, SEEK_END);
+								fputc('\n', statuslogfd);
+							}
+							fseeko(statuslogfd, 0, SEEK_END);
+						}
 					}
 					else {
 						/*

--- a/xymond/xymond_history.c
+++ b/xymond/xymond_history.c
@@ -387,7 +387,7 @@ int main(int argc, char *argv[])
 				}
 
 				if (statuslogfd) {
-					if (logexists) {
+					if (logexists && *oldcol) {
 						struct tm oldtm;
 
 						/* Re-print the old record, now with the final duration */

--- a/xymond/xymond_history.c
+++ b/xymond/xymond_history.c
@@ -299,6 +299,7 @@ int main(int argc, char *argv[])
 					 */
 					off_t pos = -1;
 					char l[1024];
+					char scancol[100];
 					int gotit;
 
 					MEMDEFINE(l);
@@ -323,14 +324,15 @@ int main(int argc, char *argv[])
 						if (fgets(l, sizeof(l)-1, statuslogfd)) {
 							/* Sun Oct 10 06:49:42 2004 red   1097383782 602 */
 
-							if ((strlen(l) > 24) && 
-							    (sscanf(l+24, " %s %d %d", oldcol, &lastchg_i, &dur_i) == 2) &&
-							    (parse_color(oldcol) != -1)) {
-								/* 
+							if ((strlen(l) > 24) &&
+							    (sscanf(l+24, " %99s %d %d", scancol, &lastchg_i, &dur_i) == 2) &&
+							    (parse_color(scancol) != -1)) {
+								/*
 								 * Record the start location of the line
 								 */
 								pos = tmppos;
 								lastchg = lastchg_i;
+								strncpy(oldcol, scancol, sizeof(oldcol));
 							}
 						}
 						else {
@@ -339,13 +341,27 @@ int main(int argc, char *argv[])
 					}
 
 					if (pos == -1) {
-						/* 
+						/*
 						 * Couldnt find anything in the log.
 						 * Take lastchg from the timestamp of the logfile,
 						 * and just append the data.
 						 */
 						lastchg = st.st_mtime;
 						fseeko(statuslogfd, 0, SEEK_END);
+						if (st.st_size > 0) {
+							char lastbyte;
+
+							/*
+							 * If the last line is unterminated garbage, terminate it
+							 * so the record we append below starts on a line of its own.
+							 */
+							fseeko(statuslogfd, -1, SEEK_END);
+							if ((fread(&lastbyte, 1, 1, statuslogfd) == 1) && (lastbyte != '\n')) {
+								fseeko(statuslogfd, 0, SEEK_END);
+								fputc('\n', statuslogfd);
+							}
+							fseeko(statuslogfd, 0, SEEK_END);
+						}
 					}
 					else {
 						/*
@@ -387,7 +403,7 @@ int main(int argc, char *argv[])
 				}
 
 				if (statuslogfd) {
-					if (logexists) {
+					if (logexists && *oldcol) {
 						struct tm oldtm;
 
 						/* Re-print the old record, now with the final duration */
@@ -401,6 +417,19 @@ int main(int argc, char *argv[])
 					memcpy(&tstamptm, localtime(&tstamp), sizeof(tstamptm));
 					strftime(timestamp, sizeof(timestamp), "%a %b %e %H:%M:%S %Y", &tstamptm);
 					fprintf(statuslogfd, "%s %s %d", timestamp, colorname(newcolor), (int)tstamp);
+
+					/*
+					 * When we seek-back rewrote inside the file (open record
+					 * followed by a malformed tail), stale bytes may remain
+					 * past what we just wrote; drop them so the open record
+					 * is the last thing in the file. A no-op in the append
+					 * paths, where the position is already EOF.
+					 */
+					fflush(statuslogfd);
+					if (ftruncate(fileno(statuslogfd), ftello(statuslogfd)) != 0) {
+						errprintf("Cannot truncate status historyfile '%s' : %s\n",
+							statuslogfn, strerror(errno));
+					}
 
 					fclose(statuslogfd);
 				}


### PR DESCRIPTION
Fixes #269

## Problem

When a status change arrives and the tail of the existing hist file contains no *valid open record* (empty file from a partial copy, bbd/BB-migrated file, torn last line, or any garbage tail), the fallback path in the `save_statusevents` block writes corrupt records. Three variants, all from the same scan:

1. **Empty color** — scan matched nothing, `oldcol` still `""`:
   ```
   Sat Apr  4 09:27:22 2020  1585985242 220809
   ```
2. **Garbage color / negative duration** — `sscanf` filled `oldcol` as a side effect of a line it *rejected*:
   ```
   Thu Jul 23 07:49:06 2026 :31 1784785746 -198576095
   ```
3. **Glued records** — with an unterminated last line, the appended record starts mid-line, is unreadable, and re-triggers the failure (and further gluing) on every subsequent status change.

`lib/availability.c:get_historyline()` silently skips all of these, so the history CGI shows holes — or nothing. Full analysis in #269.

## Fix (three parts, same code block)

1. Only write the closing record when the color of the period being closed is known: `if (logexists && *oldcol)`.
2. Only copy the scanned color into `oldcol` when the record fully validates (scan into a temp buffer, bounded with `%99s` so an overlong garbage token cannot overflow it) — kills the garbage-color/negative-duration variant.
3. When falling back to append-at-EOF, terminate an unterminated last line first, so the appended record starts on a line of its own and the file re-syncs.

**Intentional behavior change:** for a bbd-migrated file (tail = completed, newline-terminated record), the old code fabricated a closing record from side-effect state (last record's color spread across an mtime-based timespan). Now nothing is fabricated: the migrated history is left untouched and the new open record starts cleanly. The gap between migration and first Xymon status is simply unrecorded — which is what every reader already saw, since the fabricated record was frequently malformed.

## How to test (before/after)

Build `xymond/xymond_history`, then, with two status-change messages:

```sh
mkdir -p /tmp/ht/hist /tmp/ht/logs /tmp/ht/histlogs
printf '@@stachg#1|1586206051.00000|127.0.0.1|xymond|junk.host|disk|1586206351|red|green|1586205951|0||0|0|\nbody\n@@\n@@stachg#2|1586209651.00000|127.0.0.1|xymond|junk.host|disk|1586209951|yellow|red|1586206051|0||0|0|\nbody\n@@\n' > /tmp/ht/msg2x
RUN='env XYMONSERVERLOGS=/tmp/ht/logs XYMONHISTLOGS=/tmp/ht/histlogs ./xymond/xymond_history --histdir=/tmp/ht/hist'
```

**Case A — unterminated garbage tail (+2 changes):**
```sh
printf 'xx yy zz' > /tmp/ht/hist/junk,host.disk; touch -d '2020-04-04 09:27:22' /tmp/ht/hist/junk,host.disk
$RUN < /tmp/ht/msg2x; cat -A /tmp/ht/hist/junk,host.disk
```
Before: `xx yy zzMon Apr  6 ... red 1586206051Thu Jul 23 ... :31 1784785746 -198576095` — glued + garbage record, repeats forever.
After:
```
xx yy zz
Mon Apr  6 22:47:31 2020 red 1586206051 3600
Mon Apr  6 23:47:31 2020 yellow 1586209651
```

**Case B — existing but empty hist file (+1 change):**
Before: `Sat Apr  4 09:27:22 2020  1585985242 220809` (empty color) + open record. After: the open record only.

**Case C — regression, normal file ending with a proper open record (+1 change):**
Output byte-identical before and after (record closed with final duration, new open record appended).

**Case D — bbd-style file, completed newline-terminated tail (+2 changes):**
```sh
printf 'Wed Apr  1 08:00:00 2020 green 1585724400 261622\n' > /tmp/ht/hist/bb,host.disk
```
Before: fabricated `... green <mtime> <gap>` record inserted. After:
```
Wed Apr  1 08:00:00 2020 green 1585724400 261622
Mon Apr  6 22:47:31 2020 red 1586206051 3600
Mon Apr  6 23:47:31 2020 yellow 1586209651
```
(migrated history untouched, subsequent operation normal).

All four cases were run against both binaries; outputs above are actual results.

