### PR TITLE
tests: guard seven under-tested behaviours (config, matching, CGI, crash/overflow fixes)

### DIFF
--- a/tests/network/netrc-password.sh
+++ b/tests/network/netrc-password.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/network/netrc-password.sh
+#
+# Regression guard for the off-by-one in load_netrc() that dropped the last
+# character of every .netrc password (commit b4c4775dc).
+#
+# load_netrc() packs "login:password" into item->auth. It allocated the right
+# size -- malloc(login_len + 1), where login_len = strlen(login) + strlen(pw)
+# + 1 for the ':' -- but passed login_len (one byte short) as snprintf()'s
+# size, so snprintf's own NUL landed on the password's last character and
+# silently truncated it. The fix passes login_len + 1.
+#
+# load_netrc() is static and pulls the whole URL machinery in, so -- like
+# tests/server/digest-md5hash.sh -- this (1) binds to the real source: the
+# corrected size argument must be present and the short one gone, and (2)
+# compiles a faithful copy of the pack step and shows the fixed size yields the
+# whole password while the buggy size truncates it. Skips if the file or a C
+# compiler is absent.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SRC="$ROOT/lib/url.c"
+CC=${CC:-cc}
+
+[ -f "$SRC" ] || skip "lib/url.c absent"
+src=$(cat "$SRC")
+
+# (1) Bind to the real code: fixed size argument present, buggy one gone. The
+# fixed line is `snprintf(item->auth, login_len + 1, ...)`; the bug was
+# `snprintf(item->auth, login_len, ...)`. The " + 1," / "," suffixes keep the
+# two apart so the fixed form cannot satisfy the buggy pattern.
+assert_contains "snprintf(item->auth, login_len + 1," "$src" \
+	"url.c load_netrc() lost the corrected snprintf size (login_len + 1) (#226 / b4c4775dc)"
+assert_not_contains "snprintf(item->auth, login_len," "$src" \
+	"url.c load_netrc() regressed to the one-short snprintf size (login_len) (#226 / b4c4775dc)"
+
+# (2) Behavioural demo of the property, if we can compile.
+command -v "$CC" >/dev/null 2>&1 \
+	|| pass "url.c keeps the #226 fix (static check; no C compiler for the run)"
+
+work=$(mktempdir)
+cat >"$work/t.c" <<'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* A faithful copy of the load_netrc() pack step for one entry. */
+static char *pack(const char *login, const char *password, int use_fix)
+{
+	unsigned int login_len = strlen(login) + strlen(password) + 1;  /* +1 for ':' */
+	char *auth = (char *)malloc(login_len + 1);
+	snprintf(auth, use_fix ? (login_len + 1) : login_len, "%s:%s", login, password);
+	return auth;
+}
+
+int main(void)
+{
+	const char *login = "user";
+	const char *password = "s3cr3t";        /* last char 't' is what got dropped */
+	char want[64];
+	char *fixed, *buggy;
+
+	snprintf(want, sizeof(want), "%s:%s", login, password);
+
+	fixed = pack(login, password, 1);
+	buggy = pack(login, password, 0);
+
+	/* Fixed: the whole "login:password" survives, last char included. */
+	if (strcmp(fixed, want) != 0) {
+		fprintf(stderr, "fixed size mangled the pair: got '%s', want '%s'\n", fixed, want);
+		return 1;
+	}
+	/* Buggy: exactly the off-by-one symptom -- last char of the password lost. */
+	if (strcmp(buggy, want) == 0) {
+		fprintf(stderr, "buggy size did not truncate -- the demo no longer models #226\n");
+		return 1;
+	}
+	if (strlen(buggy) != strlen(want) - 1) {
+		fprintf(stderr, "buggy size truncated by %zu chars, expected 1\n", strlen(want) - strlen(buggy));
+		return 1;
+	}
+	return 0;
+}
+EOF
+
+"$CC" -std=c99 -Wall -Wextra -Werror -o "$work/t" "$work/t.c" 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "netrc pack probe did not compile"; }
+"$work/t" || fail "netrc pack probe failed: the size-argument property broke (#226)"
+
+pass "load_netrc() packs the full login:password; the one-short size truncates it (#226)"

--- a/tests/network/netrc-password.sh
+++ b/tests/network/netrc-password.sh
@@ -8,88 +8,101 @@
 #
 # load_netrc() packs "login:password" into item->auth. It allocated the right
 # size -- malloc(login_len + 1), where login_len = strlen(login) + strlen(pw)
-# + 1 for the ':' -- but passed login_len (one byte short) as snprintf()'s
-# size, so snprintf's own NUL landed on the password's last character and
-# silently truncated it. The fix passes login_len + 1.
+# + 1 for the ':' -- but passed login_len (one byte short) to snprintf(), so
+# snprintf's NUL landed on the password's last character and truncated it. The
+# fix passes login_len + 1.
 #
-# load_netrc() is static and pulls the whole URL machinery in, so -- like
-# tests/server/digest-md5hash.sh -- this (1) binds to the real source: the
-# corrected size argument must be present and the short one gone, and (2)
-# compiles a faithful copy of the pack step and shows the fixed size yields the
-# whole password while the buggy size truncates it. Skips if the file or a C
-# compiler is absent.
+# Two layers, so coverage does not depend on the tree being built:
+#   (1) A build-independent source check that the snprintf() size is login_len
+#       + 1 and not the one-short login_len. Runs with no compiler.
+#   (2) A behavioural check, when a compiler is available: parse_url() runs the
+#       real (static) load_netrc() and hands back the packed credential in
+#       url.auth, so any regression that SHORTENS it -- the length calc, the
+#       snprintf size, or a format change -- fails here, not just the snprintf
+#       argument that (1) pins. (An undersized malloc overflows rather than
+#       truncates, so it is out of scope for this content check.)
+#
+# Skips only when lib/url.c itself is absent.
 
 set -euo pipefail
 # shellcheck source=tests/lib/assert.sh
 . "$(dirname "$0")/../lib/assert.sh"
 
 ROOT=$(find_root)
