### PR TITLE
build: generate the manual pages with mandoc, one page at a time

### DIFF
--- a/build/dorelease.sh
+++ b/build/dorelease.sh
@@ -10,8 +10,6 @@ fi
 ./build/generate-md5.sh >build/md5.dat.new
 mv build/md5.dat.new build/md5.dat
 
-./build/updmanver $VERSION
-./build/makehtml.sh $VERSION
-
-exit 0
+./build/updmanver "$VERSION"
+./build/makehtml.sh --version "$VERSION"
 

--- a/build/makehtml.sh
+++ b/build/makehtml.sh
@@ -2,30 +2,48 @@
 #
 # Generate docs/manpages/manN/*.html from the manual page sources.
 #
-#   build/makehtml.sh VERSION                       regenerate every page
-#   build/makehtml.sh VERSION common/hosts.cfg.5    regenerate one page
+#   build/makehtml.sh --version 4.3.31              regenerate every page (release)
+#   build/makehtml.sh                               regenerate every page
+#   build/makehtml.sh common/hosts.cfg.5            regenerate one page
 #
-# The second form exists so that editing one manual page does not mean
+# The last form exists so that editing one manual page does not mean
 # rewriting all 69 HTML files, which buries the real change in the diff.
 set -euo pipefail
 
 # LC_ALL, not LANG: LANG=C is overridden by any LC_* the caller has set.
 export LC_ALL=C
-if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
-	DATE=$(date -u -d "@$SOURCE_DATE_EPOCH" +"%e %b %Y" 2>/dev/null) \
-		|| DATE=$(date -u -r "$SOURCE_DATE_EPOCH" +"%e %b %Y")
-else
-	DATE=$(date +"%e %b %Y")
-fi
-VERSION="${1:-}"
-if [ "$VERSION" = "" ]
+
+# dorelease.sh passes --version with the version it is releasing, and that is
+# the only time the .TH line is rewritten: updmanver writes the same version
+# into the sources in the same run, so the two agree by construction.
+#
+# Without --version, the .TH line is left exactly as the source has it. There
+# is no number to invent, nothing derived from a commit that could name the
+# wrong one, and nothing that moves when the tree moves - the page says what
+# its source says, which is the only thing worth guaranteeing between
+# releases. Regenerating changes a page when its source changed, and not
+# otherwise.
+#
+# The version is a flag rather than a positional argument so that a mistyped
+# page path can never be mistaken for a version: anything that is not
+# --version must be a readable source file, or the run fails.
+VERSION=""
+if [ "${1:-}" = "--version" ]
 then
-	echo "Usage: $0 VERSION [manpage-source ...]"
-	echo "       $0 4.3.31                      # every page"
-	echo "       $0 4.3.31 common/hosts.cfg.5   # just this one"
-	exit 1
+	if [ -z "${2:-}" ]
+	then
+		echo "$0: --version needs a value" >&2
+		exit 1
+	fi
+	VERSION="$2"
+	shift 2
+	if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+		DATE=$(date -u -d "@$SOURCE_DATE_EPOCH" +"%e %b %Y" 2>/dev/null) \
+			|| DATE=$(date -u -r "$SOURCE_DATE_EPOCH" +"%e %b %Y")
+	else
+		DATE=$(date +"%e %b %Y")
+	fi
 fi
-shift
 
 POST="`dirname "$0"`/manpage-html.py"
 if [ ! -x "$POST" ]
@@ -82,7 +100,12 @@ onepage()
 	fi
 
 	mkdir -p "docs/manpages/man$SECT"
-	(echo ".TH $NAME $SECTION \"Version $VERSION: $DATE\" \"Xymon\""; tail -n +2 "$FILE") | \
+	if [ -n "$VERSION" ]
+	then
+		(echo ".TH $NAME $SECTION \"Version $VERSION: $DATE\" \"Xymon\""; tail -n +2 "$FILE")
+	else
+		cat "$FILE"
+	fi | \
 	mandoc -T html -O style=../mandoc.css | \
 	"$POST" $KNOWN >"docs/manpages/man$SECT/`basename $FILE`.html"
 }

