### PR TITLE
svcstatus: fix COMPACT: tag parsing

### DIFF
--- a/web/svcstatus.c
+++ b/web/svcstatus.c
@@ -350,10 +350,15 @@ int do_request(void)
 		if (compacts && *compacts) {
 			char *p;
 
+			/* Copy first: compacts points into the host record, and strtok()
+			 * would truncate the stored tag. complist keeps pointing into
+			 * the copy, which lives until this CGI exits. */
+			compacts = xstrdup(compacts);
 			compitem = strtok(compacts, ",");
 			while (compitem && !complist) {
 				p = strchr(compitem, '='); if (p) *p = '\0';
-				if (strcmp(service, compitem) == 0) complist = p+1;
+				/* An entry without '=' has no member list */
+				if (p && (strcmp(service, compitem) == 0)) complist = p+1;
 				compitem = strtok(NULL, ",");
 			}
 		}


### PR DESCRIPTION
Split out of #301, found while reviewing the aliasing class there.

Two fixes in the `compacts` loop of `do_request()`:

- The `COMPACT:` tag `loadhostdata()` returns through its out-parameter points into the host record; `strtok()` and the `=` split wrote `'\0'`s into the stored configuration. Copy first — the aliasing class behind #276 and #300. Harmless today only because this CGI is one-shot; the copy is deliberately not freed since `complist` points into it until exit.

- An entry without `=` that matched the requested service set `complist = p+1` with `p` NULL, and the xymondboard branch then called `strlen((char *)1)` — a segfault reachable from `hosts.cfg` (e.g. `COMPACT:web` and a request for service `web`). An entry without `=` has no member list, so it now simply cannot match.