-SRC="$ROOT/lib/url.c"
 CC=${CC:-cc}
 
+SRC="$ROOT/lib/url.c"
 [ -f "$SRC" ] || skip "lib/url.c absent"
 src=$(cat "$SRC")
 
-# (1) Bind to the real code: fixed size argument present, buggy one gone. The
-# fixed line is `snprintf(item->auth, login_len + 1, ...)`; the bug was
-# `snprintf(item->auth, login_len, ...)`. The " + 1," / "," suffixes keep the
-# two apart so the fixed form cannot satisfy the buggy pattern.
+# (1) Build-independent source guard: the snprintf() size must be login_len + 1.
+# The " + 1," / "," suffixes keep the fixed and buggy forms apart so the fixed
+# line cannot satisfy the buggy pattern.
 assert_contains "snprintf(item->auth, login_len + 1," "$src" \
 	"url.c load_netrc() lost the corrected snprintf size (login_len + 1) (#226 / b4c4775dc)"
 assert_not_contains "snprintf(item->auth, login_len," "$src" \
-	"url.c load_netrc() regressed to the one-short snprintf size (login_len) (#226 / b4c4775dc)"
+	"url.c load_netrc() regressed to the one-short snprintf size (#226 / b4c4775dc)"
 
-# (2) Behavioural demo of the property, if we can compile.
+# (2) Behavioural check, when a compiler and the prebuilt library are present.
+# It compiles the CURRENT lib/url.c fresh into the harness (so the result
+# reflects the source, not a possibly-stale url.o inside the archive) and links
+# the rest from the archive -- no make, no writable tree. If either is missing,
+# the source guard above already stands, so pass with a note.
 command -v "$CC" >/dev/null 2>&1 \
