### PR TITLE
xymond: save next client log on request

### DIFF
--- a/common/xymon.1
+++ b/common/xymon.1
@@ -404,8 +404,10 @@ hostdata worker for storage. The request expires after 30 minutes unless the
 optional MINUTES value specifies another lifetime between 1 and 1440 minutes.
 It is held in memory and consumed by the next client message only; dropping or
 renaming the host, or restarting xymond, cancels it. Cached client messages must
-be enabled, and the hostdata worker must be running. The hostdata worker's
-normal recent-save limits apply.
+be enabled, and the hostdata worker must be running. The command reports whether
+the request was armed or rejected. Explicitly requested saves bypass the
+hostdata worker's recent-save limit, but its free-space check still applies;
+therefore an armed response does not guarantee that the report reaches disk.
 
 .IP "\fBping\fR"
 Attempts to contact the Xymon server. If successful, the Xymon server version ID

--- a/common/xymon.1
+++ b/common/xymon.1
@@ -405,9 +405,11 @@ hostdata. The request expires after 30 minutes, or after MINUTES when specified
 canceled when the host is dropped or renamed, or when xymond restarts. Cached
 client messages and the
 hostdata worker must be enabled. Requested saves bypass the recent-save limit,
-but still require sufficient free space. The response reports whether the
-request was armed, not whether the hostdata was written to disk. Hostdata is the
-client data shown as the clientlog service in the web interface.
+but still require sufficient free space. Requests are rejected when no CLICHG
+channel reader is connected. A connected reader does not prove that the
+hostdata worker is running. The response reports whether the request was armed,
+not whether the hostdata was written to disk. Hostdata is the client data shown
+as the clientlog service in the web interface.
 
 .IP "\fBping\fR"
 Attempts to contact the Xymon server. If successful, the Xymon server version ID

--- a/common/xymon.1
+++ b/common/xymon.1
@@ -398,6 +398,15 @@ normal client data.
 Retrieves the current raw client message last sent by HOSTNAME. The optional
 "section" filter is used to select specific sections of the client data.
 
+.IP "\fBhostdatasave HOSTNAME [MINUTES]\fR"
+Requests that the next client message received from HOSTNAME be sent to the
+hostdata worker for storage. The request expires after 30 minutes unless the
+optional MINUTES value specifies another lifetime between 1 and 1440 minutes.
+It is held in memory and consumed by the next client message only; dropping or
+renaming the host, or restarting xymond, cancels it. Cached client messages must
+be enabled, and the hostdata worker must be running. The hostdata worker's
+normal recent-save limits apply.
+
 .IP "\fBping\fR"
 Attempts to contact the Xymon server. If successful, the Xymon server version ID
 is reported.

--- a/common/xymon.1
+++ b/common/xymon.1
@@ -395,17 +395,19 @@ to the standard client data. The data will be concatenated with the
 normal client data.
 
 .IP "\fBclientlog\fR \fIHOSTNAME\fR [\fBsection\fR=\fISECTIONNAME\fR[,\fISECTIONNAME\fR...]]"
-Retrieves the current raw client message last sent by HOSTNAME. The optional
-"section" filter is used to select specific sections of the client data.
+Retrieves the current raw client message (hostdata) last sent by
+HOSTNAME. The optional "section" filter selects specific sections of the data.
 
 .IP "\fBhostdatasave HOSTNAME [MINUTES]\fR"
-Requests storage of the next client message received from HOSTNAME. The request
-expires after 30 minutes, or after MINUTES when specified (1 to 1440), and is
-consumed by the next client message. Pending requests are canceled when the host
-is dropped or renamed, or when xymond restarts. Cached client messages and the
+Requests that the next client message received from HOSTNAME be saved as
+hostdata. The request expires after 30 minutes, or after MINUTES when specified
+(1 to 1440), and is consumed by the next client message. Pending requests are
+canceled when the host is dropped or renamed, or when xymond restarts. Cached
+client messages and the
 hostdata worker must be enabled. Requested saves bypass the recent-save limit,
 but still require sufficient free space. The response reports whether the
-request was armed, not whether the message was written to disk.
+request was armed, not whether the hostdata was written to disk. Hostdata is the
+client data shown as the clientlog service in the web interface.
 
 .IP "\fBping\fR"
 Attempts to contact the Xymon server. If successful, the Xymon server version ID

--- a/common/xymon.1
+++ b/common/xymon.1
@@ -399,15 +399,13 @@ Retrieves the current raw client message last sent by HOSTNAME. The optional
 "section" filter is used to select specific sections of the client data.
 
 .IP "\fBhostdatasave HOSTNAME [MINUTES]\fR"
