### PR TITLE
tests: run the tree's Makefiles with GNU make, not whatever is named make

### DIFF
--- a/tests/buildsystem/docs-templating.sh
+++ b/tests/buildsystem/docs-templating.sh
@@ -19,9 +19,8 @@ set -euo pipefail
 
 ROOT=$(find_root)
 DOCS="$ROOT/docs"
-MAKE="${MAKE:-make}"
 
-command -v "$MAKE" >/dev/null 2>&1 || skip "no make"
+require_gnu_make
 for f in Makefile install.html.DIST xymon-apacheconf.txt.DIST; do
 	[ -f "$DOCS/$f" ] || skip "docs/$f absent -- predates #90"
 done
@@ -30,7 +29,7 @@ work=$(mktempdir)
 cp "$DOCS/Makefile" "$DOCS/install.html.DIST" \
    "$DOCS/xymon-apacheconf.txt.DIST" "$work/"
 
-"$MAKE" -C "$work" install.html xymon-apacheconf.txt \
+"$XYMON_MAKE" -C "$work" install.html xymon-apacheconf.txt \
 	INSTALLETCDIR=/etc/xymon XYMONTOPDIR=/opt/xymon XYMONUSER=xymonuser \
 	INSTALLWWWDIR=/var/www/xymon CGIDIR=/cgi SECURECGIDIR=/secure-cgi \
 	>"$work/make.log" 2>&1 \

--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -179,14 +179,50 @@ asan_usable() {
 	[ "$__xymon_tests_asan_usable" = yes ]
 }
 
-# require_c_buildenv ROOT -- skip unless a C compiler, make, and a configured
-# tree (include/config.h) are present. The shared baseline for every test
-# that compiles a harness against the in-tree libraries, so a new shared
+# require_gnu_make -- resolve GNU make into $XYMON_MAKE, or skip.
+#
+# Every Makefile in the tree is GNU make: lib/Makefile opens with an `ifeq`,
+# build/Makefile.rules uses pattern rules. On the BSDs /usr/bin/make is BSD
+# make, which stops at the first conditional --
+#
+#     make: lib/Makefile:10: Invalid line "ifeq ($(LOCALCLIENT),yes)"
+#
+# -- so a test that ran `make` there hard-failed on a tree that builds
+# perfectly well with gmake, which is what the build itself uses.
+#
+# Resolution order: $MAKE if the caller exported one (autopkgtest, a distro
+# build), then gmake, then make. Each candidate must identify itself as GNU
+# make; a candidate that exists but is not GNU make is passed over rather
+# than trusted, because "a program named make is on PATH" is the assumption
+# that produced the failure above.
+#
+# No GNU make at all is a missing host dependency, so it skips -- same
+# contract as a missing compiler (tests/README.md). Resolved once: PATH
+# cannot change inside one test process.
+require_gnu_make() {
+	[ -n "${XYMON_MAKE:-}" ] && return 0
+	local candidate
+	for candidate in ${MAKE:-} gmake make; do
+		command -v "$candidate" >/dev/null 2>&1 || continue
+		# Matched on the whole banner rather than `--version | head -1`:
+		# every test runs under `set -o pipefail`, and head exiting after
+		# the first line can SIGPIPE the writer, failing the pipeline for
+		# a candidate that answered correctly.
+		case $("$candidate" --version 2>/dev/null) in
+			"GNU Make"*) XYMON_MAKE=$candidate; return 0 ;;
+		esac
+	done
+	skip "GNU make not found (the tree's Makefiles are GNU make -- install gmake)"
+}
+
+# require_c_buildenv ROOT -- skip unless a C compiler, GNU make, and a
+# configured tree (include/config.h) are present. The shared baseline for every
+# test that compiles a harness against the in-tree libraries, so a new shared
 # skip condition lands in one place; a test may still add stricter
 # conditions of its own (e.g. "tree already built") next to its call.
 require_c_buildenv() {
 	require_cc
-	command -v make >/dev/null 2>&1 || skip "make not available"
+	require_gnu_make
 	[ -f "$1/include/config.h" ] || skip "tree not configured (no include/config.h)"
 }
 