-	|| pass "url.c keeps the #226 fix (static check; no C compiler for the run)"
+	|| pass "url.c keeps the #226 snprintf size (source check; no C compiler for the behavioural run)"
+[ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| pass "url.c keeps the #226 snprintf size (source check; library not built for the behavioural run)"
 
 work=$(mktempdir)
-cat >"$work/t.c" <<'EOF'
+
+# Link flags for the prebuilt library. Tolerate an absent top-level Makefile
+# (e.g. only lib/ configured): fall back to no extra SSL flags rather than
+# letting sed abort the script under 'set -e'.
+ssllibs=""
+[ -f "$ROOT/Makefile" ] && ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+pcre_libs=${PCRELIBS:-}
+if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+fi
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+cat >"$work/harness.c" <<'EOF'
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
+#include "libxymon.h"
 
-/* A faithful copy of the load_netrc() pack step for one entry. */
-static char *pack(const char *login, const char *password, int use_fix)
+/* Drive the real parse_url(), which loads the .netrc via load_netrc() and
+ * hands back the packed "login:password" in url.auth. */
+int main(int argc, char *argv[])
 {
-	unsigned int login_len = strlen(login) + strlen(password) + 1;  /* +1 for ':' */
-	char *auth = (char *)malloc(login_len + 1);
-	snprintf(auth, use_fix ? (login_len + 1) : login_len, "%s:%s", login, password);
-	return auth;
-}
+	urlelem_t url;
 
-int main(void)
-{
-	const char *login = "user";
-	const char *password = "s3cr3t";        /* last char 't' is what got dropped */
-	char want[64];
-	char *fixed, *buggy;
-
-	snprintf(want, sizeof(want), "%s:%s", login, password);
-
-	fixed = pack(login, password, 1);
-	buggy = pack(login, password, 0);
-
-	/* Fixed: the whole "login:password" survives, last char included. */
-	if (strcmp(fixed, want) != 0) {
-		fprintf(stderr, "fixed size mangled the pair: got '%s', want '%s'\n", fixed, want);
-		return 1;
-	}
-	/* Buggy: exactly the off-by-one symptom -- last char of the password lost. */
-	if (strcmp(buggy, want) == 0) {
-		fprintf(stderr, "buggy size did not truncate -- the demo no longer models #226\n");
-		return 1;
-	}
-	if (strlen(buggy) != strlen(want) - 1) {
-		fprintf(stderr, "buggy size truncated by %zu chars, expected 1\n", strlen(want) - strlen(buggy));
-		return 1;
-	}
+	memset(&url, 0, sizeof(url));
+	parse_url(argv[1], &url);
+	printf("%s\n", url.auth ? url.auth : "");
 	return 0;
 }
 EOF
 
-"$CC" -std=c99 -Wall -Wextra -Werror -o "$work/t" "$work/t.c" 2>"$work/cc.log" \
-	|| { cat "$work/cc.log" >&2; fail "netrc pack probe did not compile"; }
-"$work/t" || fail "netrc pack probe failed: the size-argument property broke (#226)"
+# lib/url.c goes before the archive so its fresh objects satisfy the netrc
+# symbols and the archive's (possibly stale) url.o is never pulled in.
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+	"$work/harness.c" "$SRC" "$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "netrc harness does not compile"; }
 
-pass "load_netrc() packs the full login:password; the one-short size truncates it (#226)"
+# A password whose last byte matters: the off-by-one drops the trailing 't'.
+login="user"
+password="s3cr3t"
+printf 'machine testhost login %s password %s\n' "$login" "$password" >"$work/.netrc"
+chmod 600 "$work/.netrc"
+
+# Point load_netrc() at our fixture: it reads $XYMONHOME/etc/netrc first, then
+# $HOME/.netrc -- give XYMONHOME a dir with no etc/netrc so it falls through.
+got=$(HOME="$work" XYMONHOME="$work/empty" "$work/harness" "http://testhost/" 2>"$work/run.log") \
+	|| { cat "$work/run.log" >&2; fail "harness run failed"; }
+
+want="$login:$password"
+assert_equal "$want" "$got" \
+	"load_netrc() packed the wrong credential -- the .netrc password off-by-one regressed (#226 / b4c4775dc)"
+
+pass "load_netrc() packs the full login:password end to end; the last character survives (#226)"

--- a/tests/server/analysis-ds-firstmatch-harness.c
+++ b/tests/server/analysis-ds-firstmatch-harness.c
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * tests/server/analysis-ds-firstmatch-harness.c
+ *
+ * Driver for check_rrdds_thresholds() (xymond/client_config.c), used by
+ * analysis-ds-firstmatch.sh to exercise the analysis.cfg first-match rule for
+ * DS (RRD dataset) thresholds -- issue #32, fixed in commit 999c3ee03.
+ *
+ * check_rrdds_thresholds() takes the RRD's dataset-name tree (valnames) and a
+ * colon-separated value string; for every DS rule that matches the RRD key it
+ * may emit a "modify <host>.<column> <color> rrdds ..." line. The fix makes a
+ * rule shadow every later rule sharing its (column, dataset, colour) target,
+ * so we probe it by counting "modify" lines for a given RRD key.
+ *
+ * The harness builds a one-dataset value tree, loads the hosts.cfg and
+ * analysis.cfg passed on argv, and prints "<key>=<modify-count>" for each RRD
+ * key it is asked about. The scenarios and their expected counts live in the
+ * shell script, which owns the pass/fail decision.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "libxymon.h"
+
+extern int load_client_config(char *configfn);
+extern strbuffer_t *check_rrdds_thresholds(char *hostname, char *classname,
+	char *pagepaths, char *rrdkey, void *valnames, char *vals);
+
+/* A value tree with a single dataset DSNAM at index 0 of the value string. */
+static void *make_valnames(const char *dsnam)
+{
+	void *tree = xtreeNew(strcasecmp);
+	rrdtplnames_t *n = calloc(1, sizeof(rrdtplnames_t));
+
+	n->dsnam = strdup(dsnam);
+	n->idx = 0;
+	xtreeAdd(tree, n->dsnam, n);
+	return tree;
+}
+
+static int count_modify(strbuffer_t *b)
+{
+	int c = 0;
+	char *p = b ? STRBUF(b) : NULL;
+
+	while (p && (p = strstr(p, "modify "))) { c++; p += 7; }
+	return c;
+}
+
+/*
+ * argv[1] = hosts.cfg, argv[2] = analysis.cfg, argv[3] = dataset name,
+ * argv[4] = single value, argv[5..] = RRD keys to probe.
+ */
+int main(int argc, char *argv[])
+{
+	void *valnames;
+	int i;
+
+	if (argc < 6) {
+		fprintf(stderr, "usage: %s hosts.cfg analysis.cfg dsname value key [key...]\n", argv[0]);
+		return 2;
+	}
+
+	load_hostnames(argv[1], NULL, get_fqdn());
+	load_client_config(argv[2]);
+	valnames = make_valnames(argv[3]);
+
+	for (i = 5; i < argc; i++) {
+		strbuffer_t *r = check_rrdds_thresholds("testhost", "", "", argv[i], valnames, argv[4]);
+		printf("%s=%d\n", argv[i], count_modify(r));
+	}
+
+	return 0;
+}

--- a/tests/server/analysis-ds-firstmatch.sh
+++ b/tests/server/analysis-ds-firstmatch.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/analysis-ds-firstmatch.sh
+#
+# Regression guard for analysis.cfg first-match semantics on DS (RRD dataset)
+# threshold rules -- issue #32, fixed in commit 999c3ee03.
+#
+# analysis.cfg is documented as evaluated top-to-bottom, first match wins: put
+# the specific settings first, the generic ones last. Every threshold type
+# honoured that except DS: check_rrdds_thresholds() looped over *every* matching
+# DS rule and emitted a "modify" for each, so a later wildcard rule was not
+# shadowed by an earlier specific one -- both fired.
+#
+# The fix records each (column, dataset, colour) target the moment a rule
+# applies to it -- i.e. as soon as the dataset is present and has a value, even
+# if that rule's own threshold does not trigger -- and shadows later rules for
+# the same target and colour. Different colours are deliberately kept, so a
+# yellow and a red threshold on one dataset both still fire.
+#
+# check_rrdds_thresholds() is not exposed by any binary's CLI, so this compiles
+# a small harness (analysis-ds-firstmatch-harness.c) against the real
+# xymond/client_config.c and lib, loads real hosts.cfg/analysis.cfg fixtures,
+# and counts "modify" lines per RRD key. Three scenarios, keyed by distinct RRD
+# keys so they do not interfere:
+#
+#   k_shadow  : a specific rule that does NOT trigger, then a general rule of the
+#               same colour that WOULD -> 0 modifies. This is the sharp edge of
+#               the fix: the first matching rule claims the target and shadows
+#               the later one even though it never raised a status itself.
+#               Before the fix this scenario emitted 1.
+#   k_colours : a yellow rule and a red rule on the same dataset, both
+#               triggering -> 2 modifies. Guards the other side: the shadow must
+#               be per-colour, so multi-level DS checks keep working. A fix that
+#               shadowed across colours would drop this to 1.
+#   k_first   : two same-colour rules where the FIRST triggers -> 1 modify. The
+#               first-match result; before the fix this emitted 2.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+here=$(dirname "$0")
+
+CLIENT_CONFIG_C="$ROOT/xymond/client_config.c"
+[ -f "$CLIENT_CONFIG_C" ] || skip "xymond/client_config.c not present in this checkout"
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+command -v make  >/dev/null 2>&1 || skip "make not available"
+
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+
+work=$(mktempdir)
+
+make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+pcre_libs=${PCRELIBS:-}
+if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+fi
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" -I"$ROOT/xymond" -o "$work/harness" \
+	"$here/analysis-ds-firstmatch-harness.c" "$CLIENT_CONFIG_C" \
+	"$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+cat >"$work/hosts.cfg" <<'EOF'
+127.0.0.1 testhost #
+EOF
+
+# DS syntax: DS <column> <rrdkey>:<dataset> <threshold> color=<colour>
+# Dataset is always "load"; the harness feeds the value 3.5.
+cat >"$work/analysis.cfg" <<'EOF'
+DS c_shadow  k_shadow:load  >10.0 color=red
+DS c_shadow  k_shadow:load  >1.0  color=red
+DS c_colours k_colours:load >1.0  color=yellow
+DS c_colours k_colours:load >2.0  color=red
+DS c_first   k_first:load   >1.0  color=red
+DS c_first   k_first:load   >2.0  color=red
+EOF
+
+out=$("$work/harness" "$work/hosts.cfg" "$work/analysis.cfg" \
+	load 3.5 k_shadow k_colours k_first 2>"$work/run.log") \
+	|| { cat "$work/run.log" >&2; fail "harness run failed"; }
+
+get() { printf '%s\n' "$out" | sed -n "s/^$1=//p"; }
+
+assert_equal "0" "$(get k_shadow)" \
+	"DS first-match regressed: a non-triggering specific rule no longer shadows a later same-colour rule (#32)"
+assert_equal "2" "$(get k_colours)" \
+	"DS shadowing is too aggressive: yellow and red thresholds on one dataset must both fire (#32)"
+assert_equal "1" "$(get k_first)" \
+	"DS first-match regressed: two same-colour rules both fired instead of the first winning (#32)"
+
+pass "DS threshold rules honour analysis.cfg first-match per (column, dataset, colour) (#32)"

--- a/tests/server/analysis-file-ifexist.sh
+++ b/tests/server/analysis-file-ifexist.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/analysis-file-ifexist.sh
+#
+# Regression guard for IFEXIST being accepted as an alias for OPTIONAL in a
+# FILE rule (analysis.cfg / client-local.cfg), added for compatibility with
+# the long-standing Debian "27_hobbit_files_ifexist" patch.
+#
+# The client-config parser maps both keywords onto the same CHK_OPTIONAL flag,
+# so a rule written with IFEXIST must behave exactly like one written with
+# OPTIONAL: the file check is skipped (no warning) when the target file is
+# absent. The parser is what the alias lives in, and `xymond_client
+# --dump-config` prints CHK_OPTIONAL back as the literal word "OPTIONAL", so
+# the dump is a faithful, build-driven witness of how each rule was parsed.
+#
+# Edge cases pinned here:
+#   - IFEXIST  -> the dumped rule carries OPTIONAL   (the alias resolves)
+#   - OPTIONAL -> the dumped rule carries OPTIONAL   (unchanged baseline)
+#   - neither  -> the dumped rule carries NO OPTIONAL (proves OPTIONAL is not a
+#                 default the dump prints for every FILE rule, so the IFEXIST
+#                 assertion above cannot pass vacuously)
+#
+# Before the alias existed, IFEXIST was an unknown trailing token and the rule
+# dumped without OPTIONAL, so assertion (1) is exactly what regressing the
+# alias would break.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+# Drives the built server-side client-data processor. Skips if unbuilt; a
+# CMake/autopkgtest caller that exports XYMOND_CLIENT to a real path makes a
+# dangling path a failure rather than a skip (see require_bin).
+require_bin XYMOND_CLIENT xymond/xymond_client
+
+work=$(mktempdir)
+
+cat >"$work/analysis.cfg" <<'EOF'
+FILE /xymon-tests/ifexist-target  red IFEXIST
+FILE /xymon-tests/optional-target red OPTIONAL
+FILE /xymon-tests/plain-target    red
+EOF
+
+dump=$("$XYMOND_CLIENT" --config="$work/analysis.cfg" --dump-config 2>/dev/null) \
+	|| fail "xymond_client --dump-config exited non-zero"
+
+# Pick out the three FILE lines by their (unique) filenames.
+ifexist_line=$(printf '%s\n' "$dump" | grep -F '/xymon-tests/ifexist-target')  || true
+optional_line=$(printf '%s\n' "$dump" | grep -F '/xymon-tests/optional-target') || true
+plain_line=$(printf '%s\n' "$dump" | grep -F '/xymon-tests/plain-target')       || true
+
+[ -n "$ifexist_line" ]  || fail "IFEXIST rule missing from dump-config output: $dump"
+[ -n "$optional_line" ] || fail "OPTIONAL rule missing from dump-config output: $dump"
+[ -n "$plain_line" ]    || fail "plain FILE rule missing from dump-config output: $dump"
+
+# (1) IFEXIST resolves to the OPTIONAL flag -- the alias itself.
+assert_contains "OPTIONAL" "$ifexist_line" \
+	"IFEXIST no longer maps to OPTIONAL in a FILE rule (Debian 27_hobbit_files_ifexist compatibility, #161)"
+
+# (2) OPTIONAL keeps meaning OPTIONAL -- the baseline the alias mirrors.
+assert_contains "OPTIONAL" "$optional_line" \
+	"OPTIONAL keyword no longer dumps as OPTIONAL"
+
+# (3) A FILE rule with neither keyword must NOT be marked OPTIONAL, so (1) is a
+# real signal and not something the dump prints for every FILE rule.
+assert_not_contains "OPTIONAL" "$plain_line" \
+	"plain FILE rule is unexpectedly OPTIONAL -- the IFEXIST check would pass vacuously"
+
+pass "IFEXIST parses as an alias for OPTIONAL in FILE rules (#161)"

--- a/tests/server/combostatus-overflow.sh
+++ b/tests/server/combostatus-overflow.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/combostatus-overflow.sh
+#
+# Regression guard for the stack buffer overflow in combostatus evaluate()
+# (issue #187, commit 6252bd9ca).
+#
+# evaluate() formatted a compute() error into a fixed errtext[1024] stack
+# buffer with an unbounded sprintf(), while the expression it interpolates
+# (expr) can be up to MAX_LINE_LEN (16 KB). A combo expression longer than
+# ~990 chars that makes compute() fail overran the stack. The fix bounds the
+# write with snprintf(errtext, sizeof(errtext), ...).
+#
+# evaluate() is static and pulls in compute() and the value machinery, so --
+# like tests/server/digest-md5hash.sh -- this (1) binds to the real source:
+# the bounded snprintf must be present and the unbounded sprintf into errtext
+# gone, and (2) compiles a faithful copy of the format step and shows that a
+# 16 KB expression is written into the 1 KB buffer without touching a trailing
+# canary. The unbounded form is deliberately NOT executed (it is the overflow
+# under test); the demo asserts the fixed form's safety property instead.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SRC="$ROOT/xymond/combostatus.c"
+CC=${CC:-cc}
+
+[ -f "$SRC" ] || skip "xymond/combostatus.c absent"
+
+# (1) Bind to the real code. The fixed line is
+#   snprintf(errtext, sizeof(errtext), "compute(%s)...
+# the bug was an unbounded
+#   sprintf(errtext, "compute(%s)...
+# "sprintf(errtext" is a substring of "snprintf(errtext", so match the buggy
+# form as sprintf NOT preceded by an 'n' -- that fires only on the real bug.
+assert_contains "snprintf(errtext, sizeof(errtext)," "$(cat "$SRC")" \
+	"combostatus.c evaluate() lost the bounded snprintf for the compute() error (#187 / 6252bd9ca)"
+grep -Eq '(^|[^n])sprintf\(errtext,' "$SRC" \
+	&& fail "combostatus.c evaluate() regressed to an unbounded sprintf into errtext[1024] (#187 / 6252bd9ca)"
+
+# (2) Behavioural demo of the property, if we can compile.
+command -v "$CC" >/dev/null 2>&1 \
+	|| pass "combostatus.c keeps the #187 fix (static check; no C compiler for the run)"
+
+work=$(mktempdir)
+cat >"$work/t.c" <<'EOF'
+#include <stdio.h>
+#include <string.h>
+
+#define MAX_LINE_LEN 16384
+
+int main(void)
+{
+	/* Mirror evaluate()'s stack layout: the 1 KB target plus a canary right
+	 * after it, so an overrun of errtext would be observable. */
+	struct { char errtext[1024]; char canary; } s;
+	char expr[MAX_LINE_LEN];
+	int written;
+
+	s.canary = '#';
+	memset(expr, 'A', sizeof(expr) - 1);
+	expr[sizeof(expr) - 1] = '\0';   /* a full 16 KB expression, as compute() may see */
+
+	/* The fixed format step: bounded by the real buffer size. */
+	written = snprintf(s.errtext, sizeof(s.errtext), "compute(%s) returned error %d\n", expr, 7);
+
+	/* snprintf must not have written past the buffer... */
+	if (strlen(s.errtext) >= sizeof(s.errtext)) {
+		fprintf(stderr, "errtext not NUL-bounded: len=%zu\n", strlen(s.errtext));
+		return 1;
+	}
+	/* ...the canary just past it must be intact... */
+	if (s.canary != '#') {
+		fprintf(stderr, "canary clobbered -- errtext overran\n");
+		return 1;
+	}
+	/* ...and snprintf must report the truncation (return >= buffer size), which
+	 * is exactly the signal the unbounded sprintf ignored while overrunning. */
+	if (written < (int)sizeof(s.errtext)) {
+		fprintf(stderr, "expected truncation (written=%d >= %zu)\n", written, sizeof(s.errtext));
+		return 1;
+	}
+	return 0;
+}
+EOF
+
+"$CC" -std=c99 -Wall -Wextra -Werror -o "$work/t" "$work/t.c" 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "combostatus overflow probe did not compile"; }
+"$work/t" || fail "combostatus overflow probe failed: the bounded-format property broke (#187)"
+
+pass "combostatus evaluate() bounds a 16 KB expression into errtext[1024] without overrunning (#187)"