-Requests that the next client message received from HOSTNAME be sent to the
-hostdata worker for storage. The request expires after 30 minutes unless the
-optional MINUTES value specifies another lifetime between 1 and 1440 minutes.
-It is held in memory and consumed by the next client message only; dropping or
-renaming the host, or restarting xymond, cancels it. Cached client messages must
-be enabled, and the hostdata worker must be running. The command reports whether
-the request was armed or rejected. Explicitly requested saves bypass the
-hostdata worker's recent-save limit, but its free-space check still applies;
-therefore an armed response does not guarantee that the report reaches disk.
+Requests storage of the next client message received from HOSTNAME. The request
+expires after 30 minutes, or after MINUTES when specified (1 to 1440), and is
+consumed by the next client message. Pending requests are canceled when the host
+is dropped or renamed, or when xymond restarts. Cached client messages and the
+hostdata worker must be enabled. Requested saves bypass the recent-save limit,
+but still require sufficient free space. The response reports whether the
+request was armed, not whether the message was written to disk.
 
 .IP "\fBping\fR"
 Attempts to contact the Xymon server. If successful, the Xymon server version ID

--- a/common/xymon.c
+++ b/common/xymon.c
@@ -169,6 +169,7 @@ int main(int argc, char *argv[])
 	else if (strncmp(STRBUF(msg), "schedule ", 9) == 0) wantresponse = 0;
 	else if (strncmp(STRBUF(msg), "schedule", 8) == 0) wantresponse = 1;
 	else if (strncmp(STRBUF(msg), "clientlog ", 10) == 0) wantresponse = 1;
+	else if ((strcmp(STRBUF(msg), "hostdatasave") == 0) || (strncmp(STRBUF(msg), "hostdatasave ", 13) == 0)) wantresponse = 1;
 	else if (strncmp(STRBUF(msg), "hostinfo", 8) == 0) wantresponse = 1;
 	else if (strncmp(STRBUF(msg), "ping", 4) == 0) wantresponse = 1;
 	else if (strncmp(STRBUF(msg), "pullclient", 10) == 0) wantresponse = 1;

--- a/docs/manpages/man1/xymon.1.html
+++ b/docs/manpages/man1/xymon.1.html
@@ -459,9 +459,24 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
   <dt id="clientlog"><a class="permalink" href="#clientlog"><b>clientlog</b>
     <i>HOSTNAME</i>
     [<b>section</b>=<i>SECTIONNAME</i>[,<i>SECTIONNAME</i>...]]</a></dt>
-  <dd>Retrieves the current raw client message last sent by HOSTNAME. The
-      optional &quot;section&quot; filter is used to select specific sections of
-      the client data.
+  <dd>Retrieves the current raw client message (hostdata) last sent by HOSTNAME.
+      The optional &quot;section&quot; filter selects specific sections of the
+      data.
+    <p class="Pp"></p>
+  </dd>
+  <dt id="hostdatasave"><a class="permalink" href="#hostdatasave"><b>hostdatasave
+    HOSTNAME [MINUTES]</b></a></dt>
+  <dd>Requests that the next client message received from HOSTNAME be saved as
+      hostdata. The request expires after 30 minutes, or after MINUTES when
+      specified (1 to 1440), and is consumed by the next client message. Pending
+      requests are canceled when the host is dropped or renamed, or when xymond
+      restarts. Cached client messages and the hostdata worker must be enabled.
+      Requested saves bypass the recent-save limit, but still require sufficient
+      free space. Requests are rejected when no CLICHG channel reader is
+      connected. A connected reader does not prove that the hostdata worker is
+      running. The response reports whether the request was armed, not whether
+      the hostdata was written to disk. Hostdata is the client data shown as the
+      clientlog service in the web interface.
     <p class="Pp"></p>
   </dd>
   <dt id="ping"><a class="permalink" href="#ping"><b>ping</b></a></dt>

--- a/tests/server/hostdata-save-next.sh
+++ b/tests/server/hostdata-save-next.sh
@@ -54,7 +54,7 @@ assert_contains 'ERROR: hostdatasave requires HOSTNAME' "$response" \
 response=$("$XYMON" "127.0.0.1:$port" 'hostdatasave unknown-host 5')
 assert_equal 'ERROR: unknown host unknown-host' "$response"
 response=$("$XYMON" "127.0.0.1:$port" 'hostdatasave testhost 5')
-assert_equal 'ERROR: no hostdata worker is listening' "$response"
+assert_equal 'ERROR: no CLICHG channel reader is listening' "$response"
 
 "$XYMOND_CHANNEL" --env="$work/xymonserver.cfg" --channel=clichg \
 	--pidfile="$work/channel.pid" --daemon --log="$work/logs/hostdata.log" \

