### PR TITLE
fix: keep hosts.cfg noflap= lists intact across status updates

### DIFF
--- a/tests/server/xymond-noflap-list-harness.c
+++ b/tests/server/xymond-noflap-list-harness.c
@@ -12,14 +12,10 @@
  * stored tag permanently -- so every later status update saw only the first
  * test.
  *
- * Why this mirrors the function instead of calling it: isset_noflap() is
- * static in xymond/xymond.c and xymond has no library form, so it cannot be
- * linked here. The copy below is kept identical to the real one, and the
- * companion shell test asserts at the source level that xymond.c still
- * copies before tokenizing -- that source assertion, not this file, is what
- * stops the two drifting apart. What this file adds is proof that the
- * copy-first logic actually produces the right answers on real host records
- * loaded through the real lib/loadhosts.c.
+ * The companion shell test prepends xymond/xymond.c's real static
+ * isset_noflap() implementation when it builds the harness. This file adds
+ * only the assertions that drive it against real host records loaded through
+ * the real lib/loadhosts.c.
  *
  * The list assertions deliberately share one host and run in sequence: the
  * old defect only appeared on the SECOND and later evaluations, because the
@@ -27,12 +23,6 @@
  * where isset_noflap() runs once per incoming status message. A test using
  * a fresh host per test name would have passed even before the fix.
  */
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include "libxymon.h"
-
 static int failures = 0;
 
 static void expect(const char *label, int cond, const char *detail)
@@ -41,33 +31,6 @@ static void expect(const char *label, int cond, const char *detail)
 		fprintf(stderr, "%s: %s\n", label, detail);
 		failures++;
 	}
-}
-
-/* Kept identical to xymond/xymond.c's isset_noflap(), minus its dbgprintf. */
-static int isset_noflap(void *hinfo, char *testname, char *hostname)
-{
-	char *tok, *dstr, *dbuf;
-	int keylen, listed;
-
-	dstr = xmh_item(hinfo, XMH_NOFLAP);
-	if (!dstr) return 0;
-
-	if (strcmp(dstr, "NOFLAP") == 0) return 1;
-
-	if (*dstr == '=') dstr++;
-
-	dbuf = strdup(dstr);
-	if (!dbuf) return 0;
-
-	keylen = strlen(testname);
-	tok = strtok(dbuf, ",");
-	while (tok && (strncmp(testname, tok, keylen) != 0)) tok = strtok(NULL, ",");
-	listed = (tok != NULL);
-	xfree(dbuf);
-
-	if (!listed) return 0;
-
-	return 1;
 }
 
 int main(int argc, char *argv[])

