### PR TITLE
lib/loadhosts: warn about web-unreachable canonical hostnames (#309)

### DIFF
--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -27,6 +27,24 @@ The IP-address and hostname are mandatory; all of the tags are optional.
 Listing a host with only IP-address and hostname will cause a network
 test to be executed for the host - the connectivity test is enabled
 by default, but no other tests.
+.sp
+The hostname is the host's canonical name: it keys the status database and
+appears in web-page URLs and RRD file paths. It is reachable through the web
+interface only when built from the characters
+.B A-Z a-z 0-9
+and
+.BR : . _ -
+(letters, digits, colon, period, underscore and hyphen). A host whose name
+contains any other character - other punctuation, a literal comma (which the
+web URLs use to encode a period, so it cannot appear in a name), or a
+non-ASCII byte - is still monitored, but
+.I xymond(8)
+writes a warning to the Xymon log when it loads the configuration and its
+status pages are not reachable through the web interface. To show a non-ASCII
+or otherwise decorated name in the web interface, give the host an ASCII
+canonical name and carry the display spelling in the
+.B NAME:
+tag (see below).
 
 The optional tags are then used to define which tests are
 relevant for the host, and also to set e.g. the time-interval used

--- a/docs/manpages/man5/hosts.cfg.5.html
+++ b/docs/manpages/man5/hosts.cfg.5.html
@@ -52,6 +52,18 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     optional. Listing a host with only IP-address and hostname will cause a
     network test to be executed for the host - the connectivity test is enabled
     by default, but no other tests.</p>
+<p class="Pp">The hostname is the host's canonical name: it keys the status
+    database and appears in web-page URLs and RRD file paths. It is reachable
+    through the web interface only when built from the characters <b>A-Z a-z
+    0-9</b> and <b>:</b>.<b>_</b>- (letters, digits, colon, period, underscore
+    and hyphen). A host whose name contains any other character - other
+    punctuation, a literal comma (which the web URLs use to encode a period, so
+    it cannot appear in a name), or a non-ASCII byte - is still monitored, but
+    <i><a href="../man8/xymond.8.html">xymond</a>(8)</i> writes a warning to the Xymon log when it loads the
+    configuration and its status pages are not reachable through the web
+    interface. To show a non-ASCII or otherwise decorated name in the web
+    interface, give the host an ASCII canonical name and carry the display
+    spelling in the <b>NAME:</b> tag (see below).</p>
 <p class="Pp">The optional tags are then used to define which tests are relevant
     for the host, and also to set e.g. the time-interval used for availability
     reporting by <i><a href="../man1/xymongen.1.html">xymongen</a>(1)</i></p>

--- a/lib/cgi.c
+++ b/lib/cgi.c
@@ -52,8 +52,10 @@ char *safe_basename(char *path)
  * not survive on a backend where '\\' separates directories. One set, one
  * rule, every parameter; widening it (e.g. to accept UTF-8) is a
  * documented policy change for another day (see hosts.cfg(5) discussion).
+ * The set itself is XYMON_HOSTNAME_CHARS (cgi.h), shared with the hosts.cfg
+ * loader and the xymond ghost-name guard so all three agree.
  */
-#define CGI_NAMECHARS "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ:,._-"
+#define CGI_NAMECHARS XYMON_HOSTNAME_CHARS
 
 /*
  * Confine a CGI value to a single legal path component -- the one policy

--- a/lib/cgi.h
+++ b/lib/cgi.h
@@ -21,6 +21,17 @@ typedef struct cgidata_t {
 enum cgi_method_t { CGI_OTHER, CGI_GET, CGI_POST };
 extern enum cgi_method_t cgi_method;
 
+/*
+ * The character set a Xymon canonical hostname (and the CGI host/service
+ * parameters derived from it) may use: ASCII letters and digits plus the
+ * punctuation real names need -- ':' (IPv6), ',' (the URL spelling of '.'),
+ * '.' (FQDNs / host.service), '_' and '-'. Single point of record so the
+ * hosts.cfg loader, the xymond ghost-name guard and the web CGIs all accept
+ * the same set; widening it (e.g. to UTF-8) is a deliberate policy change
+ * made here, once. See issue #309.
+ */
+#define XYMON_HOSTNAME_CHARS "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ:,._-"
+
 extern char *cgi_error(void);
 extern int cgi_ispost(void);
 extern cgidata_t *cgi_request(void);

--- a/tests/server/loadhosts-canonical-charset.sh
+++ b/tests/server/loadhosts-canonical-charset.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/loadhosts-canonical-charset.sh
+#
+# Behavioural test of the BUILT xymongrep binary, exercising the real
+# load_hostnames() path in libxymon. A canonical hostname (field 2 of
+# hosts.cfg) outside the character set the web CGIs serve
+# (XYMON_HOSTNAME_CHARS, shared with lib/cgi.c and the xymond ghost-name
+# guard) is still loaded and monitored -- it is NOT dropped: dropping it
+# would remove it from the roster, falling out of alerting and letting
+# trimhistory(1) delete its history as orphaned (issue #309).
+#
+# The "your host is web-unreachable" warning is emitted once per config load
+# by xymond, NOT by the shared loader -- the loader runs in every short-lived
+# CGI process, so warning there would repeat on every page render. This test
+# pins both halves: xymongrep (a loader client) loads every host AND stays
+# silent; it does not emit the warning.
+#
+# A space cannot reach field 2 (the parser's "%s" stops at whitespace), so it
+# is not a case here; the reachable violations are punctuation and non-ASCII.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+default="common/xymongrep"
+if [ -z "${XYMONGREP:-}" ] && [ ! -x "$(find_root)/$default" ] \
+		&& [ -x "$(find_root)/client/xymongrep" ]; then
+	default="client/xymongrep"
+fi
+require_bin XYMONGREP "$default"
+
+work=$(mktempdir)
+# Every host is tagged "cpu" so one grep lists all that load. raksmorgas keeps
+# an ASCII canonical name and its non-ASCII spelling in NAME:.
+cat >"$work/hosts.cfg" <<'EOF'
+1.2.3.4		goodhost		# cpu
+1.2.3.5		host.example.com	# cpu
+1.2.3.6		fe80-host		# cpu
+1.2.3.7		host_01			# cpu
+1.2.3.8		raksmorgas		# NAME:"räksmörgås" cpu
+1.2.3.9		host(1)			# cpu
+1.2.3.10	bad!host		# cpu
+1.2.3.11	räkserver		# cpu
+EOF
+
+# --hosts= keeps the test hermetic (no xymond needed).
+out=$("$XYMONGREP" --hosts="$work/hosts.cfg" cpu 2>"$work/err")
+err=$(cat "$work/err")
+
+# Every host loads and is selectable -- the well-formed names AND the ones with
+# characters the web cannot serve: the loader keeps them, it does not drop them.
+assert_contains "goodhost # cpu"         "$out" "plain ASCII name loads"
+assert_contains "host.example.com # cpu" "$out" "FQDN (dots) loads"
+assert_contains "fe80-host # cpu"        "$out" "hyphenated name loads"
+assert_contains "host_01 # cpu"          "$out" "underscore name loads"
+assert_contains "raksmorgas # cpu"       "$out" "ASCII canonical with a non-ASCII NAME: loads"
+assert_contains "host(1) # cpu"          "$out" "punctuation name is still monitored, not dropped"
+assert_contains "bad!host # cpu"         "$out" "punctuation name is still monitored, not dropped"
+assert_contains "räkserver # cpu"        "$out" "non-ASCII name is still monitored, not dropped"
+
+# The shared loader stays silent: the web-unreachability warning is emitted by
+# xymond once per config load, not by every CGI/xymongrep run.
+assert_not_contains "not reachable"    "$err" "the loader does not warn (warning is daemon-only)"
+assert_not_contains "Warning: hostname" "$err" "the loader emits no per-load hostname warning"
+
+pass "loadhosts keeps web-unreachable canonical hostnames and stays silent (#309)"

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -983,6 +983,41 @@ void posttoall(char *msg)
 }
 
 