--- a/tests/server/config-include-dir.sh
+++ b/tests/server/config-include-dir.sh
@@ -32,21 +32,33 @@ ROOT=$(find_root)
 
 # ---- (A) shipped configs still declare their drop-in directory -------------
 #
+# These .DIST files are the shipped config *sources*. A build tree or an
+# installed package may not carry them, so gate the whole section on the
+# source tree being present (xymond/etcfiles). Once it is, every expected
+# declaration MUST be there: a deleted file or a commented-out directive is a
+# regression to catch, not a per-file skip.
+[ -d "$ROOT/xymond/etcfiles" ] || skip "shipped config sources absent (xymond/etcfiles) -- not a source tree"
+
 # name -> shipped file. The directive is "optional directory
 # @XYMONHOME@/etc/<name>.d", except the two configs whose basename already
 # carries .cfg keep it in the directory name (xymonserver.cfg.d,
 # xymonclient.cfg.d) -- so assert per-file on its own expected suffix.
 check_declares() {  # check_declares <file> <expected-dir-suffix>
-	local f=$1 suffix=$2
-	[ -f "$f" ] || { skipped_artefacts="$skipped_artefacts $f"; return; }
-	local want="optional directory @XYMONHOME@/etc/$suffix"
-	assert_contains "$want" "$(cat "$f")" \
-		"shipped $(basename "$f") no longer declares its drop-in directory '$want' (#222)"
-	checked_artefacts=$((checked_artefacts + 1))
+	local f=$1 suffix=$2 re
+	# A sparse checkout (e.g. server-only, no client/) may lack a whole
+	# subtree; only require files whose directory is actually present, so such
+	# a tree skips them rather than failing. Within a present directory the
+	# file MUST exist.
+	[ -d "$(dirname "$f")" ] || return 0
+	assert_file_exists "$f" "shipped config $(basename "$f") is missing (#222)"
+	# Match an ACTIVE, whole-line declaration: a commented "# optional
+	# directory ..." (or a fragment on another line) must not satisfy the
+	# guard. Escape the '.' in the suffix so it stays literal in the ERE --
+	# otherwise "alerts.d" would also match "alertsXd".
+	re=$(printf '%s' "$suffix" | sed 's/[.]/\\./g')
+	grep -qE "^[[:space:]]*optional directory @XYMONHOME@/etc/${re}[[:space:]]*\$" "$f" \
+		|| fail "shipped $(basename "$f") has no active 'optional directory @XYMONHOME@/etc/$suffix' line (#222)"
 }