--- a/tests/server/hostdata-save-next.sh
+++ b/tests/server/hostdata-save-next.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+XYMOND_C="$ROOT/xymond/xymond.c"
+[ -f "$XYMOND_C" ] || skip "xymond/xymond.c not present in this checkout"
+
+source=$(cat "$XYMOND_C")
+command_block=$(sed -n '/else if (strncmp(msg->buf, "hostdatasave "/,/else if (strncmp(msg->buf, "dummy"/p' "$XYMOND_C")
+rename_block=$(sed -n '/case CMD_RENAMEHOST:/,/case CMD_RENAMETEST:/p' "$XYMOND_C")
+
+assert_contains 'time_t hostdatasaveexpires;' "$source" \
+	"expiry state must belong to the in-memory host record"
+assert_contains '{ "hostdatasave", 0 }' "$source" \
+	"hostdatasave must be included in command statistics"
+assert_contains 'else if (strncmp(msg->buf, "hostdatasave ", 13) == 0)' "$command_block" \
+	"hostdatasave command parser is missing"
+assert_contains 'oksender(adminsenders, NULL, msg->addr.sin_addr, msg->buf)' "$command_block" \
+	"administrative sender authorization is missing"
+assert_contains 'if (canonhostname && clientsavemem)' "$command_block" \
+	"requests must not remain pending when cached client logs are disabled"
+assert_contains 'long ttlminutes = HOSTDATASAVE_DEFAULT_TTL;' "$command_block" \
+	"hostdatasave must default to a 30-minute lifetime"
+assert_contains '#define HOSTDATASAVE_DEFAULT_TTL 30' "$source" \
+	"hostdatasave default lifetime must remain 30 minutes"
+assert_contains '#define HOSTDATASAVE_MAX_TTL 1440' "$source" \
+	"hostdatasave override must remain bounded to 24 hours"
+assert_contains '(ttlminutes <= 0) || (ttlminutes > HOSTDATASAVE_MAX_TTL)' "$command_block" \
+	"hostdatasave must reject lifetimes outside the allowed range"
+assert_contains 'knownhost(hostname, hostip, GH_IGNORE)' "$command_block" \
+	"hostdatasave must resolve configured hosts without accepting ghosts"
+assert_contains 'hwalk = create_hostlist_t(canonhostname, hostip);' "$command_block" \
+	"configured hosts must be armable before their first report"
+assert_contains 'hwalk->hostdatasaveexpires = gettimer() + (ttlminutes * 60);' "$command_block" \
+	"hostdatasave must store a monotonic expiry"
+assert_contains 'if (hwalk && hwalk->hostdatasaveexpires)' "$source" \
+	"client messages must check for an armed host"
+assert_contains 'post_clientdata_to_clichg(sender, hwalk);' "$source" \
+	"the next cached client message must be published to CLICHG"
+assert_contains 'hwalk->hostdatasaveexpires = 0;' "$source" \
+	"the request must be consumed after one client message"
+assert_contains 'hwalk->hostdatasaveexpires = 0;' "$rename_block" \
+	"renaming a host must cancel its pending request"
+
+pass "hostdatasave remains an authorized, in-memory, one-shot request"

--- a/tests/server/hostdata-save-next.sh
+++ b/tests/server/hostdata-save-next.sh
@@ -5,45 +5,83 @@ set -euo pipefail
 # shellcheck source=tests/lib/assert.sh
 . "$(dirname "$0")/../lib/assert.sh"
 
-ROOT=$(find_root)
-XYMOND_C="$ROOT/xymond/xymond.c"
-[ -f "$XYMOND_C" ] || skip "xymond/xymond.c not present in this checkout"
+require_bin XYMOND xymond/xymond
+require_bin XYMOND_CHANNEL xymond/xymond_channel
+require_bin XYMOND_HOSTDATA xymond/xymond_hostdata
+require_bin XYMON common/xymon
 
-source=$(cat "$XYMOND_C")
-command_block=$(sed -n '/else if (strncmp(msg->buf, "hostdatasave "/,/else if (strncmp(msg->buf, "dummy"/p' "$XYMOND_C")
-rename_block=$(sed -n '/case CMD_RENAMEHOST:/,/case CMD_RENAMETEST:/p' "$XYMOND_C")
+work=$(mktempdir)
+port=$((20000 + ($$ % 20000)))
+mkdir -p "$work"/{home/etc,home/tmp,var,logs,hostdata}
+printf '127.0.0.1 testhost # noconn\n' >"$work/home/etc/hosts.cfg"
+cat >"$work/xymonserver.cfg" <<EOF
+XYMONHOME="$work/home"
+XYMONVAR="$work/var"
+XYMONSERVERLOGS="$work/logs"
+XYMONTMP="$work/home/tmp"
+CLIENTLOGS="$work/hostdata"
+HOSTSCFG="$work/home/etc/hosts.cfg"
+XYMONSERVERHOSTNAME="testhost"
+XYMONSERVERIP="127.0.0.1"
+MACHINEDOTS="testhost"
+XYMONDPORT="$port"
+EOF
 
