### PR TITLE
xymond_history: validate command-line options

### DIFF
--- a/docs/manpages/man8/xymond_history.8.html
+++ b/docs/manpages/man8/xymond_history.8.html
@@ -41,34 +41,38 @@ Section: Maintenance Commands (8)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a
 <dl class="Bl-tag">
   <dt id="histdir"><a class="permalink" href="#histdir"><b>--histdir</b>=<i>DIRECTORY</i></a></dt>
   <dd>The directory for the history files. If not specified, the directory given
-      by the XYMONHISTDIR environment is used.
+      by the XYMONHISTDIR environment is used. An empty directory name produces
+      an error and prevents xymond_history from starting.
     <p class="Pp"></p>
   </dd>
   <dt id="histlogdir"><a class="permalink" href="#histlogdir"><b>--histlogdir</b>=<i>DIRECTORY</i></a></dt>
   <dd>The directory for the historical status-logs. If not specified, the
-      directory given by the XYMONHISTLOGS environment is used.
+      directory given by the XYMONHISTLOGS environment is used. An empty
+      directory name produces an error and prevents xymond_history from
+      starting.
     <p class="Pp"></p>
   </dd>
   <dt id="minimum-free"><a class="permalink" href="#minimum-free"><b>--minimum-free</b>=<i>N</i></a></dt>
   <dd>Sets the minimum percentage of free filesystem space on the $XYMONHISTLOGS
       directory. If there is less than N% free space, xymond_history will not
       save the detailed status-logs. N is a percentage between 0 and 100; 0
-      disables the free-space check. The value must be a plain integer; anything
-      else (including a &quot;%&quot; suffix) falls back to the default.
-      Out-of-range values are clamped. Default: 5
+      disables the free-space check. The value must be a plain integer; invalid
+      or negative values produce a warning and use the default of 5. Values
+      above 100 produce a warning and are capped at 100.
     <p class="Pp"></p>
   </dd>
   <dt id="pidfile"><a class="permalink" href="#pidfile"><b>--pidfile</b>=<i>FILENAME</i></a></dt>
   <dd>xymond_history writes the process-ID it is running with to this file. This
       is for use in automated startup scripts. The default file is
-      $XYMONSERVERLOGS/xymond_history.pid.
+      $XYMONSERVERLOGS/xymond_history.pid. An empty filename produces an error
+      and prevents xymond_history from starting.
     <p class="Pp"></p>
   </dd>
   <dt id="debug"><a class="permalink" href="#debug"><b>--debug</b></a></dt>
-  <dd>Enable debugging output.
-    <p class="Pp"></p>
-  </dd>
+  <dd>Enable debugging output.</dd>
 </dl>
+<p class="Pp">Unknown options produce a warning and are ignored.</p>
+<p class="Pp"></p>
 </section>
 <section class="Sh">
 <p>&#160;</p>

--- a/docs/manpages/man8/xymond_history.8.html
+++ b/docs/manpages/man8/xymond_history.8.html
@@ -41,35 +41,35 @@ Section: Maintenance Commands (8)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a
 <dl class="Bl-tag">
   <dt id="histdir"><a class="permalink" href="#histdir"><b>--histdir</b>=<i>DIRECTORY</i></a></dt>
   <dd>The directory for the history files. If not specified, the directory given
-      by the XYMONHISTDIR environment is used. An empty directory name produces
-      an error and prevents xymond_history from starting.
+      by the XYMONHISTDIR environment is used.
     <p class="Pp"></p>
   </dd>
   <dt id="histlogdir"><a class="permalink" href="#histlogdir"><b>--histlogdir</b>=<i>DIRECTORY</i></a></dt>
   <dd>The directory for the historical status-logs. If not specified, the
-      directory given by the XYMONHISTLOGS environment is used. An empty
-      directory name produces an error and prevents xymond_history from
-      starting.
+      directory given by the XYMONHISTLOGS environment is used.
     <p class="Pp"></p>
   </dd>
   <dt id="minimum-free"><a class="permalink" href="#minimum-free"><b>--minimum-free</b>=<i>N</i></a></dt>
   <dd>Sets the minimum percentage of free filesystem space on the $XYMONHISTLOGS
       directory. If there is less than N% free space, xymond_history will not
       save the detailed status-logs. N is a percentage between 0 and 100; 0
-      disables the free-space check. The value must be a plain integer; invalid
-      or negative values produce a warning and use the default of 5. Values
-      above 100 produce a warning and are capped at 100.
+      disables the free-space check. The value must be a plain integer. Invalid
+      values produce a warning and use the default of 5. Negative values produce
+      a warning and are clamped to 0, preserving their historical meaning of
+      disabling the check. Values above 100 produce a warning and are capped at
+      100.
     <p class="Pp"></p>
   </dd>
   <dt id="pidfile"><a class="permalink" href="#pidfile"><b>--pidfile</b>=<i>FILENAME</i></a></dt>
   <dd>xymond_history writes the process-ID it is running with to this file. This
       is for use in automated startup scripts. The default file is
-      $XYMONSERVERLOGS/xymond_history.pid. An empty filename produces an error
-      and prevents xymond_history from starting.
+      $XYMONSERVERLOGS/xymond_history.pid. If the file cannot be opened or
+      written, a warning identifies the path and history processing continues.
     <p class="Pp"></p>
   </dd>
-  <dt id="debug"><a class="permalink" href="#debug"><b>--debug</b></a></dt>
-  <dd>Enable debugging output.</dd>
+  <dt id="debug"><a class="permalink" href="#debug"><b>--debug</b>[=VALUE]</a></dt>
+  <dd>Enable debugging output. Suffixed forms such as <b>--debug=1</b> are
+      accepted for compatibility.</dd>
 </dl>
 <p class="Pp">Unknown options produce a warning and are ignored.</p>
 <p class="Pp"></p>

--- a/tests/server/xymond-history-options.sh
+++ b/tests/server/xymond-history-options.sh
@@ -8,34 +8,53 @@ set -euo pipefail
 require_bin XYMOND_HISTORY xymond/xymond_history
 
 work=$(mktempdir)
