### PR TITLE
docs: improve alerts.cfg and alerts.cfg.DIST

### DIFF
--- a/xymond/alerts.cfg.5
+++ b/xymond/alerts.cfg.5
@@ -108,14 +108,20 @@ Rule matching an alert by the time-of-day. This is specified as the DOWNTIME tim
 .BR "EXTIME=timespecification"
 Rule excluding an alert by the time-of-day. This is specified as the DOWNTIME timespecification in the hosts.cfg file.
 .sp
-.BR "DURATION>time, DURATION<time"
-Rule matching an alert if the event has lasted longer/shorter than the given duration. E.g. DURATION>1h (lasted longer than 1 hour) or DURATION<30 (only sends alerts the first 30 minutes). The duration is specified as a number, optionally followed by 'm' (minutes, default), 'h' (hours) or 'd' (days).
+.BR "DURATION>time, DURATION>=time, DURATION<time, DURATION<=time"
+Rule matching an alert if the event has lasted longer/shorter than the given duration. E.g. DURATION>1h (lasted longer than 1 hour) or DURATION<30 (only sends alerts the first 30 minutes). The duration is specified as a number, optionally followed by 'm' (minutes, default), 'h' (hours), 'd' (days) or 'w' (weeks).
 .sp
 .BR RECOVERED
-Rule matches if the alert has recovered from an alert state.
+Send recovery and disabled-state messages to matching recipients. This can be set on a rule or on an individual recipient.
+.sp
+.BR NORECOVERED
+Suppress recovery and disabled-state messages. On a recipient, this overrides a RECOVERED setting inherited from the rule.
 .sp
 .BR NOTICE
-Rule matches if the message is a "notify" message. This type of message is sent when a host or test is disabled or enabled.
+Send "notify" messages to matching recipients. This type of message is sent when a host or test is disabled or enabled.
+.sp
+.BR NONOTICE
+Suppress notify messages. On a recipient, this overrides a NOTICE setting inherited from the rule.
 
 The "targetstring" is either a simple pagename, hostname or servicename, OR a '%' 
 followed by a Perl-compatible regular expression. E.g. "HOST=%www(.*)" will match 
@@ -143,19 +149,36 @@ is matched, no more recipients will be considered. So the location of this recip
 set of recipients is important.
 .sp
 .BR "FORMAT=formatstring"
-Format of the text message with the alert. Default is "TEXT" (suitable for e-mail alerts). "PLAIN" is the same as text, but without the URL link to the status webpage. "SMS" is a short message with no subject for SMS alerts. "SCRIPT" is a brief message template for scripts.
+Format of the text message with the alert. Default is "TEXT" (suitable for e-mail alerts). "PLAIN" is the same as text, but without the URL link to the status webpage. "SMS" is a short message with no subject for SMS alerts. "PAGER" produces an empty message body. "SCRIPT" is a brief message template for scripts.
 .sp
 .BR "REPEAT=time"
-How often an alert gets repeated. As with DURATION, time is a number optionally followed by 'm', 'h' or 'd'.
+How often an alert gets repeated. Time is a number optionally followed by 'm' (minutes, default), 'h' (hours), 'd' (days) or 'w' (weeks).
 .sp
 .BR UNMATCHED
 The alert is sent to this recipient ONLY if no other recipients received an alert for this event.
+.PP
+For example, place an UNMATCHED recipient after more specific rules to provide a fallback:
+.IP
+.nf
+HOST=database.example.com SERVICE=cpu
+	MAIL database-team@example.com
+
+HOST=%.*
+	MAIL operations@example.com UNMATCHED
+.fi
+.LP
+The operations recipient is used only when an earlier recipient did not receive the alert, so recipient order is significant.
 .sp
 .BR STOP
 Stop looking for more recipients after this one matches. This is implicit on IGNORE recipients.
 .sp
