### PR TITLE
docs: match the tag case in hosts.cfg(5) to the keys loadhosts stores (#278)

### DIFF
--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -80,7 +80,7 @@ the file or directory is not present on a system.
 
 
 .SH GENERAL PER-HOST OPTIONS
-.IP noclear
+.IP NOCLEAR
 Controls whether stale status messages go purple or clear when
 a host is down. Normally, when a host is down the client statuses
 ("cpu", "disk", "memory" etc) will stop updating - this would usually
@@ -88,9 +88,9 @@ make them go "purple" which can trigger alerts. To avoid that, Xymon
 checks if the "conn" test has failed, and if that is true then the
 other tests will go "clear" instead of purple so you only get alerts
 for the "conn" test. If you do want the stale statuses to go purple,
-you can use the "noclear" tag to override this behaviour.
+you can use the "NOCLEAR" tag to override this behaviour.
 
-Note that "noclear" also affects the behaviour of network tests;
+Note that "NOCLEAR" also affects the behaviour of network tests;
 see below.
 
 .IP prefer
@@ -107,7 +107,7 @@ Note: This only applies to hosts that are defined multiple
 times in the hosts.cfg file, although it will not hurt to add it
 on other hosts as well.
 
-.IP multihomed
+.IP MULTIHOMED
 Tell Xymon that data from the host can arrive from multiple IP-addresses.
 By default, Xymon will warn if it sees data for one host coming from
 different IP-addresses, because this usually indicates a mis-configuration
@@ -586,7 +586,7 @@ E.g. "WARNSTOPS:5" turns the report red once a 6th outage occurs in
 the reporting interval.
 Default: -1 (disabled - no limit on the number of down-periods).
 
-.IP "noflap[=test1,test2,...]"
+.IP "NOFLAP[=test1,test2,...]"
 Disable flap detection for this host, or for specific tests on this
 host. Flap detection is globally controlled by options given to 
 xymond on the command line, but, if enabled, it can be disabled 
@@ -613,23 +613,23 @@ Note: The "\-\-test\-untagged" option modifies this behaviour,
 see
 .I xymonnet(1)
 
-.IP noclear
+.IP NOCLEAR
 Some network tests depend on others. E.g. if the host does not
 respond to ping, then there's a good chance that the entire host 
 is down and all network tests will fail. Or if the http server
 is down, then any web content checks are also likely to fail.
 To avoid floods of alerts, the default behaviour is for xymonnet
 to change the status of these tests that fail because of another
-problem to "clear" instead of "red". The "noclear" tag disables this
+problem to "clear" instead of "red". The "NOCLEAR" tag disables this
 behaviour and causes all failing tests to be reported with their
 true color.
 
 This behaviour can also be implemented on a per-test basis by
 putting the "~" flag on any network test.
 
-Note that "noclear" also affects whether stale status messages
+Note that "NOCLEAR" also affects whether stale status messages
 from e.g. a client on the host go purple or clear when the
-host is down; see the "noclear" description in the
+host is down; see the "NOCLEAR" description in the
 "GENERAL PER-HOST OPTIONS" section above.
 
 .IP nosslcert
@@ -1445,8 +1445,8 @@ this should be listed FIRST in your file.
 tags - others are silently ignored: delayred, delayyellow, NOCOLUMNS, 
 COMMENT, DESCR, DOC, CLASS, dialup, nonongreen, nodisp, noinfo, 
 notrends, noclient, TRENDS, NOPROPRED, NOPROPYELLOW, NOPROPPURPLE, NOPROPACK, 
-REPORTTIME, WARNPCT, WARNSTOPS, testip, NET, noclear, nosslcert, ssldays, DOWNTIME, depends, 
-noping, noconn, trace, notrace, HIDEHTTP, browser, pulldata. Specifically, 
+REPORTTIME, WARNPCT, WARNSTOPS, testip, NET, NOCLEAR, nosslcert, ssldays, DOWNTIME, depends, 
+noping, noconn, trace, notrace, HIDEHTTP, browser, PULLDATA. Specifically, 
 note that network tests, "badTEST" settings, and alternate pageset 
 relations cannot be listed on the ".default." host.
 
@@ -1494,7 +1494,7 @@ the URL must point to a web page from the default set of Xymon webpages.
 
 
 .SH OTHER TAGS
-.IP pulldata[=[IP][:port]]
+.IP PULLDATA[=[IP][:port]]
 This option is recognized by the
 .I xymonfetch(8)
 utility, and causes it to poll the host for client data. The optional

--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -942,7 +942,7 @@ for testing described for the "dns" test are also available for
 the "dig" test.
 
 .IP "dns=hostname"
-.IP "dns=TYPE:lookup[,TYPE:lookup...]
+.IP "dns=TYPE:lookup[,TYPE:lookup...]"
 The default DNS tests will attempt a DNS lookup
 of the DNS' servers own hostname. You can specify the hostname
 to lookup on a DNS server by listing it on each test.

--- a/docs/manpages/man5/hosts.cfg.5.html
+++ b/docs/manpages/man5/hosts.cfg.5.html
@@ -106,7 +106,7 @@ the file or directory is not present on a system.
 <H2>GENERAL PER-HOST OPTIONS</H2>
 
 <DL COMPACT>
-<DT>noclear<DD>
+<DT>NOCLEAR<DD>
 Controls whether stale status messages go purple or clear when
 a host is down. Normally, when a host is down the client statuses
 (&quot;cpu&quot;, &quot;disk&quot;, &quot;memory&quot; etc) will stop updating - this would usually
@@ -114,9 +114,9 @@ make them go &quot;purple&quot; which can trigger alerts. To avoid that, Xymon
 checks if the &quot;conn&quot; test has failed, and if that is true then the
 other tests will go &quot;clear&quot; instead of purple so you only get alerts
 for the &quot;conn&quot; test. If you do want the stale statuses to go purple,
-you can use the &quot;noclear&quot; tag to override this behaviour.
+you can use the &quot;NOCLEAR&quot; tag to override this behaviour.
 <P>
-Note that &quot;noclear&quot; also affects the behaviour of network tests;
+Note that &quot;NOCLEAR&quot; also affects the behaviour of network tests;
 see below.
 <P>
 <DT>prefer<DD>
@@ -133,7 +133,7 @@ Note: This only applies to hosts that are defined multiple
 times in the hosts.cfg file, although it will not hurt to add it
 on other hosts as well.
 <P>
-<DT>multihomed<DD>
+<DT>MULTIHOMED<DD>
 Tell Xymon that data from the host can arrive from multiple IP-addresses.
 By default, Xymon will warn if it sees data for one host coming from
 different IP-addresses, because this usually indicates a mis-configuration
@@ -611,7 +611,7 @@ threshold is defined as the percentage of the time that the host
 must be available, e.g. &quot;WARNPCT:98.5&quot; if you want the threshold to
 be at 98.5%
 <P>
-<DT>noflap[=test1,test2,...]<DD>
+<DT>NOFLAP[=test1,test2,...]<DD>
 Disable flap detection for this host, or for specific tests on this
 host. Flap detection is globally controlled by options given to 
 xymond on the command line, but, if enabled, it can be disabled 
@@ -643,23 +643,23 @@ see
 <I><A HREF="../man1/xymonnet.1.html">xymonnet</A>(1)</I>
 
 <P>
-<DT>noclear<DD>
+<DT>NOCLEAR<DD>
 Some network tests depend on others. E.g. if the host does not
 respond to ping, then there's a good chance that the entire host 
 is down and all network tests will fail. Or if the http server
 is down, then any web content checks are also likely to fail.
 To avoid floods of alerts, the default behaviour is for xymonnet
 to change the status of these tests that fail because of another
-problem to &quot;clear&quot; instead of &quot;red&quot;. The &quot;noclear&quot; tag disables this
+problem to &quot;clear&quot; instead of &quot;red&quot;. The &quot;NOCLEAR&quot; tag disables this
 behaviour and causes all failing tests to be reported with their
 true color.
 <P>
 This behaviour can also be implemented on a per-test basis by
 putting the &quot;~&quot; flag on any network test.
 <P>
-Note that &quot;noclear&quot; also affects whether stale status messages
+Note that &quot;NOCLEAR&quot; also affects whether stale status messages
 from e.g. a client on the host go purple or clear when the
-host is down; see the &quot;noclear&quot; description in the
+host is down; see the &quot;NOCLEAR&quot; description in the
 &quot;GENERAL PER-HOST OPTIONS&quot; section above.
 <P>
 <DT>nosslcert<DD>
@@ -1564,8 +1564,8 @@ this should be listed FIRST in your file.
 tags - others are silently ignored: delayyellow, delayred, NOCOLUMNS, 
 COMMENT, DESCR, CLASS, dialup, testip, nonongreen, nodisp, noinfo, 
 notrends, noclient, TRENDS, NOPROPRED, NOPROPYELLOW, NOPROPPURPLE, NOPROPACK, 
-REPORTTIME, WARNPCT, NET, noclear, nosslcert, ssldays, DOWNTIME, depends, 
-noping, noconn, trace, notrace, HIDEHTTP, browser, pulldata. Specifically, 
+REPORTTIME, WARNPCT, NET, NOCLEAR, nosslcert, ssldays, DOWNTIME, depends,
+noping, noconn, trace, notrace, HIDEHTTP, browser, PULLDATA. Specifically,
 note that network tests, &quot;badTEST&quot; settings, and alternate pageset 
 relations cannot be listed on the &quot;.default.&quot; host.
 <P>
@@ -1621,7 +1621,7 @@ the URL must point to a web page from the default set of Xymon webpages.
 <H2>OTHER TAGS</H2>
 
 <DL COMPACT>
-<DT>pulldata[=[IP][:port]]<DD>
+<DT>PULLDATA[=[IP][:port]]<DD>
 This option is recognized by the
 <I><A HREF="../man8/xymonfetch.8.html">xymonfetch</A>(8)</I>
 

--- a/docs/manpages/man8/xymond.8.html
+++ b/docs/manpages/man8/xymond.8.html
@@ -117,7 +117,7 @@ Default: 10 seconds.
 Track the N latest status-changes for flap-detection. See the
 <B>--flap-seconds</B> option also. To disable flap-checks globally, 
 set N to zero. To disable for a specific host, you must use the 
-&quot;noflap&quot; option in <I><A HREF="../man5/hosts.cfg.5.html">hosts.cfg</A>(5)</I>.
+&quot;NOFLAP&quot; option in <I><A HREF="../man5/hosts.cfg.5.html">hosts.cfg</A>(5)</I>.
 Default: 5
 <P>
 <DT>--flap-seconds=N<DD>

--- a/docs/manpages/man8/xymonfetch.8.html
+++ b/docs/manpages/man8/xymonfetch.8.html
@@ -33,14 +33,14 @@ utility on the client, and using <B>xymonfetch</B> on the Xymon
 server to collect data from the clients.
 <P>
 xymonfetch will only collect data from clients that have the
-<B>pulldata</B> tag listed in the
+<B>PULLDATA</B> tag listed in the
 <I><A HREF="../man5/hosts.cfg.5.html">hosts.cfg</A>(5)</I>
 
 file. The IP-address listed in the hosts.cfg file must be correct,
 since this is the IP-address where xymonfetch will attempt to contact
 the client.  If the msgcache daemon is running on a non-standard 
 IP-address or portnumber, you can specify the portnumber as in
-<B>pulldata=192.168.1.2:8084</B> for contacting the msgcache daemon 
+<B>PULLDATA=192.168.1.2:8084</B> for contacting the msgcache daemon
 using IP 192.168.1.2 port 8084. If the IP-address is omitted, the
 default IP in the hosts.cfg file is used. If the port number is
 omitted, the portnumber from the XYMONDPORT setting in

--- a/tests/packaging/hosts-cfg-tag-case.sh
+++ b/tests/packaging/hosts-cfg-tag-case.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/packaging/hosts-cfg-tag-case.sh
+#
+# hosts.cfg(5) must spell each tag the same way lib/loadhosts.c stores it in
+# xmh_item_key[]. The case matters: xmh_find_item() matches a tag
+# case-insensitively (so either spelling sets the attribute), but
+# xmh_item_idx() -- which web/svcstatus-info.c uses to decide a tag is
+# already a recognized attribute, and xymonnet/xymonnet.c to decide a tag is
+# not a network test -- matches case-sensitively. A tag written in the
+# documented case therefore has to match the stored key exactly, or following
+# the manual produces a tag that works yet is reported as unrecognized.
+#
+# Four tags used to be documented lower-case while stored upper-case
+# (noclear, pulldata, noflap, multihomed); they were the only tags where
+# reading the manual triggered that mismatch.
+#
+# Compares every ".IP <tag>" entry in the manpage against the key table, so
+# a new tag documented in the wrong case is caught too. Tags with no manpage
+# entry are not flagged here -- several are genuinely undocumented, which is
+# a separate gap.
+#
+# No build required: both inputs are source files.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+LOADHOSTS="$ROOT/lib/loadhosts.c"
+MANPAGE="$ROOT/common/hosts.cfg.5"
+
+for f in "$LOADHOSTS" "$MANPAGE"; do
+	[ -f "$f" ] || skip "$(basename "$f") not present in this checkout"
+done
+
+command -v awk >/dev/null 2>&1 || skip "awk not available"
+
+work=$(mktempdir)
+
+# Stored keys, minus the ':' / '=' value separator: "COMMENT:" -> COMMENT
+sed -nE 's/.*xmh_item_key\[XMH_[A-Z0-9_]+\][[:space:]]*=[[:space:]]*"([^"]*)".*/\1/p' \
+	"$LOADHOSTS" | sed -E 's/[:=]$//' | sort -u > "$work/keys"
+[ -s "$work/keys" ] || fail "found no xmh_item_key[] entries in lib/loadhosts.c -- parser is stale"
+
+# Documented tag names: leading identifier of each ".IP" entry, unquoted.
+sed -nE 's/^\.IP[[:space:]]+"?([A-Za-z0-9_-]+).*/\1/p' "$MANPAGE" | sort -u > "$work/documented"
+[ -s "$work/documented" ] || fail "found no .IP entries in hosts.cfg.5 -- parser is stale"
+
+# A documented tag whose lower-cased form matches a key's lower-cased form,
+# but which differs from the key in case, is a mismatch.
+mismatched=$(awk '
+	NR == FNR { key[tolower($0)] = $0; next }
+	{ lc = tolower($0); if (lc in key && key[lc] != $0) printf "  hosts.cfg(5) says \"%s\", lib/loadhosts.c stores \"%s\"\n", $0, key[lc] }
+' "$work/keys" "$work/documented")
+
+[ -z "$mismatched" ] || fail "hosts.cfg(5) documents tags in a different case than lib/loadhosts.c stores them.
+Because xmh_item_idx() matches case-sensitively, the documented spelling must match the stored key exactly:
+$mismatched"
+
+pass "hosts.cfg(5) documents every tag in the case lib/loadhosts.c stores it"

--- a/tests/packaging/hosts-cfg-tag-case.sh
+++ b/tests/packaging/hosts-cfg-tag-case.sh
@@ -3,14 +3,11 @@
 #
 # tests/packaging/hosts-cfg-tag-case.sh
 #
-# hosts.cfg(5) must spell each tag the same way lib/loadhosts.c stores it in
-# xmh_item_key[]. The case matters: xmh_find_item() matches a tag
-# case-insensitively (so either spelling sets the attribute), but
-# xmh_item_idx() -- which web/svcstatus-info.c uses to decide a tag is
-# already a recognized attribute, and xymonnet/xymonnet.c to decide a tag is
-# not a network test -- matches case-sensitively. A tag written in the
-# documented case therefore has to match the stored key exactly, or following
-# the manual produces a tag that works yet is reported as unrecognized.
+# A tag written the way hosts.cfg(5) documents it must be recognized by
+# xmh_item_idx(). Today that function compares case-sensitively, so the
+# documented spelling has to match the stored xmh_item_key[] entry exactly.
+# If xmh_item_idx() becomes case-insensitive, the manual's tag case is free and
+# this test must not preserve the old case policy as an accidental invariant.
 #
 # Four tags used to be documented lower-case while stored upper-case
 # (noclear, pulldata, noflap, multihomed); they were the only tags where
@@ -39,6 +36,16 @@ command -v awk >/dev/null 2>&1 || skip "awk not available"
 
 work=$(mktempdir)
 
+# Mirror the comparison xmh_item_idx() actually performs instead of fixing a
+# case policy that the implementation may deliberately change.
+idx_body=$(awk '/^int xmh_item_idx/,/^}/' "$LOADHOSTS")
+[ -n "$idx_body" ] || fail "could not locate xmh_item_idx() in lib/loadhosts.c"
+case "$idx_body" in
+	*strncasecmp*) pass "xmh_item_idx() matches case-insensitively, so the manual's tag case is free" ;;
+	*strncmp*) ;;
+	*) fail "xmh_item_idx() no longer compares keys with strncmp()/strncasecmp() -- this test needs updating" ;;
+esac
+
 # Stored keys, minus the ':' / '=' value separator: "COMMENT:" -> COMMENT
 sed -nE 's/.*xmh_item_key\[XMH_[A-Z0-9_]+\][[:space:]]*=[[:space:]]*"([^"]*)".*/\1/p' \
 	"$LOADHOSTS" | sed -E 's/[:=]$//' | sort -u > "$work/keys"