-mkdir -p "$work/hist"
+mkdir -p "$work/hist" "$work/histlogs"
+input=/dev/null
+allhist=TRUE
+hosthist=FALSE
+statuslogs=FALSE
+pidarg="--pidfile=$work/xymond_history.pid"
+
+printf '%s\n' \
+	'@@stachg#1|1586206051.00000|127.0.0.1|xymond|test.host|disk|1586206351|red|green|1586205451|0||0|0|' \
+	'body' '@@' > "$work/message"
 
 run_history() {
 	set +e
 	output=$(env \
 		XYMONSERVERLOGS="$work" \
-		XYMONALLHISTLOG=TRUE \
-		XYMONHOSTHISTLOG=FALSE \
-		SAVESTATUSLOG=FALSE \
+		XYMONHISTLOGS="$work/histlogs" \
+		XYMONALLHISTLOG="$allhist" \
+		XYMONHOSTHISTLOG="$hosthist" \
+		SAVESTATUSLOG="$statuslogs" \
 		"$XYMOND_HISTORY" \
 		--histdir="$work/hist" \
-		--pidfile="$work/xymond_history.pid" \
-		"$@" </dev/null 2>&1)
+		${pidarg:+"$pidarg"} \
+		"$@" <"$input" 2>&1)
 	status=$?
 	set -e
 }
 
+input="$work/message"
+statuslogs=TRUE
 run_history --minimum-free=junk
 assert_equal 0 "$status" "invalid minimum-free must fall back without aborting"
-assert_contains "is invalid (must be 0 through 100), using default 5" "$output" \
+assert_contains "is not a plain integer, using default 5" "$output" \
 	"invalid minimum-free must warn"
 
-run_history --minimum-free=-1
-assert_equal 0 "$status" "negative minimum-free must fall back without aborting"
-assert_contains "is invalid (must be 0 through 100), using default 5" "$output" \
-	"negative minimum-free must warn"
+run_history --minimum-free=10%
+assert_equal 0 "$status" "minimum-free with a unit must fall back without aborting"
+assert_contains "--minimum-free=10% is not a plain integer, using default 5" "$output" \
+	"minimum-free with a unit must be rejected as a non-integer"
 
-run_history --minimum-free=101
+run_history --minimum-free=-5
+assert_equal 0 "$status" "negative minimum-free must retain compatibility"
+assert_contains "is below 0, using 0" "$output" \
+	"negative minimum-free must clamp to its historical disabled value"
+assert_not_contains "less than" "$output" \
+	"negative minimum-free must keep the free-space check disabled"
+
+run_history --minimum-free=200
 assert_equal 0 "$status" "minimum-free above 100 must be capped without aborting"
 assert_contains "is too large, capping at 100" "$output" \
 	"minimum-free above 100 must warn"
@@ -51,31 +70,116 @@ for boundary in 0 100; do
 	assert_not_contains "is invalid" "$output" "valid boundary must not warn"
 	assert_not_contains "capping" "$output" "valid boundary must not be capped"
 done
+run_history --minimum-free=0
+assert_not_contains "less than" "$output" \
+	"minimum-free=0 must disable the runtime free-space check"
+input=/dev/null
+statuslogs=FALSE
 
 run_history --definitely-invalid
 assert_equal 0 "$status" "unknown option must be ignored"
 assert_contains "Unknown option '--definitely-invalid' - ignored" "$output" \
 	"ignored unknown option must identify itself"
 
-run_history --debugging
-assert_equal 0 "$status" "an option extending --debug must be ignored"
-assert_contains "Unknown option '--debugging' - ignored" "$output" \
-	"--debug must require an exact match and report the ignored option"
+for debugopt in --debug --debug=1; do
+	run_history "$debugopt"
+	assert_equal 0 "$status" "$debugopt must retain debug compatibility"
+	assert_not_contains "Unknown option" "$output" \
+		"$debugopt must still enable debug mode"
+	assert_contains "get_xymond_message:" "$output" \
+		"$debugopt must produce debug output"
+done
 
+allhist=FALSE
 run_history --histdir=
-[ "$status" -ne 0 ] || fail "empty history directory must prevent startup"
-assert_contains "No history directory given, aborting" "$output" \
-	"empty history directory must explain the failure"
+assert_equal 0 "$status" "empty history directory must retain upgrade compatibility"
 
+statuslogs=TRUE
+input="$work/message"
+rm -f "$work/hist/test,host.disk"
 run_history --histlogdir=
-[ "$status" -ne 0 ] || fail "empty history-log directory must prevent startup"
-assert_contains "History-log directory cannot be empty" "$output" \
-	"empty history-log directory must explain the failure"
+assert_equal 0 "$status" "empty history-log directory must not prevent startup"
+assert_file_exists "$work/hist/test,host.disk" \
+	"empty history-log directory must not prevent message processing"
+input=/dev/null
 
+statuslogs=FALSE
 run_history --pidfile=
-[ "$status" -ne 0 ] || fail "empty pidfile must prevent startup"
-assert_contains "Pidfile path cannot be empty" "$output" \
-	"empty pidfile must explain the failure"
+assert_equal 0 "$status" "empty pidfile must not prevent history processing"
+assert_contains "Cannot open PID file ''" "$output" \
+	"empty pidfile must report the unusable path"
+
+pidarg=
+history_fifo="$work/history-input"
+mkfifo "$history_fifo"
+env \
+	XYMONSERVERLOGS="$work" \
+	XYMONHISTLOGS="$work/histlogs" \
+	XYMONALLHISTLOG=FALSE \
+	XYMONHOSTHISTLOG=FALSE \
+	SAVESTATUSLOG=FALSE \
+	"$XYMOND_HISTORY" \
+	--histdir="$work/hist" \
+	<"$history_fifo" >"$work/default-pid.log" 2>&1 &
+history_worker=$!
+register_cleanup "kill $history_worker 2>/dev/null"
+exec 3>"$history_fifo"
+for _ in {1..1000}; do
+	[ -s "$work/xymond_history.pid" ] && break
+done
+assert_file_exists "$work/xymond_history.pid" "default pidfile"
+default_pid=$(cat "$work/xymond_history.pid")
+assert_match '^[0-9]+$' "$default_pid" "default pidfile must contain a PID"
+kill -0 "$default_pid" 2>/dev/null || fail "default pidfile does not identify the running worker"
+exec 3>&-
+set +e
+wait "$history_worker"
+status=$?
+set -e
+assert_equal 0 "$status" "default pidfile path must work"
+[ ! -e "$work/xymond_history.pid" ] || \
+	fail "default pidfile was not removed on clean shutdown"
+
+pidarg="--pidfile=/dev/full"
+run_history
+assert_equal 0 "$status" "pidfile write failure must not stop history processing"
+assert_contains "Cannot write PID file '/dev/full'" "$output" \
+	"pidfile close failure must identify the path"
+
+pidarg="--pidfile=$work/pid-link"
+ln -s "$work/hist" "$work/pid-link"
+run_history
+assert_equal 0 "$status" "pidfile open failure must not stop history processing"
+assert_contains "Cannot open PID file '$work/pid-link'" "$output" \
+	"pidfile failure must identify the path"
+[ -L "$work/pid-link" ] || fail "worker removed a pidfile it never opened"
+rm "$work/pid-link"
+
+pidarg="--pidfile=$work/stale.pid"
+allhist=TRUE
+run_history --histdir="$work/missing"
+[ "$status" -ne 0 ] || fail "unopenable allevents path must prevent startup"
+[ ! -e "$work/stale.pid" ] || \
+	fail "startup validation failure left a stale pidfile"
+
+allhist=TRUE
+hosthist=TRUE
+long_testname=$(printf 't%.0s' {1..5000})
+rm -f "$work/hist/allevents" "$work/hist/short.host"
+printf '@@stachg#1|1586206051.00000|127.0.0.1|xymond|short.host|%s|1586206351|red|green|1586205451|0||0|0|\nbody\n@@\n' \
+	"$long_testname" > "$work/message"
+input="$work/message"
+run_history
+assert_equal 0 "$status" "long message-derived path must not crash"
+assert_contains "History path is too long" "$output" \
+	"long message-derived path must be rejected"
+[ -s "$work/hist/allevents" ] || \
+	fail "rejected status path suppressed the all-events record"
+[ -s "$work/hist/short.host" ] || \
+	fail "rejected status path suppressed the per-host record"
+input=/dev/null
+allhist=FALSE
+hosthist=FALSE
 
 long_pidfile=$(printf 'x%.0s' {1..5000})
 run_history --pidfile="$long_pidfile"