-.BR Rules
-You can specify rules for a recipient also. This limits the alerts sent to this particular recipient.
+.BR NOALERT
+Suppress paging, recovery and disabled-state messages for this recipient. Notify messages are still allowed.
+.sp
+.BR "Recipient rules"
+You can specify rule filters after a recipient on the same logical line. This limits the alerts sent to that recipient. End a physical line with a backslash to continue the logical line. If multiple recipients occur on one logical line, trailing rule filters apply to all recipients on that line.
+
+FORMAT, REPEAT, STOP, UNMATCHED and NOALERT are recipient-only modifiers. They can also be placed on a following line, where they modify the preceding recipient.
 
 .SH MACROS
 It is possible to use \fBmacros\fR in the configuration file. To define a macro:
@@ -171,6 +194,9 @@ It is possible to nest macros, as long as the macro is defined before it is used
 .SH "ALERT SCRIPTS"
 Alerts can go out via custom scripts, by using the SCRIPT keyword for a recipient.
 Such scripts have access to the following environment variables:
+.sp
+.BR BBCOLORLEVEL
+The color of the alert: "red", "yellow" or "purple".
 .sp
 .BR BBALPHAMSG
 The full text of the status log triggering the alert
@@ -209,7 +235,7 @@ recovered, "2" if the service was disabled.
 .BR EVENTSTART
 Timestamp when the current status (color) began.
 .sp
-.BR SECS
+.BR DOWNSECS
 Number of seconds the service has been down.
 .sp
 .BR DOWNSECSMSG
@@ -218,8 +244,18 @@ When recovered, holds the text "Event duration : N" where N is the DOWNSECS valu
 .BR CFID
 Line-number in the alerts.cfg file that caused the script to be invoked.
 Can be useful when troubleshooting alert configuration rules.
+.sp
+.BR ALERTID
+Unique identifier derived from the host, service and event start time.
+.PP
+Available host metadata is also exported as
+.B XMH_*
+environment variables.
+See
+.I xymon-xmh(5)
+for the full list and descriptions.
 
 .SH "SEE ALSO"
-xymond_alert(8), xymond(8), xymon(7), the "Configuring Xymon Alerts"
+xymond_alert(8), xymond(8), xymon(7), xymon-xmh(5), the "Configuring Xymon Alerts"
 guide in the Online documentation.
 

--- a/xymond/etcfiles/alerts.cfg.DIST
+++ b/xymond/etcfiles/alerts.cfg.DIST
@@ -1,22 +1,15 @@
 #
-# The alerts.cfg file controls who receives alerts
-# when a status in the XYmon system goes into a critical
-# state (usually: red, yellow or purple).
+# The alerts.cfg file controls who receives alerts when a status in
+# Xymon enters a critical state (usually red, yellow or purple).
 #
-# This file is made up from RULES and RECIPIENTS.
+# The file consists of RULES and their RECIPIENTS. A rule begins with
+# one or more filters. The following indented lines define recipients
+# for that rule. A recipient can be a MAIL address, a SCRIPT, or IGNORE.
 #
-# A RULE is a filter made from the PAGE where a host
-# is located in XYmon; the HOST name, the SERVICE name,
-# the COLOR of the status, the TIME of day, and the
-# DURATION of the event.
-#
-# A RECIPIENT can be a MAIL address, or a SCRIPT.
-#
-# Recipients can also have rules associated with them,
-# that modify the rules for a single recipient, e.g.
-# you can define a rule for alerting, then add an
-# extra criteria e.g. so a single recipient does not get
-# alerted until after 20 minutes.
+# Filters written after a recipient on the same logical line apply only
+# to that recipient. Use a trailing backslash to continue a logical line.
+# Recipient modifiers such as REPEAT, FORMAT and STOP may also be placed
+# on a following line, where they modify the preceding recipient.
 #
 # A sample rule:
 #
