### PR TITLE
lib/loadhosts: drop the duplicate XMH_CLIENTALIAS name registration

### DIFF
--- a/lib/loadhosts.c
+++ b/lib/loadhosts.c
@@ -200,7 +200,6 @@ static void xmh_item_list_setup(void)
 	xmh_item_name[XMH_ACCEPT_ONLY]         = "XMH_ACCEPT_ONLY";
 
 	xmh_item_name[XMH_IP]                  = "XMH_IP";
-	xmh_item_name[XMH_CLIENTALIAS]         = "XMH_CLIENTALIAS";
 	xmh_item_name[XMH_HOSTNAME]            = "XMH_HOSTNAME";
 	xmh_item_name[XMH_PAGENAME]            = "XMH_PAGENAME";
 	xmh_item_name[XMH_PAGEPATH]            = "XMH_PAGEPATH";


### PR DESCRIPTION
Fixes #294.

`xmh_item_list_setup()` registered the name of `XMH_CLIENTALIAS` twice: at `lib/loadhosts.c:88` alongside its `CLIENT:` key, and again at `:203` inside the block for items that have a **name but no key** — values derived at run time rather than parsed from a `hosts.cfg` tag.

`XMH_CLIENTALIAS` has a key, so the second line was a stray. The split between the two blocks is not cosmetic; the self-check immediately below depends on it:

```c
i = 0; while (xmh_item_key[i]) i++;
if (i != XMH_IP) errprintf("ERROR: Setup failure in xmh_item_key position %d\n", i);
```

## No functional change

Both lines stored the same string, so the second was a no-op, and it never touched `xmh_item_key[]`, which is what that check reads.

Verified rather than assumed: I dumped the full name table and the `xmh_key_idx()` resolution for all 71 entries from a build before and after the change. The two dumps are identical, and the contiguity check stays silent.

```
=== diff of the tables ===
IDENTIQUES (71 entrées)
```

No test is added. There is no behaviour to pin — the change removes a dead assignment — and a runtime round-trip check cannot see this class of duplicate anyway, since the entry resolves back to its own slot either way. Only reading the source finds it.