--- a/tests/server/xymond-history-options.sh
+++ b/tests/server/xymond-history-options.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMOND_HISTORY xymond/xymond_history
+
+work=$(mktempdir)
+mkdir -p "$work/hist"
+
+run_history() {
+	set +e
+	output=$(env \
+		XYMONSERVERLOGS="$work" \
+		XYMONALLHISTLOG=TRUE \
+		XYMONHOSTHISTLOG=FALSE \
+		SAVESTATUSLOG=FALSE \
+		"$XYMOND_HISTORY" \
+		--histdir="$work/hist" \
+		--pidfile="$work/xymond_history.pid" \
+		"$@" </dev/null 2>&1)
+	status=$?
+	set -e
+}
+
+run_history --minimum-free=junk
+assert_equal 0 "$status" "invalid minimum-free must fall back without aborting"
+assert_contains "is invalid (must be 0 through 100), using default 5" "$output" \
+	"invalid minimum-free must warn"
+
+run_history --minimum-free=-1
+assert_equal 0 "$status" "negative minimum-free must fall back without aborting"
+assert_contains "is invalid (must be 0 through 100), using default 5" "$output" \
+	"negative minimum-free must warn"
+
+run_history --minimum-free=101
+assert_equal 0 "$status" "minimum-free above 100 must be capped without aborting"
+assert_contains "is too large, capping at 100" "$output" \
+	"minimum-free above 100 must warn"
+
+run_history --minimum-free=99999999999999999999999999999999999999
+assert_equal 0 "$status" "overflowing minimum-free must be capped without aborting"
+assert_contains "is too large, capping at 100" "$output" \
+	"overflowing minimum-free must warn"
+
+for boundary in 0 100; do
+	run_history --minimum-free="$boundary"
+	assert_equal 0 "$status" "minimum-free=$boundary must be accepted"
+	assert_not_contains "is invalid" "$output" "valid boundary must not warn"
+	assert_not_contains "capping" "$output" "valid boundary must not be capped"
+done
+
+run_history --definitely-invalid
+assert_equal 0 "$status" "unknown option must be ignored"
+assert_contains "Unknown option '--definitely-invalid' - ignored" "$output" \
+	"ignored unknown option must identify itself"
+
+run_history --debugging
+assert_equal 0 "$status" "an option extending --debug must be ignored"
+assert_contains "Unknown option '--debugging' - ignored" "$output" \
+	"--debug must require an exact match and report the ignored option"
+
+run_history --histdir=
+[ "$status" -ne 0 ] || fail "empty history directory must prevent startup"
+assert_contains "No history directory given, aborting" "$output" \
+	"empty history directory must explain the failure"
+
+run_history --histlogdir=
+[ "$status" -ne 0 ] || fail "empty history-log directory must prevent startup"
+assert_contains "History-log directory cannot be empty" "$output" \
+	"empty history-log directory must explain the failure"
+
+run_history --pidfile=
+[ "$status" -ne 0 ] || fail "empty pidfile must prevent startup"
+assert_contains "Pidfile path cannot be empty" "$output" \
+	"empty pidfile must explain the failure"
+
+long_pidfile=$(printf 'x%.0s' {1..5000})
+run_history --pidfile="$long_pidfile"
+assert_equal 0 "$status" "long pidfile must not overflow fixed storage"
+assert_contains "Cannot open PID file" "$output" \
+	"an unusable long pidfile must report the filesystem error"
+
+pass "xymond_history validates numeric, path, and unknown options"

--- a/xymond/xymond_history.8
+++ b/xymond/xymond_history.8
@@ -15,31 +15,31 @@ that is compatible with the standard Big Brother daemon, bbd.
 .SH OPTIONS
 .IP "\fB\-\-histdir\fR=\fIDIRECTORY\fR"
 The directory for the history files. If not specified, the
-directory given by the XYMONHISTDIR environment is used. An empty directory
-name produces an error and prevents xymond_history from starting.
+directory given by the XYMONHISTDIR environment is used.
 
 .IP "\fB\-\-histlogdir\fR=\fIDIRECTORY\fR"
 The directory for the historical status-logs. If not specified, the
-directory given by the XYMONHISTLOGS environment is used. An empty directory
-name produces an error and prevents xymond_history from starting.
+directory given by the XYMONHISTLOGS environment is used.
 
 .IP "\fB\-\-minimum\-free\fR=\fIN\fR"
 Sets the minimum percentage of free filesystem space on the $XYMONHISTLOGS
 directory. If there is less than N% free space, xymond_history will
 not save the detailed status-logs.
 N is a percentage between 0 and 100; 0 disables the free-space check.