--- a/tests/server/xymond-noflap-list-harness.c
+++ b/tests/server/xymond-noflap-list-harness.c
@@ -1,0 +1,137 @@
+/* Behavioural half of tests/server/xymond-noflap-list.sh.
+ *
+ * Guards the fix for hosts.cfg "noflap=test1,test2,..." silently losing
+ * effect for every test after the first one evaluated.
+ *
+ * xmh_item() for XMH_NOFLAP returns a pointer straight INTO the host
+ * record's own allelems buffer, not a copy (lib/loadhosts.c's XMH_NOFLAP
+ * case falls through to xmh_find_item(), which returns
+ * `host->elems[i] + keylen`; contrast XMH_DOCURL, which builds a copy).
+ * xymond's isset_noflap() used to hand that pointer to strtok() directly,
+ * which overwrote the list's first comma with a NUL and truncated the
+ * stored tag permanently -- so every later status update saw only the first
+ * test.
+ *
+ * Why this mirrors the function instead of calling it: isset_noflap() is
+ * static in xymond/xymond.c and xymond has no library form, so it cannot be
+ * linked here. The copy below is kept identical to the real one, and the
+ * companion shell test asserts at the source level that xymond.c still
+ * copies before tokenizing -- that source assertion, not this file, is what
+ * stops the two drifting apart. What this file adds is proof that the
+ * copy-first logic actually produces the right answers on real host records
+ * loaded through the real lib/loadhosts.c.
+ *
+ * The list assertions deliberately share one host and run in sequence: the
+ * old defect only appeared on the SECOND and later evaluations, because the
+ * first call still tokenized an intact string. That mirrors production,
+ * where isset_noflap() runs once per incoming status message. A test using
+ * a fresh host per test name would have passed even before the fix.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libxymon.h"
+
+static int failures = 0;
+
+static void expect(const char *label, int cond, const char *detail)
+{
+	if (!cond) {
+		fprintf(stderr, "%s: %s\n", label, detail);
+		failures++;
+	}
+}
+
+/* Kept identical to xymond/xymond.c's isset_noflap(), minus its dbgprintf. */
+static int isset_noflap(void *hinfo, char *testname, char *hostname)
+{
+	char *tok, *dstr, *dbuf;
+	int keylen, listed;
+
+	dstr = xmh_item(hinfo, XMH_NOFLAP);
+	if (!dstr) return 0;
+
+	if (strcmp(dstr, "NOFLAP") == 0) return 1;
+
+	if (*dstr == '=') dstr++;
+
+	dbuf = strdup(dstr);
+	if (!dbuf) return 0;
+
+	keylen = strlen(testname);
+	tok = strtok(dbuf, ",");
+	while (tok && (strncmp(testname, tok, keylen) != 0)) tok = strtok(NULL, ",");
+	listed = (tok != NULL);
+	xfree(dbuf);
+
+	if (!listed) return 0;
+
+	return 1;
+}
+
+int main(int argc, char *argv[])
+{
+	void *barehost, *listhost, *recordhost;
+	char *before, *after;
+
+	if (argc != 2) { fprintf(stderr, "usage: %s hosts.cfg\n", argv[0]); return 2; }
+
+	if (load_hostnames(argv[1], NULL, 1) == -1) {
+		fprintf(stderr, "cannot load %s\n", argv[1]);
+		return 2;
+	}
+
+	barehost   = hostinfo("barehost.example.com");
+	listhost   = hostinfo("listhost.example.com");
+	recordhost = hostinfo("recordhost.example.com");
+	if (!barehost || !listhost || !recordhost) {
+		fprintf(stderr, "test hosts not found\n");
+		return 2;
+	}
+
+	/* Bare flag form. lib/loadhosts.c's XMH_NOFLAP case mirrors flag
+	 * semantics for it, so the value is the key string "NOFLAP" and
+	 * isset_noflap() short-circuits before tokenizing anything. This path
+	 * was never broken; assert it stayed that way. */
+	expect("bare noflap: suppresses flapping for the first test queried",
+	       isset_noflap(barehost, "web", "barehost") == 1,
+	       "a bare noflap tag must disable flapping for every test on the host");
+	expect("bare noflap: still suppresses on a second, different test",
+	       isset_noflap(barehost, "cpu", "barehost") == 1,
+	       "a bare noflap tag must keep working across repeated evaluations");
+
+	/* The regression: every test in the list must stay suppressed no matter
+	 * how many evaluations have already happened on this record. */
+	expect("noflap list: first test evaluated is suppressed",
+	       isset_noflap(listhost, "web", "listhost") == 1,
+	       "web is listed in noflap=web,cpu,disk and must be suppressed");
+	expect("noflap list: second test in the list is still suppressed",
+	       isset_noflap(listhost, "cpu", "listhost") == 1,
+	       "cpu is listed in noflap=web,cpu,disk and must still be suppressed after "
+	       "an earlier evaluation of the same host");
+	expect("noflap list: third test in the list is still suppressed",
+	       isset_noflap(listhost, "disk", "listhost") == 1,
+	       "disk is listed in noflap=web,cpu,disk and must still be suppressed after "
+	       "two earlier evaluations of the same host");
+
+	/* Control: an unlisted test must stay unsuppressed, so the assertions
+	 * above cannot be satisfied by making the function always return 1. */
+	expect("noflap list: an unlisted test is not suppressed",
+	       isset_noflap(listhost, "mem", "listhost") == 0,
+	       "mem is absent from noflap=web,cpu,disk and must not be suppressed");
+
+	/* The root cause, stated directly: evaluating a host must leave its
+	 * configuration record byte-for-byte intact. */
+	before = strdup(xmh_item(recordhost, XMH_NOFLAP));
+	(void)isset_noflap(recordhost, "web", "recordhost");
+	after = xmh_item(recordhost, XMH_NOFLAP);
+	expect("noflap: evaluating a host leaves its record intact",
+	       after && (strcmp(before, after) == 0),
+	       "isset_noflap() must not tokenize the pointer xmh_item() returned - it points "
+	       "into the host record's own allelems buffer, so the stored tag gets modified");
+	free(before);
+
+	printf(failures ? "FAILED\n" : "ALL OK\n");
+	return failures ? 1 : 0;
+}

