### PR TITLE
tests: decide on ASAN by running a probe, not by compiling one

### DIFF
--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -142,6 +142,43 @@ require_cc() {
 	command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
 }
 
+# asan_usable -- true when $CC can build a sanitized binary AND the result
+# runs. Compiling is not the question: distros that ship the sanitizer
+# runtime in its own package (Amazon Linux 2023 and the other RPM families,
+# where it is libasan/libubsan) link -fsanitize=address happily, and only
+# the finished binary fails, at startup, with
+#
+#     error while loading shared libraries: libasan.so.6: ...
+#
+# and exit 127. A caller that gated on the compile alone then reads that as
+# a crash in the code under test -- the symptom this helper exists to stop.
+# So the probe is executed, not just built.
+#
+# Callers use it to pick between a sanitized build and a plain one, or to
+# skip outright when the sanitizer is the point of the test. The verdict
+# cannot change inside one test process, so it is computed once.
+#
+# The probe directory is removed here rather than left to the EXIT trap
+# registered at the top of this file: several callers install a trap of
+# their own for their work dir, which replaces that one, and the probe
+# would then survive the run. A helper cannot assume the shared cleanup is
+# still armed by the time it is called, so it cleans up after itself.
+asan_usable() {
+	if [ -z "${__xymon_tests_asan_usable:-}" ]; then
+		local probe
+		__xymon_tests_asan_usable=no
+		probe=$(mktempdir)
+		printf 'int main(void){return 0;}\n' >"$probe/probe.c"
+		if "${CC:-cc}" -fsanitize=address,undefined -o "$probe/probe" \
+					"$probe/probe.c" 2>/dev/null \
+				&& "$probe/probe" >/dev/null 2>&1; then
+			__xymon_tests_asan_usable=yes
+		fi
+		rm -rf "$probe"
+	fi
+	[ "$__xymon_tests_asan_usable" = yes ]
+}
+
 # require_c_buildenv ROOT -- skip unless a C compiler, make, and a configured
 # tree (include/config.h) are present. The shared baseline for every test
 # that compiles a harness against the in-tree libraries, so a new shared

--- a/tests/network/ntp-probe.sh
+++ b/tests/network/ntp-probe.sh
@@ -19,6 +19,8 @@ if [ -r "$here/../lib/assert.sh" ]; then
 else
 	fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 	skip() { printf 'SKIP: %s\n' "$*" >&2; exit 77; }
+	# Standalone copy, no assert.sh to probe with: take the plain build.
+	asan_usable() { return 1; }
 fi
 
 CC=${CC:-cc}
@@ -27,8 +29,11 @@ command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
+# The sanitized build is a bonus, so fall back to a plain one whenever it is
+# not available -- including where -fsanitize links but will not run (see
+# asan_usable), which no compile check can see.
 harness="$work/ntp-probe"
-if ! "$CC" -g -O1 -fsanitize=address,undefined -o "$harness" \
+if ! asan_usable || ! "$CC" -g -O1 -fsanitize=address,undefined -o "$harness" \
 		"$here/ntp-probe-harness.c" 2>"$work/cc-asan.log"; then
 	"$CC" -g -O1 -o "$harness" "$here/ntp-probe-harness.c" 2>"$work/cc.log" \
 		|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/network/udp-query.sh
+++ b/tests/network/udp-query.sh
@@ -18,6 +18,8 @@ if [ -r "$here/../lib/assert.sh" ]; then
 else
 	fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 	skip() { printf 'SKIP: %s\n' "$*" >&2; exit 77; }
+	# Standalone copy, no assert.sh to probe with: take the plain build.
+	asan_usable() { return 1; }
 fi
 
 CC=${CC:-cc}
@@ -31,8 +33,11 @@ trap 'rm -rf "$work"' EXIT
 # path; the loopback hosts that run this test all have <sys/select.h>.
 printf '#define HAVE_SYS_SELECT_H 1\n' > "$work/config.h"
 
+# The sanitized build is a bonus, so fall back to a plain one whenever it is
+# not available -- including where -fsanitize links but will not run (see
+# asan_usable), which no compile check can see.
 harness="$work/udp-query"
-if ! "$CC" -g -O1 -fsanitize=address,undefined -I"$work" -o "$harness" \
+if ! asan_usable || ! "$CC" -g -O1 -fsanitize=address,undefined -I"$work" -o "$harness" \
 		"$here/udp-query-harness.c" 2>"$work/cc-asan.log"; then
 	"$CC" -g -O1 -I"$work" -o "$harness" "$here/udp-query-harness.c" 2>"$work/cc.log" \
 		|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/rrd/ntp-offset-parse.sh
