### PR TITLE
docs: add HTTP content check examples

### DIFF
--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -1179,11 +1179,13 @@ For example, the complete content-check tag is:
 .br
 The regular expression follows the second semicolon directly and is
 written without surrounding slash delimiters.
-To report the result in a custom column and require an exact response:
+To report the result in a custom column and match "OK", optionally
+followed by a line ending:
 .br
-   cont=health;https://example.com/health;^OK$
+   cont=health;https://example.com/health;^OK[[:cntrl:]]*$
 .br
-This reports in the "health" column and matches only the response "OK".
+This reports in the "health" column and rejects additional printable text.
+For a byte-exact response check, use the message-digest form described above.
 For a more advanced match, grouping and alternation can accept multiple values:
 .br
    cont=api;https://example.com/api;status=(ok|ready)

--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -1173,6 +1173,23 @@ Note that this may depend on your particular implementation
 of the regex functions found in your C library. Thanks to 
 Charles Goyard for this tip.
 
+For example, the complete content-check tag is:
+.br
+   cont;https://example.com/;All[[:space:]]is[[:space:]]OK
+.br
+The regular expression follows the second semicolon directly and is
+written without surrounding slash delimiters.
+To report the result in a custom column and require an exact response:
+.br
+   cont=health;https://example.com/health;^OK$
+.br
+This reports in the "health" column and matches only the response "OK".
+For a more advanced match, grouping and alternation can accept multiple values:
+.br
+   cont=api;https://example.com/api;status=(ok|ready)
+.br
+This matches either "status=ok" or "status=ready" in the response.
+
 Note: If you are migrating from the "cont2.sh" script,
 you must change the '_' used as wildcards by cont2.sh 
 into '.' which is the regular-expression wildcard character.


### PR DESCRIPTION
## Summary

Adds practical HTTP response-content check examples to `hosts.cfg.5`.

- Shows a complete `cont;URL;REGEX` tag using `[[:space:]]`.
- Clarifies that the regular expression follows the second semicolon directly and does not use surrounding slash delimiters.
- Demonstrates assigning a content check to a custom status column.
- Adds an advanced POSIX extended-regex example using grouping and alternation.

Closes #231.

## Testing

- Rendered `common/hosts.cfg.5` successfully with `groff`.
- Built and ran the real `xymonnet` against local HTTP fixtures.
- Confirmed all three documented examples produced green `Content OK` statuses.
- Confirmed the advanced `status=(ok|ready)` expression rejects `status=degraded` with a red `Content match failed` status.
- Verified the patch with `git diff --check`.