-
-checked_artefacts=0
-skipped_artefacts=""
 
 check_declares "$ROOT/xymond/etcfiles/alerts.cfg.DIST"          "alerts.d"
 check_declares "$ROOT/xymond/etcfiles/analysis.cfg.DIST"        "analysis.d"
@@ -58,9 +70,6 @@ check_declares "$ROOT/xymond/etcfiles/rrddefinitions.cfg.DIST"  "rrddefinitions.
 check_declares "$ROOT/xymond/etcfiles/xymonserver.cfg.DIST"     "xymonserver.cfg.d"
 check_declares "$ROOT/client/clientlaunch.cfg.DIST"             "clientlaunch.d"
 check_declares "$ROOT/client/xymonclient.cfg.DIST"              "xymonclient.cfg.d"
-
-[ "$checked_artefacts" -gt 0 ] || skip "no shipped .DIST configs present in this checkout"
-[ -z "$skipped_artefacts" ] || echo "note: shipped configs absent, not checked:$skipped_artefacts" >&2
 
 # ---- (B) the directive actually works, via the real stackio reader ---------
 

--- a/tests/server/config-include-dir.sh
+++ b/tests/server/config-include-dir.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/config-include-dir.sh
+#
+# Regression guard for the ".d drop-in directory" mechanism shipped for every
+# server and client config (#222): each shipped config ends with
+#
+#     optional directory @XYMONHOME@/etc/<name>.d
+#
+# so packagers and local admins can drop fragments into alerts.d, analysis.d,
+# graphs.d, ... without editing the shipped file. 'optional' means a missing
+# directory is silently ignored; 'directory' reads every file in it.
+#
+# Two things could regress independently, so the test pins both:
+#
+#   (A) Shipped artefact: every .DIST that PR #222 gave a drop-in directory
+#       still declares it. A dropped or mistyped line silently disables the
+#       drop-in for that config, which no build would catch.
+#
+#   (B) Mechanism: the 'optional directory' directive actually merges the
+#       fragments AND tolerates the directory being absent. This is what the
+#       shipped line relies on. Driven through the real stackio reader
+#       (lib/stackio.c) built STANDALONE, with a present dir carrying two
+#       fragments and, for contrast, a missing dir with and without 'optional'.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+# ---- (A) shipped configs still declare their drop-in directory -------------
+#
+# name -> shipped file. The directive is "optional directory
+# @XYMONHOME@/etc/<name>.d", except the two configs whose basename already
+# carries .cfg keep it in the directory name (xymonserver.cfg.d,
+# xymonclient.cfg.d) -- so assert per-file on its own expected suffix.
+check_declares() {  # check_declares <file> <expected-dir-suffix>
+	local f=$1 suffix=$2
+	[ -f "$f" ] || { skipped_artefacts="$skipped_artefacts $f"; return; }
+	local want="optional directory @XYMONHOME@/etc/$suffix"
+	assert_contains "$want" "$(cat "$f")" \
+		"shipped $(basename "$f") no longer declares its drop-in directory '$want' (#222)"
+	checked_artefacts=$((checked_artefacts + 1))
+}
+
+checked_artefacts=0
+skipped_artefacts=""
+
+check_declares "$ROOT/xymond/etcfiles/alerts.cfg.DIST"          "alerts.d"
+check_declares "$ROOT/xymond/etcfiles/analysis.cfg.DIST"        "analysis.d"
+check_declares "$ROOT/xymond/etcfiles/combo.cfg.DIST"           "combo.d"
+check_declares "$ROOT/xymond/etcfiles/graphs.cfg.DIST"          "graphs.d"
+check_declares "$ROOT/xymond/etcfiles/hosts.cfg.DIST"           "hosts.d"
+check_declares "$ROOT/xymond/etcfiles/client-local.cfg.DIST"    "client-local.d"
+check_declares "$ROOT/xymond/etcfiles/rrddefinitions.cfg.DIST"  "rrddefinitions.d"
+check_declares "$ROOT/xymond/etcfiles/xymonserver.cfg.DIST"     "xymonserver.cfg.d"
+check_declares "$ROOT/client/clientlaunch.cfg.DIST"             "clientlaunch.d"
+check_declares "$ROOT/client/xymonclient.cfg.DIST"              "xymonclient.cfg.d"
+
+[ "$checked_artefacts" -gt 0 ] || skip "no shipped .DIST configs present in this checkout"
+[ -z "$skipped_artefacts" ] || echo "note: shipped configs absent, not checked:$skipped_artefacts" >&2
+
+# ---- (B) the directive actually works, via the real stackio reader ---------
+
+CC=${CC:-cc}
+if ! command -v "$CC" >/dev/null 2>&1 \
+	|| [ ! -f "$ROOT/include/config.h" ] || [ ! -f "$ROOT/lib/libxymoncomm.a" ]; then
+	pass "shipped configs declare their drop-in directories (#222); stackio mechanism check skipped (tree not built)"
+fi
+
+work=$(mktempdir)
+
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+pcre_libs=${PCRELIBS:-}
+if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+fi
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+"$CC" -DSTANDALONE -I"$ROOT/include" -I"$ROOT/lib" -o "$work/stackio" \
+	"$ROOT/lib/stackio.c" "$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "standalone stackio does not compile"; }
+
+# The STANDALONE reader reads argv[1] via stackfgets() (which expands include
+# directives), prints every line, then prompts on stdin -- feed it '.' to quit.
+render() { printf '.\n' | "$work/stackio" "$1" 2>"$work/err.log"; }
+
+mkdir -p "$work/frags"
+printf 'FRAGMENT_ALPHA\n' >"$work/frags/10-alpha.cfg"
+printf 'FRAGMENT_BETA\n'  >"$work/frags/20-beta.cfg"
+
+# Present directory: both fragments are merged into the stream.
+printf 'BASELINE_LINE\noptional directory %s\n' "$work/frags" >"$work/present.cfg"
+out=$(render "$work/present.cfg")
+assert_contains "BASELINE_LINE"   "$out" "stackio dropped the base config line"
+assert_contains "FRAGMENT_ALPHA"  "$out" "'optional directory' did not merge a drop-in fragment (#222)"
+assert_contains "FRAGMENT_BETA"   "$out" "'optional directory' merged only the first fragment (#222)"
+
+# Missing directory + 'optional': silently ignored, no WARNING.
+printf 'BASELINE_LINE\noptional directory %s/absent\n' "$work" >"$work/missing.cfg"
+render "$work/missing.cfg" >/dev/null
+assert_not_contains "WARNING" "$(cat "$work/err.log")" \
+	"a missing 'optional directory' warned instead of being silently ignored (#222)"
+
+# Contrast: without 'optional', a missing directory DOES warn -- proves the
+# silence above is the 'optional' keyword doing its job, not a dead code path.
+printf 'BASELINE_LINE\ndirectory %s/absent\n' "$work" >"$work/missing-required.cfg"
+render "$work/missing-required.cfg" >/dev/null
+assert_contains "WARNING" "$(cat "$work/err.log")" \
+	"a missing non-optional 'directory' unexpectedly stayed silent -- the optional contrast is meaningless"
+
+pass "shipped configs declare drop-in dirs and 'optional directory' merges fragments / tolerates absence (#222)"

