### PR TITLE
docs: per-OS parity for the client filesystem filter (cfg.DIST + cfg.5)

### DIFF
--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -18,120 +18,42 @@ XYMONCLIENTLOGS="$XYMONHOME/logs"     # Where we store the client logfiles
 LOGFETCHOPTS=""
 
 
-# Filesystem reporting (Linux client) -- used by xymonclient-linux.sh when
-# collecting df and inode data. By default it excludes the nodev pseudo
-# filesystems (except rootfs) and the always-full iso9660/squashfs images,
-# reports the real local filesystems including zfs/virtiofs/tmpfs, and passes
-# -l to df. The noisy tmpfs mounts (/run, /run/lock, /run/user/N) are filtered
-# server-side by the CLASS=linux block in analysis.cfg, not here.
+# Filesystem reporting -- the XYMONCLIENT_FS_* variables tune which mounts the
+# client's disk and inode reports include. The full contract - per-OS
+# mechanisms, matching rules, examples - lives in xymonclient.cfg(5); the
+# blocks below list only each OS's defaults. Unlisted OSes ignore the
+# variables. WARNING: XYMONCLIENT_FS_DF_LOCAL_ONLY=no can hang df on a stale
+# remote mount and turn the whole host purple - see the manual first.
 #
-# XYMONCLIENT_FS_INCLUDE_TYPES: whitespace-separated nodev FS types to surface
-#    (they would otherwise be dropped). Defaults to "zfs virtiofs tmpfs" -- the
-#    real local filesystems that merely happen to be nodev. Examples:
-#      ""                    -- restore the historical "exclude every nodev
-#                               type" behaviour (drops zfs/virtiofs/tmpfs too).
-#      "zfs virtiofs tmpfs nfs nfs4 ceph"
-#                            -- also include remote filesystems (requires
-#                               XYMONCLIENT_FS_DF_LOCAL_ONLY=no, since
-#                               df -l hides remote mounts).
-#
-# XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated FS types to also exclude,
-#    on top of the nodev default. Defaults to "iso9660 squashfs fuse.snapfuse"
-#    -- read-only images always reported 100% full by design (snaps mount as
-#    squashfs, or as fuse.snapfuse where snapd falls back to FUSE). Matching is
-#    on the exact df type token, and nodev types (overlay, bare fuse, ...) are
-#    already excluded by default, so other effective entries name a type that is
-#    NOT a nodev default -- a device-backed type, or a specific FUSE subtype the
-#    bare nodev "fuse" default cannot match. Examples:
-#      ""                    -- monitor iso9660/squashfs/snaps too.
-#      "iso9660 squashfs fuse.snapfuse fuse.sshfs vfat"
-#                            -- keep the defaults and also drop a specific FUSE
-#                               subtype and a device-backed mount.
-#    If a type appears in both lists, EXCLUDE wins (it is applied after
-#    INCLUDE), so the type stays excluded.
-#
-# XYMONCLIENT_FS_DF_LOCAL_ONLY: "yes" (default) passes -l to df, hiding
-#    remote filesystems. Set to "no" to report nfs/ceph/etc. Any other
-#    value produces a warning and falls back to "yes".
-#    WARNING: with "no", a stale or hard-blocked remote mount can wedge df
-#    indefinitely (an uninterruptible D-state wait). The client run never
-#    finishes, so the whole host goes PURPLE -- no data for ALL metrics,
-#    not just disk -- until the mount recovers or the host reboots.
-#
-#    A df that *exits* non-zero with no output (a real error, not a hang)
-#    is marked failed (yellow) rather than left empty, so a failed probe is
-#    not silently reported green. This does not cover the hang above: a
-#    wedged df never exits.
-#
+# Linux (xymonclient-linux.sh) - excludes nodev pseudo-filesystems and the
+# always-full iso9660/squashfs images:
 # XYMONCLIENT_FS_INCLUDE_TYPES="zfs virtiofs tmpfs"
 # XYMONCLIENT_FS_EXCLUDE_TYPES="iso9660 squashfs fuse.snapfuse"
 # XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
