### PR TITLE
docs: document the macOS filesystem filter in xymonclient.cfg.DIST

### DIFF
--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -68,6 +68,43 @@ LOGFETCHOPTS=""
 # XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
 
 
+# Filesystem reporting (macOS client) -- used by xymonclient-darwin.sh. Same
+# three variables as above, matched on mount ATTRIBUTES rather than filesystem
+# type: macOS df has no "-t", and type would not help anyway, since the sealed
+# root, the system helper volumes and the volume holding every user file are
+# all "apfs". Both variables therefore accept attributes as well as types.
+#
+# By default it drops "nobrowse" and "read-only" mounts -- devfs, the autofs
+# map, the system helpers and the sealed root, none of which carries a
+# meaningful capacity signal -- and keeps every other local mount. The data
+# volume, which Apple flags "root data", is exempt and always reported. The
+# inode report also skips apfs, whose ifree comes from the shared container
+# and never signals exhaustion.
+#
+# XYMONCLIENT_FS_INCLUDE_TYPES: types or attributes to surface. Empty by
+#    default. Naming an attribute is the only way to switch off a default drop:
+#      "nobrowse"  -- report volumes hidden from the Finder. WARNING: this
+#                     switches the drop off entirely, so devfs (/dev) and the
+#                     autofs map come back too, both permanently 100% full.
+#                     Pair it with XYMONCLIENT_FS_EXCLUDE_TYPES="devfs autofs".
+#
+# XYMONCLIENT_FS_EXCLUDE_TYPES: types or attributes to exclude on top of the
+#    defaults. Empty by default. Wins over XYMONCLIENT_FS_INCLUDE_TYPES and over
+#    the "root data" exemption:
+#      "lifs fusefs"  -- drop external FAT/exFAT/NTFS media (macOS Ventura and
+#                     later mount these through LiveFiles as "lifs") and macFUSE
+#                     volumes such as NTFS-3G. Both are kept by default.
+#    Beware attributes most mounts carry: excluding "local" drops everything.
+#
+# XYMONCLIENT_FS_DF_LOCAL_ONLY: "yes" (default) reports only mounts flagged
+#    "local", hiding nfs and smbfs; "no" surfaces them. The warning above about
+#    stale remote mounts wedging df applies here too.
+#
+# XYMONCLIENT_FS_INCLUDE_TYPES=""
+# XYMONCLIENT_FS_EXCLUDE_TYPES="lifs fusefs"
+# XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
+
+
 # Local Mode (Only) Options
 #
 # Running the Xymon client in local-config mode will cause threshold evaluation to


### PR DESCRIPTION
`xymonclient-darwin.sh` points the reader at this file — *"configurable; see xymonclient.cfg.DIST"* — which described only the Linux client and never mentioned macOS, `nobrowse`, or the attribute matching the Darwin filter actually performs. Sixty lines of comment, no code change.

## Why the two clients differ, and why that needs saying

macOS `df` has no `-t`, and type would not help anyway: on APFS the sealed root, the `VM`/`Preboot`/`Update` helpers and the volume holding every user file are **all `apfs`**. Only the mount attributes tell them apart, so the Darwin filter matches attributes — and both `XYMONCLIENT_FS_*_TYPES` variables therefore accept attributes as well as filesystem types.

That is deliberate: naming an attribute in `INCLUDE_TYPES` is the only way to switch off one of the default drops. But a reader of the Linux text, which talks about `zfs virtiofs tmpfs` and `iso9660 squashfs`, would not guess it.

## Verified, not asserted

Every statement in the block was checked by running the shipped filter over a mount table:

| claim | result |
|---|---|
| `nobrowse` / `read-only` dropped by default | confirmed |
| `root data` exemption keeps the data volume | confirmed |
| `EXCLUDE_TYPES` beats the `root data` exemption | confirmed — the data volume disappears |
| `apfs` skipped in the inode report | confirmed |
| `lifs` and `fusefs` volumes kept by default | confirmed |

The `lifs`/`fusefs` line is worth stating explicitly. macOS Ventura and later mount external FAT/exFAT/NTFS media through LiveFiles as type `lifs`, and macFUSE volumes appear as `fusefs`. Neither name occurs anywhere in the client, so an administrator looking for the knob that drops them had nothing to search for.

## One example carries a warning

`INCLUDE_TYPES="nobrowse"` is the documented way to report a deliberately hidden volume — and the measurement showed it also brings back `devfs` and the autofs map, both permanently 100% full. That is the false disk/inode PANIC of #156 all over again, reintroduced by following the documentation. The block says so, and gives the paired `EXCLUDE_TYPES="devfs autofs"` that avoids it; that combination was verified too.

## Not covered

FreeBSD, NetBSD and OpenBSD carry the same *"see xymonclient.cfg.DIST"* pointer into a file that does not describe them either. Same gap, different clients, left for separate changes.