--- a/tests/server/namematch-case.sh
+++ b/tests/server/namematch-case.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/namematch-case.sh
+#
+# Regression guard for namematch() doing case-insensitive comparison of the
+# plain (no-wildcard) name list (#182).
+#
+# namematch(needle, haystack, NULL) tokenises a comma-separated haystack and
+# compares each token to needle. #182 switched those comparisons from strcmp()
+# to strcasecmp() so that e.g. a hosts.cfg tag list written "CONN" matches the
+# test named "conn". Negated tokens ("!name") must fold case the same way.
+#
+# namematch() is exported from libxymon, so this compiles a tiny harness that
+# links the real library and drives the function directly. No wildcard/regex
+# path is exercised here (that goes through PCRE and is unchanged); only the
+# plain-list branch, which is what #182 touched.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+[ -f "$ROOT/lib/libxymoncomm.a" ] || skip "tree not built (lib/libxymoncomm.a absent)"
+
+work=$(mktempdir)
+
+make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+pcre_libs=${PCRELIBS:-}
+if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+fi
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+cat >"$work/harness.c" <<'EOF'
+#include <stdio.h>
+#include "libxymon.h"
+
+/* namematch() may write into its haystack (strtok_r), so pass writable copies. */
+static int nm(const char *needle, const char *haystack)
+{
+	char buf[256];
+	snprintf(buf, sizeof(buf), "%s", haystack);
+	return namematch(needle, buf, NULL);
+}
+
+int main(void)
+{
+	int fails = 0;
+#define CHECK(needle, haystack, want) do { \
+	int got = nm((needle), (haystack)); \
+	if (got != (want)) { \
+		fprintf(stderr, "namematch(\"%s\", \"%s\") = %d, want %d\n", \
+			(needle), (haystack), got, (want)); \
+		fails++; \
+	} \
+} while (0)
+
+	/* Case-insensitivity, both directions (the #182 change). */
+	CHECK("conn", "CONN", 1);
+	CHECK("CONN", "conn", 1);
+	CHECK("Conn", "coNN", 1);
+	/* Within a comma list, a later mixed-case token still matches. */
+	CHECK("disk", "cpu,DISK,mem", 1);
+	/* A genuine non-match must still be a non-match (not everything passes). */
+	CHECK("http", "cpu,disk,mem", 0);
+	/* Negation folds case the same way: "!CONN" excludes "conn". */
+	CHECK("conn", "!CONN", 0);
+	/* Exact-case behaviour is unchanged. */
+	CHECK("cpu", "cpu", 1);
+
+	if (fails) { fprintf(stderr, "%d namematch case checks failed\n", fails); return 1; }
+	return 0;
+}
+EOF
+
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+"$work/harness" 2>"$work/run.log" \
+	|| fail "namematch case-insensitivity regressed (#182):
+$(cat "$work/run.log")"
+
+pass "namematch() compares the plain name list case-insensitively, negation included (#182)"