-
-
-# Filesystem reporting (NetBSD client) -- xymonclient-netbsd.sh uses the same
-# three variables for both disk-capacity and inode reports. By default it
-# excludes kernfs, procfs, cd9660, null and ptyfs, and passes -l to df so remote
-# filesystems are hidden. NetBSD tmpfs remains included: its inode counts are
-# memory-derived and can provide a meaningful exhaustion signal. The inode
-# report additionally excludes zfs and rows without usable inode accounting.
-# The ptyfs exclusion is new; set XYMONCLIENT_FS_INCLUDE_TYPES="ptyfs" to keep
-# reporting it after an upgrade.
 #
-# XYMONCLIENT_FS_INCLUDE_TYPES: whitespace-separated types to remove from the
-#    default exclusion list. For example, "ptyfs" reports ptyfs despite the
-#    default. Types are exact tokens, not shell patterns.
-#
-# XYMONCLIENT_FS_EXCLUDE_TYPES: whitespace-separated types to add to the
-#    exclusion list. If a type appears in both settings, exclusion wins.
-#
-# XYMONCLIENT_FS_DF_LOCAL_ONLY: "yes" (default) passes -l to df. Set to "no"
-#    to report remote filesystems. The stale-remote-mount warning above applies.
-#    A df invocation that exits non-zero with no output marks the corresponding
-#    disk or inode report failed (yellow) instead of silently reporting green.
-#
+# FreeBSD (xymonclient-freebsd.sh) - excludes via df -tno<csv>; the inode
+# report also drops zfs/tmpfs:
 # XYMONCLIENT_FS_INCLUDE_TYPES=""
 # XYMONCLIENT_FS_EXCLUDE_TYPES=""
 # XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
-
-
-# Filesystem reporting (macOS client) -- used by xymonclient-darwin.sh. Same
-# three variables as above, matched on mount ATTRIBUTES rather than filesystem
-# type: macOS df has no "-t", and type would not help anyway, since the sealed
-# root, the system helper volumes and the volume holding every user file are
-# all "apfs". Both variables therefore accept attributes as well as types.
 #
-# By default it drops "nobrowse" and "read-only" mounts -- devfs, the autofs
-# map, the system helpers and the sealed root, none of which carries a
-# meaningful capacity signal -- and keeps every other local mount. The data
-# volume, which Apple flags "root data", is exempt and always reported. The
-# inode report also skips apfs, whose ifree comes from the shared container
-# and never signals exhaustion.
-#
-# XYMONCLIENT_FS_INCLUDE_TYPES: types or attributes to surface. Empty by
-#    default. Naming an attribute is the only way to switch off a default drop:
-#      "nobrowse"  -- report volumes hidden from the Finder. WARNING: this
-#                     switches the drop off entirely, so devfs (/dev) and the
-#                     autofs map come back too, both permanently 100% full.
-#                     Pair it with XYMONCLIENT_FS_EXCLUDE_TYPES="devfs autofs".
-#
-# XYMONCLIENT_FS_EXCLUDE_TYPES: types or attributes to exclude on top of the
-#    defaults. Empty by default. Wins over XYMONCLIENT_FS_INCLUDE_TYPES and over
-#    the "root data" exemption:
-#      "lifs"      -- drop external FAT/exFAT/NTFS media (macOS Ventura and
-#                     later mount these through LiveFiles as "lifs"). They are
-#                     local disks, so they are reported by default.
-#      "fusefs"    -- drop macFUSE volumes such as NTFS-3G. Only useful for
-#                     volumes mounted "-o local", or with DF_LOCAL_ONLY="no":
-#                     macFUSE marks its volumes non-local by default, so the
-#                     local filter already drops them.
-#    Beware attributes most mounts carry: excluding "local" drops everything.
-#
-# XYMONCLIENT_FS_DF_LOCAL_ONLY: "yes" (default) reports only mounts flagged
-#    "local", hiding nfs and smbfs; "no" surfaces them. The warning above about
-#    stale remote mounts wedging df applies here too.
-#
+# NetBSD (xymonclient-netbsd.sh) - excludes kernfs/procfs/cd9660/null/ptyfs;
+# the inode report also drops zfs:
 # XYMONCLIENT_FS_INCLUDE_TYPES=""