--- a/build/makehtml.sh
+++ b/build/makehtml.sh
@@ -1,34 +1,109 @@
 #!/bin/bash
+#
+# Generate docs/manpages/manN/*.html from the manual page sources.
+#
+#   build/makehtml.sh VERSION                       regenerate every page
+#   build/makehtml.sh VERSION common/hosts.cfg.5    regenerate one page
+#
+# The second form exists so that editing one manual page does not mean
+# rewriting all 69 HTML files, which buries the real change in the diff.
 
 export LANG=C
 DATE=`date +"%e %b %Y" --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}"`
 VERSION="$1"
 if [ "$VERSION" = "" ]
 then
-	echo "Usage: $0 VERSION"
+	echo "Usage: $0 VERSION [manpage-source ...]"
+	echo "       $0 4.3.31                      # every page"
+	echo "       $0 4.3.31 common/hosts.cfg.5   # just this one"
 	exit 1
 fi
+shift
 
-# cd ~/xymon/trunk
-rm -f docs/*~ docs/manpages/index.html* docs/manpages/man1/* docs/manpages/man5/* docs/manpages/man7/* docs/manpages/man8/*
+POST="`dirname "$0"`/manpage-html.py"
+if [ ! -x "$POST" ]
+then
+	echo "$0: $POST is missing or not executable" >&2
+	exit 1
+fi
+command -v mandoc >/dev/null 2>&1 || {
+	echo "$0: mandoc is not installed (Debian/Ubuntu: mandoc, RHEL: mandoc)" >&2
+	exit 1
+}
 
-for DIR in xymongen xymonnet xymonproxy common xymond web
-do
-	for SECT in 1 5 7 8
+# The post-processor only links references to pages this tree actually ships,
+# so it needs the list. Built once, from the same directories the walk uses.
+KNOWN=`for d in xymongen xymonnet xymonproxy common xymond web; do \
+	for s in 1 5 7 8; do \
+		for f in $d/*.$s; do [ -r "$f" ] && basename "$f"; done; \
+	done; \
+done 2>/dev/null | sed -e 's/$/.html/' | sort -u | tr '\n' ' '`
+
+# Convert one source file. The section comes from the filename, so this works
+# whether we were handed a path or found it by walking the source directories.
+onepage()
+{
+	FILE="$1"
+
+	if [ ! -r "$FILE" ]
+	then
+		echo "$0: cannot read $FILE" >&2
+		return 1
+	fi
+
+	SECT=`echo "$FILE" | sed -e 's/.*\.//'`
+	case "$SECT" in
+		1|5|7|8) ;;
+		*) echo "$0: $FILE is not a manual page in section 1, 5, 7 or 8" >&2
+		   return 1 ;;
+	esac
+
+	NAME=`head -n 1 "$FILE" | awk '{print $2}'`
+	SECTION=`head -n 1 "$FILE" | awk '{print $3}'`
+	if [ "$NAME" = "" -o "$SECTION" = "" ]
+	then
+		echo "$0: $FILE has no usable .TH line" >&2
+		return 1
+	fi
+
+	mkdir -p "docs/manpages/man$SECT"
+	(echo ".TH $NAME $SECTION \"Version $VERSION: $DATE\" \"Xymon\""; tail -n +2 "$FILE") | \
+	mandoc -T html -O style=../mandoc.css | \
+	"$POST" $KNOWN >"docs/manpages/man$SECT/`basename $FILE`.html"
+}
+
+rc=0
+
+if [ $# -gt 0 ]
+then
+	# Named pages only: leave the rest of docs/manpages alone.
+	for FILE in "$@"
 	do
-		for FILE in $DIR/*.$SECT
+		onepage "$FILE" || rc=1
+	done
+else
+	# Everything. Clear the output first, so that a page removed from the
+	# sources does not leave its HTML behind.
+	rm -f docs/*~ docs/manpages/index.html* \
+	      docs/manpages/man1/* docs/manpages/man5/* \
+	      docs/manpages/man7/* docs/manpages/man8/*
+
+	for DIR in xymongen xymonnet xymonproxy common xymond web
+	do
+		for SECT in 1 5 7 8
 		do
-			if [ -r $FILE ]
-			then
-				NAME=`head -n 1 $FILE | awk '{print $2}'`;
-				SECTION=`head -n 1 $FILE | awk '{print $3}'`;
-				(echo ".TH $NAME $SECTION \"Version $VERSION: $DATE\" \"Xymon\""; tail -n +2 $FILE) | \
-				man2html -H localhost -r - | tail -n +2 >docs/manpages/man$SECT/`basename $FILE`.html
-			fi
+			for FILE in $DIR/*.$SECT
+			do
+				if [ -r "$FILE" ]
+				then
+					onepage "$FILE" || rc=1
+				fi
+			done
 		done
 	done
-done
+fi
+
+exit $rc
 
 # Sourceforge update
 # cd ~/xymon/trunk/docs && rsync -av --rsh=ssh --exclude=RCS ./ storner@shell.sourceforge.net:/home/groups/x/xy/xymon/htdocs/docs/
-

--- a/build/makehtml.sh
+++ b/build/makehtml.sh
@@ -7,10 +7,17 @@
 #
 # The second form exists so that editing one manual page does not mean
 # rewriting all 69 HTML files, which buries the real change in the diff.
+set -euo pipefail
 
-export LANG=C
-DATE=`date +"%e %b %Y" --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}"`
-VERSION="$1"
+# LC_ALL, not LANG: LANG=C is overridden by any LC_* the caller has set.
+export LC_ALL=C
+if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+	DATE=$(date -u -d "@$SOURCE_DATE_EPOCH" +"%e %b %Y" 2>/dev/null) \
+		|| DATE=$(date -u -r "$SOURCE_DATE_EPOCH" +"%e %b %Y")
+else
+	DATE=$(date +"%e %b %Y")
+fi
+VERSION="${1:-}"
 if [ "$VERSION" = "" ]
 then
 	echo "Usage: $0 VERSION [manpage-source ...]"
@@ -26,6 +33,14 @@ then
 	echo "$0: $POST is missing or not executable" >&2
 	exit 1
 fi
+# The post-processor is Python, and being executable does not mean its
+# interpreter is installed: without one the shebang fails inside the pipeline,
+# after the output file has already been truncated, leaving a 0-byte page and
+# a bare "command not found". Refuse first, the way mandoc is refused.
+"$POST" --selftest </dev/null >/dev/null 2>&1 || {
+	echo "$0: cannot run $POST - is python3 installed?" >&2
+	exit 1
+}
 command -v mandoc >/dev/null 2>&1 || {
 	echo "$0: mandoc is not installed (Debian/Ubuntu: mandoc, RHEL: mandoc)" >&2
 	exit 1
@@ -83,8 +98,11 @@ then
 	done
 else
 	# Everything. Clear the output first, so that a page removed from the
-	# sources does not leave its HTML behind.
-	rm -f docs/*~ docs/manpages/index.html* \
+	# sources does not leave its HTML behind. Only the output: the list used
+	# to start with docs/manpages/index.html, which this script has never
+	# written - it is the hand-kept docs/man-index.html, put there by
+	# docs/Makefile at install time.
+	rm -f docs/*~ \
 	      docs/manpages/man1/* docs/manpages/man5/* \
 	      docs/manpages/man7/* docs/manpages/man8/*
 

--- a/build/manpage-html.py
+++ b/build/manpage-html.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Post-process mandoc(1) HTML so it matches the pages Xymon has always shipped.
+
+mandoc converts the manual pages more faithfully than man2html - it keeps the
+definition-list structure exactly, and gives every tag a named anchor - but it
+does not produce the navigation man2html generates, and it lays the page out
+differently. This script closes both gaps, so that switching converters changes
+what the pages are made of without changing what they look like.
+
+Reads one page on standard input, writes it to standard output.
+
+  1. cross-page links   "xymongen(1)" becomes a link to ../man1/xymongen.1.html,
+                        for the pages this tree actually ships. References to
+                        pages we do not ship are left as text rather than
+                        pointed at a 404.
+  2. per-page index     the "Index" block man2html appends, built from mandoc's
+                        section anchors.
+  3. banner and footer  the shape man2html gives them, minus its wall-clock
+                        stamp, which is not reproducible.
+  4. section spacing    man2html precedes each heading with a non-breaking
+                        space, which is a real line box; reproduce it so the
+                        vertical rhythm is unchanged.
+"""
+import re
+import sys
+
+# "name(N)", with or without the font markup a man(7) page may wrap it in.
+XREF = re.compile(r'<([ib])>([A-Za-z0-9_.+-]+)\((\d)\)</\1>')
+BARE = re.compile(r'\b([A-Za-z0-9_.+-]+)\((\d)\)')
+TAG = re.compile(r'(<[^>]*>)')
+HEAD = re.compile(r'<h1 class="Sh" id="([^"]+)"><a[^>]*>(.*?)</a></h1>', re.S)
+HEADTBL = re.compile(
+    r'<table class="head">.*?<td class="head-ltitle">([^<]*)</td>\s*'
+    r'<td class="head-vol">([^<]*)</td>.*?</table>', re.S)
+FOOTTBL = re.compile(r'<table class="foot">.*?</table>', re.S)
+FOOTDATE = re.compile(r'<td class="foot-date">([^<]*)</td>')
+SHOPEN = re.compile(r'(<h1 class="Sh")')
+
+# mandoc and man2html name the volumes differently. Keep man2html's, so the
+# banner text does not change under the switch.
+VOLUME = {
+    "1": "User Commands",
+    "5": "File Formats",
+    "7": "Environments, Tables, and Troff Macros",
+    "8": "Maintenance Commands",
+}
+
+
+def linkify(html, known):
+    def link(name, sect):
+        target = "%s.%s.html" % (name, sect)
+        if target not in known:
+            return None
+        return '<a href="../man%s/%s">%s</a>(%s)' % (sect, target, name, sect)
+
+    def font_repl(m):
+        font, name, sect = m.groups()
+        a = link(name, sect)
+        return m.group(0) if a is None else "<%s>%s</%s>" % (font, a, font)
+
+    html = XREF.sub(font_repl, html)
+
+    # Second pass over text nodes only: SEE ALSO sections write their
+    # references as plain text, and man(7) has no macro that marks them.
+    out, in_anchor = [], False
+    for part in TAG.split(html):
+        if part.startswith("<"):
+            low = part.lower()
+            if low.startswith("<a "):
+                in_anchor = True
+            elif low.startswith("</a"):
+                in_anchor = False
+            out.append(part)
+        elif in_anchor or not part.strip():
+            out.append(part)
+        else:
+            out.append(BARE.sub(
+                lambda m: link(m.group(1), m.group(2)) or m.group(0), part))
+    return "".join(out)
+
+
+def add_index(html):
+    heads = HEAD.findall(html)
+    if not heads:
+        return html
+    items = "\n".join(
+        '<dt><a href="#%s">%s</a></dt>' % (i, re.sub(r"\s+", " ", t).strip())
+        for i, t in heads)
+    block = ('<h1 class="Sh" id="INDEX"><a class="permalink" href="#INDEX">'
+             'Index</a></h1>\n<dl class="Bl-tag">\n' + items + '\n</dl>\n')
+    return html.replace('</div>\n<table class="foot"',
+                        block + '</div>\n<table class="foot"', 1)
+
+
+def rewrite_banner(html):
+    m = HEADTBL.search(html)
+    if not m:
+        return html
+    title, vol = m.group(1).strip(), m.group(2).strip()
+    name, _, sect = title.partition("(")
+    sect = sect.rstrip(")")
+    vol = VOLUME.get(sect, re.sub(r"\s*Manual$", "", vol))
+    d = FOOTDATE.search(html)
+    updated = d.group(1).strip() if d else ""
+    banner = ('<h1 class="head-name">%s</h1>\n'
+              'Section: %s (%s)<br/>Updated: %s<br/>'
+              '<a href="#INDEX">Index</a>\n'
+              '<a href="../index.html">Return to Main Contents</a><hr/>\n'
+              % (name, vol, sect, updated))
+    return html[:m.start()] + banner + html[m.end():]
+
+
+def rewrite_footer(html):
+    """Close the page as man2html does, without its wall-clock stamp.
+
+    man2html writes "Time: 23:08:11 GMT, September 04, 2019" from the clock at
+    generation time; the committed pages carry two different values one second
+    apart, so re-generating them diffs every page even when nothing changed.
+
+    No date replaces it. The obvious candidate is the .TH date, but it is
+    already in the banner as "Updated: Version 4.3.31: 7 Aug 2026", and putting
+    it here as well reads as "Time: Version 4.3.31: 7 Aug 2026" - a label that
+    announces a time followed by something that is not one.
+    """
+    foot = ('<hr/>\n'
+            'This document was created by mandoc, using the manual pages.\n')
+    return FOOTTBL.sub(foot, html, count=1)
+
+
+def match_spacing(html):
+    """man2html precedes every heading with <A NAME=...>&nbsp;</A>, which is a
+    real line box: it blocks margin collapsing and adds a line of height above
+    each section. Reproducing the markup keeps the spacing right in any
+    browser, which guessing at a CSS margin would not."""
+    return SHOPEN.sub(r'<p>&#160;</p>\n\1', html)
+
+
+
+DTID = re.compile(r'<dt id="([^"]*)"><a class="permalink" href="#\1">(.*?)</a></dt>', re.S)
+
+
+def rename_anchors(html):
+    """Name each definition anchor after its label, not after mandoc's slug.
+
+    mandoc truncates at the first hyphen and keeps the argument placeholder, so
+    "--sender=STRING" becomes #sender=STRING and, worse, "--no-pin" and
+    "--no-cookies" both become #no, distinguished only by a ~2 suffix that
+    depends on document order - inserting an option above silently repoints
+    every link below it.
+
+    The label's first token, cut at "=", is stable and readable: #sender,
+    #no-pin, #LOAD. Collisions are numbered the way mandoc numbers its own.
+    """
+    seen = {}
+    mapping = {}
+
+    def slug(label):
+        t = re.sub(r"<[^>]*>", "", label).strip()
+        t = t.split()[0] if t.split() else ""
+        t = t.split("=")[0].strip("-[](){}<>\"',.:;")
+        return t
+
+    def collect(m):
+        old, label = m.group(1), m.group(2)
+        new = slug(label)
+        if not new:
+            return m.group(0)
+        seen[new] = seen.get(new, 0) + 1
+        if seen[new] > 1:
+            new = "%s~%d" % (new, seen[new])
+        mapping[old] = new
+        return '<dt id="%s"><a class="permalink" href="#%s">%s</a></dt>' % (new, new, label)
+
+    html = DTID.sub(collect, html)
+    # Any in-page link to a renamed anchor has to follow.
+    for old, new in mapping.items():
+        if old != new:
+            html = html.replace('href="#%s"' % old, 'href="#%s"' % new)
+    return html
+
+
+def main():
+    known = set(sys.argv[1:])
+    html = sys.stdin.read()
+    html = linkify(html, known)
+    html = rename_anchors(html)
+    html = add_index(html)
+    html = match_spacing(html)
+    html = rewrite_banner(html)
+    html = rewrite_footer(html)
+    sys.stdout.write(html)
+
+
+if __name__ == "__main__":
+    main()

--- a/build/manpage-html.py
+++ b/build/manpage-html.py
@@ -88,8 +88,15 @@ def add_index(html):
         for i, t in heads)
     block = ('<h1 class="Sh" id="INDEX"><a class="permalink" href="#INDEX">'
              'Index</a></h1>\n<dl class="Bl-tag">\n' + items + '\n</dl>\n')
-    return html.replace('</div>\n<table class="foot"',
-                        block + '</div>\n<table class="foot"', 1)
+    # The insertion point is the footer table, which rewrite_footer() replaces
+    # later in main(). Run these two in the other order and str.replace finds
+    # nothing, drops the index from every page and says so to no one - so say
+    # it here instead of returning the document unchanged.
+    anchor = '</div>\n<table class="foot"'
+    if anchor not in html:
+        sys.exit("manpage-html: no footer table to insert the index before - "
+                 "has rewrite_footer() already run?")
+    return html.replace(anchor, block + anchor, 1)
 
 
 def rewrite_banner(html):
@@ -180,6 +187,19 @@ def rename_anchors(html):
 
 
 def main():
+    # Called by makehtml.sh before the pipeline starts, to check that this
+    # script runs at all - see the comment there.
+    if "--selftest" in sys.argv[1:]:
+        return
+
+    # makehtml.sh exports LC_ALL=C, and under a C locale Python decodes stdin
+    # as ASCII up to 3.6; 3.7 promotes it to UTF-8 (PEP 538/540). The pages are
+    # ASCII today, so nothing breaks either way - but the first accented
+    # character in a manual page would fail with a traceback on the older
+    # interpreter. Say what the encoding is instead of inheriting it.
+    sys.stdin.reconfigure(encoding="utf-8")
+    sys.stdout.reconfigure(encoding="utf-8")
+
     known = set(sys.argv[1:])
     html = sys.stdin.read()
     html = linkify(html, known)

--- a/build/manpage-html.py
+++ b/build/manpage-html.py
@@ -187,18 +187,21 @@ def rename_anchors(html):
 
 
 def main():
-    # Called by makehtml.sh before the pipeline starts, to check that this
-    # script runs at all - see the comment there.
-    if "--selftest" in sys.argv[1:]:
-        return
-
     # makehtml.sh exports LC_ALL=C, and under a C locale Python decodes stdin
     # as ASCII up to 3.6; 3.7 promotes it to UTF-8 (PEP 538/540). The pages are
     # ASCII today, so nothing breaks either way - but the first accented
     # character in a manual page would fail with a traceback on the older
     # interpreter. Say what the encoding is instead of inheriting it.
+    # reconfigure() itself only exists from 3.7 on, which is why it runs
+    # before the selftest exit: an interpreter too old to have it must be
+    # refused by the selftest, not fail halfway through the pipeline.
     sys.stdin.reconfigure(encoding="utf-8")
     sys.stdout.reconfigure(encoding="utf-8")
+
+    # Called by makehtml.sh before the pipeline starts, to check that this
+    # script runs at all - see the comment there.
+    if "--selftest" in sys.argv[1:]:
+        return
 
     known = set(sys.argv[1:])
     html = sys.stdin.read()

--- a/docs/manpages/mandoc.css
+++ b/docs/manpages/mandoc.css
@@ -1,0 +1,55 @@
+/* Make mandoc(1) HTML render like the man2html output Xymon ships today.
+ *
+ * man2html emits no stylesheet at all, so what users see is the browser's own
+ * default rendering. The closest match to "no stylesheet" is therefore to add
+ * as little as possible: both converters emit the same elements for the body
+ * text - p, dl, dt, dd, pre, b, i, a, br, hr - and those already render
+ * identically without help.
+ *
+ * Only four things differ in markup, and only those are styled here.
+ */
+
+/* 1. Sections. man2html emits <H2>; mandoc emits <h1 class="Sh">. Restore the
+ *    <h2> defaults so size and spacing are unchanged. */
+h1.Sh {
+	font-size: 1.5em;
+	margin: .83em 0;
+}
+h2.Ss {					/* subsections, where man2html has <H3> */
+	font-size: 1.17em;
+	margin: 1em 0;
+}
+
+/* 2. Anchors. mandoc wraps every heading and every tag in <a class="permalink">;
+ *    man2html has none. Left alone they would paint 1454 headings blue and
+ *    underlined, which would be the most visible change of all. Keep them
+ *    clickable, reveal them on hover. */
+a.permalink {
+	color: inherit;
+	text-decoration: none;
+}
+a.permalink:hover {
+	text-decoration: underline;
+}
+
+/* 3. Footer. man2html closes with a rule and a line of text; mandoc uses a
+ *    two-cell table. Give it the rule, and spread the cells. */
+table.foot {
+	width: 100%;
+	border-top: 1px solid;
+	margin-top: 1em;
+}
+td.foot-os {
+	text-align: right;
+}
+
+/* 4. mandoc indents literal displays with a wrapper div. Match the 40px that
+ *    <dd> gets from the browser, which is what man2html's blocks sit at. */
+div.Bd-indent {
+	margin-left: 40px;
+}
+
+/* Everything else - the page title <h1>, paragraphs, definition lists, <pre>,
+ * <b>, <i>, <a>, <hr> - is deliberately left to the browser, because relying
+ * on those defaults is precisely what man2html does.
+ */


