### PR TITLE
ci: update actions/checkout to v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # The runner lives in tests/testsuite so developers can run the exact
       # same thing locally (./tests/testsuite or make test). It auto-detects

--- a/.github/workflows/workflow-release.yaml
+++ b/.github/workflows/workflow-release.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 #---------------------------------------------------


### PR DESCRIPTION
## Summary

Update `actions/checkout` from v6 to v7 in all GitHub Actions workflows:

- Build workflow
- Shell regression test workflow
- Release tarball workflow

`softprops/action-gh-release@v3` is already on its latest major release and remains unchanged.

## Motivation

`actions/checkout` v7 is the current stable major release. It moves the action to the supported Node.js 24 runtime and includes current dependency, compatibility, and security updates.

## Security implications

Checkout v7 includes additional safeguards around unsafe pull-request checkouts and incorporates the latest security hardening from the action maintainers.