-The value must be a plain integer; invalid or negative values produce a warning
-and use the default of 5. Values above 100 produce a warning and are capped at
-100.
+The value must be a plain integer. Invalid values produce a warning and use the
+default of 5. Negative values produce a warning and are clamped to 0, preserving
+their historical meaning of disabling the check. Values above 100 produce a
+warning and are capped at 100.
 
 .IP "\fB\-\-pidfile\fR=\fIFILENAME\fR"
 xymond_history writes the process-ID it is running with to this file.
 This is for use in automated startup scripts. The default file is
-$XYMONSERVERLOGS/xymond_history.pid. An empty filename produces an error and
-prevents xymond_history from starting.
+$XYMONSERVERLOGS/xymond_history.pid. If the file cannot be opened or written,
+a warning identifies the path and history processing continues.
 
-.IP "\fB\-\-debug\fR"
-Enable debugging output.
+.IP "\fB\-\-debug\fR[=VALUE]"
+Enable debugging output. Suffixed forms such as \fB\-\-debug=1\fR are accepted
+for compatibility.
 .PP
 Unknown options produce a warning and are ignored.
 

--- a/xymond/xymond_history.8
+++ b/xymond/xymond_history.8
@@ -15,28 +15,33 @@ that is compatible with the standard Big Brother daemon, bbd.
 .SH OPTIONS
 .IP "\fB\-\-histdir\fR=\fIDIRECTORY\fR"
 The directory for the history files. If not specified, the
-directory given by the XYMONHISTDIR environment is used.
+directory given by the XYMONHISTDIR environment is used. An empty directory
+name produces an error and prevents xymond_history from starting.
 
 .IP "\fB\-\-histlogdir\fR=\fIDIRECTORY\fR"
 The directory for the historical status-logs. If not specified, the
-directory given by the XYMONHISTLOGS environment is used.
+directory given by the XYMONHISTLOGS environment is used. An empty directory
+name produces an error and prevents xymond_history from starting.
 
 .IP "\fB\-\-minimum\-free\fR=\fIN\fR"
 Sets the minimum percentage of free filesystem space on the $XYMONHISTLOGS
 directory. If there is less than N% free space, xymond_history will
 not save the detailed status-logs.
 N is a percentage between 0 and 100; 0 disables the free-space check.
-The value must be a plain integer; anything else (including a "%"
-suffix) falls back to the default. Out-of-range values are clamped.
-Default: 5
+The value must be a plain integer; invalid or negative values produce a warning
+and use the default of 5. Values above 100 produce a warning and are capped at
+100.
 
 .IP "\fB\-\-pidfile\fR=\fIFILENAME\fR"
 xymond_history writes the process-ID it is running with to this file.
 This is for use in automated startup scripts. The default file is
-$XYMONSERVERLOGS/xymond_history.pid.
+$XYMONSERVERLOGS/xymond_history.pid. An empty filename produces an error and
+prevents xymond_history from starting.
 
 .IP "\fB\-\-debug\fR"
 Enable debugging output.
+.PP
+Unknown options produce a warning and are ignored.
 
 .SH ENVIRONMENT
 .IP "\fBXYMONALLHISTLOG\fR"

--- a/xymond/xymond_history.c
+++ b/xymond/xymond_history.c
@@ -27,6 +27,7 @@ static char rcsid[] = "$Id$";
 #include <sys/wait.h>
 #include <time.h>
 #include <limits.h>
+#include <stdarg.h>
 
 #include "libxymon.h"
 
@@ -59,24 +60,21 @@ typedef struct columndef_t {
 } columndef_t;
 void * columndefs;
 
-static int parse_minimum_free(char *arg)
+static int format_path(char *buffer, size_t size, const char *format, ...)
 {
-	char *value = strchr(arg, '=') + 1;
-	char *endp;
-	long result;
+	va_list args;
+	int result;
 
-	errno = 0;
-	result = strtol(value, &endp, 10);
-	if ((endp == value) || (*endp != '\0') || (result < 0)) {
-		errprintf("%s is invalid (must be 0 through 100), using default %d\n", arg, DEFAULT_MINLOGSPACE);
-		return DEFAULT_MINLOGSPACE;
-	}
-	if ((errno == ERANGE) || (result > 100)) {
-		errprintf("%s is too large, capping at 100\n", arg);
-		return 100;
+	va_start(args, format);
+	result = vsnprintf(buffer, size, format, args);
+	va_end(args);
+	if ((result < 0) || (result >= (int)size)) {
+		buffer[0] = '\0';
+		errprintf("History path is too long\n");
+		return 0;
 	}
 
-	return (int)result;
+	return 1;
 }
 
 int main(int argc, char *argv[])
@@ -85,7 +83,7 @@ int main(int argc, char *argv[])
 	char *histdir = NULL;
 	char *histlogdir = NULL;
 	char *msg;
-	int argi, seq, pathlen;
+	int argi, seq;
 	int save_allevents = 1;
 	int save_hostevents = 1;
 	int save_statusevents = 1;
@@ -97,6 +95,7 @@ int main(int argc, char *argv[])
 	char oldcol2[3];
 	char alleventsfn[PATH_MAX];
 	char *pidfile = NULL;
+	int pidfile_created = 0;
 	int logdirfull = 0;
 	int minlogspace = DEFAULT_MINLOGSPACE;
 
@@ -120,17 +119,13 @@ int main(int argc, char *argv[])
 		}
 		else if (argnmatch(argv[argi], "--pidfile=")) {
 			char *value = strchr(argv[argi], '=')+1;
-			if (*value == '\0') {
-				errprintf("Pidfile path cannot be empty\n");
-				return 1;
-			}
 			if (pidfile != NULL) xfree(pidfile);
-			pidfile = strdup(value);
+			pidfile = xstrdup(value);
 		}
 		else if (argnmatch(argv[argi], "--minimum-free=")) {
-			minlogspace = parse_minimum_free(argv[argi]);
+			minlogspace = parse_int_opt(argv[argi], 0, 100, DEFAULT_MINLOGSPACE);
 		}