### PR DESCRIPTION
Replaces man2html with mandoc in `build/makehtml.sh`, lets it regenerate a single page, hardens it, and stops it inventing a version number.

**Tooling only — the generated HTML is not here.** The pages depend on this script *and* on the roff sources changed in #303, and the two touch no file in common. Carrying the output here would let git merge both cleanly while leaving the HTML describing a state that no longer exists: measured, 62 of the 69 pages would have been stale. The regeneration is #304, to merge after this and #303.

Three commits, three claims.

## 1. mandoc instead of man2html

On conversion fidelity the two are equivalent. Over all 69 pages, excluding the index block man2html appends, both emit **932 definition items and 579 headings** — matching the 926 `.IP` + 6 `.TP` and the 510 `.SH` + 69 page titles in the sources. Neither loses nor invents structure.

What differs is everything around it:

| | mandoc | man2html |
|---|---|---|
| named anchors | 876 | 25 |
| dead cross-links | 0 | 56 |
| reproducible | yes | no |
| upstream | maintained | last release 2010, site gone |

man2html numbers its anchors in document order (`#lbAF`), so inserting a section silently repoints every link below it. It links anything shaped like `name(N)`, including pages this tree does not ship, such as `ftp(1)`. And it stamps every footer with the wall clock, so two consecutive runs never matched.