--- a/tests/web/svcstatus-scriptname.sh
+++ b/tests/web/svcstatus-scriptname.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/svcstatus-scriptname.sh
+#
+# Regression guard for svcstatus crashing when SCRIPT_NAME is unset
+# (commit f01d07dfa).
+#
+# parse_query() built the client URI from getenv("SCRIPT_NAME") and ran
+# strlen() on it unchecked. A web server always sets SCRIPT_NAME, but any
+# other invocation -- a shell, a test harness, a misconfigured wrapper --
+# left it NULL and svcstatus segfaulted in parse_query() before emitting a
+# single line. The fix substitutes "" for a missing SCRIPT_NAME.
+#
+# This drives the built svcstatus.cgi with SCRIPT_NAME removed from the
+# environment and a minimal status request, and asserts it does NOT die from
+# a signal. parse_query() runs before any host lookup, so no Xymon server is
+# needed: past the fix the request simply fails later (unknown host, exit 1);
+# without the fix it is killed by SIGSEGV (exit 139) inside parse_query().
+# The discriminator is therefore "terminated by a signal" (exit >= 128), not
+# a specific non-zero code.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin SVCSTATUS_CGI web/svcstatus.cgi
+
+work=$(mktempdir)
+
+# Wrap in `timeout` when available so a stray local xymond that keeps the
+# connection open makes the test time out rather than stall the suite. The
+# request is minimal but well-formed enough to reach the FRM_STATUS branch
+# that touches SCRIPT_NAME; the crash (or its absence) is decided in
+# parse_query(), before the host is ever looked up.
+runner=("$SVCSTATUS_CGI")
+command -v timeout >/dev/null 2>&1 && runner=(timeout 30 "$SVCSTATUS_CGI")
+
+set +e
+env -u SCRIPT_NAME \
+	REQUEST_METHOD=GET \
+	QUERY_STRING="HOST=nosuchhost.example&SERVICE=conn" \
+	XYMONHOME="$work" XYMONHISTLOGS="$work" \
+	"${runner[@]}" >/dev/null 2>&1
+rc=$?
+set -e
+
+# 124 = timeout fired (environment problem, not the bug under test).
+[ "$rc" -ne 124 ] || skip "svcstatus.cgi did not return within the time limit (environment)"
+
+# The bug manifests as termination by a signal: exit code >= 128. SIGSEGV
+# gives 139. A graceful failure (unknown host with no server) is < 128.
+if [ "$rc" -ge 128 ]; then
+	sig=$((rc - 128))
+	fail "svcstatus.cgi was killed by signal $sig with SCRIPT_NAME unset -- parse_query() crash regressed (f01d07dfa)"
+fi
+
+pass "svcstatus.cgi survives a missing SCRIPT_NAME (exit $rc, no signal)"


