### PR TITLE
fix: register XMH_FLAG_MULTIHOMED under its documented name

### DIFF
--- a/lib/loadhosts.c
+++ b/lib/loadhosts.c
@@ -173,7 +173,7 @@ static void xmh_item_list_setup(void)
 	xmh_item_key[XMH_NOFLAP]               = "NOFLAP";
 	xmh_item_name[XMH_NOFLAP]              = "XMH_NOFLAP";
 	xmh_item_key[XMH_FLAG_MULTIHOMED]      = "MULTIHOMED";
-	xmh_item_name[XMH_FLAG_MULTIHOMED]     = "XMH_MULTIHOMED";
+	xmh_item_name[XMH_FLAG_MULTIHOMED]     = "XMH_FLAG_MULTIHOMED";
 	xmh_item_key[XMH_FLAG_HTTP_HEADER_MATCH]             = "headermatch";
 	xmh_item_name[XMH_FLAG_HTTP_HEADER_MATCH]            = "XMH_FLAG_HTTP_HEADER_MATCH";
 	xmh_item_key[XMH_FLAG_SNI]             = "sni";			// Enable SNI (Server name Indication) for TLS requests

--- a/tests/server/xmh-item-names-harness.c
+++ b/tests/server/xmh-item-names-harness.c
@@ -1,0 +1,111 @@
+/* Regression test for the XMH_ item-name table in lib/loadhosts.c.
+ *
+ * xmh_item_name[] holds the public name of each host attribute. Those names
+ * are not internal labels - they are the field names clients use in
+ * xymondboard/hostinfo requests (xymond/xymond.c), the names xymond emits in
+ * hostinfo responses and lib/loadhosts_net.c parses back, and what web
+ * templates resolve via xmh_item_byname() (lib/headfoot.c). They are
+ * documented in xymon-xmh(5).
+ *
+ * XMH_FLAG_MULTIHOMED was registered as "XMH_MULTIHOMED", missing the FLAG_
+ * that its enum name and xymon-xmh(5) both carry. Two consequences:
+ *   - the documented name XMH_FLAG_MULTIHOMED did not resolve, so a
+ *     board/hostinfo field selector or template reference using it was
+ *     silently rejected;
+ *   - xmh_item_isflag[] is derived by prefix-matching "XMH_FLAG_" against
+ *     the registered name, so MULTIHOMED was never treated as a flag and
+ *     xmh_item() returned the empty remainder after the key instead of the
+ *     canonical key string that every other flag yields.
+ *
+ * Everything here drives the real lib/loadhosts.c through its public
+ * interface - no mirrored logic.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libxymon.h"
+
+static int failures = 0;
+
+static void expect(const char *label, int cond, const char *detail)
+{
+	if (!cond) {
+		fprintf(stderr, "%s: %s\n", label, detail);
+		failures++;
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	void *taghost, *plainhost;
+	enum xmh_item_t idx;
+	char *v, *name;
+
+	if (argc != 2) { fprintf(stderr, "usage: %s hosts.cfg\n", argv[0]); return 2; }
+
+	if (load_hostnames(argv[1], NULL, 1) == -1) {
+		fprintf(stderr, "cannot load %s\n", argv[1]);
+		return 2;
+	}
+
+	taghost   = hostinfo("taghost.example.com");    /* dialup MULTIHOMED */
+	plainhost = hostinfo("plainhost.example.com");  /* neither tag */
+	if (!taghost || !plainhost) { fprintf(stderr, "test hosts not found\n"); return 2; }
+
+	/* The documented name must resolve to its own enum value. */
+	expect("XMH_FLAG_MULTIHOMED resolves by its documented name",
+	       xmh_key_idx("XMH_FLAG_MULTIHOMED") == XMH_FLAG_MULTIHOMED,
+	       "xymon-xmh(5) documents XMH_FLAG_MULTIHOMED, so xmh_key_idx() must resolve it "
+	       "rather than returning XMH_LAST");
+	expect("XMH_FLAG_MULTIHOMED reports its documented name",
+	       (name = xmh_item_id(XMH_FLAG_MULTIHOMED)) && (strcmp(name, "XMH_FLAG_MULTIHOMED") == 0),
+	       "xmh_item_id() is what xymond emits in hostinfo responses, so it must match "
+	       "the documented name");
+
+	/* Flag semantics: a present flag yields its canonical key string, an
+	 * absent one yields NULL. dialup is the control - a flag that was always
+	 * registered correctly. */
+	v = xmh_item(taghost, XMH_FLAG_DIALUP);
+	expect("control: dialup flag yields its canonical key", v && (strcmp(v, "dialup") == 0),
+	       "a correctly registered flag returns its key string");
+	v = xmh_item(taghost, XMH_FLAG_MULTIHOMED);
+	expect("MULTIHOMED flag yields its canonical key", v && (strcmp(v, "MULTIHOMED") == 0),
+	       "MULTIHOMED must behave like every other flag and return its key string, not "
+	       "the empty remainder after the key");
+
+	/* The one in-tree consumer (xymond/xymond.c, suppressing the
+	 * multiple-source-IP warning) tests the result against NULL. Absent must
+	 * stay NULL, present must stay non-NULL. */
+	expect("MULTIHOMED absent reads as NULL",
+	       xmh_item(plainhost, XMH_FLAG_MULTIHOMED) == NULL,
+	       "a host without the tag must read NULL so the == NULL consumer keeps working");
+	expect("MULTIHOMED present reads as non-NULL",
+	       xmh_item(taghost, XMH_FLAG_MULTIHOMED) != NULL,
+	       "a host with the tag must read non-NULL so the == NULL consumer keeps working");
+
+	/* Table-wide invariant: every registered name must resolve back to the
+	 * entry that registered it, catching duplicated or colliding names. Note
+	 * this does NOT catch a misnamed entry - "XMH_MULTIHOMED" round-tripped
+	 * to its own slot perfectly well. The companion source check in the shell
+	 * test is what catches that. */
+	for (idx = 0; idx < XMH_LAST; idx++) {
+		char detail[256];
+		enum xmh_item_t back;
+
+		name = xmh_item_id(idx);
+		if (!name) continue;	/* not every slot is a named item */
+
+		back = xmh_key_idx(name);
+		if (back != idx) {
+			snprintf(detail, sizeof(detail),
+				 "xmh_item_id(%d) is \"%s\", but xmh_key_idx(\"%s\") gives %d%s",
+				 (int)idx, name, name, (int)back,
+				 (back == XMH_LAST) ? " (XMH_LAST - unresolvable)" : " (another entry)");
+			expect("every XMH_ name round-trips to its own entry", 0, detail);
+		}
+	}
+
+	printf(failures ? "FAILED\n" : "ALL OK\n");
+	return failures ? 1 : 0;
+}