**It also loses spaces.** Found while comparing the two outputs page by page:

```
man2html   Note:</B>Use<B>of</B>this<B>option</B>requires<B>that</B>access<B>to</B>the...
mandoc     Note: Use of this option requires that access to the appfeed.cgi tool is...
```

`appfeed.cgi(1)` reads `Note:Useofthisoptionrequiresthataccesstotheappfeed.cgitoolispassword-protected` on the page shipped today. `analysis.cfg(5)` has the same defect. Both roff sources are correct — the converter ate the spaces.

The pages are installed into `$INSTALLWWWDIR/help/manpages/` on every Xymon server and reached from the Help menu, so the anchors and the broken links are front-line documentation, not archive material.

`build/manpage-html.py` restores what mandoc does not do by itself: cross-page links, the per-page Index block, the banner and footer shapes, and the blank line man2html puts above each heading. Post-processing only, so mandoc's structure stays intact.

It also names the anchors. mandoc derives one from the label by truncating at the first hyphen and keeping the argument placeholder, giving `#sender=STRING`, and collapses `--no-pin` and `--no-cookies` onto `#no` and `#no~2` — order-dependent, the very defect that rules out man2html's numbering. Each anchor is now named after the first token of its label, cut at `=`. Across the 69 pages: **1454 anchors, no duplicate, no broken in-page link.**