@@ -25,97 +18,137 @@
 #      MAIL cio@foo.com DURATION>60 COLOR=red
 #      SCRIPT /usr/local/bin/sendsms 1234567890 FORMAT=SMS
 #
-# The first line sets up a rule that catches alerts
-# for the host "www.foo.com" and the "http" service.
-# There are three recipients for these alerts: The first
-# one is the "webadmin@foo.com" - they get alerted 
-# immediately when the status goes into an alert state,
-# and the alert is repeated every 20 minutes until it
-# recovers. When it recovers, a message is sent about
-# the recovery.
+# The first line catches alerts for host "www.foo.com" and service
+# "http". There are three recipients. The first, "webadmin@foo.com",
+# is alerted immediately and every 20 minutes until recovery. RECOVERED
+# opts this recipient into a recovery message.
 #
-# The second recipient is "cio@foo.com". He gets alerted
-# only when the service goes "red" for more than 60 minutes.
+# The second recipient, "cio@foo.com", is alerted only when the service
+# has been red for more than 60 minutes.
 #
-# The third recipient is a script, "/usr/local/bin/sendsms".
-# The real recipient is "1234567890", but it is handled
-# by the script - the script receives a set of environment
-# variables with the details about the alert, including the
-# real recipient. The alert message is preformatted for 
-# an SMS recipient.
+# The third recipient invokes "/usr/local/bin/sendsms". The script gets
+# "1234567890" and the alert details through environment variables. The
+# message is formatted for an SMS recipient.
 #
-# You can use Perl-compatible "regular expressions" for
-# the PAGE, HOST and SERVICE definitions, by putting a "%"
-# in front of the regex. E.g.
+# PAGE, DISPLAYGROUP, HOST, SERVICE, CLASS and GROUP filters, including
+# their EX variants, accept a Perl-compatible regular expression when
+# the value begins with "%". For example:
 #
 # HOST=%^www.*
 #      MAIL webadmin@foo.com EXHOST=www.testsite.foo.com
 #
-# This sets up a rule so that alerts from any hostname 
-# beginning with "www" goes to "webadmin@foo.com", EXCEPT
-# alerts from "www.testsite.foo.com"
+# This sends alerts from hostnames beginning with "www" to the web
+# administrator, except alerts from "www.testsite.foo.com".
 #
-# The following keywords are recognized:
+# IGNORE suppresses a matching alert and stops recipient processing:
+#
+# HOST=development.example.com SERVICE=cpu
+#      IGNORE
+#
+# Rule-level delivery settings are inherited by recipients. A recipient
+# can override them on its own logical line:
+#
+# HOST=%.* SERVICE=cpu RECOVERED
+#      MAIL operations@example.com
+#      MAIL paging@example.com NORECOVERED DURATION>=15m COLOR=red
+#
+# Both recipients get active cpu alerts, but only operations@example.com
+# gets recovery messages. The paging recipient waits 15 minutes and only
+# receives red alerts.
+#
+# RULE FILTERS
+#
 #    PAGE      - rule matching an alert by the name of the
 #                page in XYmon. This is the name following
 #                the "page", "subpage" or "subparent" keyword
 #                in the hosts.cfg file.
 #    EXPAGE    - rule excluding an alert if the pagename matches.
+#    DISPLAYGROUP
+#              - rule matching the display-group text from hosts.cfg.
+#                Use DISPLAYGROUP=NONE for hosts without a display group.
+#    EXDISPLAYGROUP
+#              - rule excluding an alert by display-group text.
 #    HOST      - rule matching an alert by the hostname.
 #    EXHOST    - rule excluding an alert by matching the hostname.
 #    SERVICE   - rule matching an alert by the service name.
-#    EXSERVICE - rule excluding an alert by matching the hostname.
+#    EXSERVICE - rule excluding an alert by matching the service name.
+#    CLASS     - rule matching the host class. By default this is the
+#                operating-system name unless another class is configured.
+#    EXCLASS   - rule excluding an alert by matching the host class.
 #    GROUP     - rule matching an alert by the group ID.
 #                (Group ID's are associated with a status through the
 #                 analysis.cfg configuration).
 #    EXGROUP   - rule excluding an alert by matching the group ID.
