### PR TITLE
docs: correct the macFUSE claim in the macOS filesystem filter block

### DIFF
--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -91,9 +91,13 @@ LOGFETCHOPTS=""
 # XYMONCLIENT_FS_EXCLUDE_TYPES: types or attributes to exclude on top of the
 #    defaults. Empty by default. Wins over XYMONCLIENT_FS_INCLUDE_TYPES and over
 #    the "root data" exemption:
-#      "lifs fusefs"  -- drop external FAT/exFAT/NTFS media (macOS Ventura and
-#                     later mount these through LiveFiles as "lifs") and macFUSE
-#                     volumes such as NTFS-3G. Both are kept by default.
+#      "lifs"      -- drop external FAT/exFAT/NTFS media (macOS Ventura and
+#                     later mount these through LiveFiles as "lifs"). They are
+#                     local disks, so they are reported by default.
+#      "fusefs"    -- drop macFUSE volumes such as NTFS-3G. Only useful for
+#                     volumes mounted "-o local", or with DF_LOCAL_ONLY="no":
+#                     macFUSE marks its volumes non-local by default, so the
+#                     local filter already drops them.
 #    Beware attributes most mounts carry: excluding "local" drops everything.
 #
 # XYMONCLIENT_FS_DF_LOCAL_ONLY: "yes" (default) reports only mounts flagged
@@ -101,7 +105,7 @@ LOGFETCHOPTS=""
 #    stale remote mounts wedging df applies here too.
 #
 # XYMONCLIENT_FS_INCLUDE_TYPES=""
-# XYMONCLIENT_FS_EXCLUDE_TYPES="lifs fusefs"
+# XYMONCLIENT_FS_EXCLUDE_TYPES="lifs"
 # XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
 
 


### PR DESCRIPTION
Follow-up to #291, correcting a factual error in the block it added.

## What was wrong

```
#      "lifs fusefs"  -- drop external FAT/exFAT/NTFS media (macOS Ventura and
#                     later mount these through LiveFiles as "lifs") and macFUSE
#                     volumes such as NTFS-3G. Both are kept by default.
```

"Both are kept by default" is false for `fusefs`. macFUSE marks its volumes
**non-local** by default; the `local` mount option exists precisely to change
that. `XYMONCLIENT_FS_DF_LOCAL_ONLY` defaults to `"yes"`, and the filter in
`client/xymonclient-darwin.sh` is `/[(, ]local[,) ]/!d` — a mount line without
the `local` attribute is dropped before `EXCLUDE_TYPES` is ever consulted. The
existing `nfs` assertion in `tests/client/fs-filter-darwin.sh` already pins that
behaviour.

So the recommended example was worse than harmless:

```
# XYMONCLIENT_FS_EXCLUDE_TYPES="lifs fusefs"
```

`fusefs` there does nothing under the default configuration, which is exactly
the kind of line an admin copies and then trusts.

## What this changes

Splits the entry so each type says when it actually applies, and drops `fusefs`
from the example:

```
#      "lifs"      -- drop external FAT/exFAT/NTFS media (macOS Ventura and
#                     later mount these through LiveFiles as "lifs"). They are
#                     local disks, so they are reported by default.
#      "fusefs"    -- drop macFUSE volumes such as NTFS-3G. Only useful for
#                     volumes mounted "-o local", or with DF_LOCAL_ONLY="no":
#                     macFUSE marks its volumes non-local by default, so the
#                     local filter already drops them.
```

Worth stating plainly, since it is the practical upshot: the default is the
right one and needs no change. Stale remote FUSE mounts (sshfs and friends) are
the ones that wedge `df` on macOS, and being non-local they are already excluded
— which is what keeps a hung mount from turning the whole host purple rather
than just the disk column.

Documentation only; no behaviour change. `tests/client/fs-filter-darwin.sh`
passes.

Source: [macFUSE — Mount options](https://github.com/macfuse/macfuse/wiki/Mount-options)