--- a/tests/server/xymond-noflap-list.sh
+++ b/tests/server/xymond-noflap-list.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-noflap-list.sh
+#
+# Regression guard for the list form of the hosts.cfg "noflap=test1,test2,..."
+# tag silently losing effect for every test after the first one evaluated.
+#
+# xmh_item() for XMH_NOFLAP returns a pointer into the host record's own tag
+# buffer rather than a copy, so xymond's isset_noflap() tokenizing it with
+# strtok() overwrote the list's first comma with a NUL and truncated the
+# stored tag permanently. With isset_noflap() running once per incoming
+# status message, only the first test ever kept its flap suppression:
+#
+#   before any call    raw tags: [conn] [noflap=web,cpu,disk]
+#   isset_noflap(web)  = 1
+#   after first call   raw tags: [conn] [noflap=web]
+#   isset_noflap(cpu)  = 0
+#   isset_noflap(disk) = 0
+#
+# The bare "noflap" flag form was unaffected: lib/loadhosts.c's XMH_NOFLAP
+# case mirrors flag semantics for it, so isset_noflap() short-circuits
+# before tokenizing.
+#
+# Two halves, because isset_noflap() is static in xymond/xymond.c and xymond
+# has no library form to link against:
+#   1. a source assertion that xymond.c still copies before tokenizing --
+#      this is what actually guards the fix in the real file;
+#   2. a C harness (xymond-noflap-list-harness.c) that keeps an identical
+#      copy of the function and drives it against real host records loaded
+#      through the real lib/loadhosts.c, proving the copy-first logic gives
+#      the right answers and leaves the record intact.
+# The source assertion is what keeps the harness's copy from drifting from
+# the original.
+#
+# Not fixed here, and deliberately left alone: xymongen/loaddata.c tokenizes
+# the XMH_COMPACT value in place the same way. No user-visible symptom has
+# been demonstrated for it (xymongen normally visits each host once), so it
+# is out of this change's scope.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+here=$(dirname "$0")
+
+XYMOND_C="$ROOT/xymond/xymond.c"
+[ -f "$XYMOND_C" ] || skip "xymond/xymond.c not present in this checkout"
+
+# --- 1. Source assertion: the real isset_noflap() must not hand the pointer
+# xmh_item() returned straight to strtok(). Scoped to the function body so an
+# unrelated strtok() elsewhere in xymond.c cannot mask a regression here.
+body=$(awk '/^static int isset_noflap/,/^}/' "$XYMOND_C")
+[ -n "$body" ] || fail "could not locate isset_noflap() in xymond/xymond.c"
+
+assert_contains 'strdup(' "$body" \
+	"isset_noflap() must copy the XMH_NOFLAP value before tokenizing it -- xmh_item() \
+returns a pointer into the host record's own tag buffer, and strtok() would truncate \
+the stored noflap list at its first comma"
+
+assert_not_contains 'strtok(dstr' "$body" \
+	"isset_noflap() still tokenizes the xmh_item() result directly (strtok(dstr, ...)), \
+which corrupts the host record's noflap list"
+
+# --- 2. Behavioural half.
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-noflap-list.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+# Tags are spelled lowercase here because that is what hosts.cfg(5)
+# documents ("noflap[=test1,test2,...]"), even though the key table in
+# lib/loadhosts.c stores them upper-case.
+cat > "$work/hosts.cfg" <<'EOF'
+127.0.0.1 barehost.example.com # conn noflap
+127.0.0.1 listhost.example.com # conn noflap=web,cpu,disk
+127.0.0.1 recordhost.example.com # conn noflap=web,cpu
+EOF
+
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+	"$here/xymond-noflap-list-harness.c" "$ROOT/lib/libxymoncomm.a" \
+	-lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+"$work/harness" "$work/hosts.cfg" 2>"$work/stderr.log" \
+	|| fail "noflap assertions failed:
+$(cat "$work/stderr.log")"
+
+pass "noflap= list keeps working across repeated evaluations and leaves the host record intact"

