### PR TITLE
tests: find the untracked sources without "grep --include"

### DIFF
--- a/tests/packaging/loadhosts-aliasing.sh
+++ b/tests/packaging/loadhosts-aliasing.sh
@@ -390,13 +390,17 @@ diff -u "$work/selftest.expected" "$work/selftest.out" >&2 \
 	|| fail "self-test: scanner output differs from expected (diff above)"
 
 # --- The real scan -----------------------------------------------------------
-# Tracked sources when this tree is the tracked one; otherwise (a tarball,
-# even one unpacked inside some other git repo) everything present.
+# Tracked sources when this tree is the tracked one; otherwise (a tarball, even
+# one unpacked inside some other git repo) everything present. The untracked
+# branch selects with find, not "grep --include": that option is GNU-only, and
+# busybox grep -- the whole of Alpine and any container without GNU grep --
+# rejects it, leaving an empty list that reads as a stale parser.
 cd "$ROOT"
 if git ls-files --error-unmatch lib/loadhosts.c >/dev/null 2>&1; then
 	git ls-files -- '*.c' | { xargs -r grep -l 'xmh_item' || true; } > "$work/files"
 else
-	grep -rl 'xmh_item' --include=*.c . > "$work/files" || true
+	find . -name '*.c' -type f -print \
+		| { xargs -r grep -l 'xmh_item' || true; } > "$work/files"
 fi
 [ -s "$work/files" ] || fail "found no xmh_item() call sites -- the parser is stale"
 


### PR DESCRIPTION
loadhosts-aliasing.sh scans every `.c` file for callers that mutate a pointer returned by the loadhosts API. It builds the file list two ways: `git ls-files` when the tree is the tracked one, and a recursive grep otherwise, so a tarball — or a checkout git declines to read — still gets scanned.

The fallback asked for `grep -rl --include=*.c`. `--include` is a GNU extension. busybox grep rejects it, which is every Alpine container and any image without GNU grep installed:

```
grep: unrecognized option: include=*.c
BusyBox v1.37.0 (2025-12-16 14:19:28 UTC) multi-call binary.
...
FAIL: found no xmh_item() call sites -- the parser is stale
```

The `|| true` meant to tolerate "no matches" swallowed the usage error instead, the list came out empty, and the emptiness check reported a stale parser — pointing at the scanner rather than at the missing option.

## Change

Select with `find` and hand the names to a plain `grep -l`, the same shape the tracked branch immediately above already uses.

```diff
-	grep -rl 'xmh_item' --include=*.c . > "$work/files" || true
+	find . -name '*.c' -type f -print \
+		| { xargs -r grep -l 'xmh_item' || true; } > "$work/files"
```

## Why it was never caught

The suite only ever ran on ubuntu, where grep is GNU, so the fallback path's portability was never exercised. It surfaced when the suite was run inside each distro's own container.

## Verification

Both branches (tracked and untracked) under GNU grep and busybox grep:

| tree | GNU grep | busybox grep |
|---|---|---|
| tracked (git) | PASS | PASS |
| untracked | PASS | PASS — was the failure |

All four select the identical 38 files. With an offender planted in `xymond/`, the untracked+busybox run still reports it and exits 1, so the test passes for the right reason rather than by scanning nothing.

Full suite green; `shellcheck` emits the same two pre-existing informational findings before and after.