### PR TITLE
lib/timefunc: make timestr2timet() correct and non-destructive

### DIFF
--- a/lib/timefunc.c
+++ b/lib/timefunc.c
@@ -537,19 +537,45 @@ time_t timestr2timet(char *s)
 {
 	/* Convert a string "YYYYMMDDHHMM" to time_t value */
 	struct tm tm;
+	int year, mon, day, hour, min;
+	time_t result;
 
-	if (strlen(s) != 12) {
+	/* sscanf() does not enforce the format: "%d" skips whitespace and takes a
+	 * sign. strlen() for the length, strspn() for the digits. */
+	if ((strlen(s) != 12) || (strspn(s, "0123456789") != 12)) {
 		errprintf("Invalid timestring: '%s'\n", s);
 		return -1;
 	}
 
-	tm.tm_min = atoi(s+10); *(s+10) = '\0';
-	tm.tm_hour = atoi(s+8); *(s+8) = '\0';
-	tm.tm_mday = atoi(s+6); *(s+6) = '\0';
-	tm.tm_mon = atoi(s+4) - 1; *(s+4) = '\0';
-	tm.tm_year = atoi(s) - 1900; *(s+4) = '\0';
+	/* sscanf(), not atoi() over truncated copies: the callers pass the pointer
+	 * xmh_item() returned, which aliases the host record's own tag buffer. */
+	if (sscanf(s, "%4d%2d%2d%2d%2d", &year, &mon, &day, &hour, &min) != 5) {
+		errprintf("Invalid timestring: '%s'\n", s);
+		return -1;
+	}
+
+	/* mktime() reads every field, and normalizes an uninitialized tm_sec into
+	 * the result. */
+	memset(&tm, 0, sizeof(tm));
+	tm.tm_year = year - 1900;
+	tm.tm_mon = mon - 1;
+	tm.tm_mday = day;
+	tm.tm_hour = hour;
+	tm.tm_min = min;
 	tm.tm_isdst = -1;
-	return mktime(&tm);
+
+	result = mktime(&tm);
+	if (result == -1) return -1;
+
+	/* mktime() turns 31 February into 2 March rather than failing, rewriting
+	 * the struct as it goes - compare the fields back to catch it. */
+	if ((tm.tm_year != year - 1900) || (tm.tm_mon != mon - 1) ||
+	    (tm.tm_mday != day) || (tm.tm_hour != hour) || (tm.tm_min != min)) {
+		errprintf("Invalid timestring: '%s'\n", s);
+		return -1;
+	}
+
+	return result;
 }
 
 

--- a/tests/server/notbefore-notafter.sh
+++ b/tests/server/notbefore-notafter.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/notbefore-notafter.sh
+#
+# Regression guard for issue #298: the NOTBEFORE:/NOTAFTER: hosts.cfg tags did
+# not work. timestr2timet() converts their YYYYMMDDHHMM timestamps and had two
+# defects, both fixed together:
+#
+#   1. struct tm was never initialized. tm_sec was left holding whatever was on
+#      the stack, and mktime() normalizes it, so the converted time moved by an
+#      unbounded amount -- "202001011200" came out as 1995-12-20 17:57:17 in one
+#      measurement and 2046-09-03 in another. A host carrying NOTBEFORE: was
+#      therefore either permanently visible or permanently invisible, depending
+#      on stack residue.
+#
+#   2. It truncated the string in place with *(s+N) = '\0'. lib/loadhosts.c
+#      hands it the pointer xmh_item() returned, which points into the host
+#      record's own tag buffer, so the stored tag was left as "NOTBEFORE:2020" --
+#      the same aliasing that caused the noflap bug in #276. Everything that
+#      reports raw tags showed the mutilated value: XMH_RAW, hostinfo responses,
+#      the info page's "Other tags:" row, xymongrep.
+#
+# The window assertions below exercise defect 1 and the record assertion
+# exercises defect 2. Only the record assertion fails deterministically against
+# the old code -- the window ones depend on what was on the stack -- so that is
+# the one that anchors this test.
+#
+# Dates are deliberately far outside any plausible run time, so the test does
+# not rot.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+[ -f "$ROOT/lib/timefunc.c" ] || skip "lib/timefunc.c not present in this checkout"
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-notbefore.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+cat > "$work/hosts.cfg" <<'EOF'
+127.0.0.1 inwindow.example.com # conn NOTBEFORE:199001010000 NOTAFTER:209001010000
+127.0.0.1 notyet.example.com # conn NOTBEFORE:209001010000
+127.0.0.1 expired.example.com # conn NOTAFTER:199001010000
+127.0.0.1 plain.example.com # conn
+EOF
+
+cat > "$work/harness.c" <<'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "libxymon.h"
+
+static int failures = 0;
+
+static void expect(const char *label, int cond, const char *detail)
+{
+	if (!cond) {
+		fprintf(stderr, "%s: %s\n", label, detail);
+		failures++;
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	void *h;
+	char *raw;
+	time_t t;
+	struct tm *lt;
+	char stamp[] = "202001011200";	/* writable: the old code wrote into it */
+
+	if (argc != 2) { fprintf(stderr, "usage: %s hosts.cfg\n", argv[0]); return 2; }
+
+	if (load_hostnames(argv[1], NULL, 1) == -1) {
+		fprintf(stderr, "cannot load %s\n", argv[1]);
+		return 2;
+	}
+
+	/* The conversion itself must be exact, and must not depend on what was on
+	 * the stack when it ran. */
+	t = timestr2timet(stamp);
+	lt = localtime(&t);
+	expect("timestr2timet converts the timestamp it was given",
+	       lt && (lt->tm_year + 1900 == 2020) && (lt->tm_mon == 0) && (lt->tm_mday == 1) &&
+	       (lt->tm_hour == 12) && (lt->tm_min == 0) && (lt->tm_sec == 0),
+	       "202001011200 must convert to 2020-01-01 12:00:00 - every field mktime() "
+	       "reads has to be set, an uninitialized tm_sec moves the result by years");
+
+	/* And it must leave its argument alone: callers pass a pointer into the
+	 * host record's own tag buffer. */
+	expect("timestr2timet does not write into the string it was given",
+	       strcmp(stamp, "202001011200") == 0,
+	       "the caller's string must come back unchanged - lib/loadhosts.c passes "
+	       "the pointer xmh_item() returned, which aliases the stored tag");
+
+	/* hosts.cfg(5) documents the timestamp as exactly 12 digits, so anything
+	 * else has to be refused rather than converted into a date nobody wrote.
+	 * Neither of these is caught by sscanf() on its own: "%d" skips leading
+	 * whitespace and accepts a sign, and mktime() normalizes a date that does
+	 * not exist instead of failing. */
+	{
+		char signed_[] = "-20200101120";	/* 12 chars, one of them a sign */
+		char spaced[]  = "2020 1011200";	/* 12 chars, one of them a space */
+		char month13[] = "202013011200";	/* mktime() would say 2021-01-01 */
+		char feb31[]   = "202002311200";	/* mktime() would say 2020-03-02 */
+		char leapok[]  = "202002291200";	/* 2020 is a leap year: must pass */
+
+		expect("a timestamp with a sign is refused", timestr2timet(signed_) == -1,
+		       "'-20200101120' is not twelve digits");
+		expect("a timestamp with a space is refused", timestr2timet(spaced) == -1,
+		       "'2020 1011200' is not twelve digits");
+		expect("a month that does not exist is refused", timestr2timet(month13) == -1,
+		       "month 13 must not be normalized into January of the next year");
+		expect("a day that does not exist is refused", timestr2timet(feb31) == -1,
+		       "31 February must not be normalized into 2 March");
+		expect("a real leap day is accepted", timestr2timet(leapok) != -1,
+		       "29 February 2020 exists and must convert");
+	}
+
+	/* The window itself. */
+	expect("a host inside its window is visible",
+	       hostinfo("inwindow.example.com") != NULL,
+	       "NOTBEFORE in the past and NOTAFTER in the future must leave the host active");
+	expect("a host before its NOTBEFORE is hidden",
+	       hostinfo("notyet.example.com") == NULL,
+	       "a host whose NOTBEFORE has not arrived must be treated as not listed");
+	expect("a host after its NOTAFTER is hidden",
+	       hostinfo("expired.example.com") == NULL,
+	       "a host whose NOTAFTER has passed must be treated as not listed");
+	expect("control: a host with neither tag is visible",
+	       hostinfo("plain.example.com") != NULL,
+	       "an untagged host must be unaffected, so the assertions above cannot be "
+	       "satisfied by hiding everything");
+
+	/* The record, which is what defect 2 destroyed. */
+	h = hostinfo("inwindow.example.com");
+	raw = (h ? xmh_item(h, XMH_RAW) : NULL);
+	expect("loading a host leaves its NOTBEFORE/NOTAFTER tags intact",
+	       raw && strstr(raw, "NOTBEFORE:199001010000") && strstr(raw, "NOTAFTER:209001010000"),
+	       raw ? raw : "(no record)");
+
+	printf(failures ? "FAILED\n" : "ALL OK\n");
+	return failures ? 1 : 0;
+}
+EOF
+
+# Link flags come from the build's own Makefile: SSLLIBS is absent on a
+# --no-ssl build, and carries the -L a non-standard OpenSSL prefix needs.
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
+	$ssllibs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+"$work/harness" "$work/hosts.cfg" 2>"$work/stderr.log" \
+	|| fail "NOTBEFORE/NOTAFTER assertions failed:
+$(cat "$work/stderr.log")"
+
+pass "NOTBEFORE:/NOTAFTER: convert exactly and leave the host record intact"


### PR DESCRIPTION
Fixes #298.

`NOTBEFORE:` and `NOTAFTER:` did not work. `timestr2timet()` — whose only callers are those two tags (`lib/loadhosts.c:339` and `:343`) — had two defects.

## 1. The converted time was arbitrary

`struct tm` was never initialised, and `tm_sec` was never assigned. `mktime()` reads it and normalises out-of-range values, so whatever was on the stack moved the result without bound. Converting `202001011200`:

```
expected   2020-01-01 12:00:00
measured   1995-12-20 17:57:17     (1955-04-22 with a clean stack, 2046-09-03 after dirtying it)
```

`lib/loadhosts.c:414` and `:460` hide a host when `notbefore > now`, so a host carrying the tag was either permanently visible or permanently invisible, decided by stack residue rather than by its timestamp.

## 2. It destroyed the tag it parsed

Each `*(s+N) = '\0'` truncated the string in place, and `loadhosts.c` passes the pointer `xmh_item()` returned — which points into the host record's own tag buffer. The same aliasing that caused the noflap bug in #276.

```
127.0.0.1 nb.example.com # conn NOTBEFORE:202001011200 NOTAFTER:203001011200

XMH_RAW : conn|NOTBEFORE:2020|NOTAFTER:2030
```

The parse survived, because each field was read before the NUL after it was written. What was destroyed was the stored tag, so everything reporting raw tags showed the mutilated value: `XMH_RAW`, `hostinfo` responses, the info page's "Other tags:" row, `xymongrep`.

## 3. It accepted what is not a date

Both raised by SoundGoof in review.

`sscanf()` does not enforce the documented format: `%d` skips leading whitespace and accepts a sign, so twelve characters that are not twelve digits still convert five fields.

```
"2020 1011200"  ->  2020-10-11 20:00     the space shifts every field
"-20200101120"  ->  year -202
"20200101120+"  ->  the trailing sign is ignored
```

`strlen()` and `strspn()` answer different questions - how long, and made of what - so both are needed to say *exactly twelve digits*, which is what `hosts.cfg(5)` documents.

`mktime()` then normalises a date that does not exist instead of refusing it:

```
202013011200  ->  2021-01-01     month 13
202002311200  ->  2020-03-02     31 February
202102291200  ->  2021-03-01     29 February outside a leap year
202001012500  ->  2020-01-02     hour 25
```

A `NOTAFTER:` of `202002311200` would not have been rejected - the host would have disappeared two days after the date its administrator wrote. Same class of defect as the two above: a wrong value accepted in silence.

`mktime()` rewrites the struct while normalising, so comparing the fields back against what was parsed separates the two cases. 29 February 2020 exists and still converts; 2021 does not and no longer does.

## The fix

`sscanf()` settles both at once — it reads the fields without writing to the source — and an explicit `memset()` leaves nothing for `mktime()` to normalise.

The duplicated `*(s+4) = '\0'` on the old `tm_year` line goes with it.

## Test

`tests/server/notbefore-notafter.sh` drives the real library through its public interface. Against the unpatched code:

```
timestr2timet does not write into the string it was given: ...
a host inside its window is visible: ...
loading a host leaves its NOTBEFORE/NOTAFTER tags intact: (no record)
FAILED
```

and with the fix applied, `ALL OK`.

Worth stating: only the record assertion fails *deterministically* against the old code. The window assertions depend on what was on the stack, which is the bug — so the record one is what anchors the test, and the header says so.

The fixture uses 1990 and 2090 so the test does not rot, and includes an untagged host as a control, so the two "must be hidden" assertions cannot be satisfied by hiding everything.

Five further assertions cover the validation: a signed timestamp, a spaced one, an impossible month, an impossible day, and a real leap day as the control that stops the other four from being satisfied by refusing everything. Unlike the window assertions, all four failure cases fail deterministically against the code before the fix.


