### PR TITLE
xymond_hostdata: make the save throttle actually throttle (#288)

### DIFF
--- a/docs/manpages/man8/xymond_history.8.html
+++ b/docs/manpages/man8/xymond_history.8.html
@@ -52,7 +52,10 @@ Section: Maintenance Commands (8)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a
   <dt id="minimum-free"><a class="permalink" href="#minimum-free"><b>--minimum-free</b>=<i>N</i></a></dt>
   <dd>Sets the minimum percentage of free filesystem space on the $XYMONHISTLOGS
       directory. If there is less than N% free space, xymond_history will not
-      save the detailed status-logs. Default: 5
+      save the detailed status-logs. N is a percentage between 0 and 100; 0
+      disables the free-space check. The value must be a plain integer; anything
+      else (including a &quot;%&quot; suffix) falls back to the default.
+      Out-of-range values are clamped. Default: 5
     <p class="Pp"></p>
   </dd>
   <dt id="pidfile"><a class="permalink" href="#pidfile"><b>--pidfile</b>=<i>FILENAME</i></a></dt>

--- a/docs/manpages/man8/xymond_hostdata.8.html
+++ b/docs/manpages/man8/xymond_hostdata.8.html
@@ -43,10 +43,29 @@ Section: Maintenance Commands (8)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a
 <p>&#160;</p>
 <h1 class="Sh" id="OPTIONS"><a class="permalink" href="#OPTIONS">OPTIONS</a></h1>
 <dl class="Bl-tag">
+  <dt id="recent-period"><a class="permalink" href="#recent-period"><b>--recent-period</b>=<i>N</i></a></dt>
+  <dd>Sets the length of the save-throttling window, in <b>minutes</b>. Client
+      data for a host is saved at most --recent-count times within this window;
+      further messages are dropped. A value of 0 disables the throttle, so all
+      client data is saved. The value must be a plain integer number of minutes;
+      anything else falls back to the default. Negative values are clamped to 0.
+      Default: 60
+    <p class="Pp"></p>
+  </dd>
+  <dt id="recent-count"><a class="permalink" href="#recent-count"><b>--recent-count</b>=<i>N</i></a></dt>
+  <dd>Sets how many times a host's client data may be saved within the
+      --recent-period window. A value of 0 disables saving entirely. The value
+      must be a plain integer; anything else falls back to the default. Negative
+      values are clamped to 0 and values above 10000 to 10000. Default: 5
+    <p class="Pp"></p>
+  </dd>
   <dt id="minimum-free"><a class="permalink" href="#minimum-free"><b>--minimum-free</b>=<i>N</i></a></dt>
   <dd>Sets the minimum percentage of free filesystem space on the $CLIENTLOGS
       directory. If there is less than N% free space, xymond_hostdata will not
-      save the data. Default: 5
+      save the data. N is a percentage between 0 and 100; 0 disables the
+      free-space check. The value must be a plain integer; anything else
+      (including a &quot;%&quot; suffix) falls back to the default. Out-of-range
+      values are clamped. Default: 5
     <p class="Pp"></p>
   </dd>
   <dt id="debug"><a class="permalink" href="#debug"><b>--debug</b></a></dt>

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -747,3 +747,46 @@ int chkfreespace(char *path, int minblks, int mininodes)
 	return 1;
 }
 
+/*
+ * Parse the value of a numeric "--option=N" argument. The value must be a
+ * plain integer: strtol (not atoi) so overflow is not undefined behaviour,
+ * and any trailing non-digit is rejected rather than silently ignored, so
+ * a wrong-unit typo like "--minimum-free=10%" or "--recent-period=90min"
+ * is caught instead of quietly parsed as 10 / 90. A rejected value falls
+ * back to 'dflt' with a message. Out-of-range integers are clamped to the
+ * nearest bound, not rejected: with atoi they passed through to checks
+ * that treated them like the bound (e.g. a negative threshold behaved as
+ * "disabled" = 0), so clamping keeps deployed setups working where a
+ * fallback to the default would change behavior.
+ *
+ * 'arg' must contain '=' (it is matched with a trailing '=' by every
+ * caller); the value is everything after the first '='.
+ */
+int parse_int_opt(char *arg, int minval, int maxval, int dflt)
+{
+	char *eq = strchr(arg, '=');
+	char *p, *ep;
+	long v;
+
+	if (eq == NULL) {
+		errprintf("%s has no '=' value, using default %d\n", arg, dflt);
+		return dflt;
+	}
+	p = eq + 1;
+	v = strtol(p, &ep, 10);
+
+	if ((ep == p) || (*ep)) {
+		errprintf("%s is not a plain integer, using default %d\n", arg, dflt);
+		return dflt;
+	}
+	if (v < minval) {
+		errprintf("%s is below %d, using %d\n", arg, minval, minval);
+		return minval;
+	}
+	if (v > maxval) {
+		errprintf("%s is too large, capping at %d\n", arg, maxval);
+		return maxval;
+	}
+	return (int)v;
+}
+

--- a/lib/misc.h
+++ b/lib/misc.h
@@ -45,6 +45,8 @@ extern int selectcolumn(char *heading, char *wanted);
 extern char *getcolumn(char *s, int wanted);
 
 extern int chkfreespace(char *path, int minblks, int mininodes);
+extern int parse_int_opt(char *arg, int minval, int maxval, int dflt);	/* 'arg' must contain '='; value must be a plain integer */
+#define DEFAULT_MINLOGSPACE 5	/* --minimum-free fallback, in percent (xymond_hostdata, xymond_history) */
 
 #endif
 

