### PR TITLE
fix: initialize alpns in httptest.c SSL options to avoid uninitialized read

### DIFF
--- a/xymonnet/httptest.c
+++ b/xymonnet/httptest.c
@@ -675,11 +675,10 @@ void add_http_test(testitem_t *t)
 
 	/* Pickup any SSL options the user wants */
 	if (sslopt_ciphers || (sslopt_version != SSLVERSION_DEFAULT) || sslopt_clientcert){
-		sslopt = (ssloptions_t *) malloc(sizeof(ssloptions_t));
+		sslopt = (ssloptions_t *) calloc(1, sizeof(ssloptions_t));
 		sslopt->cipherlist = sslopt_ciphers;
 		sslopt->sslversion = sslopt_version;
 		sslopt->clientcert = sslopt_clientcert;
-		sslopt->alpns = NULL;
 	}
 
 	/* Add to TCP test queue */

--- a/xymonnet/httptest.c
+++ b/xymonnet/httptest.c
@@ -679,6 +679,7 @@ void add_http_test(testitem_t *t)
 		sslopt->cipherlist = sslopt_ciphers;
 		sslopt->sslversion = sslopt_version;
 		sslopt->clientcert = sslopt_clientcert;
+		sslopt->alpns = NULL;
 	}
 
 	/* Add to TCP test queue */


### PR DESCRIPTION
## Summary

Fixes a segfault in `xymonnet` on HTTPS checks that set a custom cipher list, SSL version, or client certificate (e.g. `https://CERT:client.pem@host/path`).

## Root cause

`add_http_test()` in `xymonnet/httptest.c` `malloc()`s a per-request `ssloptions_t` but never initializes the `alpns` field (added by 75cfe50b for ALPN support). `setup_ssl()` in `contest.c` reads that garbage value as a fallback ALPN string and `strdup()`s it, segfaulting on invalid memory.

Pre-existing on `main`, not introduced by this branch — just never hit until a client-cert HTTPS test exercised the path.

## Fix

Initialize `sslopt->alpns = NULL;` alongside the other fields.

## Verification

Reproduced under gdb (`item->ssloptions->alpns` held `0x1`); confirmed the crash is gone after the fix.