-assert_contains 'time_t hostdatasaveexpires;' "$source" \
-	"expiry state must belong to the in-memory host record"
-assert_contains '{ "hostdatasave", 0 }' "$source" \
-	"hostdatasave must be included in command statistics"
-assert_contains 'else if (strncmp(msg->buf, "hostdatasave ", 13) == 0)' "$command_block" \
-	"hostdatasave command parser is missing"
-assert_contains 'oksender(adminsenders, NULL, msg->addr.sin_addr, msg->buf)' "$command_block" \
-	"administrative sender authorization is missing"
-assert_contains 'if (canonhostname && clientsavemem)' "$command_block" \
-	"requests must not remain pending when cached client logs are disabled"
-assert_contains 'long ttlminutes = HOSTDATASAVE_DEFAULT_TTL;' "$command_block" \
-	"hostdatasave must default to a 30-minute lifetime"
-assert_contains '#define HOSTDATASAVE_DEFAULT_TTL 30' "$source" \
-	"hostdatasave default lifetime must remain 30 minutes"
-assert_contains '#define HOSTDATASAVE_MAX_TTL 1440' "$source" \
-	"hostdatasave override must remain bounded to 24 hours"
-assert_contains '(ttlminutes <= 0) || (ttlminutes > HOSTDATASAVE_MAX_TTL)' "$command_block" \
-	"hostdatasave must reject lifetimes outside the allowed range"
-assert_contains 'knownhost(hostname, hostip, GH_IGNORE)' "$command_block" \
-	"hostdatasave must resolve configured hosts without accepting ghosts"
-assert_contains 'hwalk = create_hostlist_t(canonhostname, hostip);' "$command_block" \
-	"configured hosts must be armable before their first report"
-assert_contains 'hwalk->hostdatasaveexpires = gettimer() + (ttlminutes * 60);' "$command_block" \
-	"hostdatasave must store a monotonic expiry"
-assert_contains 'if (hwalk && hwalk->hostdatasaveexpires)' "$source" \
-	"client messages must check for an armed host"
-assert_contains 'post_clientdata_to_clichg(sender, hwalk);' "$source" \
-	"the next cached client message must be published to CLICHG"
-assert_contains 'hwalk->hostdatasaveexpires = 0;' "$source" \
-	"the request must be consumed after one client message"
-assert_contains 'hwalk->hostdatasaveexpires = 0;' "$rename_block" \
-	"renaming a host must cancel its pending request"
+stop_daemons() {
+	"$XYMON" "127.0.0.1:$port" shutdown >/dev/null 2>&1 || true
+	for pidfile in "$work/channel.pid" "$work/xymond.pid"; do
+		if [ -f "$pidfile" ]; then
+			kill "$(cat "$pidfile")" 2>/dev/null || true
+		fi
+	done
+}
+register_cleanup stop_daemons
 
-pass "hostdatasave remains an authorized, in-memory, one-shot request"
+"$XYMOND" --env="$work/xymonserver.cfg" --hosts="$work/home/etc/hosts.cfg" \
+	--listen="127.0.0.1:$port" --pidfile="$work/xymond.pid" --daemon
+
+response=''
+for attempt in {1..1000}; do
+	response=$("$XYMON" "127.0.0.1:$port" 'hostdatasave testhost nope' 2>/dev/null || true)
+	[ -n "$response" ] && break
+done
+assert_contains 'ERROR: hostdatasave requires HOSTNAME' "$response" \
+	"an invalid lifetime must be rejected immediately"
+response=$("$XYMON" "127.0.0.1:$port" hostdatasave)
+assert_contains 'ERROR: hostdatasave requires HOSTNAME' "$response" \
+	"a missing hostname must be rejected immediately"
+
+response=$("$XYMON" "127.0.0.1:$port" 'hostdatasave unknown-host 5')
+assert_equal 'ERROR: unknown host unknown-host' "$response"
+response=$("$XYMON" "127.0.0.1:$port" 'hostdatasave testhost 5')
+assert_equal 'ERROR: no hostdata worker is listening' "$response"
+
+"$XYMOND_CHANNEL" --env="$work/xymonserver.cfg" --channel=clichg \
+	--pidfile="$work/channel.pid" --daemon --log="$work/logs/hostdata.log" \
+	"$XYMOND_HOSTDATA" --env="$work/xymonserver.cfg" \
+	--logdir="$work/hostdata" --minimum-free=0 --recent-count=0
+
+response=''
+for attempt in {1..1000}; do
+	response=$("$XYMON" "127.0.0.1:$port" 'hostdatasave testhost 5' 2>/dev/null || true)
+	[[ $response == OK:* ]] && break
+done
+assert_equal 'OK: next client report for testhost armed for 5 minutes' "$response"
+
+"$XYMON" "127.0.0.1:$port" $'client testhost.linux\n[test]\nforced payload'
+saved=''
+for attempt in {1..1000}; do
+	saved=$(find "$work/hostdata/testhost" -type f -print -quit 2>/dev/null || true)
+	[ -n "$saved" ] && break
+done
+assert_file_exists "$saved" "the armed client report must reach the hostdata worker"
+assert_contains 'forced payload' "$(cat "$saved")" \
+	"the forced snapshot payload changed"
+
+"$XYMON" "127.0.0.1:$port" $'client testhost.linux\n[test]\nsecond payload'
+assert_equal '1' "$(find "$work/hostdata/testhost" -type f | wc -l)" \
+	"the request must be consumed after one client report"
+assert_not_contains 'second payload' "$(cat "$saved")" \
+	"a consumed request was applied to a later client report"
+
+pass "hostdatasave arms one forced, quota-bypassing client snapshot"

