### PR TITLE
xymond_hostdata: don't drop client data during the first hour of uptime (#285)

### DIFF
--- a/tests/xymond/hostdata-recent-window.sh
+++ b/tests/xymond/hostdata-recent-window.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/hostdata-recent-window.sh
+#
+# Regression guard: xymond_hostdata must save client data even when the
+# machine's uptime is below --recent-period.
+#
+# A first-seen host has calloc'ed (zero) save timestamps, and gettimer() is
+# CLOCK_MONOTONIC (seconds since boot), so while uptime is below the window
+# "now - recentperiod" is negative, every empty slot counts as a recent
+# save, and the data is dropped unlogged.
+#
+# The test cannot reboot the host, but the comparison only depends on
+# "now - recentperiod", so a window larger than the current uptime
+# reproduces the condition exactly.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+command -v make >/dev/null 2>&1 || skip "make not available"
+[ -f "$ROOT/include/config.h" ] || skip "tree not configured (no include/config.h)"
+[ -f "$ROOT/Makefile" ] || skip "tree not configured (no Makefile)"
+
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+pcre_libs=${PCRELIBS:-}
+if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+fi
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-hostdata-window.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+make -C "$ROOT/lib" libxymon.a libxymoncomm.a libxymontime.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot build the xymon libraries"; }
+
+# HOSTDATAOBJS = xymond_hostdata.o xymond_worker.o (xymond/Makefile).
+# Archives listed twice rather than --start-group, which is GNU ld only.
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" -I"$ROOT/xymond" -o "$work/xymond_hostdata" \
+	"$ROOT/xymond/xymond_hostdata.c" "$ROOT/xymond/xymond_worker.c" \
+	"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymontime.a" \
+	"$ROOT/lib/libxymon.a" \
+	$pcre_libs $ssllibs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "xymond_hostdata does not build -- cannot verify the save window"; }
+
+mkdir -p "$work/etc"
+cp "$ROOT/xymond/etcfiles/xymonserver.cfg.DIST" "$work/etc/xymonserver.cfg"
+
+save() {  # save <recent-period-minutes> -- returns 0 if the data was written
+	rm -rf "$work/var"; mkdir -p "$work/var/hostdata"
+	printf '@@clichg#1|1|10.0.0.99|realhost|SAVED|linux\nclient payload\n@@\n' \
+	| XYMONHOME="$work" XYMONVAR="$work/var" \
+		"$work/xymond_hostdata" --env="$work/etc/xymonserver.cfg" \
+		--logdir="$work/var/hostdata" --minimum-free=0 \
+		--recent-period="$1" >/dev/null 2>&1
+	[ -f "$work/var/hostdata/realhost/SAVED" ]
+}
+
+# A window no uptime can outgrow (~19 years; 60*10000000 still fits the
+# signed int used by option parsing) stands in for a freshly booted host.
+save 10000000 \
+	|| fail "client data dropped when the save window exceeds uptime -- a rebooted server loses hostdata until it has been up for --recent-period"
+
+# The ordinary case must keep working: a window well under this machine's
+# uptime, and the degenerate zero window.
+save 60 || fail "client data not saved with the default-sized window"
+save 0  || fail "client data not saved with a zero window"
+
+echo "OK $(basename "$0")"

--- a/xymond/xymond_hostdata.c
+++ b/xymond/xymond_hostdata.c
@@ -184,6 +184,7 @@ int main(int argc, char *argv[])
 			savetimes_t *itm;
 			int i, recentcount;
 			time_t now = gettimer();
+			time_t cutoff;
 			char hostdir[PATH_MAX];
 			char fn[PATH_MAX];
 			FILE *fd;
@@ -199,8 +200,15 @@ int main(int argc, char *argv[])
 				xtreeAdd(savetimes, itm->hostname, itm);
 			}
 