-		else if (strcmp(argv[argi], "--debug") == 0) {
+		else if (argnmatch(argv[argi], "--debug")) {
 			debug = 1;
 		}
 		else {
@@ -141,7 +136,7 @@ int main(int argc, char *argv[])
 	if (xgetenv("XYMONHISTDIR") && (histdir == NULL)) {
 		histdir = strdup(xgetenv("XYMONHISTDIR"));
 	}
-	if ((histdir == NULL) || (*histdir == '\0')) {
+	if (histdir == NULL) {
 		errprintf("No history directory given, aborting\n");
 		return 1;
 	}
@@ -149,17 +144,13 @@ int main(int argc, char *argv[])
 	if (save_histlogs && (histlogdir == NULL) && xgetenv("XYMONHISTLOGS")) {
 		histlogdir = strdup(xgetenv("XYMONHISTLOGS"));
 	}
-	if (save_histlogs && ((histlogdir == NULL) || (*histlogdir == '\0'))) {
+	if (save_histlogs && (histlogdir == NULL)) {
 		errprintf("No history-log directory given, aborting\n");
-		return 1;
-	}
-	if (!save_histlogs && (histlogdir != NULL) && (*histlogdir == '\0')) {
-		errprintf("History-log directory cannot be empty\n");
 		return 1;
 	}
 	if (pidfile == NULL) {
 		char *logdir = xgetenv("XYMONSERVERLOGS");
-		pidfile = (char *)malloc(strlen(logdir) + sizeof("/xymond_history.pid"));
+		pidfile = (char *)xmalloc(strlen(logdir) + sizeof("/xymond_history.pid"));
 		sprintf(pidfile, "%s/xymond_history.pid", logdir);
 	}
 
@@ -170,7 +161,7 @@ int main(int argc, char *argv[])
 		columndef_t *newrec;
 
 		savelist = strdup(xgetenv("SAVESTATUSLOG"));
-		defaultsave = strtok(savelist, ","); 
+		defaultsave = strtok(savelist, ",");
 		/*
 		 * TRUE: Save everything by default; may list some that are not saved.
 		 * ONLY: Save nothing by default; may list some that are saved.
@@ -195,20 +186,7 @@ int main(int argc, char *argv[])
 		xfree(savelist);
 	}
 
-	{
-		FILE *pidfd = fopen(pidfile, "w");
-		if (pidfd) {
-			fprintf(pidfd, "%lu\n", (unsigned long)getpid());
-			fclose(pidfd);
-		}
-		else {
-			errprintf("Cannot open PID file: %s\n", strerror(errno));
-		}
-	}
-
-	pathlen = snprintf(alleventsfn, sizeof(alleventsfn), "%s/allevents", histdir);
-	if ((pathlen < 0) || (pathlen >= (int)sizeof(alleventsfn))) {
-		errprintf("History directory path is too long\n");
+	if (!format_path(alleventsfn, sizeof(alleventsfn), "%s/allevents", histdir)) {
 		return 1;
 	}
 	if (save_allevents) {
@@ -219,6 +197,29 @@ int main(int argc, char *argv[])
 		}
 		else {
 			setvbuf(alleventsfd, (char *)NULL, _IOLBF, 0);
+		}
+	}
+
+	{
+		FILE *pidfd = fopen(pidfile, "w");
+		if (pidfd) {
+			int pidwriteok = (fprintf(pidfd, "%lu\n", (unsigned long)getpid()) > 0);
+			int savederrno = pidwriteok ? 0 : errno;
+
+			if (fclose(pidfd) != 0) {
+				pidwriteok = 0;
+				savederrno = errno;
+			}
+			if (pidwriteok) {
+				pidfile_created = 1;
+			}
+			else {
+				errprintf("Cannot write PID file '%s': %s\n", pidfile, strerror(savederrno));
+				unlink(pidfile);
+			}
+		}
+		else {
+			errprintf("Cannot open PID file '%s': %s\n", pidfile, strerror(errno));
 		}
 	}
 
@@ -261,15 +262,15 @@ int main(int argc, char *argv[])
 			continue;
 		}
 
-		if (nextfscheck < gettimer()) {
+		if (save_histlogs && (nextfscheck < gettimer())) {
 			logdirfull = (chkfreespace(histlogdir, minlogspace, minlogspace) != 0);
 			if (logdirfull) errprintf("Historylog directory %s has less than %d%% free space - disabling save of data for 5 minutes\n", histlogdir, minlogspace);
 			nextfscheck = gettimer() + 300;
 		}
 
-		p = strchr(msg, '\n'); 
+		p = strchr(msg, '\n');
 		if (p) {
-			*p = '\0'; 
+			*p = '\0';
 			statusdata = msg_data(p+1, 0);
 		}
 		metacount = 0;
@@ -327,7 +328,9 @@ int main(int argc, char *argv[])
 				MEMDEFINE(oldcol);
 				MEMDEFINE(timestamp);
 
-				sprintf(statuslogfn, "%s/%s.%s", histdir, hostnamecommas, testname);
+				if (!format_path(statuslogfn, sizeof(statuslogfn), "%s/%s.%s", histdir, hostnamecommas, testname)) {
+					goto statuspathdone;
+				}
 				stat(statuslogfn, &st);
 				statuslogfd = fopen(statuslogfn, "r+");
 				logexists = (statuslogfd != NULL);
@@ -339,7 +342,7 @@ int main(int argc, char *argv[])
 					 * running all the time while this system was monitored.
 					 * So get the time of the latest status change from the file,
 					 * instead of relying on the "lastchange" value we get
-					 * from xymond. This is also needed when migrating from 
+					 * from xymond. This is also needed when migrating from
 					 * standard bbd to xymond.
 					 */
 					off_t pos = -1;
@@ -425,7 +428,7 @@ int main(int argc, char *argv[])
 					lastchg = tstamp;
 					statuslogfd = fopen(statuslogfn, "a");
 					if (statuslogfd == NULL) {
-						errprintf("Cannot open status historyfile '%s' : %s\n", 
+						errprintf("Cannot open status historyfile '%s' : %s\n",
 							statuslogfn, strerror(errno));
 					}
 				}
@@ -433,7 +436,7 @@ int main(int argc, char *argv[])
 				if (strcmp(oldcol, colorname(newcolor)) == 0) {
 					/* We wont update history unless the color did change. */
 					if ((gettimer() - starttime) > 300) {
-						errprintf("Will not update %s - color unchanged (%s)\n", 
+						errprintf("Will not update %s - color unchanged (%s)\n",
 							  statuslogfn, oldcol);
 					}
 
@@ -454,7 +457,7 @@ int main(int argc, char *argv[])
 						/* Re-print the old record, now with the final duration */
 						memcpy(&oldtm, localtime(&lastchg), sizeof(oldtm));
 						strftime(timestamp, sizeof(timestamp), "%a %b %e %H:%M:%S %Y", &oldtm);
-						fprintf(statuslogfd, "%s %s %d %d\n", 
+						fprintf(statuslogfd, "%s %s %d %d\n",
 							timestamp, oldcol, (int)lastchg, (int)(tstamp - lastchg));
 					}
 
@@ -479,6 +482,7 @@ int main(int argc, char *argv[])
 					fclose(statuslogfd);
 				}
 
+			statuspathdone:
 				MEMUNDEFINE(statuslogfn);
 				MEMUNDEFINE(oldcol);
 				MEMUNDEFINE(timestamp);
@@ -486,19 +490,22 @@ int main(int argc, char *argv[])
 
 			if (save_histlogs && saveit->saveit && !logdirfull) {
 				char *hostdash;
+				char *logtime;
 				char fname[PATH_MAX];
 				FILE *histlogfd;
+				int pathok;
 
 				MEMDEFINE(fname);
+				logtime = histlogtime(tstamp);
 
 				p = hostdash = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = '_';
-				sprintf(fname, "%s/%s", histlogdir, hostdash);
-				mkdir(fname, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
-				p = fname + sprintf(fname, "%s/%s/%s", histlogdir, hostdash, testname);
-				mkdir(fname, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
-				p += sprintf(p, "/%s", histlogtime(tstamp));
+				pathok = format_path(fname, sizeof(fname), "%s/%s", histlogdir, hostdash);
+				if (pathok) mkdir(fname, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
+				if (pathok) pathok = format_path(fname, sizeof(fname), "%s/%s/%s", histlogdir, hostdash, testname);
+				if (pathok) mkdir(fname, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
+				if (pathok) pathok = format_path(fname, sizeof(fname), "%s/%s/%s/%s", histlogdir, hostdash, testname, logtime);
 
-				histlogfd = fopen(fname, "w");
+				histlogfd = pathok ? fopen(fname, "w") : NULL;
 				if (histlogfd) {
 					/*
 					 * When a host gets disabled or goes purple, the status
@@ -519,7 +526,7 @@ int main(int argc, char *argv[])
 
 					if (dismsg && *dismsg) nldecode(dismsg);
 					if (disabletime > 0) {
-						fprintf(histlogfd, " Disabled until %s\n%s\n\n", 
+						fprintf(histlogfd, " Disabled until %s\n%s\n\n",
 							ctime(&disabletime), (dismsg ? dismsg : ""));
 						fprintf(histlogfd, "Status message when disabled follows:\n\n");
 						statusdata = origstatus;
@@ -569,7 +576,7 @@ int main(int argc, char *argv[])
 
 					if (!ok) remove(fname);
 				}
-				else {
+				else if (pathok) {
 					errprintf("Cannot create histlog file '%s' : %s\n", fname, strerror(errno));
 				}
 				xfree(hostdash);
@@ -589,18 +596,19 @@ int main(int argc, char *argv[])
 			if (save_hostevents) {
 				char hostlogfn[PATH_MAX];
 				FILE *hostlogfd;
+				int pathok;
 
 				MEMDEFINE(hostlogfn);
 
-				sprintf(hostlogfn, "%s/%s", histdir, hostname);
-				hostlogfd = fopen(hostlogfn, "a");
+				pathok = format_path(hostlogfn, sizeof(hostlogfn), "%s/%s", histdir, hostname);
+				hostlogfd = pathok ? fopen(hostlogfn, "a") : NULL;
 				if (hostlogfd) {
 					fprintf(hostlogfd, "%s %d %d %d %s %s %d\n",
 						testname, (int)tstamp, (int)lastchg, (int)(tstamp - lastchg),
 						newcol2, oldcol2, trend);
 					fclose(hostlogfd);
 				}
-				else {
+				else if (pathok) {
 					errprintf("Cannot open host logfile '%s' : %s\n", hostlogfn, strerror(errno));
 				}
 
@@ -629,8 +637,7 @@ int main(int argc, char *argv[])
 
 				/* Remove all directories below the host-specific histlog dir */
 				p = hostdash = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = '_';
-				sprintf(testdir, "%s/%s", histlogdir, hostdash);
-				dropdirectory(testdir, 1);
+				if (format_path(testdir, sizeof(testdir), "%s/%s", histlogdir, hostdash)) dropdirectory(testdir, 1);
 				xfree(hostdash);
 
 				MEMUNDEFINE(testdir);
@@ -642,8 +649,8 @@ int main(int argc, char *argv[])
 
 				MEMDEFINE(hostlogfn);
 
-				sprintf(hostlogfn, "%s/%s", histdir, hostname);
-				if ((stat(hostlogfn, &st) == 0) && S_ISREG(st.st_mode)) {
+				if (format_path(hostlogfn, sizeof(hostlogfn), "%s/%s", histdir, hostname) &&
+				    (stat(hostlogfn, &st) == 0) && S_ISREG(st.st_mode)) {
 					unlink(hostlogfn);
 				}
 
@@ -668,8 +675,8 @@ int main(int argc, char *argv[])
 				if (dirfd) {
 					while ((de = readdir(dirfd)) != NULL) {
 						if (strncmp(de->d_name, hostlead, strlen(hostlead)) == 0) {
-							sprintf(statuslogfn, "%s/%s", histdir, de->d_name);
-							if ((stat(statuslogfn, &st) == 0) && S_ISREG(st.st_mode)) {
+							if (format_path(statuslogfn, sizeof(statuslogfn), "%s/%s", histdir, de->d_name) &&
+							    (stat(statuslogfn, &st) == 0) && S_ISREG(st.st_mode)) {
 								unlink(statuslogfn);
 							}
 						}
@@ -696,8 +703,7 @@ int main(int argc, char *argv[])
 				MEMDEFINE(testdir);
 
 				p = hostdash = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = '_';
-				sprintf(testdir, "%s/%s/%s", histlogdir, hostdash, testname);
-				dropdirectory(testdir, 1);
+				if (format_path(testdir, sizeof(testdir), "%s/%s/%s", histlogdir, hostdash, testname)) dropdirectory(testdir, 1);
 				xfree(hostdash);
 
 				MEMUNDEFINE(testdir);
@@ -711,8 +717,8 @@ int main(int argc, char *argv[])
 				MEMDEFINE(statuslogfn);
 
 				p = hostnamecommas = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = ',';
-				sprintf(statuslogfn, "%s/%s.%s", histdir, hostnamecommas, testname);
-				if ((stat(statuslogfn, &st) == 0) && S_ISREG(st.st_mode)) unlink(statuslogfn);
+				if (format_path(statuslogfn, sizeof(statuslogfn), "%s/%s.%s", histdir, hostnamecommas, testname) &&
+				    (stat(statuslogfn, &st) == 0) && S_ISREG(st.st_mode)) unlink(statuslogfn);
 				xfree(hostnamecommas);
 
 				MEMUNDEFINE(statuslogfn);
@@ -735,9 +741,8 @@ int main(int argc, char *argv[])
 
 				p = hostdash = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = '_';
 				p = newhostdash = strdup(newhostname); while ((p = strchr(p, '.')) != NULL) *p = '_';
-				sprintf(olddir, "%s/%s", histlogdir, hostdash);
-				sprintf(newdir, "%s/%s", histlogdir, newhostdash);
-				rename(olddir, newdir);
+				if (format_path(olddir, sizeof(olddir), "%s/%s", histlogdir, hostdash) &&
+				    format_path(newdir, sizeof(newdir), "%s/%s", histlogdir, newhostdash)) rename(olddir, newdir);
 				xfree(newhostdash);
 				xfree(hostdash);
 
@@ -750,9 +755,8 @@ int main(int argc, char *argv[])
 
 				MEMDEFINE(hostlogfn); MEMDEFINE(newhostlogfn);
 
-				sprintf(hostlogfn, "%s/%s", histdir, hostname);
-				sprintf(newhostlogfn, "%s/%s", histdir, newhostname);
-				rename(hostlogfn, newhostlogfn);
+				if (format_path(hostlogfn, sizeof(hostlogfn), "%s/%s", histdir, hostname) &&
+				    format_path(newhostlogfn, sizeof(newhostlogfn), "%s/%s", histdir, newhostname)) rename(hostlogfn, newhostlogfn);
 
 				MEMUNDEFINE(hostlogfn); MEMUNDEFINE(newhostlogfn);
 			}
@@ -779,9 +783,8 @@ int main(int argc, char *argv[])
 					while ((de = readdir(dirfd)) != NULL) {
 						if (strncmp(de->d_name, hostlead, strlen(hostlead)) == 0) {
 							char *testname = strchr(de->d_name, '.');
-							sprintf(statuslogfn, "%s/%s", histdir, de->d_name);
-							sprintf(newlogfn, "%s/%s%s", histdir, newhostnamecommas, testname);
-							rename(statuslogfn, newlogfn);
+							if (format_path(statuslogfn, sizeof(statuslogfn), "%s/%s", histdir, de->d_name) &&
+							    format_path(newlogfn, sizeof(newlogfn), "%s/%s%s", histdir, newhostnamecommas, testname)) rename(statuslogfn, newlogfn);
 						}
 					}
 					closedir(dirfd);
@@ -810,9 +813,8 @@ int main(int argc, char *argv[])
 				MEMDEFINE(olddir); MEMDEFINE(newdir);
 
 				p = hostdash = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = '_';
-				sprintf(olddir, "%s/%s/%s", histlogdir, hostdash, testname);
-				sprintf(newdir, "%s/%s/%s", histlogdir, hostdash, newtestname);
-				rename(olddir, newdir);
+				if (format_path(olddir, sizeof(olddir), "%s/%s/%s", histlogdir, hostdash, testname) &&
+				    format_path(newdir, sizeof(newdir), "%s/%s/%s", histlogdir, hostdash, newtestname)) rename(olddir, newdir);
 				xfree(hostdash);
 
 				MEMUNDEFINE(newdir); MEMUNDEFINE(olddir);
@@ -826,9 +828,8 @@ int main(int argc, char *argv[])
 				MEMDEFINE(statuslogfn); MEMDEFINE(newstatuslogfn);
 
 				p = hostnamecommas = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = ',';
-				sprintf(statuslogfn, "%s/%s.%s", histdir, hostnamecommas, testname);
-				sprintf(newstatuslogfn, "%s/%s.%s", histdir, hostnamecommas, newtestname);
-				rename(statuslogfn, newstatuslogfn);
+				if (format_path(statuslogfn, sizeof(statuslogfn), "%s/%s.%s", histdir, hostnamecommas, testname) &&
+				    format_path(newstatuslogfn, sizeof(newstatuslogfn), "%s/%s.%s", histdir, hostnamecommas, newtestname)) rename(statuslogfn, newstatuslogfn);
 				xfree(hostnamecommas);
 
 				MEMUNDEFINE(newstatuslogfn); MEMUNDEFINE(statuslogfn);
@@ -857,8 +858,8 @@ int main(int argc, char *argv[])
 	MEMUNDEFINE(oldcol2);
 	MEMUNDEFINE(alleventsfn);
 
-	fclose(alleventsfd);
-	unlink(pidfile);
+	if (alleventsfd) fclose(alleventsfd);
+	if (pidfile_created) unlink(pidfile);
 	xfree(pidfile);
 
 	return 0;

--- a/xymond/xymond_history.c
+++ b/xymond/xymond_history.c
@@ -59,13 +59,33 @@ typedef struct columndef_t {
 } columndef_t;
 void * columndefs;
 
+static int parse_minimum_free(char *arg)
+{
+	char *value = strchr(arg, '=') + 1;
+	char *endp;
+	long result;
+
+	errno = 0;
+	result = strtol(value, &endp, 10);
+	if ((endp == value) || (*endp != '\0') || (result < 0)) {
+		errprintf("%s is invalid (must be 0 through 100), using default %d\n", arg, DEFAULT_MINLOGSPACE);
+		return DEFAULT_MINLOGSPACE;
+	}
+	if ((errno == ERANGE) || (result > 100)) {
+		errprintf("%s is too large, capping at 100\n", arg);
+		return 100;
+	}
+
+	return (int)result;
+}
+
 int main(int argc, char *argv[])
 {
 	time_t starttime = gettimer();
 	char *histdir = NULL;
 	char *histlogdir = NULL;
 	char *msg;
-	int argi, seq;
+	int argi, seq, pathlen;
 	int save_allevents = 1;
 	int save_hostevents = 1;
 	int save_statusevents = 1;
@@ -76,11 +96,10 @@ int main(int argc, char *argv[])
 	char newcol2[3];
 	char oldcol2[3];
 	char alleventsfn[PATH_MAX];
-	char pidfn[PATH_MAX];
+	char *pidfile = NULL;
 	int logdirfull = 0;
 	int minlogspace = DEFAULT_MINLOGSPACE;
 
-	MEMDEFINE(pidfn);
 	MEMDEFINE(alleventsfn);
 	MEMDEFINE(newcol2);
 	MEMDEFINE(oldcol2);
@@ -88,7 +107,6 @@ int main(int argc, char *argv[])
 	/* Don't save the error buffer */
 	save_errbuf = 0;
 
-	sprintf(pidfn, "%s/xymond_history.pid", xgetenv("XYMONSERVERLOGS"));
 	if (xgetenv("XYMONALLHISTLOG")) save_allevents = (strcmp(xgetenv("XYMONALLHISTLOG"), "TRUE") == 0);
 	if (xgetenv("XYMONHOSTHISTLOG")) save_hostevents = (strcmp(xgetenv("XYMONHOSTHISTLOG"), "TRUE") == 0);
 	if (xgetenv("SAVESTATUSLOG")) save_histlogs = (strncmp(xgetenv("SAVESTATUSLOG"), "FALSE", 5) != 0);
@@ -101,22 +119,29 @@ int main(int argc, char *argv[])
 			histlogdir = strchr(argv[argi], '=')+1;
 		}
 		else if (argnmatch(argv[argi], "--pidfile=")) {
-			strcpy(pidfn, strchr(argv[argi], '=')+1);
+			char *value = strchr(argv[argi], '=')+1;
+			if (*value == '\0') {
+				errprintf("Pidfile path cannot be empty\n");
+				return 1;
+			}
+			if (pidfile != NULL) xfree(pidfile);
+			pidfile = strdup(value);
 		}
 		else if (argnmatch(argv[argi], "--minimum-free=")) {
-			/* Percent of filesystem space; 0 disables the check, and
-			 * negatives clamp to it (they also disabled it with atoi). */
-			minlogspace = parse_int_opt(argv[argi], 0, 100, DEFAULT_MINLOGSPACE);
+			minlogspace = parse_minimum_free(argv[argi]);
 		}
-		else if (argnmatch(argv[argi], "--debug")) {
+		else if (strcmp(argv[argi], "--debug") == 0) {
 			debug = 1;
+		}
+		else {
+			errprintf("Unknown option '%s' - ignored\n", argv[argi]);
 		}
 	}
 
 	if (xgetenv("XYMONHISTDIR") && (histdir == NULL)) {
 		histdir = strdup(xgetenv("XYMONHISTDIR"));
 	}
-	if (histdir == NULL) {
+	if ((histdir == NULL) || (*histdir == '\0')) {
 		errprintf("No history directory given, aborting\n");
 		return 1;
 	}
@@ -124,9 +149,18 @@ int main(int argc, char *argv[])
 	if (save_histlogs && (histlogdir == NULL) && xgetenv("XYMONHISTLOGS")) {
 		histlogdir = strdup(xgetenv("XYMONHISTLOGS"));
 	}
-	if (save_histlogs && (histlogdir == NULL)) {
+	if (save_histlogs && ((histlogdir == NULL) || (*histlogdir == '\0'))) {
 		errprintf("No history-log directory given, aborting\n");
 		return 1;
+	}
+	if (!save_histlogs && (histlogdir != NULL) && (*histlogdir == '\0')) {
+		errprintf("History-log directory cannot be empty\n");
+		return 1;
+	}
+	if (pidfile == NULL) {
+		char *logdir = xgetenv("XYMONSERVERLOGS");
+		pidfile = (char *)malloc(strlen(logdir) + sizeof("/xymond_history.pid"));
+		sprintf(pidfile, "%s/xymond_history.pid", logdir);
 	}
 
 	columndefs = xtreeNew(strcmp);
@@ -162,14 +196,21 @@ int main(int argc, char *argv[])
 	}
 
 	{
-		FILE *pidfd = fopen(pidfn, "w");
+		FILE *pidfd = fopen(pidfile, "w");
 		if (pidfd) {
 			fprintf(pidfd, "%lu\n", (unsigned long)getpid());
 			fclose(pidfd);
 		}
+		else {
+			errprintf("Cannot open PID file: %s\n", strerror(errno));
+		}
 	}
 
-	sprintf(alleventsfn, "%s/allevents", histdir);
+	pathlen = snprintf(alleventsfn, sizeof(alleventsfn), "%s/allevents", histdir);
+	if ((pathlen < 0) || (pathlen >= (int)sizeof(alleventsfn))) {
+		errprintf("History directory path is too long\n");
+		return 1;
+	}
 	if (save_allevents) {
 		alleventsfd = fopen(alleventsfn, "a");
 		if (alleventsfd == NULL) {
@@ -815,10 +856,10 @@ int main(int argc, char *argv[])
 	MEMUNDEFINE(newcol2);
 	MEMUNDEFINE(oldcol2);
 	MEMUNDEFINE(alleventsfn);
-	MEMUNDEFINE(pidfn);
 
 	fclose(alleventsfd);
-	unlink(pidfn);
+	unlink(pidfile);
+	xfree(pidfile);
 
 	return 0;
 }


### PR DESCRIPTION
## Summary

Harden `xymond_history` command-line option handling.

## Changes

- Parse `--minimum-free` with `strtol()`:
  - accept `0..100`
  - use the default of `5` for invalid or negative values
  - cap values above `100`
  - emit warnings for fallback and capping
- Replace the fixed `PATH_MAX` PID-file buffer and unchecked `strcpy()` with dynamic storage, matching `xymond`.
- Reject empty `--histdir=`, `--histlogdir=`, and `--pidfile=` values.
- Bound construction of the `allevents` path.
- Report and ignore unknown options, matching `xymond`.
- Document the validation behavior under each affected option.

## Impact

Previously:

- `--minimum-free=junk` or a negative value silently became `0`, disabling free-space protection.
- Values above `100` prevented historical status logs from being saved.
- A long `--pidfile` value could overflow the fixed buffer.
- Unknown options were silently ignored.

The default configuration and valid option values retain their existing behavior.

## Compatibility

This can merge independently of #219. When #219 is rebased, the default PID directory can be changed from `XYMONSERVERLOGS` to `XYMONRUNDIR` while retaining dynamic PID-path storage.

## Testing

`tests/server/xymond-history-options.sh` drives the real built worker and covers:

- junk, negative, excessive, and overflowing `--minimum-free` values
- valid boundaries `0` and `100`
- unknown options and exact `--debug` matching
- empty history, history-log, and PID-file values
- a 5000-character PID-file value

Validation:

- Focused test passes.
- Full suite: 22 passed, 2 RRD-dependent tests skipped.
- The regression test fails against unpatched `main`.