--- a/tests/server/xmh-item-names.sh
+++ b/tests/server/xmh-item-names.sh
@@ -38,8 +38,8 @@ LOADHOSTS_C="$ROOT/lib/loadhosts.c"
 # --- Source check: xmh_item_name[XMH_X] must register the string "XMH_X".
 # A mismatch is invisible at runtime (the wrong name still resolves to its own
 # slot), so this has to be checked against the source.
-mismatched=$(grep -o 'xmh_item_name\[XMH_[A-Z0-9_]*\][[:space:]]*=[[:space:]]*"XMH_[A-Z0-9_]*"' "$LOADHOSTS_C" \
-	| sed -E 's/xmh_item_name\[(XMH_[A-Z0-9_]*)\][[:space:]]*=[[:space:]]*"(XMH_[A-Z0-9_]*)"/\1 \2/' \
+mismatched=$(grep -o 'xmh_item_name\[XMH_[A-Z0-9_]*\][[:space:]]*=[[:space:]]*"[^"]*"' "$LOADHOSTS_C" \
+	| sed -E 's/xmh_item_name\[(XMH_[A-Z0-9_]*)\][[:space:]]*=[[:space:]]*"([^"]*)"/\1 \2/' \
 	| awk '$1 != $2 { printf "  %s registered as \"%s\"\n", $1, $2 }')
 [ -z "$mismatched" ] || fail "xmh_item_name[] entries disagree with their enum names -- \
 the registered string is the public field name (xymon-xmh(5), xymondboard/hostinfo, web \
@@ -51,6 +51,8 @@ command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
 
 [ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
 	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-xmh-item-names.XXXXXX")
 trap 'rm -rf "$work"' EXIT HUP INT TERM
@@ -65,7 +67,7 @@ EOF
 
 "$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
 	"$here/xmh-item-names-harness.c" "$ROOT/lib/libxymoncomm.a" \
-	-lssl -lcrypto 2>"$work/cc.log" \
+	$ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 "$work/harness" "$work/hosts.cfg" 2>"$work/stderr.log" \

--- a/tests/server/xmh-item-names.sh
+++ b/tests/server/xmh-item-names.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xmh-item-names.sh
+#
+# Guards the XMH_ item-name table in lib/loadhosts.c. Those names are public:
+# clients select and filter xymondboard/hostinfo fields by them, xymond emits
+# them in hostinfo responses (which lib/loadhosts_net.c parses back), web
+# templates resolve them via xmh_item_byname(), and xymon-xmh(5) documents
+# them.
+#
+# XMH_FLAG_MULTIHOMED was registered as "XMH_MULTIHOMED", missing the FLAG_
+# that both its enum name and xymon-xmh(5) carry, so the documented name did
+# not resolve and MULTIHOMED was never treated as a flag.
+#
+# Two general guards back up the MULTIHOMED-specific assertions:
+#   - a source check that each xmh_item_name[XMH_X] entry registers the string
+#     "XMH_X" -- this is what actually catches the typo class, since a
+#     misnamed entry is still internally self-consistent (the wrong name
+#     resolves back to its own slot perfectly well) and no runtime assertion
+#     can see the mismatch;
+#   - a runtime check that every registered name resolves back to its own
+#     entry, which catches duplicates and collisions instead.
+#
+# See xmh-item-names-harness.c for details. The runtime half is driven
+# entirely through the real library's public interface.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+here=$(dirname "$0")
+
+LOADHOSTS_C="$ROOT/lib/loadhosts.c"
+[ -f "$LOADHOSTS_C" ] || skip "lib/loadhosts.c not present in this checkout"
+
+# --- Source check: xmh_item_name[XMH_X] must register the string "XMH_X".
+# A mismatch is invisible at runtime (the wrong name still resolves to its own
+# slot), so this has to be checked against the source.
+mismatched=$(grep -o 'xmh_item_name\[XMH_[A-Z0-9_]*\][[:space:]]*=[[:space:]]*"XMH_[A-Z0-9_]*"' "$LOADHOSTS_C" \
+	| sed -E 's/xmh_item_name\[(XMH_[A-Z0-9_]*)\][[:space:]]*=[[:space:]]*"(XMH_[A-Z0-9_]*)"/\1 \2/' \
+	| awk '$1 != $2 { printf "  %s registered as \"%s\"\n", $1, $2 }')
+[ -z "$mismatched" ] || fail "xmh_item_name[] entries disagree with their enum names -- \
+the registered string is the public field name (xymon-xmh(5), xymondboard/hostinfo, web \
+templates) and also what xmh_item_isflag[] is derived from:
+$mismatched"
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-xmh-item-names.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+cat > "$work/hosts.cfg" <<'EOF'
+127.0.0.1 taghost.example.com # conn dialup MULTIHOMED
+127.0.0.1 plainhost.example.com # conn
+EOF
+
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+	"$here/xmh-item-names-harness.c" "$ROOT/lib/libxymoncomm.a" \
+	-lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+"$work/harness" "$work/hosts.cfg" 2>"$work/stderr.log" \
+	|| fail "XMH_ item-name assertions failed:
+$(cat "$work/stderr.log")"
+
+pass "every XMH_ item name resolves to its own entry and MULTIHOMED behaves as a flag"


### PR DESCRIPTION
## Summary

`xmh_item_name[XMH_FLAG_MULTIHOMED]` was registered as `"XMH_MULTIHOMED"`, missing the `FLAG_` that the enum identifier and `xymon-xmh(5)` both carry. One-word fix in `lib/loadhosts.c`, plus a test.

That string is public: clients filter/select `xymondboard`/`hostinfo` fields by it, xymond emits it on the wire (`loadhosts_net.c` parses it back), and web templates resolve it via `xmh_item_byname()`.

## Consequences

- **The documented name didn't resolve.** `xymon-xmh(5)` documents `XMH_FLAG_MULTIHOMED` and never mentions `XMH_MULTIHOMED`, so a field selector, filter or template written from the manpage was silently rejected.
- **MULTIHOMED wasn't treated as a flag.** `xmh_item_isflag[]` is derived by prefix-matching `"XMH_FLAG_"` on the registered name, so `xmh_item()` returned `""` instead of the canonical key every other flag yields.

It was the only entry where enum and registered names disagreed — 21 vs 20; now 21/21.

The one in-tree consumer (`xymond.c`, multiple-source-IP warning) tests `== NULL`, and `""` was already non-NULL, so its behaviour is unchanged.

## History

A typo at birth, never since altered. Both halves landed the same day in the 4.3.0 merge:

- `e3f90f0e` (2011-03-08) added `xymon-xmh.5` documenting `XMH_FLAG_MULTIHOMED`
- `8b01109b` (2011-03-08) added `xmh_item_name[...] = "XMH_MULTIHOMED"`

`git blame` shows line 176 still on that original commit, and a pickaxe over all history finds only those two commits ever touching the string. So the code has disagreed with its own manpage for ~15 years, and no commit ever deliberately chose the short name — there's no historical intent to preserve.

It also means the documented name has never worked in any release, so `"XMH_MULTIHOMED"` was only ever discoverable by reading the source. 

## Testing

`tests/server/xmh-item-names.sh`, two halves:

1. **Source check** that each `xmh_item_name[XMH_X]` registers `"XMH_X"` — this is what catches the typo class, since a misnamed entry is self-consistent at runtime and no runtime assertion can see it.
2. **C harness** on the real library: documented name resolves, MULTIHOMED yields its key like the `dialup` control, present/absent still read non-NULL/NULL, and all names round-trip (catching duplicates).

Verified against `origin/main`: unfixed `exit=1`, fixed `exit=0`. Full build clean; suite 19 passed, 0 failed.

## Upgrade note

xymond now emits `XMH_FLAG_MULTIHOMED` in `hostinfo`. A mixed-version pair silently drops that one field (receivers ignore unresolvable `XMH_` keys); nothing else is affected, and nothing in-tree reads it over the network.