@@ -195,7 +231,8 @@ require_c_buildenv() {
 build_xymon_libs() {
 	local root=$1 log=$2
 	shift 2
-	make -C "$root/lib" "$@" >"$log" 2>&1 \
+	require_gnu_make
+	"$XYMON_MAKE" -C "$root/lib" "$@" >"$log" 2>&1 \
 		|| { cat "$log" >&2; fail "cannot build $*"; }
 }
 

--- a/tests/lib/build-worker.sh
+++ b/tests/lib/build-worker.sh
@@ -27,7 +27,7 @@ build_xymond_worker() {
 	cc=${CC:-cc}
 
 	command -v "$cc" >/dev/null 2>&1 || skip "no C compiler available (CC=$cc)"
-	command -v make >/dev/null 2>&1 || skip "make not available"
+	require_gnu_make
 	[ -f "$root/include/config.h" ] || skip "tree not configured (no include/config.h)"
 	[ -f "$root/Makefile" ] || skip "tree not configured (no Makefile)"
 
@@ -37,7 +37,7 @@ build_xymond_worker() {
 	# If make cannot run the stdin-makefile probe, harvest the same four
 	# variables from the Makefile plus the files it includes.
 	treelibs=$(printf '__testlibs:\n\t@echo $(ZLIBLIBS) $(SSLLIBS) $(NETLIBS) $(LIBRTDEF)\n' \
-			| make -s -C "$root" -f Makefile -f - __testlibs 2>/dev/null) || {
+			| "$XYMON_MAKE" -s -C "$root" -f Makefile -f - __testlibs 2>/dev/null) || {
 		mkfiles="$root/Makefile"
 		while read -r inc; do
 			[ -n "$inc" ] && mkfiles="$mkfiles $root/$inc"
@@ -56,7 +56,7 @@ build_xymond_worker() {
 	fi
 	[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
 
-	make -C "$root/lib" libxymon.a libxymoncomm.a libxymontime.a >"$outdir/libbuild.log" 2>&1 \
+	"$XYMON_MAKE" -C "$root/lib" libxymon.a libxymoncomm.a libxymontime.a >"$outdir/libbuild.log" 2>&1 \
 		|| { cat "$outdir/libbuild.log" >&2; fail "the xymon libraries do not build in this configured tree"; }
 
 	srcs=()

--- a/tests/rrd/inode-unix-columns.sh
+++ b/tests/rrd/inode-unix-columns.sh
@@ -16,7 +16,7 @@ mkdir -p "$work/home/etc" "$work/tmp" "$work/rrd"
 : > "$work/home/etc/analysis.cfg"
 : > "$work/hosts.cfg"
 
-buildflags_output=$(make -s -C "$ROOT" -f Makefile -f - inode-test-flags <<'EOF'
+buildflags_output=$("$XYMON_MAKE" -s -C "$ROOT" -f Makefile -f - inode-test-flags <<'EOF'
 .PHONY: inode-test-flags
 inode-test-flags:
 	@printf '%s\n' 'ldflags=$(LDFLAGS)' 'rpathopt=$(RPATHOPT)' \

--- a/tests/server/analysis-ds-firstmatch.sh
+++ b/tests/server/analysis-ds-firstmatch.sh
@@ -48,14 +48,14 @@ CLIENT_CONFIG_C="$ROOT/xymond/client_config.c"
 
 CC=${CC:-cc}
 command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
-command -v make  >/dev/null 2>&1 || skip "make not available"
+require_gnu_make
 
 [ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
 	|| skip "tree not built (run make first; the post-build CI suite covers this)"
 
 work=$(mktempdir)
 
-make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+"$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
 ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")

--- a/tests/server/namematch-case.sh
+++ b/tests/server/namematch-case.sh
@@ -28,7 +28,8 @@ command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
 
 work=$(mktempdir)
 
-make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+require_gnu_make
+"$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
 ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")

--- a/tests/server/notbefore-notafter.sh
+++ b/tests/server/notbefore-notafter.sh
@@ -46,7 +46,8 @@ command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
 work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-notbefore.XXXXXX")
 trap 'rm -rf "$work"' EXIT HUP INT TERM
 
-make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+require_gnu_make
+"$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
 cat > "$work/hosts.cfg" <<'EOF'

--- a/tests/server/xymond-noflap-list.sh
+++ b/tests/server/xymond-noflap-list.sh
@@ -53,7 +53,8 @@ command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
 work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-noflap-list.XXXXXX")
 trap 'rm -rf "$work"' EXIT HUP INT TERM
 
-make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+require_gnu_make
+"$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 

--- a/tests/server/xymond-noflap-prefix.sh
+++ b/tests/server/xymond-noflap-prefix.sh
@@ -37,7 +37,8 @@ command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
 work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-noflap-prefix.XXXXXX")
 trap 'rm -rf "$work"' EXIT HUP INT TERM
 
-make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+require_gnu_make
+"$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
 # Tags are spelled lowercase, as hosts.cfg(5) documents them, even though the

--- a/tests/web/showgraph-exec-title.sh
+++ b/tests/web/showgraph-exec-title.sh
@@ -19,7 +19,7 @@ ROOT=$(find_root)
 
 CC=${CC:-cc}
 command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
-command -v make >/dev/null 2>&1 || skip "make not available"
+require_gnu_make
 [ -f "$ROOT/web/showgraph.cgi" ] || skip "tree built without RRD support (no showgraph.cgi)"
 
 rrddef=$(sed -n 's/^RRDDEF *= *//p' "$ROOT/Makefile")
@@ -36,7 +36,7 @@ fi
 work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-showgraph-exec.XXXXXX")
 trap 'rm -rf "$work"' EXIT HUP INT TERM
 
-make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+"$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
 "$CC" -I"$ROOT/include" -I"$ROOT/lib" $rrddef -o "$work/showgraph" \

--- a/tests/web/showgraph-single-service.sh
+++ b/tests/web/showgraph-single-service.sh
@@ -17,7 +17,7 @@ ROOT=$(find_root)
 
 CC=${CC:-cc}
 command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
-command -v make >/dev/null 2>&1 || skip "make not available"
+require_gnu_make
 
 # Needs a configured/built tree (bare-tree CI skips; the post-build suite
 # runs it for real) and one built WITH RRD support.
@@ -41,7 +41,7 @@ fi
 work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-showgraph.XXXXXX")
 trap 'rm -rf "$work"' EXIT HUP INT TERM
 
-make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+"$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
 "$CC" -I"$ROOT/include" -I"$ROOT/lib" $rrddef -o "$work/showgraph" \


### PR DESCRIPTION
Closes #326.

Every Makefile in the tree is GNU make. The suite ran them with plain `make`,
which on the BSDs is BSD make and stops at `lib/Makefile`'s first conditional,
so 22 tests hard-failed on trees that build fine. The build itself already
picks gmake there; only the test stage did not.

`require_gnu_make()` resolves it once into `$XYMON_MAKE` — `$MAKE` if exported,
then `gmake`, then `make`, each having to identify itself as GNU make. Eleven
call sites go through it.

The probe was the more insidious half of the old code. `command -v make` finds
BSD make, reports the build environment as present, and leaves the test to
hard-fail — the exact outcome `require_c_buildenv` exists to prevent. Now a
host with no GNU make skips, like a missing compiler; what it can no longer do
is select a tool that cannot parse the file.

## Verified

Linux server build, three runs, no change from the `main` baseline of
`53/0/0`:

```
passed:  53 skipped: 0 failed:  0 (run 1)
passed:  53 skipped: 0 failed:  0 (run 2)
passed:  53 skipped: 0 failed:  0 (run 3)
```

The three runs are not decoration. The first draft used `make --version | head
-1 | grep -q`, and under the `set -o pipefail` every test runs with, `head`
exiting early can SIGPIPE the writer and fail the pipeline for a candidate that
answered correctly — it skipped a different test on each run. Matching the
banner through a `case` removed the pipeline and the flakiness with it.

**A BSD-like `make` first on `PATH`, gmake present** — a stub reporting `bmake
(NetBSD make) 20200710` and refusing to parse conditionals, exactly what the
FreeBSD lanes have:

```
passed:  52 skipped: 1 failed:  0
```

All 22 previously-failing tests pass by resolving gmake. The one skip is
`configure-no-rrd.sh`, which runs the real `./configure --server`; configure
does its own GNU-make detection and aborts before reaching the RRD probe, which
is that test's own documented skip path, not a regression.

**No GNU make anywhere** (both `make` and `gmake` stubbed non-GNU):

```
tests/server/namematch-case.sh          rc=77  SKIP: GNU make not found (the tree's Makefiles are GNU make -- install gmake)
tests/buildsystem/docs-templating.sh    rc=77  SKIP: GNU make not found ...
tests/xymond/hostdata-save-throttle.sh  rc=77  SKIP: GNU make not found ...
tests/rrd/inode-unix-columns.sh         rc=77  SKIP: GNU make not found ...
```

Skip, not fail, with a message naming the fix.

**`MAKE=gmake` override** — honoured (`rc=0`). `docs-templating.sh` already read
`$MAKE`; it keeps that and gains the probe.

## What this does not prove

The BSD behaviour above is a simulation on Linux, not a BSD run. `main`'s CI is
`ubuntu-latest` only, so nothing here can execute on a platform where
`/usr/bin/make` is BSD make. Real confirmation needs a run of the
multi-platform lane set after this merges.

## Merge order

Touches files also touched by the PRs for #327 and #328 — `tests/lib/assert.sh`,
`tests/lib/build-worker.sh` and seven of the inline-`make` tests. Whichever
merges second needs a rebase; the edits are on adjacent lines, not the same
ones, except in `build-worker.sh` where all three change the compile/build
lines.