### PR DESCRIPTION
A regression audit of recently merged behavioural changes against `tests/`
surfaced user-visible features and fixes that shipped without a guard. This
adds one focused test per item (one commit each), each pinning the actual edge
case rather than a smoke path, and each verified against a pre-fix build/source
so the assertion provably catches the regression. All run under
`./tests/testsuite` and skip cleanly on an unbuilt tree.

### Behavioural (compile/run and check output)

**1. FILE `IFEXIST` alias for `OPTIONAL` (#161)** —
`tests/server/analysis-file-ifexist.sh` drives `xymond_client --dump-config`
over a FILE rule written three ways; asserts `IFEXIST` folds onto the same
`OPTIONAL` flag, `OPTIONAL` is unchanged, and a bare FILE rule is *not*
`OPTIONAL` (so the alias assertion can't pass vacuously).

**2. analysis.cfg first-match for DS rules (#32)** —
`check_rrdds_thresholds()` has no CLI, so `analysis-ds-firstmatch.sh` compiles a
harness against the real `xymond/client_config.c` and counts `modify` lines per
RRD key. Three scenarios pin both sides: a non-triggering specific rule shadows
a later same-colour rule (0, was 1); yellow + red on one dataset both still fire
(2, shadow stays per-colour); two same-colour rules resolve to the first (1, was
2).

**3. Shipped `.d` drop-in directories (#222)** —
`config-include-dir.sh` asserts every server/client `.DIST` still declares its
`optional directory @XYMONHOME@/etc/<name>.d`, then drives the real stackio
reader built `STANDALONE` to show a present dir merges its fragments, a missing
`optional directory` is silent, and a missing non-optional `directory` still
warns (proving the silence is the `optional` keyword).

**4. svcstatus crash on missing `SCRIPT_NAME` (f01d07dfa)** —
`tests/web/svcstatus-scriptname.sh` runs the built `svcstatus.cgi` with
`SCRIPT_NAME` unset and asserts it is not killed by a signal. `parse_query()`
touches `SCRIPT_NAME` before any host lookup, so no server is needed; the
unguarded `strlen(NULL)` segfaults (139) while the fix exits 1.

**5. namematch() case-insensitive name lists (#182)** —
`tests/server/namematch-case.sh` links libxymon and calls `namematch()` directly
on the plain-list branch #182 switched from `strcmp()` to `strcasecmp()`: both
case directions, a mixed-case token in a comma list, negation, and a genuine
non-match (so it can't pass by matching everything).

### Hybrid source-bind + compiled property demo (static targets, following `digest-md5hash.sh`)

**6. .netrc password off-by-one (#226)** —
`tests/network/netrc-password.sh` binds to `url.c` (corrected `login_len + 1`
present, the one-short `login_len` gone) and compiles a faithful copy of the
pack step showing the fixed size keeps the whole `login:password` while the
short size drops the last character. `load_netrc()` is static.

**7. combostatus evaluate() stack overflow (#187)** —
`tests/server/combostatus-overflow.sh` binds to `combostatus.c` (bounded
`snprintf` present, unbounded `sprintf` into `errtext[1024]` gone) and compiles
a faithful copy showing a 16 KB expression is bounded into the 1 KB buffer with
a trailing canary intact. `evaluate()` is static; the unbounded form is not
executed — it is the overflow under test.