--- a/tests/xymond/hostdata-forced-save.sh
+++ b/tests/xymond/hostdata-forced-save.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMOND_HOSTDATA xymond/xymond_hostdata
+
+ROOT=$(find_root)
+work=$(mktempdir)
+mkdir -p "$work/etc" "$work/var/hostdata"
+cp "$ROOT/xymond/etcfiles/xymonserver.cfg.DIST" "$work/etc/xymonserver.cfg"
+
+set +e
+{
+	printf '@@clichg#1|1|10.0.0.99|realhost|normal\nnormal payload\n@@\n'
+	printf '@@clichg#2|1|10.0.0.99|realhost|forced|forced\nforced payload\n@@\n'
+} | XYMONHOME="$work" XYMONVAR="$work/var" \
+	"$XYMOND_HOSTDATA" --env="$work/etc/xymonserver.cfg" \
+	--logdir="$work/var/hostdata" --minimum-free=0 --recent-count=0 \
+	>"$work/worker.out" 2>"$work/worker.err"
+rc=$?
+set -e
+[ "$rc" -le 1 ] || { cat "$work/worker.err" >&2; fail "xymond_hostdata exited $rc"; }
+
+[ ! -e "$work/var/hostdata/realhost/normal" ] \
+	|| fail "an ordinary save bypassed --recent-count=0"
+assert_file_exists "$work/var/hostdata/realhost/forced" \
+	"a forced save must bypass --recent-count=0"
+assert_equal "forced payload" "$(cat "$work/var/hostdata/realhost/forced")" \
+	"the forced snapshot payload changed"
+
+pass "forced hostdata saves bypass the recent-save quota"

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -59,6 +59,8 @@ static char rcsid[] = "$Id$";
 #include "libxymon.h"
 
 #define DISABLED_UNTIL_OK -1
+#define HOSTDATASAVE_DEFAULT_TTL 30
+#define HOSTDATASAVE_MAX_TTL 1440
 
 /*
  * The absolute maximum size we'll grow our buffers to accommodate an incoming message.
@@ -161,6 +163,7 @@ typedef struct xymond_hostlist_t {
 	xymond_log_t *pinglog; /* Points to entry in logs list, but we need it often */
 	clientmsg_list_t *clientmsgs;
 	time_t clientmsgtstamp;