@@ -59,4 +66,4 @@ mismatched=$(awk '
 Because xmh_item_idx() matches case-sensitively, the documented spelling must match the stored key exactly:
 $mismatched"
 
-pass "hosts.cfg(5) documents every tag in the case lib/loadhosts.c stores it"
+pass "hosts.cfg(5) documents every tag in the case-sensitive form xmh_item_idx() recognizes"

--- a/xymond/etcfiles/tasks.cfg.DIST
+++ b/xymond/etcfiles/tasks.cfg.DIST
@@ -108,7 +108,7 @@
 # but the Xymon server can connect to the client. Normally the clients will initiate
 # a connection to the Xymon server to deliver the data they collect, but this is
 # forbidden in some firewall setups. By enabling the xymonfetch task, hosts that have
-# the "pulldata" tag in the hosts.cfg file will be polled by xymonfetch for their data.
+# the "PULLDATA" tag in the hosts.cfg file will be polled by xymonfetch for their data.
 #
 # NOTE: On the clients you must enable the "msgcache" task, since this is what 
 #       xymonfetch is talking to.

--- a/xymond/xymond.8
+++ b/xymond/xymond.8
@@ -99,7 +99,7 @@ Default: 10 seconds.
 Track the N latest status-changes for flap-detection. See the
 \fB\-\-flap\-seconds\fR option also. To disable flap-checks globally, 
 set N to zero. To disable for a specific host, you must use the 
-"noflap" option in \fIhosts.cfg(5)\fR.
+"NOFLAP" option in \fIhosts.cfg(5)\fR.
 Default: 5
 
 .IP "\-\-flap\-seconds=N"

--- a/xymond/xymonfetch.8
+++ b/xymond/xymonfetch.8
@@ -19,13 +19,13 @@ utility on the client, and using \fBxymonfetch\fR on the Xymon
 server to collect data from the clients.
 
 xymonfetch will only collect data from clients that have the
-\fBpulldata\fR tag listed in the
+\fBPULLDATA\fR tag listed in the
 .I hosts.cfg(5)
 file. The IP-address listed in the hosts.cfg file must be correct,
 since this is the IP-address where xymonfetch will attempt to contact
 the client.  If the msgcache daemon is running on a non-standard 
 IP-address or portnumber, you can specify the portnumber as in
-\fBpulldata=192.168.1.2:8084\fR for contacting the msgcache daemon 
+\fBPULLDATA=192.168.1.2:8084\fR for contacting the msgcache daemon
 using IP 192.168.1.2 port 8084. If the IP-address is omitted, the
 default IP in the hosts.cfg file is used. If the port number is
 omitted, the portnumber from the XYMONDPORT setting in


### PR DESCRIPTION
Partially addresses #278.

## Summary

`hosts.cfg(5)` documented four tags in lower case while `lib/loadhosts.c` stores their keys in upper case: `noclear`, `pulldata`, `noflap`, `multihomed`. They were the only tags where the manual and the key table disagreed.

## Why the case matters

`xmh_find_item()` matches a tag case-insensitively, so either spelling still sets the attribute. But `xmh_item_idx()` matches **case-sensitively**, and that is what `web/svcstatus-info.c` uses to decide a tag is already a recognized attribute, and `xymonnet/xymonnet.c` to decide a tag is *not* a network test.

Written in the documented case, these four worked yet were reported as unrecognized — they appeared in the info page's "Other tags:" row despite having been applied, and xymonnet accepted them as test specs. **Following the manual was what triggered the mismatch**, which is the user-facing half of #278's bug 2.

## Scope — docs only

This fixes the documentation side and nothing else. It is not a fix for #278:

- **Bug 2 (case sensitivity)** stays open. Whether `xmh_item_idx()` should match case-insensitively — as `lib/matching.c`'s `namematch()` was changed to do in #182, for the same class of inconsistency — is a decision about the code. Aligning the manual removes the trap for anyone following it, but two hosts spelling the same tag differently still render differently.
- **Bug 1 (the ten keys past the cutoff)** is untouched and unaffected by case, so nothing here helps it.

The two are not mutually exclusive: if `xmh_item_idx()` later goes case-insensitive, this change stays correct and the new test keeps the manual honest regardless.

Tags with no manpage entry at all (`holidays=`, `nobb2`, `NOPROP:`, `NOTBEFORE:`, `NOTAFTER:`, `ACCEPTONLY:`) are a separate gap and untouched. `OS:` legitimately has none — xymond sets it from client data.

## Changes

**`7296efb7`** — 12 lines in `common/hosts.cfg.5`: the `.IP` entries plus every prose reference (`noclear` alone appears 8 times and has two `.IP` entries, in *GENERAL PER-HOST OPTIONS* and *NETWORK TEST SETTINGS* — deliberate, they cross-reference each other), and the `.default.` allowed-tag list. Also one `tasks.cfg.DIST` comment naming `PULLDATA`, the only shipped example using the old spelling.

Plus `tests/packaging/hosts-cfg-tag-case.sh`, which compares every `.IP <tag>` entry against `xmh_item_key[]` — so a *new* tag documented in the wrong case is caught too, not just these four. No build required; both inputs are source files.

**`6b4ea6d0`** — closes an unbalanced quote on the second `dns=` `.IP` entry, the only one in the file. Cosmetic: groff tolerated it and the rendered output is byte-identical. Kept the quote rather than dropping it (the tag has no spaces, so quotes are optional) to match the stacked `"dns=hostname"` entry directly above it, which shares its description.

## Verification

The test against main's manpage:

```
hosts.cfg(5) says "multihomed", lib/loadhosts.c stores "MULTIHOMED"
hosts.cfg(5) says "noclear",    lib/loadhosts.c stores "NOCLEAR"
hosts.cfg(5) says "noflap",     lib/loadhosts.c stores "NOFLAP"
hosts.cfg(5) says "pulldata",   lib/loadhosts.c stores "PULLDATA"
```

Fails on main, passes here; a re-scan confirms zero mismatches remain. `groff -mandoc -z` output is identical to main (two pre-existing warnings, at lines unrelated to this change), and the four entries render as expected. Suite: 16 passed, 3 skipped (unbuilt tree), 0 failed.