Verified against the previous output: the body text is **98.5% identical word for word**. Comparing the body of each page, banner and footer excluded, **58 of the 69 are identical to the word**. Of the eleven that move, eight are pages whose committed HTML was never regenerated after their sources changed, and the rest are the converter defects above.

**Regenerating one page.** The script emptied `docs/manpages/man[1578]/` before running, so editing one manual page meant rewriting all 69 files and losing the real change in the diff.

    build/makehtml.sh --version 4.3.31            every page, stamping the release
    build/makehtml.sh                             every page, .TH left as the source has it
    build/makehtml.sh common/hosts.cfg.5          just this one

With page arguments it skips the wipe and touches only what it was given. Unreadable paths and files outside sections 1/5/7/8 now fail with a message instead of being skipped in silence.

## 2. It must refuse to fail quietly

Five ways the generator could go wrong without saying so, found by reading it rather than by it breaking.

- **It deleted `docs/manpages/index.html` on every full run.** That file is not its output — it is the hand-kept `docs/man-index.html`, which `docs/Makefile` installs as `help/manpages/index.html`, and which every page links to as *Return to Main Contents*. A no-op on a clean checkout; on a tree where someone put it there to browse the pages, it removed the target of 69 links.
- **`LANG=C` is overridden by any `LC_*` the caller has set**, and the month name of every `.TH` line depends on it.
- **`date --date=` is GNU only**, so `SOURCE_DATE_EPOCH` was ignored on BSD and macOS and reproducible builds silently were not.
- **Without `set -euo pipefail`**, a run failing midway left a half-empty tree and still exited 0.
- **The post-processor was checked for being executable**, which does not mean its interpreter exists. Without python3 the shebang failed inside the pipeline, after the shell had truncated the output file — a 0-byte page and a bare `command not found`. It is now run once with `--selftest` first, the way mandoc is checked with `command -v`.
- **`add_index()` could vanish in silence.** It inserts the Index before the footer table, which `rewrite_footer()` replaces two passes later. The order is right, but nothing holds it there and `str.replace` reports nothing when it matches nothing: swapping the two calls would drop the Index from all 69 pages without a word. It now says so and exits 1.
- **The encoding was inherited, not stated.** `makehtml.sh` exports `LC_ALL=C`, and under a C locale Python decodes stdin as ASCII up to 3.6. The pages are ASCII today, so nothing breaks — but that rests on the documentation staying ASCII and the interpreter being recent. Both streams are pinned to UTF-8.