+	time_t hostdatasaveexpires;
 } xymond_hostlist_t;
 
 typedef struct filecache_t {
@@ -278,6 +281,7 @@ xymond_statistics_t xymond_stats[] = {
 	{ "summary", 0 },
 	{ "data", 0 },
 	{ "clientlog", 0 },
+	{ "hostdatasave", 0 },
 	{ "client", 0 },
 	{ "notes", 0 },
 	{ "enable", 0 },
@@ -967,6 +971,15 @@ void posttochannel(xymond_channel_t *channel, char *channelmarker,
 	dbgprintf("<- posttochannel\n");
 
 	return;
+}
+
+void post_clientdata_to_clichg(char *sender, xymond_hostlist_t *host)
+{
+	xymond_log_t log;
+
+	memset(&log, 0, sizeof(log));
+	log.host = host;
+	posttochannel(clichgchn, channelnames[C_CLICHG], NULL, sender, host->hostname, &log, NULL);
 }
 
 void posttoall(char *msg)
@@ -2367,6 +2380,7 @@ void handle_client(char *msg, char *sender, char *hostname, char *collectorid,
 	char *chnbuf, *theclass;
 	int msglen, buflen = 0;
 	xtreePos_t hosthandle;
+	xymond_hostlist_t *hwalk = NULL;
 	clientmsg_list_t *cwalk, *chead, *ctail, *czombie;
 
 	dbgprintf("->handle_client\n");
@@ -2381,7 +2395,6 @@ void handle_client(char *msg, char *sender, char *hostname, char *collectorid,
 	if (clientsavemem) {
 		hosthandle = xtreeFind(rbhosts, hostname);
 		if (hosthandle != xtreeEnd(rbhosts)) {
-			xymond_hostlist_t *hwalk;
 			hwalk = xtreeData(rbhosts, hosthandle);
 
 			for (cwalk = hwalk->clientmsgs; (cwalk && strcmp(cwalk->collectorid, collectorid)); cwalk = cwalk->next) ;
@@ -2430,6 +2443,11 @@ void handle_client(char *msg, char *sender, char *hostname, char *collectorid,
 			}
 			hwalk->clientmsgs = chead;
 		}
+	}
+
+	if (hwalk && hwalk->hostdatasaveexpires) {
+		if (hwalk->hostdatasaveexpires > gettimer()) post_clientdata_to_clichg(sender, hwalk);
+		hwalk->hostdatasaveexpires = 0;
 	}
 
 	chnbuf = (char *)malloc(buflen);
@@ -2656,6 +2674,7 @@ void handle_dropnrename(enum droprencmd_t cmd, char *sender, char *hostname, cha
 		break;
 
 	  case CMD_RENAMEHOST:
+		hwalk->hostdatasaveexpires = 0;
 		xtreeDelete(rbhosts, hostname);
 		xfree(hwalk->hostname);
 		hwalk->hostname = strdup(n1);
@@ -4465,6 +4484,40 @@ void do_message(conn_t *msg, char *origin)
 		else if (hostname && n1 && n2) {
 			/* Test rename */
 			handle_dropnrename(CMD_RENAMETEST, sender, hostname, n1, n2);
+		}
+	}
+	else if (strncmp(msg->buf, "hostdatasave ", 13) == 0) {
+		char *hostname, *canonhostname, *ttltext, *endp, *extra, *p;
+		char hostip[IP_ADDR_STRLEN];
+		long ttlminutes = HOSTDATASAVE_DEFAULT_TTL;
+		xtreePos_t hosthandle;
+		xymond_hostlist_t *hwalk;
+
+		if (!oksender(adminsenders, NULL, msg->addr.sin_addr, msg->buf)) goto done;
+
+		p = msg->buf + strlen("hostdatasave"); p += strspn(p, " \t");
+		hostname = strtok(p, " \t");
+		ttltext = strtok(NULL, " \t");
+		extra = strtok(NULL, " \t");
+		if (ttltext) {
+			errno = 0;
+			ttlminutes = strtol(ttltext, &endp, 10);
+			if ((errno == ERANGE) || (*ttltext == '\0') || (*endp != '\0') ||
+			    (ttlminutes <= 0) || (ttlminutes > HOSTDATASAVE_MAX_TTL)) hostname = NULL;
+		}
+		if (extra) hostname = NULL;
+
+		canonhostname = (hostname ? knownhost(hostname, hostip, GH_IGNORE) : NULL);
+		if (canonhostname && clientsavemem) {
+			hosthandle = xtreeFind(rbhosts, canonhostname);
+			if (hosthandle == xtreeEnd(rbhosts)) {
+				hwalk = create_hostlist_t(canonhostname, hostip);
+				hostcount++;
+			}
+			else {
+				hwalk = xtreeData(rbhosts, hosthandle);
+			}
+			hwalk->hostdatasaveexpires = gettimer() + (ttlminutes * 60);
 		}
 	}
 	else if (strncmp(msg->buf, "dummy", 5) == 0) {

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -975,11 +975,17 @@ void posttochannel(xymond_channel_t *channel, char *channelmarker,
 
 void post_clientdata_to_clichg(char *sender, xymond_hostlist_t *host)
 {
-	xymond_log_t log;
+	char *clientdata, *readymsg;
+	int readylen;
+	time_t timeroffset = (getcurrenttime(NULL) - gettimer());
 
-	memset(&log, 0, sizeof(log));
-	log.host = host;
-	posttochannel(clichgchn, channelnames[C_CLICHG], NULL, sender, host->hostname, &log, NULL);
+	clientdata = totalclientmsg(host->clientmsgs);
+	readylen = strlen(host->hostname) + strlen(clientdata) + 64;
+	readymsg = (char *)malloc(readylen);
+	snprintf(readymsg, readylen, "%s|%d|forced\n%s", host->hostname,
+		(int)(host->clientmsgtstamp + timeroffset), clientdata);
+	posttochannel(clichgchn, channelnames[C_CLICHG], NULL, sender, host->hostname, NULL, readymsg);
+	xfree(readymsg);
 }
 
 void posttoall(char *msg)
@@ -4486,12 +4492,14 @@ void do_message(conn_t *msg, char *origin)
 			handle_dropnrename(CMD_RENAMETEST, sender, hostname, n1, n2);
 		}
 	}
-	else if (strncmp(msg->buf, "hostdatasave ", 13) == 0) {
+	else if ((strcmp(msg->buf, "hostdatasave") == 0) || (strncmp(msg->buf, "hostdatasave ", 13) == 0)) {
 		char *hostname, *canonhostname, *ttltext, *endp, *extra, *p;
 		char hostip[IP_ADDR_STRLEN];
+		char response[1024];
 		long ttlminutes = HOSTDATASAVE_DEFAULT_TTL;
 		xtreePos_t hosthandle;
 		xymond_hostlist_t *hwalk;
+		int validrequest = 1;
 
 		if (!oksender(adminsenders, NULL, msg->addr.sin_addr, msg->buf)) goto done;
 
@@ -4503,12 +4511,24 @@ void do_message(conn_t *msg, char *origin)
 			errno = 0;
 			ttlminutes = strtol(ttltext, &endp, 10);
 			if ((errno == ERANGE) || (*ttltext == '\0') || (*endp != '\0') ||
-			    (ttlminutes <= 0) || (ttlminutes > HOSTDATASAVE_MAX_TTL)) hostname = NULL;
+			    (ttlminutes <= 0) || (ttlminutes > HOSTDATASAVE_MAX_TTL)) validrequest = 0;
 		}
-		if (extra) hostname = NULL;
+		if (!hostname || extra) validrequest = 0;
 
-		canonhostname = (hostname ? knownhost(hostname, hostip, GH_IGNORE) : NULL);
-		if (canonhostname && clientsavemem) {
+		canonhostname = (validrequest ? knownhost(hostname, hostip, GH_IGNORE) : NULL);
+		if (!validrequest) {
+			snprintf(response, sizeof(response), "ERROR: hostdatasave requires HOSTNAME and an optional lifetime from 1 to %d minutes\n", HOSTDATASAVE_MAX_TTL);
+		}
+		else if (!canonhostname) {
+			snprintf(response, sizeof(response), "ERROR: unknown host %s\n", hostname);
+		}
+		else if (!clientsavemem) {
+			snprintf(response, sizeof(response), "ERROR: cached client messages are disabled\n");
+		}
+		else if (semctl(clichgchn->semid, CLIENTCOUNT, GETVAL) <= 0) {
+			snprintf(response, sizeof(response), "ERROR: no hostdata worker is listening\n");
+		}
+		else {
 			hosthandle = xtreeFind(rbhosts, canonhostname);
 			if (hosthandle == xtreeEnd(rbhosts)) {
 				hwalk = create_hostlist_t(canonhostname, hostip);
@@ -4518,7 +4538,13 @@ void do_message(conn_t *msg, char *origin)
 				hwalk = xtreeData(rbhosts, hosthandle);
 			}
 			hwalk->hostdatasaveexpires = gettimer() + (ttlminutes * 60);
+			snprintf(response, sizeof(response), "OK: next client report for %s armed for %ld minutes\n", canonhostname, ttlminutes);
 		}
+
+		msg->doingwhat = RESPONDING;
+		xfree(msg->buf);
+		msg->bufp = msg->buf = strdup(response);
+		msg->buflen = strlen(msg->buf);
 	}
 	else if (strncmp(msg->buf, "dummy", 5) == 0) {
 		/* Do nothing */

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -4526,7 +4526,7 @@ void do_message(conn_t *msg, char *origin)
 			snprintf(response, sizeof(response), "ERROR: cached client messages are disabled\n");
 		}
 		else if (semctl(clichgchn->semid, CLIENTCOUNT, GETVAL) <= 0) {
-			snprintf(response, sizeof(response), "ERROR: no hostdata worker is listening\n");
+			snprintf(response, sizeof(response), "ERROR: no CLICHG channel reader is listening\n");
 		}
 		else {
 			hosthandle = xtreeFind(rbhosts, canonhostname);

--- a/xymond/xymond_hostdata.c
+++ b/xymond/xymond_hostdata.c
@@ -70,10 +70,10 @@ static void drop_savetimes(char *hostname)
  * Find or create the per-host throttle entry, keyed on the sanitized host
  * name the files are stored under (so path-prefixed variants of one host
  * cannot each claim a separate budget). The tstamp ring is allocated only
- * when the throttle is enabled (recentperiod > 0); the small entry itself is
- * always kept, so the per-host write-error backoff has somewhere to record
- * its state even with the throttle off. Returns NULL (error logged) only on
- * allocation failure.
+ * when the throttle is enabled (recentperiod > 0 and maxrecentcount > 0); the
+ * small entry itself is always kept, so the per-host write-error backoff has
+ * somewhere to record its state even with the throttle off. Returns NULL
+ * (error logged) only on allocation failure.
  */
 static savetimes_t *get_savetimes(char *hostname, int recentperiod, int maxrecentcount)
 {
@@ -87,9 +87,9 @@ static savetimes_t *get_savetimes(char *hostname, int recentperiod, int maxrecen
 		itm->hostname = strdup(hostname);
 		/* Sized from --recent-count: deciding "N or more saves in the
 		 * window" only ever needs the N most recent save times. */
-		if (recentperiod > 0) itm->tstamp = (time_t *)calloc(maxrecentcount, sizeof(time_t));
+		if ((recentperiod > 0) && (maxrecentcount > 0)) itm->tstamp = (time_t *)calloc(maxrecentcount, sizeof(time_t));
 	}
-	if (!itm || !itm->hostname || ((recentperiod > 0) && !itm->tstamp)) {
+	if (!itm || !itm->hostname || ((recentperiod > 0) && (maxrecentcount > 0) && !itm->tstamp)) {
 		errprintf("Out of memory tracking saves for host %s, dropping message\n", hostname);
 		free_savetimes(itm);
 		return NULL;
@@ -288,6 +288,7 @@ int main(int argc, char *argv[])
 		/* @@clichg|timestamp|sender|hostname|testname|... */
 		if ((metacount > 4) && (strncmp(metadata[0], "@@clichg", 8) == 0)) {
 			savetimes_t *itm;
+			int forced;
 			time_t now = gettimer();
 			time_t cutoff;
 			char hostdir[PATH_MAX];
@@ -295,8 +296,10 @@ int main(int argc, char *argv[])
 			char *safehost, *safetest;
 			FILE *fd;
 
-			/* --recent-count=0: never save anything */
-			if (maxrecentcount == 0) continue;
+			forced = ((metacount > 5) && (strcmp(metadata[5], "forced") == 0));
+
+			/* --recent-count=0 disables ordinary saves; explicit requests bypass it. */
+			if (!forced && (maxrecentcount == 0)) continue;
 
 			safehost = confine_name(metadata[3], "hostname");
 			safetest = confine_name(metadata[4], "testname");
@@ -325,7 +328,7 @@ int main(int argc, char *argv[])
 			 * has been up that long.
 			 */
 			cutoff = (now > recentperiod) ? (now - recentperiod) : 0;
-			if (!logdirfull && (!itm->tstamp || (itm->tstamp[itm->oldest] <= cutoff))) {
+			if (!logdirfull && (forced || !itm->tstamp || (itm->tstamp[itm->oldest] <= cutoff))) {
 				int written, closestatus, ok = 1;
 
 				if (!join_path(hostdir, sizeof(hostdir), clientlogdir, safehost, "host directory")) continue;
@@ -361,7 +364,7 @@ int main(int argc, char *argv[])
 				 * attempt stored nothing, so counting it would let an I/O
 				 * problem eat the budget and then drop good data for up to
 				 * a full window after the problem clears. */
-				if (itm->tstamp) {
+				if (!forced && itm->tstamp) {
 					itm->tstamp[itm->oldest] = now;
 					itm->oldest = (itm->oldest + 1) % maxrecentcount;
 				}


### PR DESCRIPTION
## Summary

This PR should wait for #286 and #289 to merge

Add the administrative command:

`hostdatasave HOSTNAME [MINUTES]`

The command arms a one-shot request that sends the host's next client report through the existing `CLICHG` pipeline for storage by `xymond_hostdata`.

It also provides the synchronous response protocol needed for a future button on the host info page.

## Motivation

This provides an authorized remote trigger for capturing fresh client reports around maintenance.

Operators can capture a report before maintenance, and compare the resulting snapshots to verify that the client server returned to the same state it was in before maintenance.

## Behavior

- Defaults to a 30-minute request lifetime.
- Accepts lifetimes from 1 to 1440 minutes.
- Supports configured hosts before their first client report.
- Consumes the request after one client report.
- Cancels pending requests when a host is dropped or renamed, or when `xymond` restarts.
- Requires in-memory client logging and an active `CLICHG` reader.
- Returns an immediate `OK` or `ERROR` response.
- Marks explicitly requested `CLICHG` messages as forced.
- Forced saves bypass the recent-save quota without consuming quota history.
- Existing free-space protection still applies.

An accepted request confirms that it was armed. It does not guarantee a disk write if the worker subsequently encounters insufficient free space or an I/O error.

## Responses

Successful requests return:

`OK: next client report for HOSTNAME armed for MINUTES minutes`

Requests return a descriptive error for:

- Missing or invalid arguments.
- Lifetimes outside the supported range.
- Unknown hosts.
- Disabled in-memory client logging.
- No active hostdata worker.

## Info Page Integration

The synchronous response protocol prepares this command for a future button on the host info page.

Existing Xymon CGI actions communicate with `xymond` through the internal `sendmessage()` API. They construct normal Xymon protocol commands directly instead of invoking the `xymon` executable.

A future secure CGI action can follow the same pattern:

1. Receive `HOSTNAME` and optional `MINUTES` from a POST form.
2. Apply the existing web authentication and host-access checks.
3. Call `sendmessage()` with `hostdatasave HOSTNAME [MINUTES]`.
4. Capture and display the returned `OK` or `ERROR` response.

No additional daemon protocol or command-line process is required.

## Authorization

The command uses the existing `adminsenders` authorization check.

## Testing

- Built the affected `common` and `xymond` components.
- Added an end-to-end test using the real daemon, channel, worker, and command client.
- Verified success and rejection responses.
- Verified malformed requests receive immediate responses.
- Verified one-shot request consumption.
- Verified forced saves bypass `--recent-count=0`.
- Verified ordinary saves remain subject to the quota.
- Verified the saved payload remains intact.
- Full regression suite: 18 passed, 6 environment-dependent skips, 0 failures.