+/*
+ * True if a hostname uses only web-servable characters (XYMON_HOSTNAME_CHARS,
+ * shared with the CGIs). A configured host whose canonical name fails this
+ * still loads and is monitored, but its svcstatus/history/reportlog pages are
+ * unreachable; warn_unreachable_hostnames() reports that once per config load.
+ * Single scan, one definition for both the ghost-name guard and that warning.
+ * (issue #309)
+ */
+static int hostname_web_safe(const char *name)
+{
+	return name[strspn(name, XYMON_HOSTNAME_CHARS)] == '\0';
+}
+
+/*
+ * Warn about configured hosts whose canonical name the web interface cannot
+ * serve. Called once after each hosts.cfg (re)load in the daemon, NOT from the
+ * shared loader -- that runs in every short-lived CGI process and would repeat
+ * the warning on every page render.
+ */
+static void warn_unreachable_hostnames(void)
+{
+	void *hrec;
+
+	for (hrec = first_host(); hrec; hrec = next_host(hrec, 0)) {
+		char *name = xmh_item(hrec, XMH_HOSTNAME);
+
+		/* A literal comma is web-unreachable even though XYMON_HOSTNAME_CHARS
+		 * lists it (the CGIs need it for the 192,168,1,1 IP spelling): every
+		 * generated URL runs the name through uncommafy(), so a configured
+		 * "foo,bar" resolves to "foo.bar" -- a different host. */
+		if (name && (!hostname_web_safe(name) || strchr(name, ',')))
+			errprintf("Warning: hostname '%s' in hosts.cfg has characters the web interface cannot serve; it is monitored but its web pages are not reachable. Use an ASCII canonical name and a NAME: tag for the displayed spelling.\n", name);
+	}
+}
+
 char *log_ghost(char *hostname, char *sender, char *msg)
 {
 	xtreePos_t ghandle;
@@ -1004,7 +1039,7 @@ char *log_ghost(char *hostname, char *sender, char *msg)
 	gwalk = (ghandle != xtreeEnd(rbghosts)) ? (ghostlist_t *)xtreeData(rbghosts, ghandle) : NULL;
 
 	/* Disallow weird test names - Note: a future version may restrict these to valid hostname + DNS labels and not preserve case */
-	if (!gwalk && (strlen(hostname) != strspn(hostname, "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ:,._-")) ) {
+	if (!gwalk && !hostname_web_safe(hostname) ) {
 		errprintf("Bogus message from %s: Invalid new hostname '%s'\n", sender, hostname);
 		return NULL;
 	}
@@ -5646,6 +5681,11 @@ int main(int argc, char *argv[])
 		reopen_file(logfn, "a", stderr);
 	}
 
+	/* Warn about web-unreachable canonical hostnames only now that stderr
+	 * points at the log, so startup warnings land there and not just on the
+	 * launching terminal -- matching the reload path. */
+	warn_unreachable_hostnames();
+
 	if (ackinfologfn) {
 		ackinfologfd = fopen(ackinfologfn, "a");
 		if (ackinfologfd == NULL) {
@@ -5704,6 +5744,8 @@ int main(int argc, char *argv[])
 			loadresult = load_hostnames(hostsfn, NULL, get_fqdn());
 
 			if (loadresult == 0) {
+				warn_unreachable_hostnames();
+
 				/* Scan our list of hosts and weed out those we do not know about any more */
 				hosthandle = xtreeFirst(rbhosts);
 				while (hosthandle != xtreeEnd(rbhosts)) {


### PR DESCRIPTION
Closes #309.

## Problem
The `hosts.cfg` parser accepts any non-whitespace token as a canonical hostname (field 2), while the web CGIs and the xymond ghost-name guard confine host names to a safe set. Such a host loads and is monitored, yet its `svcstatus`/`history`/`reportlog` pages are unreachable — with nothing said.

## What this does
`xymond` warns once per config (re)load about a canonical name the web cannot serve — from the daemon, **not** the shared loader (which runs in every short-lived CGI process and would flood the error log). The host is **never dropped**: dropping it removes it from the roster (out of alerting) and lets `trimhistory(1)` delete its history as orphaned. Non-ASCII/decorated spellings belong in the `NAME:` display tag.

The character set is one `XYMON_HOSTNAME_CHARS` (`lib/cgi.h`), shared by `cgi.c`'s `CGI_NAMECHARS` and the ghost guard; a `hostname_web_safe()` helper backs both. A literal comma is also flagged — it stays in the set for the CGI `192,168,1,1` spelling, but `uncommafy()` collapses `foo,bar`→`foo.bar`.

Documented in `hosts.cfg(5)` (HTML regenerated); tested via the built `xymongrep`, which loads every host and stays silent. `RELEASENOTES`/`Changes` text is staged in the comment below.