--- a/tests/server/xymond-noflap-list.sh
+++ b/tests/server/xymond-noflap-list.sh
@@ -22,16 +22,10 @@
 # case mirrors flag semantics for it, so isset_noflap() short-circuits
 # before tokenizing.
 #
-# Two halves, because isset_noflap() is static in xymond/xymond.c and xymond
-# has no library form to link against:
-#   1. a source assertion that xymond.c still copies before tokenizing --
-#      this is what actually guards the fix in the real file;
-#   2. a C harness (xymond-noflap-list-harness.c) that keeps an identical
-#      copy of the function and drives it against real host records loaded
-#      through the real lib/loadhosts.c, proving the copy-first logic gives
-#      the right answers and leaves the record intact.
-# The source assertion is what keeps the harness's copy from drifting from
-# the original.
+# Since isset_noflap() is static and xymond has no library form, the test
+# extracts the real function from xymond.c into a generated translation unit,
+# then appends assertions that drive it against real host records loaded
+# through the real lib/loadhosts.c.
 #
 # Not fixed here, and deliberately left alone: xymongen/loaddata.c tokenizes
 # the XMH_COMPACT value in place the same way. No user-visible symptom has
@@ -48,22 +42,8 @@ here=$(dirname "$0")
 XYMOND_C="$ROOT/xymond/xymond.c"
 [ -f "$XYMOND_C" ] || skip "xymond/xymond.c not present in this checkout"
 
-# --- 1. Source assertion: the real isset_noflap() must not hand the pointer
-# xmh_item() returned straight to strtok(). Scoped to the function body so an
-# unrelated strtok() elsewhere in xymond.c cannot mask a regression here.
 body=$(awk '/^static int isset_noflap/,/^}/' "$XYMOND_C")
 [ -n "$body" ] || fail "could not locate isset_noflap() in xymond/xymond.c"
-
-assert_contains 'strdup(' "$body" \
-	"isset_noflap() must copy the XMH_NOFLAP value before tokenizing it -- xmh_item() \
-returns a pointer into the host record's own tag buffer, and strtok() would truncate \
-the stored noflap list at its first comma"
-
-assert_not_contains 'strtok(dstr' "$body" \
-	"isset_noflap() still tokenizes the xmh_item() result directly (strtok(dstr, ...)), \
-which corrupts the host record's noflap list"
-
-# --- 2. Behavioural half.
 CC=${CC:-cc}
 command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
 
@@ -75,6 +55,14 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 
 make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+
+{
+	printf '#include <stdio.h>\n#include <stdlib.h>\n#include <string.h>\n'
+	printf '#include "libxymon.h"\n'
+	printf '%s\n' "$body"
+	cat "$here/xymond-noflap-list-harness.c"
+} > "$work/harness.c"
 
 # Tags are spelled lowercase here because that is what hosts.cfg(5)
 # documents ("noflap[=test1,test2,...]"), even though the key table in
@@ -86,8 +74,8 @@ cat > "$work/hosts.cfg" <<'EOF'
 EOF
 
 "$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
