### PR TITLE
fix: parse reverse SOAP test data

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -571,6 +571,7 @@ char *decode_url(char *testspec, weburl_t *weburl)
 	  case WEBTEST_POST:
 	  case WEBTEST_NOPOST:
 	  case WEBTEST_SOAP:
+	  case WEBTEST_NOSOAP:
 		  poststart = strchr(urlstart, ';');
 		  if (poststart) {
 			  *poststart = '\0';


### PR DESCRIPTION
## Summary

Fix parsing of `nosoap` HTTP test specifications.

`decode_url()` already recognizes both reverse SOAP forms:

```text
nosoap;URL;SOAPMESSAGE;forbidden_data_regexp
nosoap=COLUMN;URL;SOAPMESSAGE;forbidden_data_regexp
```

However, `WEBTEST_NOSOAP` was omitted from the parser shared by the POST and SOAP test types. Consequently, the SOAP message and optional forbidden response pattern were not separated correctly from the URL.

## Change

Add `WEBTEST_NOSOAP` to the existing POST/SOAP payload parsing path.

This makes `nosoap` consistent with the existing reverse-test pairs:

| Positive test | Reverse test | Request type |
|---|---|---|
| `cont` | `nocont` | HTTP GET |
| `post` | `nopost` | Form POST |
| `soap` | `nosoap` | SOAP POST |

The existing `nosoap` request construction and reverse-content evaluation remain unchanged:

- The request uses `application/soap+xml`.
- A `SOAPAction` header is sent.
- The test is green when the forbidden pattern is absent.
- The test is red when the forbidden pattern is present.
- Without a forbidden pattern, the SOAP request is checked without response-content matching.

## Scope

This is a one-line parser fix.

## Validation

- Configured and built `xymonnet` successfully.
- Repository test suite: 15 passed, 3 build-dependent tests skipped, 0 failed.