+++ b/tests/rrd/ntp-offset-parse.sh
@@ -19,6 +19,8 @@ else
 	fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
 	skip() { printf 'SKIP: %s\n' "$*" >&2; exit 77; }
 	require_cc() { CC=${CC:-cc}; command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"; }
+	# Standalone copy, no assert.sh to probe with: take the plain build.
+	asan_usable() { return 1; }
 fi
 
 require_cc
@@ -26,8 +28,11 @@ require_cc
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
+# The sanitized build is a bonus, so fall back to a plain one whenever it is
+# not available -- including where -fsanitize links but will not run (see
+# asan_usable), which no compile check can see.
 harness="$work/ntp-offset-parse"
-if ! "$CC" -g -O1 -fsanitize=address,undefined -o "$harness" \
+if ! asan_usable || ! "$CC" -g -O1 -fsanitize=address,undefined -o "$harness" \
 		"$here/ntp-offset-parse-harness.c" 2>"$work/cc-asan.log"; then
 	"$CC" -g -O1 -o "$harness" "$here/ntp-offset-parse-harness.c" 2>"$work/cc.log" \
 		|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/web/history-reportlog-reject.sh
+++ b/tests/web/history-reportlog-reject.sh
@@ -32,7 +32,12 @@ require_c_buildenv "$ROOT"
 # the pre-daemon rejection path, so the dead-port endpoint is unused.
 svcstatus_setup
 
+# "Where available" is settled by running a probe, not by compiling one: a
+# host can link the sanitizer and still fail to load it, and the CGI would
+# then exit 127 at startup -- which run_cgi below reads as the very crash
+# this test hunts for. Without it, build plain and keep the weaker check.
 cflags="-g -O1 -fsanitize=address,undefined"
+asan_usable || cflags=""
 export ASAN_OPTIONS="exitcode=99${ASAN_OPTIONS:+:$ASAN_OPTIONS}"
 for cgi in history reportlog; do
 	"$CC" $cflags -I"$ROOT/include" -I"$ROOT/lib" -I"$ROOT/web" -o "$work/$cgi" \

--- a/tests/web/svcstatus-histlog-serving.sh
+++ b/tests/web/svcstatus-histlog-serving.sh
@@ -30,9 +30,12 @@ svcstatus_setup --no-daemon
 # Prefer an ASAN build so the long-line case below detects a stack write
 # past the parse buffer as a crash instead of silent corruption. An ASAN
 # error must not exit 1 (render treats 1 as an ordinary refusal), so make
-# it exit 99. Fall back to a plain build where ASAN is unavailable.
+# it exit 99. Fall back to a plain build where ASAN is unavailable -- which
+# asan_usable settles by running a probe, because a host can link the
+# sanitizer and still not load it, and the CGI would then die at startup
+# with exit 127, indistinguishable here from the crash we are hunting.
 export ASAN_OPTIONS="exitcode=99${ASAN_OPTIONS:+:$ASAN_OPTIONS}"
-svcstatus_build -g -O1 -fsanitize=address,undefined \
+{ asan_usable && svcstatus_build -g -O1 -fsanitize=address,undefined; } \
 	|| svcstatus_build \
 	|| { cat "$work/cc.log" >&2; fail "svcstatus does not build -- cannot verify histlog serving"; }
 


### PR DESCRIPTION
Five tests prefer a sanitized build and fall back to a plain one, and each picked between them by asking whether `-fsanitize=address,undefined` **compiles**. That is not the question that matters.

The RPM families ship the sanitizer runtime in its own package (`libasan`, `libubsan`). Where the package is absent — Amazon Linux 2023 — the compile and the link both succeed, and only the finished binary fails, at startup:

```
error while loading shared libraries: libasan.so.6: cannot open shared object file
```

exiting 127. The fallback never fired, because nothing had failed yet.

The three tests that run a harness reported a broken parser. The two that run a CGI saw exit 127 and reported a crash, having sent the loader's message to `/dev/null`:

```
FAIL: history.cgi exited 127 (crash?) on QUERY_STRING='HISTFILE=..'
FAIL: svcstatus exited 127 (crash?) on QUERY_STRING=HOST=realhost&SERVICE=web.grp&TIMEBUF=20260101
```

All five blamed the code under test for a missing package.

## Change

`asan_usable()` in `tests/lib/assert.sh`: build a probe, **run** it, cache the verdict. Running is the point — a successful link says nothing about whether the runtime is installed. The five callers gate on it, so a host without the runtime takes the plain build they already had.

The pattern is not new here. `xtree-destroy.sh` and `xtree-iterate-deleted.sh` have always executed their probe:

```sh
"$CC" -fsanitize=address -o "$work/probe" "$work/probe.c" 2>/dev/null \
	&& "$work/probe" 2>/dev/null \
	|| skip "cc does not support -fsanitize=address"
```

which is exactly why those two came through Amazon Linux 2023 green while the other five did not. This puts the check in one place rather than adding a sixth copy, and leaves those two untouched.

Standalone copies of the three harness tests — the branch taken when `assert.sh` is not readable — define `asan_usable` as false and build plain.

## Verification

A `cc` shim reproduces the condition: it strips `-fsanitize` and links a stub library reachable via `-L` but not by the loader, so the sanitized link succeeds and the binary dies at exec with 127. It reproduces both CGI failure lines above verbatim.

| | before | after |
|---|---|---|
| suite under shim | **5 failed** | **0 failed** — 50 passed, 3 skipped |
| suite unshimmed (real ASAN) | 52 / 1 / 0 | 52 / 1 / 0 |

Under the shim the two xtree tests skip via their own probe, as they should.

The non-regression check matters most: unshimmed, `asan_usable` returns true and the harness still links `libasan.so.6` and `libubsan.so.1`. This does not quietly disable the sanitizer where it works.

`shellcheck` output is unchanged before and after on every touched file.

## Note

Installing `libasan`/`libubsan` on the RPM lanes would give those distros real sanitizer coverage instead of a graceful downgrade. That is a separate CI change; this fix is needed regardless, since any host can lack the runtime.