-#    COLOR     - rule matching an alert by color. Can be "red",
-#                "yellow", or "purple".
+#    COLOR     - rule matching an alert by color. Valid colors are "red",
+#                "yellow", and "purple". Multiple colors can be comma-separated.
+#                Prefix a color with "!" to exclude it.
 #    TIME      - rule matching an alert by the time-of-day. This
 #                is specified as the DOWNTIME timespecification
 #                in the hosts.cfg file (see hosts.cfg(5)).
+#    EXTIME    - rule excluding an alert during the given DOWNTIME-style
+#                timespecification.
 #    DURATION  - Rule matching an alert if the event has lasted
-#                longer/shorter than the given duration. E.g.
-#                DURATION>10 (lasted longer than 10 minutes) or
-#                DURARION<30 (only sends alerts the first 30 minutes).
-#    RECOVERED - Rule matches if the alert has recovered from an 
-#                alert state.
-#    NOTICE    - Rule matches if the message is a "notify" message
-#                (typically sent when a status is enabled or disabled).
+#                longer or shorter than the given duration. The operators
+#                are >, >=, < and <=. A duration is a number optionally
+#                followed by m (minutes, default), h (hours), d (days),
+#                or w (weeks).
+#    RECOVERED - send recovery and disabled-state messages to matching
+#                recipients. This can be set on a rule or recipient.
+#    NORECOVERED
+#              - suppress recovery and disabled-state messages, overriding
+#                an inherited rule-level RECOVERED setting.
+#    NOTICE    - send notify messages (typically generated when a host or
+#                test is disabled or enabled) to matching recipients.
+#    NONOTICE  - suppress notify messages, overriding an inherited
+#                rule-level NOTICE setting.
+#
+# RECIPIENTS
+#
 #    MAIL      - Recipient who receives an e-mail alert. This takes
 #                one parameter, the e-mail address.
 #    SCRIPT    - Recipient that invokes a script. This takes two
 #                parameters: The script filename, and the recipient
 #                that gets passed to the script.
-#    FORMAT    - format of the text message with the alert. Default
-#                is "TEXT" (suitable for e-mail alerts). "SMS" is
-#                a short message with no subject for SMS alerts.
-#                "SCRIPT" is a brief message template for scripts.
-#    REPEAT    - How often an alert gets repeated, in minutes.
-#    STOP      - Valid for a recipient: If this recipient gets an
-#                alert, recipients further down in alerts.cfg
-#                are ignored.
-#    UNMATCHED - Matches if no alerts have been sent so far.
+#    IGNORE    - Recipient that sends no alert and stops the search for
+#                later recipients. IGNORE has an implicit STOP modifier.
+#
+# RECIPIENT MODIFIERS
+#
+#    FORMAT    - message format. TEXT is the default; PLAIN omits the URL;
+#                SMS is a short message without a subject; PAGER produces an
+#                empty message body; SCRIPT is a brief template for scripts.
+#    REPEAT    - repeat interval specified as a number optionally followed
+#                by m (minutes, default), h (hours), d (days), or w (weeks).
+#    STOP      - stop looking for more recipients after this one matches.
+#    UNMATCHED - use this recipient only if no earlier recipient has
+#                received an alert for the event.
+#    NOALERT   - suppress paging, recovery and disabled-state messages for
+#                this recipient. Notify messages are still allowed.
 #
 #
-# Script get the following environment variables pre-defined so
-# that they can send a meaningful alert:
+# For SCRIPT recipients, Xymon exports the following environment
+# variables to the invoked program:
 #