-			/* See how many times we've saved the hostdata recently (within the past 'recentperiod' seconds) */
-			for (i=0, recentcount=0; ((i < 12) && (itm->tstamp[i] > (now - recentperiod))); i++) recentcount++;
+			/*
+			 * See how many times we've saved the hostdata recently (within the past 'recentperiod' seconds).
+			 * Floor the cutoff at 0: gettimer() is monotonic (seconds since boot), so
+			 * a never-saved host's calloc'ed zero tstamps would otherwise count as
+			 * recent saves whenever uptime is below 'recentperiod', and all client
+			 * data would be dropped unlogged until the machine has been up that long.
+			 */
+			cutoff = (now > recentperiod) ? (now - recentperiod) : 0;
+			for (i=0, recentcount=0; ((i < 12) && (itm->tstamp[i] > cutoff)); i++) recentcount++;
 			/* If it's been saved less than 'maxrecentcount' times, then save it. Otherwise just drop it */
 			if (!logdirfull && (recentcount < maxrecentcount)) {
 				int written, closestatus, ok = 1;


### PR DESCRIPTION
Fixes #285.

## What

`xymond_hostdata` silently discards **all** client data while the machine's uptime is below `--recent-period` (default 3600s; the flag itself takes **minutes**, so this is `--recent-period=60`). After a reboot of the Xymon server, nothing is stored for the first hour, and nothing is logged to say so.

The save-throttle counts how many of a host's twelve recorded save times fall inside the window:

```c
for (i=0; (i < 12) && (itm->tstamp[i] > (now - recentperiod)); i++) recentcount++;
if (!logdirfull && (recentcount < maxrecentcount)) { /* ...save... */ }
```

A host seen for the first time gets a `calloc`'ed record, so those slots are zero — and `gettimer()` is `CLOCK_MONOTONIC` (`lib/timing.c:44`), so zero is not "long ago", it is the moment this machine booted. Below the window the bound goes negative, `0 > negative` holds for all twelve slots, `recentcount` reaches 12, and the save is skipped in a branch that prints nothing.

## Change

Floor the cutoff at zero.

A sentinel initialiser does **not** work, which is worth stating because it is the obvious first idea: `-1` still satisfies `-1 > (now - recentperiod)` when uptime is low, and no fixed value is safe because `--recent-period` is admin-settable. The bound is what has to be floored.

## This does not touch `gettimer()`

Deliberately. Monotonic is the correct clock for measuring an interval, which is exactly what this throttle does. #29 already dispositioned the monotonic→wall-clock swap (TBT patch `231 xymon.hist_timer.patch`) as **"drop — monotonic→wall-clock regression; PR #174 keeps `gettimer()`"**, and rejected `62 xymon.proxynow.patch` partly on the same grounds. That stance is right. The defect here is the initialiser, not the timebase.

## Evidence

`tests/xymond/hostdata-recent-window.sh` drives the real binary — workers read messages on stdin, so no daemon is needed. The test cannot reboot the host, but the comparison only depends on `now - recentperiod`, so a window larger than the current uptime reproduces the condition exactly.

| window | before | after |
|---|---|---|
| larger than uptime (stands in for a fresh boot) | 🔴 nothing written, nothing logged | data saved |
| 60 min, host up 9.7h | saved | saved |
| 0 | saved | saved |

The test fails against the code this fixes, not merely passes against the fix.

## Observed while verifying, and left alone

The throttle caps nothing either way: seven messages fed to one process write seven files both before and after this change. The shift loop

```c
for (i = 10; (i > 0); i--) itm->tstamp[i+1] = itm->tstamp[i];
```

stops at `i=1`, so `tstamp[1]` is never written and stays zero forever; the counting loop halts at the first non-recent slot, so `recentcount` never exceeds 1 and `--recent-count` has no effect. That is a separate defect with a different fix, and widening this PR to cover it would make both harder to review. Flagged here so the numbers above are not mistaken for a regression introduced by this change.

## Note on overlap

Independent of #284, which touches the same function for an unrelated reason (path confinement). Both apply to `main`; whichever lands second will need a trivial rebase — the hunks are adjacent but do not overlap.

