### PR TITLE
fix: check SSL_CTX_set_cipher_list() return value in setup_ssl

### DIFF
--- a/RELEASENOTES
+++ b/RELEASENOTES
@@ -1,5 +1,5 @@
           <<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>
-           * * *   Release notes for Xymon 4.3.30   * * *
+           * * *   Release notes for Xymon 4.3.31   * * *
           <<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>
 
 
@@ -8,6 +8,16 @@ changes you should be aware of when upgrading.
 
 For a full list of changes and enhancements, please see the 
 Changes file.
+
+
+Changes for 4.3.31
+==================
+
+xymonnet tests with a configured cipher-list restriction now report an SSL error
+when OpenSSL rejects the restriction, instead of silently using the default
+cipher list. Such tests may therefore turn red after upgrading Xymon, or after
+an OpenSSL upgrade invalidates a previously accepted restriction. xymonnet tests
+without a cipher-list restriction are unaffected.
 
 
 Changes for 4.3.30

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -564,8 +564,16 @@ static void setup_ssl(tcptest_t *item)
 		SSL_CTX_set_quiet_shutdown(item->sslctx, 1);
 
 		/* Limit set of ciphers, if user wants to */
-		if (item->ssloptions->cipherlist) 
-			SSL_CTX_set_cipher_list(item->sslctx, item->ssloptions->cipherlist);
+		if (item->ssloptions->cipherlist && !SSL_CTX_set_cipher_list(item->sslctx, item->ssloptions->cipherlist)) {
+			char sslerrmsg[256];
+
+			ERR_error_string(ERR_get_error(), sslerrmsg);
+			errprintf("Cannot set cipher list '%s' - IP %s, service %s: %s\n",
+				   item->ssloptions->cipherlist, inet_ntoa(item->addr.sin_addr), item->svcinfo->svcname, sslerrmsg);
+			item->sslrunning = 0;
+			item->errcode = CONTEST_ESSL;
+			return;
+		}
 
 		/* Set ALPN protocols if specified */
 		/* First check service definition for ALPN, then fallback to ssloptions */

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -571,6 +571,7 @@ static void setup_ssl(tcptest_t *item)
 			errprintf("Cannot set cipher list '%s' - IP %s, service %s: %s\n",
 				   item->ssloptions->cipherlist, inet_ntoa(item->addr.sin_addr), item->svcinfo->svcname, sslerrmsg);
 			item->sslrunning = 0;
+			SSL_CTX_free(item->sslctx);
 			item->errcode = CONTEST_ESSL;
 			return;
 		}
@@ -637,6 +638,7 @@ static void setup_ssl(tcptest_t *item)
 				errprintf("Cannot load SSL client certificate/key %s: %s\n", 
 					  item->ssloptions->clientcert, sslerrmsg);
 				item->sslrunning = 0;
+				SSL_CTX_free(item->sslctx);
 				item->errcode = CONTEST_ESSL;
 				return;
 			}
@@ -671,6 +673,8 @@ static void setup_ssl(tcptest_t *item)
 			if (!SSL_CTX_check_private_key(item->sslctx)) {
 				errprintf("Private/public key mismatch for certificate %s\n", item->ssloptions->clientcert);
 				item->sslrunning = 0;
+				SSL_free(item->ssldata);
+				SSL_CTX_free(item->sslctx);
 				item->errcode = CONTEST_ESSL;
 				return;
 			}


### PR DESCRIPTION
## Summary

Fixes a silent SSL misconfiguration in `xymonnet`: forcing a cipher-strength restriction (e.g. the `m`/`httpsm` scheme-suffix dialect from hosts.cfg(5)) can silently have no effect instead of restricting the connection or failing.

## Root cause

`setup_ssl()` in `xymonnet/contest.c` calls `SSL_CTX_set_cipher_list()` but never checks its return value:

```c
if (item->ssloptions->cipherlist) 
    SSL_CTX_set_cipher_list(item->sslctx, item->ssloptions->cipherlist);
```

On failure, OpenSSL leaves the SSL_CTX's previous cipher list untouched rather than clearing it — so the connection silently proceeds without the requested restriction, indistinguishable from success.

Confirmed on OpenSSL 3.0.13: `openssl ciphers MEDIUM` errors with "no cipher match" (that cipher class has been removed entirely), so any test using `httpsm` was actually connecting with the default cipher list, not a medium-strength one.

## Fix

Check the return value and treat failure the same as the existing SSL-context-creation error a few lines above (report via `errprintf`, mark the test as an SSL error) instead of silently continuing.

## Verification

Ran the full loopback test suite in a container: before the fix, a test forcing `MEDIUM` ciphers reported green (false success); after the fix, it correctly reports red ("SSL error"), while `HIGH` (which does match ciphers) still reports green.