-	"$here/xymond-noflap-list-harness.c" "$ROOT/lib/libxymoncomm.a" \
-	-lssl -lcrypto 2>"$work/cc.log" \
+	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
+	$ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 "$work/harness" "$work/hosts.cfg" 2>"$work/stderr.log" \

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -1388,8 +1388,8 @@ static int changedelay(void *hinfo, int newcolor, char *testname, int currcolor)
 
 static int isset_noflap(void *hinfo, char *testname, char *hostname)
 {
-	char *tok, *dstr;
-	int keylen;
+	char *tok, *dstr, *dbuf;
+	int keylen, listed;
 
 	dstr = xmh_item(hinfo, XMH_NOFLAP);
 	if (!dstr) return 0; /* no 'noflap' set */
@@ -1400,11 +1400,19 @@ static int isset_noflap(void *hinfo, char *testname, char *hostname)
 
 	/* if not 'NOFLAP', we should receive "=test1,test2". Skip the = */
 	if (*dstr == '=') dstr++;
-	
+
+	/* Copy first: xmh_item() points into the host's own tag buffer, and strtok()
+	 * would truncate the stored list at its first comma. */
+	dbuf = strdup(dstr);
+	if (!dbuf) return 0;	/* OOM - don't let strtok(NULL, ...) resume stale state */
+
 	keylen = strlen(testname);
-	tok = strtok(dstr, ",");
+	tok = strtok(dbuf, ",");
 	while (tok && (strncmp(testname, tok, keylen) != 0)) tok = strtok(NULL, ",");
-	if (!tok) return 0; /* specifies noflap, but this test is not in the list */
+	listed = (tok != NULL);
+	xfree(dbuf);
+
+	if (!listed) return 0; /* specifies noflap, but this test is not in the list */
 
 	/* do not use flapping for the test */
 	dbgprintf("Ignoring flapping for %s:%s due to noflap set.\n", hostname, testname);


### PR DESCRIPTION
## Summary

`noflap=test1,test2,...` in `hosts.cfg` silently stopped suppressing flap detection for every test except the first one evaluated. The bare `noflap` flag form was never affected.

## Root cause

`xmh_item()` for `XMH_NOFLAP` returns a pointer **into the host record's own tag buffer**, not a copy. `isset_noflap()` handed it straight to `strtok()`, which overwrote the list's first comma with a `NUL` — truncating the stored tag permanently. Since `isset_noflap()` runs once per incoming status message, the first evaluation destroyed the list for every later one:

```
before any call    raw tags: [conn] [noflap=web,cpu,disk]
isset_noflap(web)  = 1
after first call   raw tags: [conn] [noflap=web]        <-- truncated in place
isset_noflap(cpu)  = 0
isset_noflap(disk) = 0
```

Whichever test reported first kept suppression; the rest quietly lost it until the next `hosts.cfg` reload.

## Fix

Tokenize a copy (`strdup` / `xfree`) instead of the live buffer. Matching semantics, return values and the debug log are unchanged.

This is the established pattern — four of the six places that tokenize an `xmh_item()` result already copy first: `convertnk.c` (`XMH_NK`), `xymond_client.c` and `xymongen/loaddata.c` (`XMH_NOCOLUMNS`), `lib/webaccess.c` (`XMH_ALLPAGEPATHS`). That's what makes this an oversight rather than a design choice.

## Testing

`tests/server/xymond-noflap-list.sh`, in two halves since `isset_noflap()` is `static` and xymond has no library form to link against:

1. a source assertion that `xymond.c` still copies before tokenizing — the actual guard on the real file, matching the existing style of `digest-md5hash.sh`;
2. a C harness with an identical copy of the function, driven against real host records through the real `lib/loadhosts.c`.

Verified failing before the change (`exit=1`) and passing after (`exit=0`). Full suite: 18 passed, 1 skipped (RRD not built), 0 failed.

Deliberate in the test: the list assertions share one host and run in sequence, because the defect only appeared on the *second* and later evaluations — a fresh host per test name would have passed against the bug.

## Scope / notes

- The `strdup()` NULL check deviates slightly from the precedent sites. `XYMON_MEMORY_WRAPPERS` is `#undef`'d, so this is plain `strdup`, and on failure `strtok(NULL, ...)` would resume stale tokenizer state and return a wrong answer rather than crash.