-#    BBCOLORLEVEL  - The color of the alert: "red", "yellow" or "purple"
-#    BBALPHAMSG    - The full text of the status log triggering the alert
-#    ACKCODE       - The "cookie" that can be used to acknowledge the alert
-#    RCPT          - The recipient, from the SCRIPT entry
-#    BBHOSTNAME    - The name of the host that the alert is about
-#    MACHIP        - The IP-address of the host that has a problem
-#    BBSVCNAME     - The name of the service that the alert is about
-#    BBSVCNUM      - The numeric code for the service. From SVCCODES definition.
-#    BBHOSTSVC     - HOSTNAME.SERVICE that the alert is about.
-#    BBHOSTSVCCOMMAS - As BBHOSTSVC, but dots in the hostname replaced with commas
-#    BBNUMERIC     - A 22-digit number made by BBSVCNUM, MACHIP and ACKCODE.
-#    RECOVERED     - Is "1" if the service has recovered.
-#    DOWNSECS      - Number of seconds the service has been down.
-#    DOWNSECSMSG   - When recovered, holds the text "Event duration : N" where
-#                    N is the DOWNSECS value.
+#    BBCOLORLEVEL      - The color of the alert: "red", "yellow" or "purple"
+#    BBALPHAMSG        - The full text of the status log triggering the alert
+#    ACKCODE           - The "cookie" that can be used to acknowledge the alert
+#    RCPT              - The recipient, from the SCRIPT entry
+#    BBHOSTNAME        - The name of the host that the alert is about
+#    MACHIP            - The IP-address of the host that has a problem
+#    BBSVCNAME         - The name of the service that the alert is about
+#    BBSVCNUM          - The numeric code for the service. From SVCCODES definition.
+#    BBHOSTSVC         - HOSTNAME.SERVICE that the alert is about.
+#    BBHOSTSVCCOMMAS   - As BBHOSTSVC, but dots in the hostname are replaced with commas.
+#    BBNUMERIC         - A 22-digit number made by BBSVCNUM, MACHIP and ACKCODE.
+#    RECOVERED         - Is "0" while alerting, "1" if recovered, or "2" if the service was disabled.
+#    EVENTSTART        - Timestamp when the current status began.
+#    DOWNSECS          - Number of seconds the service has been down.
+#    DOWNSECSMSG       - When recovered, holds the text "Event duration : N" where N is the DOWNSECS value.
+#    CFID              - Line number in alerts.cfg that selected the script.
+#    ALERTID           - Unique identifier derived from the host, service and event start time.
+#
+# Available host metadata is also exported as XMH_* environment variables.
+# See xymon-xmh(5) for the full list and descriptions.
 
 # Local additions: any file dropped into the directory below is included
 optional directory @XYMONHOME@/etc/alerts.d


### PR DESCRIPTION
## Summary

Improves the `alerts.cfg` documentation and keeps the example configuration synchronized with the implemented alert parser behavior.

- Reorganizes `alerts.cfg.DIST` into rule filters, recipients, recipient modifiers, examples, and script environment variables.
- Documents missing filters and modifiers, including `DISPLAYGROUP`, `CLASS`, `EXTIME`, `NORECOVERED`, `NONOTICE`, `IGNORE`, `NOALERT`, and `UNMATCHED`.
- Clarifies recipient inheritance, duration and repeat units, color matching, message formats, recovery messages, and notification behavior.
- Corrects stale or inaccurate descriptions in both the template and man page.
- Documents additional `SCRIPT` environment variables, including `EVENTSTART`, `DOWNSECS`, `DOWNSECSMSG`, `CFID`, and `ALERTID`.
- References `xymon-xmh(5)` for dynamically exported `XMH_*` host metadata.

Closes #268.

## Testing

- Rendered `xymond/alerts.cfg.5` successfully with `groff`.
- Ran the existing test suite: 17 passed, 1 unrelated RRD-dependent test skipped, 0 failed.
- Verified the changes with `git diff --check`.