The three middle ones come from #102, which hardened the same header for its release workflow. Taking them here leaves that branch nothing to do to this file, and removes the conflict the two rewrites would otherwise have had.

## 3. No invented version number

The version stamped into every page came from the caller, and nothing checked it against the tree. Regenerating by hand meant picking a number, and picking the wrong one produced 69 files claiming a release that had not happened, with no diagnostic.

Deriving one instead is the obvious fix and it does not work, three ways over. Keyed to `HEAD`, the stamp rewrote all 69 pages on any commit, including commits touching no manual page. Keyed to the commit that last touched a page, it cannot name the commit that will contain it, so a page committed alongside its source describes the state *before* the edit it was generated from. Keyed to a date it cannot be both stable and true: git does not store mtimes — a fresh checkout gives all 69 pages one identical timestamp — and a commit timestamp collides for two commits made in the same second.

There is nothing to invent. **Without a version the `.TH` line is now left exactly as the source has it**, and the page says what its source says. That is the only property worth guaranteeing between releases, and it holds by construction: regenerating moves a page when its source moved, and never otherwise.

Since the version may be omitted, it is passed as the explicit `--version` flag. Recognising it positionally would mean classifying the first argument, and the obvious classifier — "not an existing path" — reads a typo as a version: `makehtml.sh comon/hosts.cfg.5` would exit 0 and stamp all 69 pages `Version comon/hosts.cfg.5` where the advertised failure was `cannot read`. With the flag there is nothing to classify: anything else on the command line must be a readable source file, or the run fails.

`dorelease.sh` follows, passing `--version` with the version it releases; `updmanver` writes the same one into the sources in the same run, and the `.TH` line is rewritten then — the one moment a number is known rather than guessed. Its calling lines match the rewrite #102 gives the same file, so the two branches merge without conflict.

## Checked

Each commit generates all 69 pages on its own. A full run and a single-page run exit 0; `--version` without a value fails; an unreadable path — including a mistyped one that would once have passed for a version — and a wrong section report and return 1; a page with no `.TH` line is reported without stopping the pages after it. The index survives a full regeneration. Reordering the post-processor's passes on purpose produces the new error. An accented page comes through under `LC_ALL=C`. Two runs of one commit are byte-identical, an unrelated commit changes 0 of 69 pages, and a visible edit to one source changes exactly that page.