--- a/tests/lib/build-worker.sh
+++ b/tests/lib/build-worker.sh
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# shellcheck shell=bash
+#
+# tests/lib/build-worker.sh -- compile a xymond worker from the configured
+# tree for a test. Source after assert.sh, then e.g.:
+#
+#     build_xymond_worker "$outdir" xymond_hostdata \
+#         xymond/xymond_hostdata.c xymond/xymond_worker.c
+#
+# Source paths are relative to the repo root; the binary lands in
+# <outdir>/<name>.
+#
+# Skips (not fails) when the toolchain or a configured tree is absent -
+# those are missing preconditions of the environment. Once both are
+# present, a library or worker that fails to build is a product
+# regression and FAILS the test, exactly as the pre-refactor tests did:
+# demoting it to skip would let a build-breaking change turn every
+# worker test green-by-absence.
+
+[ -n "${__XYMON_TESTS_BUILD_WORKER_SOURCED:-}" ] && return 0
+__XYMON_TESTS_BUILD_WORKER_SOURCED=1
+
+build_xymond_worker() {
+	local outdir=$1 prog=$2 root cc treelibs pcre_libs src srcs mkfiles inc
+	shift 2
+	root=$(find_root)
+	cc=${CC:-cc}
+
+	command -v "$cc" >/dev/null 2>&1 || skip "no C compiler available (CC=$cc)"
+	command -v make >/dev/null 2>&1 || skip "make not available"
+	[ -f "$root/include/config.h" ] || skip "tree not configured (no include/config.h)"
+	[ -f "$root/Makefile" ] || skip "tree not configured (no Makefile)"
+
+	# The extra libraries the product link uses (XYMONCOMMLIBS in
+	# xymond/Makefile). Asked of make, not sed from the Makefile: NETLIBS,
+	# ZLIBLIBS and LIBRTDEF live in the per-OS file the Makefile includes.
+	# If make cannot run the stdin-makefile probe, harvest the same four
+	# variables from the Makefile plus the files it includes.
+	treelibs=$(printf '__testlibs:\n\t@echo $(ZLIBLIBS) $(SSLLIBS) $(NETLIBS) $(LIBRTDEF)\n' \
+			| make -s -C "$root" -f Makefile -f - __testlibs 2>/dev/null) || {
+		mkfiles="$root/Makefile"
+		while read -r inc; do
+			[ -n "$inc" ] && mkfiles="$mkfiles $root/$inc"
+		done < <(sed -n 's/^include  *//p' "$root/Makefile")
+		# shellcheck disable=SC2086  # mkfiles is a deliberate word-split list
+		treelibs=$(sed -n -E 's/^(ZLIBLIBS|SSLLIBS|NETLIBS|LIBRTDEF) *= *//p' $mkfiles 2>/dev/null | tr '\n' ' ')
+	}
+
+	# PCRELIBS: explicit env override first, then the configured tree's own
+	# setting (which carries any -L for a nonstandard install), then
+	# pkg-config, then the bare library as a last resort.
+	pcre_libs=${PCRELIBS:-}
+	[ -n "$pcre_libs" ] || pcre_libs=$(sed -n 's/^PCRELIBS *= *//p' "$root/Makefile")
+	if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+		pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+	fi
+	[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+	make -C "$root/lib" libxymon.a libxymoncomm.a libxymontime.a >"$outdir/libbuild.log" 2>&1 \
+		|| { cat "$outdir/libbuild.log" >&2; fail "the xymon libraries do not build in this configured tree"; }
+
+	srcs=()
+	for src in "$@"; do srcs+=("$root/$src"); done
+
+	# Archives listed twice rather than --start-group, which is GNU ld only.
+	"$cc" -I"$root/include" -I"$root/lib" -I"$root/xymond" -o "$outdir/$prog" \
+		"${srcs[@]}" \
+		"$root/lib/libxymon.a" "$root/lib/libxymoncomm.a" "$root/lib/libxymontime.a" \
+		"$root/lib/libxymon.a" \
+		$pcre_libs $treelibs 2>"$outdir/cc.log" \
+		|| { cat "$outdir/cc.log" >&2; fail "$prog does not build -- cannot run this test"; }
+}

--- a/tests/lib/xymond-hostdata.sh
+++ b/tests/lib/xymond-hostdata.sh
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# shellcheck shell=bash
+#
+# tests/lib/xymond-hostdata.sh -- shared build/run recipe for the
+# xymond_hostdata tests. Source after assert.sh, then:
+#
+#     setup_xymond_hostdata "$work"
+#     ... | run_xymond_hostdata "$work" <worker options>
+#
+# run_xymond_hostdata feeds its stdin (a CLICHG channel stream) to a freshly
+# built worker with the tree's stock environment and an empty
+# <work>/var/hostdata; saved files appear under <work>/var/hostdata/<host>/.
+
+[ -n "${__XYMON_TESTS_HOSTDATA_SOURCED:-}" ] && return 0
+__XYMON_TESTS_HOSTDATA_SOURCED=1
+
+# shellcheck source=tests/lib/build-worker.sh
+. "$(dirname "${BASH_SOURCE[0]}")/build-worker.sh"
+
+setup_xymond_hostdata() {
+	local work=$1
+	build_xymond_worker "$work" xymond_hostdata \
+		xymond/xymond_hostdata.c xymond/xymond_worker.c
+	mkdir -p "$work/etc"
+	cp "$(find_root)/xymond/etcfiles/xymonserver.cfg.DIST" "$work/etc/xymonserver.cfg"
+}
+
+# Run the worker against <work>/var without wiping it first, so the caller
+# can pre-seed the hostdata tree (e.g. a blocker that makes a save fail).
+# The caller must have created <work>/var/hostdata.
+run_xymond_hostdata_keepvar() {
+	local work=$1
+	shift
+	XYMONHOME="$work" XYMONVAR="$work/var" \
+		"$work/xymond_hostdata" --env="$work/etc/xymonserver.cfg" \
+		--logdir="$work/var/hostdata" --minimum-free=0 "$@"
+}
+
+run_xymond_hostdata() {
+	local work=$1
+	shift
+	rm -rf "${work:?}/var"; mkdir -p "$work/var/hostdata"
+	run_xymond_hostdata_keepvar "$work" "$@"
+}

--- a/tests/xymond/hostdata-hostname-sanitize.sh
+++ b/tests/xymond/hostdata-hostname-sanitize.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/hostdata-hostname-sanitize.sh
+#
+# The clichg save path builds filesystem paths from the channel-supplied
+# host and test names. A legitimate xymon name is a single path component,
+# so both are confined with safe_basename(), which rejects any name that
+# carries a '/' or is one of the degenerate ".", "..", "" (a bare "..",
+# which POSIX basename() passes through unchanged, would otherwise escape
+# the CLIENTLOGS tree). A rejected name drops the message; nothing is
+# written and nothing outside the tree is touched.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-hostdata.sh
+. "$(dirname "$0")/../lib/xymond-hostdata.sh"
+
+work=$(mktempdir)
+
+setup_xymond_hostdata "$work"
+
+# assert_rejected <label> -- run one clichg message (on stdin) in a fresh
+# tree (run_xymond_hostdata wipes var each call), then assert nothing was
+# written: the only paths under var are the empty hostdata directory
+# itself. A confined name that is rejected saves nothing and creates no
+# directory, inside the tree or above it.
+assert_rejected() {
+	local label=$1 tree
+	run_xymond_hostdata "$work" >/dev/null 2>>"$work/worker.log" || true
+	tree=$(find "$work/var" | sort)
+	[ "$tree" = "$(printf '%s\n%s' "$work/var" "$work/var/hostdata")" ] \
+		|| { echo "$tree" >&2; fail "$label was not rejected cleanly"; }
+}
+
+# Positive control: an ordinary host/test pair is saved under the tree.
+printf '@@clichg#0|1|10.0.0.99|realhost|F0|linux\npayload\n@@\n' |
+	run_xymond_hostdata "$work" >/dev/null 2>>"$work/worker.log" || true
+[ -f "$work/var/hostdata/realhost/F0" ] \
+	|| { cat "$work/worker.log" >&2; fail "an ordinary hostname was not saved"; }
+
+# A '/'-bearing hostname: safe_basename() rejects it outright rather than
+# trimming to a component, so "../escapee" is neither saved as "escapee"
+# nor allowed to escape the tree.
+printf '@@clichg#1|1|10.0.0.99|../escapee|F1|linux\npayload\n@@\n' | assert_rejected "hostname '../escapee'"
+
+# A '/'-bearing test name is rejected the same way.
+printf '@@clichg#2|1|10.0.0.99|realhost|../../../escape2|linux\npayload\n@@\n' | assert_rejected "testname '../../../escape2'"
+
+# A bare ".." hostname: POSIX basename("..") is ".." unchanged, which would
+# make the save path "$CLIENTLOGS/../<testname>" and drop a file in the
+# parent of the hostdata tree. safe_basename() rejects it.
+printf '@@clichg#3|1|10.0.0.99|..|F3|linux\npayload\n@@\n' | assert_rejected "bare '..' hostname"
+[ ! -e "$work/var/F3" ] \
+	|| fail "bare '..' hostname wrote a file into the parent of the hostdata tree"
+
+echo "OK $(basename "$0")"

--- a/tests/xymond/hostdata-minfree-validate.sh
+++ b/tests/xymond/hostdata-minfree-validate.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/hostdata-minfree-validate.sh
+#
+# --minimum-free must go through the validated option parser: with atoi,
+# garbage collapsed to 0 and silently disabled the free-space protection,
+# and out-of-range values passed through unchecked. Disk fullness cannot
+# be arranged in a test, so this asserts the parser's verdicts on stderr:
+# garbage falls back to the default of 5, negatives clamp to 0 (check
+# off, as with atoi), values above 100 are capped.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-hostdata.sh
+. "$(dirname "$0")/../lib/xymond-hostdata.sh"
+
+work=$(mktempdir)
+
+setup_xymond_hostdata "$work"
+
+one_msg() { printf '@@clichg#1|1|10.0.0.99|realhost|F1|linux\npayload\n@@\n'; }
+
+one_msg | run_xymond_hostdata "$work" --minimum-free=junk \
+	>/dev/null 2>"$work/minfree.log" || true
+grep -q -- "--minimum-free=junk is not a plain integer, using default 5" "$work/minfree.log" \
+	|| { cat "$work/minfree.log" >&2; fail "--minimum-free=junk was not rejected for the default of 5"; }
+
+# A numeric value with a trailing unit is a plain-integer violation, not a
+# valid number: "10%" (a natural but wrong spelling, since the value is
+# already a percentage) is rejected, not silently parsed as 10. Catches the
+# wrong-unit typo instead of quietly honoring half of it.
+one_msg | run_xymond_hostdata "$work" --minimum-free=10% \
+	>/dev/null 2>"$work/minfree.log" || true
+grep -q -- "--minimum-free=10% is not a plain integer, using default 5" "$work/minfree.log" \
+	|| { cat "$work/minfree.log" >&2; fail "--minimum-free=10% was not rejected as a non-integer"; }
+
+one_msg | run_xymond_hostdata "$work" --minimum-free=-5 \
+	>/dev/null 2>"$work/minfree.log" || true
+grep -q -- "--minimum-free=-5 is below 0, using 0" "$work/minfree.log" \
+	|| { cat "$work/minfree.log" >&2; fail "--minimum-free=-5 was not clamped to 0"; }
+
+# A plain integer above the range is clamped, not rejected: 200 is a valid
+# number, just out of bounds, so it caps at 100 rather than reverting to
+# the default.
+one_msg | run_xymond_hostdata "$work" --minimum-free=200 \
+	>/dev/null 2>"$work/minfree.log" || true
+grep -q -- "--minimum-free=200 is too large, capping at 100" "$work/minfree.log" \
+	|| { cat "$work/minfree.log" >&2; fail "--minimum-free=200 was not capped at 100"; }
+
+echo "OK $(basename "$0")"

--- a/tests/xymond/hostdata-recent-window.sh
+++ b/tests/xymond/hostdata-recent-window.sh
@@ -18,47 +18,16 @@
 set -euo pipefail
 # shellcheck source=tests/lib/assert.sh
 . "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-hostdata.sh
+. "$(dirname "$0")/../lib/xymond-hostdata.sh"
 
-ROOT=$(find_root)
+work=$(mktempdir)
 
-CC=${CC:-cc}
-command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
-command -v make >/dev/null 2>&1 || skip "make not available"
-[ -f "$ROOT/include/config.h" ] || skip "tree not configured (no include/config.h)"
-[ -f "$ROOT/Makefile" ] || skip "tree not configured (no Makefile)"
-
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
-pcre_libs=${PCRELIBS:-}
-if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
-	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
-fi
-[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
-
-work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-hostdata-window.XXXXXX")
-trap 'rm -rf "$work"' EXIT HUP INT TERM
-
-make -C "$ROOT/lib" libxymon.a libxymoncomm.a libxymontime.a >"$work/libbuild.log" 2>&1 \
-	|| { cat "$work/libbuild.log" >&2; fail "cannot build the xymon libraries"; }
-
-# HOSTDATAOBJS = xymond_hostdata.o xymond_worker.o (xymond/Makefile).
-# Archives listed twice rather than --start-group, which is GNU ld only.
-"$CC" -I"$ROOT/include" -I"$ROOT/lib" -I"$ROOT/xymond" -o "$work/xymond_hostdata" \
-	"$ROOT/xymond/xymond_hostdata.c" "$ROOT/xymond/xymond_worker.c" \
-	"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymontime.a" \
-	"$ROOT/lib/libxymon.a" \
-	$pcre_libs $ssllibs 2>"$work/cc.log" \
-	|| { cat "$work/cc.log" >&2; fail "xymond_hostdata does not build -- cannot verify the save window"; }
-
-mkdir -p "$work/etc"
-cp "$ROOT/xymond/etcfiles/xymonserver.cfg.DIST" "$work/etc/xymonserver.cfg"
+setup_xymond_hostdata "$work"
 
 save() {  # save <recent-period-minutes> -- returns 0 if the data was written
-	rm -rf "$work/var"; mkdir -p "$work/var/hostdata"
 	printf '@@clichg#1|1|10.0.0.99|realhost|SAVED|linux\nclient payload\n@@\n' \
-	| XYMONHOME="$work" XYMONVAR="$work/var" \
-		"$work/xymond_hostdata" --env="$work/etc/xymonserver.cfg" \
-		--logdir="$work/var/hostdata" --minimum-free=0 \
-		--recent-period="$1" >/dev/null 2>&1
+	| run_xymond_hostdata "$work" --recent-period="$1" >/dev/null 2>&1
 	[ -f "$work/var/hostdata/realhost/SAVED" ]
 }
 
@@ -68,8 +37,8 @@ save 10000000 \
 	|| fail "client data dropped when the save window exceeds uptime -- a rebooted server loses hostdata until it has been up for --recent-period"
 
 # The ordinary case must keep working: a window well under this machine's
-# uptime, and the degenerate zero window.
+# uptime, and the explicit throttle-off value.
 save 60 || fail "client data not saved with the default-sized window"
-save 0  || fail "client data not saved with a zero window"
+save 0  || fail "client data not saved with --recent-period=0 (throttle disabled)"
 
 echo "OK $(basename "$0")"

--- a/tests/xymond/hostdata-rename-throttle-reset.sh
+++ b/tests/xymond/hostdata-rename-throttle-reset.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/hostdata-rename-throttle-reset.sh
+#
+# @@renamehost must drop the old name's throttle bookkeeping, not just move
+# its directory. The savetimes entry (hostname + tstamp ring) is per-process
+# state; if it survives the rename it both leaks and keeps the old name's
+# throttle budget, so a host that later reappears under the old name stays
+# throttled against saves it no longer has on disk.
+#
+# renamehost is used rather than drophost because drophost removes the
+# directory with a backgrounded fork (dropdirectory(dir,1)); re-saving the
+# same host immediately would race that child's rmdir. rename() is a plain
+# syscall and exercises the identical drop_savetimes() path deterministically.
+#
+# The whole exchange goes through one process in a single stream, because
+# the save-time state lives in per-process memory.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-hostdata.sh
+. "$(dirname "$0")/../lib/xymond-hostdata.sh"
+
+work=$(mktempdir)
+
+setup_xymond_hostdata "$work"
+
+# --recent-count=1 in a long window: A/F1 saves and fills A's budget, A/F2
+# is throttled; renaming A->B moves the directory and must clear A's budget;
+# a later A/F3 must save because A's throttle state is gone.
+{
+	printf '@@clichg#1|1|10.0.0.99|hostA|F1|linux\npayload 1\n@@\n'
+	printf '@@clichg#2|1|10.0.0.99|hostA|F2|linux\npayload 2\n@@\n'
+	printf '@@renamehost|1|10.0.0.99|hostA|hostB\n@@\n'
+	printf '@@clichg#3|1|10.0.0.99|hostA|F3|linux\npayload 3\n@@\n'
+} | run_xymond_hostdata "$work" --recent-period=3600 --recent-count=1 \
+	>/dev/null 2>>"$work/worker.log" || true
+
+# The rename moved A's single saved file under B.
+[ -f "$work/var/hostdata/hostB/F1" ] \
+	|| { cat "$work/worker.log" >&2; fail "renamehost did not move the hostdata directory"; }
+# F2 was throttled, so it never existed under either name.
+[ ! -e "$work/var/hostdata/hostA/F2" ] && [ ! -e "$work/var/hostdata/hostB/F2" ] \
+	|| fail "F2 was saved despite the budget being full"
+# The fix: A's throttle entry was dropped by the rename, so F3 saves again.
+# Without it, A's ring is still full within the window and F3 is dropped.
+[ -f "$work/var/hostdata/hostA/F3" ] \
+	|| { cat "$work/worker.log" >&2; fail "throttle budget not reset by renamehost: F3 for the reused old name was dropped"; }
+
+echo "OK $(basename "$0")"

--- a/tests/xymond/hostdata-save-throttle.sh
+++ b/tests/xymond/hostdata-save-throttle.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/hostdata-save-throttle.sh
+#
+# Regression guard: xymond_hostdata must stop saving a host's data once it
+# has been saved --recent-count times inside --recent-period.
+#
+# The limit was kept as twelve save timestamps per host, shifted down on
+# each save. The shift stopped at slot 1, so tstamp[1] was never written
+# and stayed at its calloc'ed zero for the life of the record; the throttle
+# check stopped there, the limit was never reached, and --recent-count did
+# nothing at all.
+#
+# Workers read their messages from stdin (xymond_worker.c), and the save
+# times live in per-process state, so the burst has to go through one
+# process in a single stream.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-hostdata.sh
+. "$(dirname "$0")/../lib/xymond-hostdata.sh"
+
+work=$(mktempdir)
+
+setup_xymond_hostdata "$work"
+
+burst() {  # burst <count> <recent-count> [<recent-period>] -- prints the number of files written
+	local n=$1 limit=$2 period=${3:-1} k rc
+	set +e
+	{
+		for k in $(seq 1 "$n"); do
+			printf '@@clichg#%d|1|10.0.0.99|realhost|F%d|linux\npayload %d\n@@\n' "$k" "$k" "$k"
+		done
+	} | run_xymond_hostdata "$work" --recent-period="$period" --recent-count="$limit" \
+		>/dev/null 2>>"$work/worker.log"
+	rc=$?
+	set -e
+	[ "$rc" -le 1 ] || fail "xymond_hostdata exited $rc (crash?) during the burst"
+	# The host directory only exists once something was saved.
+	if [ -d "$work/var/hostdata/realhost" ]; then
+		ls "$work/var/hostdata/realhost" | wc -l
+	else
+		echo 0
+	fi
+}
+
+# Sanity: saving has to work at all here, or "the limit held" is
+# indistinguishable from "nothing was ever written".
+saved=$(burst 1 5)
+[ "$saved" -eq 1 ] \
+	|| { cat "$work/worker.log" >&2; fail "a single clichg was not saved (got $saved) -- the limit check below would be meaningless"; }
+
+# Eight messages, limit five: five saved, the rest dropped.
+saved=$(burst 8 5)
+[ "$saved" -eq 5 ] \
+	|| fail "save throttle ignored: 8 messages with --recent-count=5 wrote $saved files, expected 5"
+
+# The limit is what --recent-count says, not a constant.
+saved=$(burst 8 2)
+[ "$saved" -eq 2 ] \
+	|| fail "--recent-count=2 wrote $saved files, expected 2"
+
+# Below the limit nothing is dropped.
+saved=$(burst 3 5)
+[ "$saved" -eq 3 ] \
+	|| fail "3 messages with --recent-count=5 wrote $saved files, expected 3"
+
+# The history is sized from --recent-count, so limits beyond the once
+# fixed twelve slots hold exactly too.
+saved=$(burst 14 12)
+[ "$saved" -eq 12 ] \
+	|| fail "--recent-count=12 wrote $saved files, expected 12"
+saved=$(burst 15 13)
+[ "$saved" -eq 13 ] \
+	|| fail "--recent-count=13 wrote $saved files, expected 13"
+
+# 0 keeps its historical meaning: never save anything.
+saved=$(burst 3 0)
+[ "$saved" -eq 0 ] \
+	|| fail "--recent-count=0 wrote $saved files, expected saving disabled"
+
+# Garbage counts fall back to the default of 5 (with atoi they collapsed
+# to 0 and silently turned the module off); negative counts clamp to 0,
+# which is what atoi-era negatives effectively did - never save.
+saved=$(burst 8 junk)
+[ "$saved" -eq 5 ] \
+	|| fail "--recent-count=junk wrote $saved files, expected fallback to the default of 5"
+saved=$(burst 8 -3)
+[ "$saved" -eq 0 ] \
+	|| fail "--recent-count=-3 wrote $saved files, expected clamp to 0 (never save, as with atoi)"
+
+# An absurd count is capped, not crashed on: the per-host history is
+# allocated from this value.
+saved=$(burst 8 2000000000)
+[ "$saved" -eq 8 ] \
+	|| fail "--recent-count=2000000000 wrote $saved files, expected all 8 (capped limit far above burst)"
+
+# --recent-period=0 is the explicit throttle-off value: the cutoff lands
+# at "now" and every message in the burst is saved.
+saved=$(burst 8 5 0)
+[ "$saved" -eq 8 ] \
+	|| fail "--recent-period=0 wrote $saved files, expected all 8 (throttle disabled)"
+
+# Garbage periods fall back to the 60-minute default, inside which the
+# burst is still throttled; negative periods clamp to 0 (throttle off),
+# which is what atoi-era negatives effectively did - a future cutoff
+# counts no saves.
+saved=$(burst 8 5 junk)
+[ "$saved" -eq 5 ] \
+	|| fail "--recent-period=junk wrote $saved files, expected fallback and a throttled burst of 5"
+saved=$(burst 8 5 -1)
+[ "$saved" -eq 8 ] \
+	|| fail "--recent-period=-1 wrote $saved files, expected clamp to 0 (throttle off, as with atoi)"
+
+# A failed save must not consume a throttle slot: five messages whose
+# test name overflows PATH_MAX are dropped at the filename check, and
+# the five good messages that follow in the same stream must all be
+# saved. With the slot charged up front, the failures would burn the
+# whole budget and the good data would be dropped.
+longname=$(printf 'X%.0s' $(seq 1 5000))
+{
+	for k in $(seq 1 5); do
+		printf '@@clichg#%d|1|10.0.0.99|realhost|%s|linux\npayload %d\n@@\n' "$k" "$longname" "$k"
+	done
+	for k in $(seq 1 5); do
+		printf '@@clichg#%d|1|10.0.0.99|realhost|F%d|linux\npayload %d\n@@\n' "$((k+5))" "$k" "$k"
+	done
+} | run_xymond_hostdata "$work" --recent-period=1 --recent-count=5 \
+	>/dev/null 2>>"$work/worker.log" || true
+saved=$(ls "$work/var/hostdata/realhost" 2>/dev/null | wc -l)
+[ "$saved" -eq 5 ] \
+	|| fail "failed saves burned throttle slots: $saved good files written, expected 5"
+
+echo "OK $(basename "$0")"

--- a/tests/xymond/hostdata-write-error-backoff.sh
+++ b/tests/xymond/hostdata-write-error-backoff.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/hostdata-write-error-backoff.sh
+#
+# A hostdata write can fail for a reason chkfreespace() cannot see - a
+# read-only mount or a permission problem, where free space still looks
+# fine. Since a save is only counted against the throttle when it succeeds
+# (the ring must mean "real saves"), a persistent write failure would
+# otherwise retry and log on every @@clichg. The worker instead backs off
+# that host for 5 minutes, so the failure is retried and logged at most
+# once per window - and crucially, only that host: other hosts must keep
+# saving.
+#
+# Reproduced by planting a regular file where one host's directory is
+# expected: every save under it then fails with ENOTDIR. keepvar is used
+# because the blocker has to survive into the run.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-hostdata.sh
+. "$(dirname "$0")/../lib/xymond-hostdata.sh"
+
+work=$(mktempdir)
+
+setup_xymond_hostdata "$work"
+mkdir -p "$work/var/hostdata"
+# A regular file where "$CLIENTLOGS/badhost" should be a directory: saving
+# "$CLIENTLOGS/badhost/<test>" then fails with ENOTDIR on every message.
+printf 'blocker' > "$work/var/hostdata/badhost"
+
+# Interleave five failing messages for badhost with a save for goodhost, so
+# the good host lands while badhost is already backed off.
+{
+	printf '@@clichg#1|1|10.0.0.99|badhost|F1|linux\npayload 1\n@@\n'
+	printf '@@clichg#2|1|10.0.0.99|badhost|F2|linux\npayload 2\n@@\n'
+	printf '@@clichg#3|1|10.0.0.99|goodhost|G1|linux\npayload g\n@@\n'
+	printf '@@clichg#4|1|10.0.0.99|badhost|F3|linux\npayload 3\n@@\n'
+	printf '@@clichg#5|1|10.0.0.99|badhost|F4|linux\npayload 4\n@@\n'
+} | run_xymond_hostdata_keepvar "$work" --recent-period=1 --recent-count=5 \
+	>/dev/null 2>"$work/wl" || true
+
+# The backoff trips exactly once: after the first failure badhost is paused
+# for the window, so its later messages neither attempt nor log.
+pauses=$(grep -c "Pausing hostdata saves" "$work/wl" || true)
+[ "$pauses" -eq 1 ] \
+	|| { cat "$work/wl" >&2; fail "expected exactly one save-pause after write errors, got $pauses"; }
+errs=$(grep -c "Cannot create file" "$work/wl" || true)
+[ "$errs" -le 1 ] \
+	|| { cat "$work/wl" >&2; fail "write-error logging not bounded: $errs 'Cannot create file' lines"; }
+
+# The backoff is per-host: goodhost, whose data changed after badhost failed,
+# must still be saved. A global backoff would have dropped it.
+[ -f "$work/var/hostdata/goodhost/G1" ] \
+	|| { cat "$work/wl" >&2; fail "goodhost was suppressed by badhost's write error (backoff not per-host)"; }
+
+echo "OK $(basename "$0")"

--- a/xymond/xymond_history.8
+++ b/xymond/xymond_history.8
@@ -25,6 +25,9 @@ directory given by the XYMONHISTLOGS environment is used.
 Sets the minimum percentage of free filesystem space on the $XYMONHISTLOGS
 directory. If there is less than N% free space, xymond_history will
 not save the detailed status-logs.
+N is a percentage between 0 and 100; 0 disables the free-space check.
+The value must be a plain integer; anything else (including a "%"
+suffix) falls back to the default. Out-of-range values are clamped.
 Default: 5
 
 .IP "\fB\-\-pidfile\fR=\fIFILENAME\fR"

--- a/xymond/xymond_history.c
+++ b/xymond/xymond_history.c
@@ -32,6 +32,8 @@ static char rcsid[] = "$Id$";
 
 #include "xymond_worker.h"
 
+/* DEFAULT_MINLOGSPACE is shared with xymond_hostdata via lib/misc.h */
+
 int rotatefiles = 0;
 time_t nextfscheck = 0;
 
@@ -76,7 +78,7 @@ int main(int argc, char *argv[])
 	char alleventsfn[PATH_MAX];
 	char pidfn[PATH_MAX];
 	int logdirfull = 0;
-	int minlogspace = 5;
+	int minlogspace = DEFAULT_MINLOGSPACE;
 
 	MEMDEFINE(pidfn);
 	MEMDEFINE(alleventsfn);
@@ -102,7 +104,9 @@ int main(int argc, char *argv[])
 			strcpy(pidfn, strchr(argv[argi], '=')+1);
 		}
 		else if (argnmatch(argv[argi], "--minimum-free=")) {
-			minlogspace = atoi(strchr(argv[argi], '=')+1);
+			/* Percent of filesystem space; 0 disables the check, and
+			 * negatives clamp to it (they also disabled it with atoi). */
+			minlogspace = parse_int_opt(argv[argi], 0, 100, DEFAULT_MINLOGSPACE);
 		}
 		else if (argnmatch(argv[argi], "--debug")) {
 			debug = 1;

--- a/xymond/xymond_hostdata.8
+++ b/xymond/xymond_hostdata.8
@@ -21,10 +21,31 @@ Note: This module requires that
 is launched with the "\-\-store\-clientlogs" option enabled.
 
 .SH OPTIONS
+.IP "\fB\-\-recent\-period\fR=\fIN\fR"
+Sets the length of the save-throttling window, in
+.BR minutes .
+Client data for a host is saved at most \-\-recent\-count times
+within this window; further messages are dropped.
+A value of 0 disables the throttle, so all client data is saved.
+The value must be a plain integer number of minutes; anything else
+falls back to the default. Negative values are clamped to 0.
+Default: 60
+
+.IP "\fB\-\-recent\-count\fR=\fIN\fR"
+Sets how many times a host's client data may be saved within the
+\-\-recent\-period window. A value of 0 disables saving entirely.
+The value must be a plain integer; anything else falls back to the
+default. Negative values are clamped to 0 and values above 10000 to
+10000.
+Default: 5
+
 .IP "\fB\-\-minimum\-free\fR=\fIN\fR"
 Sets the minimum percentage of free filesystem space on the $CLIENTLOGS
 directory. If there is less than N% free space, xymond_hostdata will
 not save the data.
+N is a percentage between 0 and 100; 0 disables the free-space check.
+The value must be a plain integer; anything else (including a "%"
+suffix) falls back to the default. Out-of-range values are clamped.
 Default: 5
 
 .IP "\fB\-\-debug\fR"

--- a/xymond/xymond_hostdata.c
+++ b/xymond/xymond_hostdata.c
@@ -24,7 +24,6 @@ static char rcsid[] = "$Id$";
 #include <errno.h>
 #include <dirent.h>
 #include <sys/stat.h>
-#include <libgen.h>
 
 #include "libxymon.h"
 #include "xymond_worker.h"
@@ -34,14 +33,113 @@ static char rcsid[] = "$Id$";
 
 #define MAX_META 20	/* The maximum number of meta-data items in a message */
 
+#define DEFAULT_RECENTPERIOD 3600	/* --recent-period fallback, in seconds */
+#define DEFAULT_RECENTCOUNT  5		/* --recent-count fallback */
+#define MAX_RECENTCOUNT      10000	/* --recent-count cap: bounds the per-host history allocation */
+/* DEFAULT_MINLOGSPACE is shared with xymond_history via lib/misc.h */
+
 typedef struct savetimes_t {
 	char *hostname;
-	time_t tstamp[12];
+	time_t *tstamp;		/* Ring of the 'maxrecentcount' most recent save times, NULL when the throttle is off */
+	int oldest;		/* Oldest slot in tstamp[] - the next one overwritten */
+	time_t suppress_until;	/* Skip saves for this host until this time (write-error backoff) */
 } savetimes_t;
 void * savetimes;
 
 static char *clientlogdir = NULL;
 int nextfscheck = 0;
+
+
+static void free_savetimes(savetimes_t *itm)
+{
+	if (!itm) return;
+	free(itm->hostname);
+	free(itm->tstamp);
+	free(itm);
+}
+
+/* Drop a host's throttle bookkeeping so a removed host does not leak its
+ * savetimes entry (hostname + tstamp ring) for the life of the process. */
+static void drop_savetimes(char *hostname)
+{
+	savetimes_t *itm = (savetimes_t *)xtreeDelete(savetimes, hostname);
+	free_savetimes(itm);
+}
+
+/*
+ * Find or create the per-host throttle entry, keyed on the sanitized host
+ * name the files are stored under (so path-prefixed variants of one host
+ * cannot each claim a separate budget). The tstamp ring is allocated only
+ * when the throttle is enabled (recentperiod > 0); the small entry itself is
+ * always kept, so the per-host write-error backoff has somewhere to record
+ * its state even with the throttle off. Returns NULL (error logged) only on
+ * allocation failure.
+ */
+static savetimes_t *get_savetimes(char *hostname, int recentperiod, int maxrecentcount)
+{
+	xtreePos_t handle = xtreeFind(savetimes, hostname);
+	savetimes_t *itm;
+
+	if (handle != xtreeEnd(savetimes)) return (savetimes_t *)xtreeData(savetimes, handle);
+
+	itm = (savetimes_t *)calloc(1, sizeof(savetimes_t));
+	if (itm) {
+		itm->hostname = strdup(hostname);
+		/* Sized from --recent-count: deciding "N or more saves in the
+		 * window" only ever needs the N most recent save times. */
+		if (recentperiod > 0) itm->tstamp = (time_t *)calloc(maxrecentcount, sizeof(time_t));
+	}
+	if (!itm || !itm->hostname || ((recentperiod > 0) && !itm->tstamp)) {
+		errprintf("Out of memory tracking saves for host %s, dropping message\n", hostname);
+		free_savetimes(itm);
+		return NULL;
+	}
+	xtreeAdd(savetimes, itm->hostname, itm);
+	return itm;
+}
+
+/*
+ * A save for this host failed for a reason chkfreespace() cannot see - a
+ * read-only mount or a permission problem, where free space still looks
+ * fine. Back off this host only for the same 5-minute window a full disk
+ * uses, so a persistent failure retries and logs at most once per window
+ * without suppressing saves for every other host. The save-time ring is left
+ * untouched - it counts real saves, so a failed attempt must not consume a
+ * host's throttle budget.
+ */
+static void suppress_host_after_write_error(savetimes_t *itm, time_t now)
+{
+	itm->suppress_until = now + 300;
+	errprintf("Pausing hostdata saves for host %s for 5 minutes after a write error\n", itm->hostname);
+}
+
+/*
+ * Confine a channel-supplied name to a single path component. safe_basename()
+ * rejects '/'-bearing and the degenerate ".", "..", "" names (a bare "..",
+ * which POSIX basename() would pass through, must not escape the hostdata
+ * tree). Returns the confined name (pointing into 'raw'), or NULL with an
+ * error logged; 'what' names the field for the message.
+ */
+static char *confine_name(char *raw, const char *what)
+{
+	char *safe = safe_basename(raw);
+	if (!*safe) {
+		errprintf("Unsafe %s '%s' in a hostdata message, dropping it\n", what, raw);
+		return NULL;
+	}
+	return safe;
+}
+
+/* Join "<base>/<leaf>" into 'out'; return 0 with an error logged if it would
+ * not fit. 'what' names the path for the message. */
+static int join_path(char *out, size_t sz, const char *base, const char *leaf, const char *what)
+{
+	if (snprintf(out, sz, "%s/%s", base, leaf) >= (int)sz) {
+		errprintf("Hostdata path too long (%s), dropping the message\n", what);
+		return 0;
+	}
+	return 1;
+}
 
 
 void sig_handler(int signum)
@@ -84,10 +182,10 @@ int main(int argc, char *argv[])
 	char *msg;
 	int running;
 	int argi, seq;
-	int recentperiod = 3600;
-	int maxrecentcount = 5;
+	int recentperiod = DEFAULT_RECENTPERIOD;
+	int maxrecentcount = DEFAULT_RECENTCOUNT;
 	int logdirfull = 0;
-	int minlogspace = 5;
+	int minlogspace = DEFAULT_MINLOGSPACE;
 	struct sigaction sa;
 
 	/* Handle program options. */
@@ -96,15 +194,23 @@ int main(int argc, char *argv[])
 			clientlogdir = strchr(argv[argi], '=')+1;
 		}
 		else if (argnmatch(argv[argi], "--recent-period=")) {
-			char *p = strchr(argv[argi], '=');
-			recentperiod = 60*atoi(p+1);
+			/* Minutes. 0 disables the throttle: the cutoff lands at
+			 * "now", so no earlier save is ever inside the window.
+			 * Negatives clamp to 0 - with atoi they also meant
+			 * "always save" (a future cutoff counts no saves). */
+			recentperiod = 60*parse_int_opt(argv[argi], 0, INT_MAX/60, DEFAULT_RECENTPERIOD/60);
 		}
 		else if (argnmatch(argv[argi], "--recent-count=")) {
-			char *p = strchr(argv[argi], '=');
-			maxrecentcount = atoi(p+1);
+			/* 0 keeps its historical meaning: never save anything;
+			 * negatives clamp to it (they also never saved with atoi).
+			 * The cap keeps the per-host save-time history (8 bytes
+			 * per slot) at a sane size. */
+			maxrecentcount = parse_int_opt(argv[argi], 0, MAX_RECENTCOUNT, DEFAULT_RECENTCOUNT);
 		}
 		else if (argnmatch(argv[argi], "--minimum-free=")) {
-			minlogspace = atoi(strchr(argv[argi], '=')+1);
+			/* Percent of filesystem space; 0 disables the check, and
+			 * negatives clamp to it (they also disabled it with atoi). */
+			minlogspace = parse_int_opt(argv[argi], 0, 100, DEFAULT_MINLOGSPACE);
 		}
 		else if (strcmp(argv[argi], "--debug") == 0) {
 			/*
@@ -179,49 +285,56 @@ int main(int argc, char *argv[])
 		}
 		metadata[metacount] = NULL;
 
-		if (strncmp(metadata[0], "@@clichg", 8) == 0) {
-			xtreePos_t handle;
+		/* @@clichg|timestamp|sender|hostname|testname|... */
+		if ((metacount > 4) && (strncmp(metadata[0], "@@clichg", 8) == 0)) {
 			savetimes_t *itm;
-			int i, recentcount;
 			time_t now = gettimer();
 			time_t cutoff;
 			char hostdir[PATH_MAX];
 			char fn[PATH_MAX];
+			char *safehost, *safetest;
 			FILE *fd;
 
-			/* metadata[3] is the hostname */
-			handle = xtreeFind(savetimes, metadata[3]);
-			if (handle != xtreeEnd(savetimes)) {
-				itm = (savetimes_t *)xtreeData(savetimes, handle);
-			}
-			else {
-				itm = (savetimes_t *)calloc(1, sizeof(savetimes_t));
-				itm->hostname = strdup(metadata[3]);
-				xtreeAdd(savetimes, itm->hostname, itm);
-			}
+			/* --recent-count=0: never save anything */
+			if (maxrecentcount == 0) continue;
+
+			safehost = confine_name(metadata[3], "hostname");
+			safetest = confine_name(metadata[4], "testname");
+			if (!safehost || !safetest) continue;
+
+			itm = get_savetimes(safehost, recentperiod, maxrecentcount);
+			if (!itm) continue;
+
+			/* Per-host write-error backoff: skip this host until its window
+			 * passes, so a persistent failure does not retry on every change. */
+			if (now < itm->suppress_until) continue;
 
 			/*
-			 * See how many times we've saved the hostdata recently (within the past 'recentperiod' seconds).
-			 * Floor the cutoff at 0: gettimer() is monotonic (seconds since boot), so
-			 * a never-saved host's calloc'ed zero tstamps would otherwise count as
-			 * recent saves whenever uptime is below 'recentperiod', and all client
-			 * data would be dropped unlogged until the machine has been up that long.
+			 * Save unless the host already had its --recent-count saves
+			 * in the past 'recentperiod' seconds. tstamp[] is a ring of
+			 * the most recent save times, with 'oldest' indexing the
+			 * oldest slot, so the limit is reached exactly when that
+			 * slot is still inside the window. A NULL ring means the
+			 * throttle is off (--recent-period=0): there is no limit.
+			 *
+			 * Floor the cutoff at 0: gettimer() is monotonic (seconds
+			 * since boot), so a never-used slot's calloc'ed zero is not
+			 * "long ago" - without the floor it would land inside the
+			 * window whenever uptime is below 'recentperiod', and all
+			 * client data would be dropped unlogged until the machine
+			 * has been up that long.
 			 */
 			cutoff = (now > recentperiod) ? (now - recentperiod) : 0;
-			for (i=0, recentcount=0; ((i < 12) && (itm->tstamp[i] > cutoff)); i++) recentcount++;
-			/* If it's been saved less than 'maxrecentcount' times, then save it. Otherwise just drop it */
-			if (!logdirfull && (recentcount < maxrecentcount)) {
+			if (!logdirfull && (!itm->tstamp || (itm->tstamp[itm->oldest] <= cutoff))) {
 				int written, closestatus, ok = 1;
 
-				for (i = 10; (i > 0); i--) itm->tstamp[i+1] = itm->tstamp[i];
-				itm->tstamp[0] = now;
-
-				snprintf(hostdir, sizeof(hostdir), "%s/%s", clientlogdir, metadata[3]);
+				if (!join_path(hostdir, sizeof(hostdir), clientlogdir, safehost, "host directory")) continue;
 				mkdir(hostdir, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
-				snprintf(fn, sizeof(fn), "%s/%s", hostdir, metadata[4]);
+				if (!join_path(fn, sizeof(fn), hostdir, safetest, "filename")) continue;
 				fd = fopen(fn, "w");
 				if (fd == NULL) {
 					errprintf("Cannot create file %s: %s\n", fn, strerror(errno));
+					suppress_host_after_write_error(itm, now);
 					continue;
 				}
 				written = fwrite(restofmsg, 1, strlen(restofmsg), fd);
@@ -238,7 +351,20 @@ int main(int argc, char *argv[])
 					}
 				}
 
-				if (!ok) remove(fn);
+				if (!ok) {
+					remove(fn);
+					suppress_host_after_write_error(itm, now);
+					continue;
+				}
+
+				/* Only a completed save consumes a throttle slot: a failed
+				 * attempt stored nothing, so counting it would let an I/O
+				 * problem eat the budget and then drop good data for up to
+				 * a full window after the problem clears. */
+				if (itm->tstamp) {
+					itm->tstamp[itm->oldest] = now;
+					itm->oldest = (itm->oldest + 1) % maxrecentcount;
+				}
 			}
 		}
 
@@ -273,16 +399,26 @@ int main(int argc, char *argv[])
 		else if ((metacount > 3) && (strncmp(metadata[0], "@@drophost", 10) == 0)) {
 			/* @@drophost|timestamp|sender|hostname */
 			char hostdir[PATH_MAX];
-			snprintf(hostdir, sizeof(hostdir), "%s/%s", clientlogdir, basename(metadata[3]));
+			char *safehost = confine_name(metadata[3], "hostname");
+			if (!safehost) continue;
+			if (!join_path(hostdir, sizeof(hostdir), clientlogdir, safehost, "host directory")) continue;
 			dropdirectory(hostdir, 1);
+			drop_savetimes(safehost);
 		}
 
 		else if ((metacount > 4) && (strncmp(metadata[0], "@@renamehost", 12) == 0)) {
 			/* @@renamehost|timestamp|sender|hostname|newhostname */
 			char oldhostdir[PATH_MAX], newhostdir[PATH_MAX];
-			snprintf(oldhostdir, sizeof(oldhostdir), "%s/%s", clientlogdir, basename(metadata[3]));
-			snprintf(newhostdir, sizeof(newhostdir), "%s/%s", clientlogdir, basename(metadata[4]));
+			char *safeold = confine_name(metadata[3], "hostname");
+			char *safenew = confine_name(metadata[4], "new hostname");
+			if (!safeold || !safenew) continue;
+			if (!join_path(oldhostdir, sizeof(oldhostdir), clientlogdir, safeold, "host directory") ||
+			    !join_path(newhostdir, sizeof(newhostdir), clientlogdir, safenew, "host directory")) continue;
 			rename(oldhostdir, newhostdir);
+			/* The old name's throttle state moves with the directory:
+			 * drop it so it neither leaks nor lingers under the old key.
+			 * The new name gets a fresh entry on its next clichg. */
+			drop_savetimes(safeold);
 
 			if (net_worker_locatorbased()) locator_rename_host(metadata[3], metadata[4], ST_HOSTDATA);
 		}


### PR DESCRIPTION
Fixes #288.

> **Stacked on #286** — the last commit is the change under review. The defects are independent, but without #286's floored cutoff a machine whose uptime is below `--recent-period` drops every save, so the throttle can't be tested deterministically.

## What

`xymond_hostdata`'s save throttle never triggers: the twelve-slot timestamp shift stops at `i = 1`, so `tstamp[1]` keeps its `calloc`'ed zero, the recent-save count halts there, and `--recent-count` has no effect — a host whose data changes every poll writes every message to disk. The shipped `tasks.cfg` runs the default of 5, so every installation is affected. (No security impact: throttle failure means more writes, not fewer.)

## Fix

- **Ring instead of shifted array** — the per-host history holds the `--recent-count` most recent save times, so any limit works (the fixed twelve silently disabled values above 12) and the check is one comparison of the oldest slot against the cutoff. A slot is consumed only by a *completed* save, so a failed write never burns budget; instead a persistent write failure `chkfreespace()` can't see (read-only mount, permissions) backs off *that host alone* for 5 minutes, retrying and logging once per window without stopping saves for the rest of the fleet.
- **Confined `clichg` paths** (review) — raw host/test names let a `/` or a bare `..` escape the CLIENTLOGS tree. Names now go through `safe_basename()`, which *rejects* `/`-bearing and degenerate `.`/`..`/`""` names (rejected → message dropped). The throttle tree is keyed on the sanitized name, so prefix variants of one host can't each claim a budget. `drophost`/`renamehost` share the same guard and free the host's throttle entry (otherwise leaked).
- **Plain-integer option parsing** (review) — `--recent-count`, `--recent-period`, `--minimum-free` use `parse_int_opt()`, a shared `strtol` helper in `lib/misc.c`. A trailing non-digit is rejected, so `--minimum-free=10%` falls back to the default rather than becoming 10; out-of-range integers clamp, matching `atoi`-era negatives so upgrades don't change deployed setups. `xymond_history`'s `--minimum-free` had the same `atoi` bug and shares the helper and `DEFAULT_MINLOGSPACE`.

Measured: eight messages with `--recent-count=5` wrote 8 files before, 5 after.

## Testing

All tests drive the real built worker on stdin (shared recipe in `tests/lib/build-worker.sh`: absent toolchain/tree skips, a build failure in a configured tree **fails**):

- `hostdata-save-throttle.sh` — the limit follows `--recent-count` (incl. 12/13), `0` disables saving, `--recent-period=0` disables the throttle, failed saves don't burn slots. Fails unfixed: *8 messages with --recent-count=5 wrote 8 files, expected 5*.
- `hostdata-hostname-sanitize.sh` — `/`-bearing and bare `..` host/test names are rejected and touch nothing in or above the tree.
- `hostdata-minfree-validate.sh` — non-integer values (incl. a `%` suffix) fall back, negatives clamp, out-of-range caps.
- `hostdata-rename-throttle-reset.sh` — renamehost clears the old name's throttle budget (renamehost, not drophost, whose background-fork rmdir would race an immediate re-save).
- `hostdata-write-error-backoff.sh` — a persistent write failure on one host trips a single 5-minute backoff and does not suppress a second, healthy host.