-# XYMONCLIENT_FS_EXCLUDE_TYPES="lifs"
+# XYMONCLIENT_FS_EXCLUDE_TYPES=""
+# XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
+#
+# OpenBSD (xymonclient-openbsd.sh) - excludes kernfs/procfs/cd9660; tmpfs is
+# kept in both reports:
+# XYMONCLIENT_FS_INCLUDE_TYPES=""
+# XYMONCLIENT_FS_EXCLUDE_TYPES=""
+# XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
+#
+# macOS (xymonclient-darwin.sh) - matches mount attributes as well as types;
+# drops nobrowse/read-only mounts (the root data volume is exempt from those
+# two defaults, but not from an explicit exclude):
+# XYMONCLIENT_FS_INCLUDE_TYPES=""
+# XYMONCLIENT_FS_EXCLUDE_TYPES=""
 # XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
 
 

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -36,23 +36,68 @@ $XYMONHOME/logs
 Directory used for temporary files. Default: $XYMONHOME/tmp/
 
 .IP "\fBXYMONCLIENT_FS_INCLUDE_TYPES\fR"
-Whitespace-separated filesystem types to include in the
-client's disk and inode reports even when they are normally excluded
-by the operating-system client. Types are matched as exact df type tokens.
-On Linux this defaults to \fBzfs virtiofs tmpfs\fR \(em real local
-filesystems that merely happen to be flagged nodev. Set it to "" to restore
-the historical behavior of dropping every nodev filesystem type.
-On NetBSD it defaults
-to empty and may be used to restore a type from the default exclusion list.
-Including remote filesystems also requires
+Whitespace-separated filesystem types to include in the client's disk
+(and, where supported, inode) reports even when the client's defaults
+would exclude them. Types are matched as exact df type tokens (on
+macOS, mount attributes are matched as well). The default exclusions
+and the mechanism are per-OS, and clients not listed here do not use
+the variable. Including remote filesystems also requires
 XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
+.br
+On Linux: types normally excluded as pseudo (\fBnodev\fR) filesystems.
+Defaults to \fBzfs virtiofs tmpfs\fR \(em real local filesystems
+that merely happen to be flagged nodev. Set to "" to restore the
+historical behaviour of dropping every nodev type. The noisy tmpfs
+mounts (/run, /run/lock, /run/user/N) are filtered server-side by the
+CLASS=linux block in analysis.cfg, not here.
+.br
+On FreeBSD: names types from the default df exclude set (\fBnullfs
+cd9660 procfs devfs linprocfs fdescfs autofs\fR, passed to df as
+one comma-joined \fB\-tno<list>\fR argument) to surface again. Empty by
+default. The inode report additionally drops \fBzfs\fR and \fBtmpfs\fR,
+whose inode counts
+carry no signal (zfs has no inode limit; FreeBSD tmpfs reports a
+constant itotal of 2^31\-1); naming them here restores them to the
+inode report as well.
+.br
+On NetBSD: names types from the default df exclude set (\fBkernfs
+procfs cd9660 null ptyfs\fR, passed to df as \fB\-tno<list>\fR) to
+surface again. Empty by default. The \fBptyfs\fR exclusion is an
+upgrade-visible change; set XYMONCLIENT_FS_INCLUDE_TYPES="ptyfs" to
+report it again. The inode report additionally drops \fBzfs\fR (no
+fixed inode pool) and rows without usable inode accounting; naming zfs
+here restores it to the inode report as well. NetBSD tmpfs is kept in
+both reports \(em its inode counts are memory-derived, so they can
+signal exhaustion.
+.br
+On OpenBSD: names types from the default df exclude set (\fBkernfs
+procfs cd9660\fR, passed to df as \fB\-tno<list>\fR) to surface again.
+Empty by default. The inode report additionally drops rows without
+usable inode accounting (OpenBSD df \-i reports those as itotal 0, not
+as "-"). OpenBSD tmpfs is kept in both reports, for the same reason as
+on NetBSD.
+.br
+On macOS: values are mount attributes as well as types; the defaults
+drop \fBnobrowse\fR and \fBread\-only\fR mounts, and the inode report
+skips apfs. Empty by default. The "root data" volume \(em the one
+holding every user file, which Catalina and later flag nobrowse \(em is
+exempt from those two default drops, so it is still reported; an
+explicit XYMONCLIENT_FS_EXCLUDE_TYPES entry that matches it (for
+instance "apfs") still removes it. Including "nobrowse" switches that
+default drop off entirely \(em devfs and the autofs map come back too
+\(em so pair it with XYMONCLIENT_FS_EXCLUDE_TYPES="devfs autofs".
 
 .IP "\fBXYMONCLIENT_FS_EXCLUDE_TYPES\fR"
-Whitespace-separated filesystem types to exclude in addition to the
-operating-system defaults. Matching is on the exact df type token.
-If a type appears in
-both include and exclude settings, exclusion takes precedence.
-On Linux this defaults to \fBiso9660 squashfs fuse.snapfuse\fR \(em read-only images
+Whitespace-separated filesystem types (attributes as well, on macOS)
+to exclude in addition to the client's default exclusions. Matching is
+on the exact df type token. If a type appears in both include and
+exclude settings, exclusion takes precedence on every OS.
+.br
+On Linux: nodev types (overlay, fuse, ...) are already excluded
+by default, so an effective entry names a type that is not a nodev
+default \(em a device-backed type, or a specific FUSE subtype such as
+\fBfuse.sshfs\fR that the bare nodev \fBfuse\fR default cannot match.
+Defaults to \fBiso9660 squashfs fuse.snapfuse\fR \(em read-only images
 reported 100% full by design (snaps mount as squashfs, or as
 fuse.snapfuse where snapd falls back to FUSE); none is a nodev type, so
 they must be named here. Set to "" to monitor these too.
@@ -65,20 +110,36 @@ disabled; the explicit XYMONCLIENT_FS_EXCLUDE_TYPES and the local-only
 \fBdf \-l\fR behaviour remain active. The script does not fall back to
 deriving exclusions from mount(8), so it is not a drop-in replacement for
 distro patches (such as Debian's) that do.
-.IP
-On NetBSD, both disk and inode reports exclude
-\fBkernfs procfs cd9660 null ptyfs\fR by default. The explicit exclude
-setting defaults to empty. The \fBptyfs\fR exclusion is an upgrade-visible
-change; set XYMONCLIENT_FS_INCLUDE_TYPES="ptyfs" to report it again.
-The inode report additionally excludes \fBzfs\fR because it has no fixed
-inode pool, and drops rows without usable inode accounting. NetBSD tmpfs is
-retained because its inode counts are memory-derived and can provide a
-meaningful exhaustion signal.
+.br
+On FreeBSD: adds types to the \fBdf \-tno<list>\fR exclude set
+(default \fBnullfs cd9660 procfs devfs linprocfs fdescfs autofs\fR).
+Empty by default. tmpfs and mfs are deliberately kept in the disk
+report \(em RAM-backed capacity is real and fills up \(em so name them
+here to drop them.
+.br
+On NetBSD: adds types to the \fBdf \-tno<list>\fR exclude set (default
+\fBkernfs procfs cd9660 null ptyfs\fR). Empty by default. tmpfs is kept
+in both reports, so name it here to drop it.
+.br
+On OpenBSD: adds types to the \fBdf \-tno<list>\fR exclude set (default
+\fBkernfs procfs cd9660\fR). Empty by default. tmpfs is kept in both
+reports, so name it here to drop it.
+.br
+On macOS: excludes types or attributes on top of the defaults. Empty by
+default. It is applied unconditionally, so it wins over both an include
+entry and the "root data" exemption above. Useful entries include
+\fBlifs\fR (external FAT/exFAT/NTFS media, mounted through LiveFiles on
+Ventura and later) and \fBfusefs\fR (macFUSE volumes mounted
+"-o local"). Beware attributes most mounts carry: excluding "local"
+drops everything.
 
 .IP "\fBXYMONCLIENT_FS_DF_LOCAL_ONLY\fR"
 Set to \fByes\fR (the default) to pass \fB\-l\fR to df and report
 local filesystems only. Set to \fBno\fR to report remote filesystems
 as well. Invalid values produce a warning and use the safe default.
+On macOS, where df is invoked per path, the same effect is achieved by
+keeping only mounts flagged "local" (MNT_LOCAL, what \fBdf \-l\fR
+selects elsewhere).
 With \fBno\fR, a stale or hard-blocked remote mount can wedge df
 indefinitely (an uninterruptible D-state wait): the client run never
 finishes, so the whole host goes purple \(em no data for all metrics,

--- a/docs/manpages/man5/xymonclient.cfg.5.html
+++ b/docs/manpages/man5/xymonclient.cfg.5.html
@@ -62,53 +62,114 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <p class="Pp"></p>
   </dd>
   <dt id="XYMONCLIENT_FS_INCLUDE_TYPES"><a class="permalink" href="#XYMONCLIENT_FS_INCLUDE_TYPES"><b>XYMONCLIENT_FS_INCLUDE_TYPES</b></a></dt>
-  <dd>Whitespace-separated filesystem types to include in the client's disk and
-      inode reports even when they are normally excluded by the operating-system
-      client. Types are matched as exact df type tokens. On Linux this defaults
-      to <b>zfs virtiofs tmpfs</b> &#x2014; real local filesystems that merely
-      happen to be flagged nodev. Set it to &quot;&quot; to restore the
-      historical behavior of dropping every nodev filesystem type. On NetBSD it
-      defaults to empty and may be used to restore a type from the default
-      exclusion list. Including remote filesystems also requires
+  <dd>Whitespace-separated filesystem types to include in the client's disk
+      (and, where supported, inode) reports even when the client's defaults
+      would exclude them. Types are matched as exact df type tokens (on macOS,
+      mount attributes are matched as well). The default exclusions and the
+      mechanism are per-OS, and clients not listed here do not use the variable.
+      Including remote filesystems also requires
       XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
+    <br/>
+    On Linux: types normally excluded as pseudo (<b>nodev</b>) filesystems.
+      Defaults to <b>zfs virtiofs tmpfs</b> &#x2014; real local filesystems that
+      merely happen to be flagged nodev. Set to &quot;&quot; to restore the
+      historical behaviour of dropping every nodev type. The noisy tmpfs mounts
+      (/run, /run/lock, /run/user/N) are filtered server-side by the CLASS=linux
+      block in analysis.cfg, not here.
+    <br/>
+    On FreeBSD: names types from the default df exclude set (<b>nullfs</b>
+      <b>cd9660 procfs devfs linprocfs fdescfs autofs</b>, passed to df as one
+      comma-joined <b>-tno&lt;list&gt;</b> argument) to surface again. Empty by
+      default. The inode report additionally drops <b>zfs</b> and <b>tmpfs</b>,
+      whose inode counts carry no signal (zfs has no inode limit; FreeBSD tmpfs
+      reports a constant itotal of 2^31-1); naming them here restores them to
+      the inode report as well.
+    <br/>
+    On NetBSD: names types from the default df exclude set (<b>kernfs</b>
+      <b>procfs cd9660 null ptyfs</b>, passed to df as <b>-tno&lt;list&gt;</b>)
+      to surface again. Empty by default. The <b>ptyfs</b> exclusion is an
+      upgrade-visible change; set XYMONCLIENT_FS_INCLUDE_TYPES=&quot;ptyfs&quot;
+      to report it again. The inode report additionally drops <b>zfs</b> (no
+      fixed inode pool) and rows without usable inode accounting; naming zfs
+      here restores it to the inode report as well. NetBSD tmpfs is kept in both
+      reports &#x2014; its inode counts are memory-derived, so they can signal
+      exhaustion.
+    <br/>
+    On OpenBSD: names types from the default df exclude set (<b>kernfs</b>
+      <b>procfs cd9660</b>, passed to df as <b>-tno&lt;list&gt;</b>) to surface
+      again. Empty by default. The inode report additionally drops rows without
+      usable inode accounting (OpenBSD df -i reports those as itotal 0, not as
+      &quot;-&quot;). OpenBSD tmpfs is kept in both reports, for the same reason
+      as on NetBSD.
+    <br/>
+    On macOS: values are mount attributes as well as types; the defaults drop
+      <b>nobrowse</b> and <b>read-only</b> mounts, and the inode report skips
+      apfs. Empty by default. The &quot;root data&quot; volume &#x2014; the one
+      holding every user file, which Catalina and later flag nobrowse &#x2014;
+      is exempt from those two default drops, so it is still reported; an
+      explicit XYMONCLIENT_FS_EXCLUDE_TYPES entry that matches it (for instance
+      &quot;apfs&quot;) still removes it. Including &quot;nobrowse&quot;
+      switches that default drop off entirely &#x2014; devfs and the autofs map
+      come back too &#x2014; so pair it with
+      XYMONCLIENT_FS_EXCLUDE_TYPES=&quot;devfs autofs&quot;.
     <p class="Pp"></p>
   </dd>
   <dt id="XYMONCLIENT_FS_EXCLUDE_TYPES"><a class="permalink" href="#XYMONCLIENT_FS_EXCLUDE_TYPES"><b>XYMONCLIENT_FS_EXCLUDE_TYPES</b></a></dt>
-  <dd>Whitespace-separated filesystem types to exclude in addition to the
-      operating-system defaults. Matching is on the exact df type token. If a
-      type appears in both include and exclude settings, exclusion takes
-      precedence. On Linux this defaults to <b>iso9660 squashfs
-      fuse.snapfuse</b> &#x2014; read-only images reported 100% full by design
-      (snaps mount as squashfs, or as fuse.snapfuse where snapd falls back to
-      FUSE); none is a nodev type, so they must be named here. Set to
-      &quot;&quot; to monitor these too. The full default exclusion list is the
-      <b>nodev</b> entries in /proc/filesystems (rootfs is always kept, and the
-      XYMONCLIENT_FS_INCLUDE_TYPES above are kept back), together with the
-      explicit XYMONCLIENT_FS_EXCLUDE_TYPES above. When /proc/filesystems is not
-      readable the dynamic nodev exclusions are disabled; the explicit
-      XYMONCLIENT_FS_EXCLUDE_TYPES and the local-only <b>df -l</b> behaviour
-      remain active. The script does not fall back to deriving exclusions from
-      mount(8), so it is not a drop-in replacement for distro patches (such as
-      Debian's) that do.</dd>
-  <dt></dt>
-  <dd>On NetBSD, both disk and inode reports exclude <b>kernfs procfs cd9660
-      null ptyfs</b> by default. The explicit exclude setting defaults to empty.
-      The <b>ptyfs</b> exclusion is an upgrade-visible change; set
-      XYMONCLIENT_FS_INCLUDE_TYPES=&quot;ptyfs&quot; to report it again. The
-      inode report additionally excludes <b>zfs</b> because it has no fixed
-      inode pool, and drops rows without usable inode accounting. NetBSD tmpfs
-      is retained because its inode counts are memory-derived and can provide a
-      meaningful exhaustion signal.
+  <dd>Whitespace-separated filesystem types (attributes as well, on macOS) to
+      exclude in addition to the client's default exclusions. Matching is on the
+      exact df type token. If a type appears in both include and exclude
+      settings, exclusion takes precedence on every OS.
+    <br/>
+    On Linux: nodev types (overlay, fuse, ...) are already excluded by default,
+      so an effective entry names a type that is not a nodev default &#x2014; a
+      device-backed type, or a specific FUSE subtype such as <b>fuse.sshfs</b>
+      that the bare nodev <b>fuse</b> default cannot match. Defaults to
+      <b>iso9660 squashfs fuse.snapfuse</b> &#x2014; read-only images reported
+      100% full by design (snaps mount as squashfs, or as fuse.snapfuse where
+      snapd falls back to FUSE); none is a nodev type, so they must be named
+      here. Set to &quot;&quot; to monitor these too. The full default exclusion
+      list is the <b>nodev</b> entries in /proc/filesystems (rootfs is always
+      kept, and the XYMONCLIENT_FS_INCLUDE_TYPES above are kept back), together
+      with the explicit XYMONCLIENT_FS_EXCLUDE_TYPES above. When
+      /proc/filesystems is not readable the dynamic nodev exclusions are
+      disabled; the explicit XYMONCLIENT_FS_EXCLUDE_TYPES and the local-only
+      <b>df -l</b> behaviour remain active. The script does not fall back to
+      deriving exclusions from mount(8), so it is not a drop-in replacement for
+      distro patches (such as Debian's) that do.
+    <br/>
+    On FreeBSD: adds types to the <b>df -tno&lt;list&gt;</b> exclude set
+      (default <b>nullfs cd9660 procfs devfs linprocfs fdescfs autofs</b>).
+      Empty by default. tmpfs and mfs are deliberately kept in the disk report
+      &#x2014; RAM-backed capacity is real and fills up &#x2014; so name them
+      here to drop them.
+    <br/>
+    On NetBSD: adds types to the <b>df -tno&lt;list&gt;</b> exclude set (default
+      <b>kernfs procfs cd9660 null ptyfs</b>). Empty by default. tmpfs is kept
+      in both reports, so name it here to drop it.
+    <br/>
+    On OpenBSD: adds types to the <b>df -tno&lt;list&gt;</b> exclude set
+      (default <b>kernfs procfs cd9660</b>). Empty by default. tmpfs is kept in
+      both reports, so name it here to drop it.
+    <br/>
+    On macOS: excludes types or attributes on top of the defaults. Empty by
+      default. It is applied unconditionally, so it wins over both an include
+      entry and the &quot;root data&quot; exemption above. Useful entries
+      include <b>lifs</b> (external FAT/exFAT/NTFS media, mounted through
+      LiveFiles on Ventura and later) and <b>fusefs</b> (macFUSE volumes mounted
+      &quot;-o local&quot;). Beware attributes most mounts carry: excluding
+      &quot;local&quot; drops everything.
     <p class="Pp"></p>
   </dd>
   <dt id="XYMONCLIENT_FS_DF_LOCAL_ONLY"><a class="permalink" href="#XYMONCLIENT_FS_DF_LOCAL_ONLY"><b>XYMONCLIENT_FS_DF_LOCAL_ONLY</b></a></dt>
   <dd>Set to <b>yes</b> (the default) to pass <b>-l</b> to df and report local
       filesystems only. Set to <b>no</b> to report remote filesystems as well.
-      Invalid values produce a warning and use the safe default. With <b>no</b>,
-      a stale or hard-blocked remote mount can wedge df indefinitely (an
-      uninterruptible D-state wait): the client run never finishes, so the whole
-      host goes purple &#x2014; no data for all metrics, not just disk &#x2014;
-      until the mount recovers or the host reboots.</dd>
+      Invalid values produce a warning and use the safe default. On macOS, where
+      df is invoked per path, the same effect is achieved by keeping only mounts
+      flagged &quot;local&quot; (MNT_LOCAL, what <b>df -l</b> selects
+      elsewhere). With <b>no</b>, a stale or hard-blocked remote mount can wedge
+      df indefinitely (an uninterruptible D-state wait): the client run never
+      finishes, so the whole host goes purple &#x2014; no data for all metrics,
+      not just disk &#x2014; until the mount recovers or the host reboots.</dd>
   <dt></dt>
   <dd>A df that <i>exits</i> non-zero with no output (a real error, not a hang)
       is marked failed (yellow) rather than left empty, so a failed filesystem

--- a/tests/packaging/fs-filter-docs-parity.sh
+++ b/tests/packaging/fs-filter-docs-parity.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/packaging/fs-filter-docs-parity.sh
+#
+# Shipped-file invariant: every client OS script that consumes the
+# XYMONCLIENT_FS_* filesystem-filter variables must be documented, per OS, in
+# BOTH halves of the config/manual pair - a "<OS> (xymonclient-<os>.sh)"
+# defaults stub in client/xymonclient.cfg.DIST, and an OS paragraph in
+# common/xymonclient.cfg.5, which is the canonical full contract. The two
+# files ship identically to every OS, so a per-OS port that lands without
+# its doc sections leaves admins reading another OS's defaults (this
+# happened: FreeBSD shipped with neither, macOS with only the cfg.DIST
+# half).
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+DIST="$ROOT/client/xymonclient.cfg.DIST"
+MAN="$ROOT/common/xymonclient.cfg.5"
+
+assert_file_exists "$DIST"
+assert_file_exists "$MAN"
+dist=$(cat "$DIST")
+man=$(cat "$MAN")
+
+checked=0
+for script in "$ROOT"/client/xymonclient-*.sh; do
+	grep -q 'XYMONCLIENT_FS_' "$script" || continue
+	os=$(basename "$script" .sh); os=${os#xymonclient-}
+	case "$os" in
+		linux)   label="Linux" ;;
+		freebsd) label="FreeBSD" ;;
+		netbsd)  label="NetBSD" ;;
+		openbsd) label="OpenBSD" ;;
+		darwin)  label="macOS" ;;
+		sunos)   label="Solaris" ;;
+		aix)     label="AIX" ;;
+		hp-ux)   label="HP-UX" ;;
+		*) fail "no OS label mapping for client script '$script' - extend this test" ;;
+	esac
+
+	assert_contains "$label (xymonclient-$os.sh)" "$dist" \
+		"xymonclient.cfg.DIST lacks the \"$label (xymonclient-$os.sh)\" defaults stub for $script"
+	assert_contains "$label" "$man" \
+		"xymonclient.cfg.5 does not mention $label although $script uses the XYMONCLIENT_FS_ variables"
+	checked=$((checked + 1))
+done
+
+[ "$checked" -gt 0 ] || fail "no client scripts using XYMONCLIENT_FS_ found - test is miswired"
+
+pass "FS-filter docs cover all $checked participating client OSes in cfg.DIST and cfg.5"


### PR DESCRIPTION
## Problem

`xymonclient.cfg.DIST` and `xymonclient.cfg.5` are both shipped identically to every client OS, so OS-specific behavior of the `XYMONCLIENT_FS_*` filter (the only per-OS-variant client config surface) must be scoped *inside* them. Coverage was uneven: **Linux** documented in both, **macOS** only in cfg.DIST, **FreeBSD** (#175) in neither — and cfg.5 described the variables as Linux settings outright, so a FreeBSD/macOS admin reading the manual got another OS's defaults. (Same gap PR #177 just closed for NetBSD, per review there.)

## Change

The split of labor is now explicit: **cfg.5 is the canonical, complete contract; cfg.DIST carries only per-OS defaults stubs** (DRY - the DIST comments no longer duplicate the manual).

- **cfg.DIST**: the verbose per-OS blocks are replaced by one short "Filesystem reporting" section with a defaults stub per OS - `<OS> (xymonclient-<os>.sh)`, that OS's three defaults, and a single hang-warning pointer at the manual. FreeBSD (previously undocumented) gains its stub; the macOS example that showed `EXCLUDE_TYPES="lifs"` although the script default is empty is corrected to `""`.
- **cfg.5**: the three entries get an OS-neutral definition followed by explicit "On Linux:" / "On FreeBSD:" / "On macOS:" paragraphs (defaults, mechanism, macOS attribute matching, the MNT_LOCAL note for DF_LOCAL_ONLY). Details that previously lived only in cfg.DIST comments (e.g. the Linux /run-tmpfs-is-filtered-server-side note) moved here, so nothing is lost. An unlisted OS means the variable does nothing there; #177's NetBSD paragraph slots in as one more.
- **tests/packaging/fs-filter-docs-parity.sh** pins the rule mechanically: every `client/xymonclient-*.sh` consuming `XYMONCLIENT_FS_` must have its defaults stub in cfg.DIST and its OS mention in cfg.5. It fails against unpatched main (the macOS/FreeBSD gaps) and passes here, so the next OS port cannot ship undocumented.

## Coordination

Overlaps with #177 in the same cfg.5 entries (both restructure them); whichever merges second resolves a mechanical conflict by keeping all per-OS paragraphs. All facts cross-checked against the shipped scripts (`xymonclient-freebsd.sh`, `xymonclient-darwin.sh`).

## Validation

- `groff -man -ww` clean on cfg.5
- New test: passes with the docs, fails against unpatched main (negative control)
- Full suite: 21 passed, 13 build-dependent skips, 0 failed
