### PR TITLE
tests: resolve the PCRE include directory, not just its libraries

### DIFF
--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -236,6 +236,57 @@ build_xymon_libs() {
 		|| { cat "$log" >&2; fail "cannot build $*"; }
 }
 
+# pcre_cflags ROOT -- print the compile flags a harness needs to reach
+# <pcre2.h>, or nothing when the header is already on the default search
+# path.
+#
+# Every harness that includes libxymon.h needs this whether or not it uses
+# PCRE: libxymon.h pulls in lib/loadalerts.h, which includes <pcre2.h>. The
+# harnesses resolved the PCRE *libraries* and assumed the *header*, which
+# holds on Linux (/usr/include/pcre2.h) and fails wherever PCRE lives under
+# a prefix -- on FreeBSD, /usr/local/include:
+#
+#     lib/loadalerts.h:20:10: fatal error: 'pcre2.h' file not found
+#
+# Resolution mirrors the PCRELIBS order already used for the link, most
+# specific first: an explicit override, then the configured tree (whose
+# PCREINCDIR is by definition what the library being linked was built
+# against, and already carries its -I), then pkg-config, then nothing.
+pcre_cflags() {
+	local root=$1 flags=${PCRECFLAGS:-}
+	[ -n "$flags" ] || [ ! -f "$root/Makefile" ] \
+		|| flags=$(sed -n 's/^PCREINCDIR *= *//p' "$root/Makefile")
+	if [ -z "$flags" ] && command -v pkg-config >/dev/null 2>&1; then
+		flags=$(pkg-config --cflags libpcre2-8 2>/dev/null || true)
+	fi
+	printf '%s' "$flags"
+}
+
+# xymon_cflags ROOT -- the include flags a harness compiled against the
+# in-tree libraries needs: the tree's own headers, and wherever <pcre2.h>
+# lives. Callers add whatever else they need after it (the harness's own
+# -iquote ROOT/web or ROOT/xymond, -DSTANDALONE, the RRD defines).
+#
+# The tree's directories go on the *quoted* path and the PCRE directory on
+# the angle-bracket one, because that is how each is included: every in-tree
+# header is reached through #include "...", while loadalerts.h asks for
+# <pcre2.h>. Putting the tree on the angle-bracket path is what makes
+# lib/availability.h answer the macOS SDK's #include <Availability.h> on a
+# case-insensitive filesystem (#328).
+#
+# Bundled into one helper rather than offered as separate flags on purpose.
+# Neither mistake here was a wrong flag: each was a flag that every harness
+# had to remember for itself. The PCRE path had to be remembered fourteen
+# times and eleven compile lines did not remember it; -iquote has to be
+# remembered at forty-two flags across nineteen files, and the next harness
+# written will have to remember it again. A compile line can no longer say
+# where the tree's headers are without also saying how to reach them and
+# where pcre2.h is.
+xymon_cflags() {
+	local root=$1
+	printf '%s' "-iquote $root/include -iquote $root/lib $(pcre_cflags "$root")"
+}
+
 # ---- repo location -----------------------------------------------------------
 
 # find_root -- print the absolute path of the repo root, derived from the

--- a/tests/lib/build-worker.sh
+++ b/tests/lib/build-worker.sh
@@ -21,7 +21,7 @@
 __XYMON_TESTS_BUILD_WORKER_SOURCED=1
 
 build_xymond_worker() {
-	local outdir=$1 prog=$2 root cc treelibs pcre_libs src srcs mkfiles inc
+	local outdir=$1 prog=$2 root cc treelibs pcre_libs harness_cflags src srcs mkfiles inc
 	shift 2
 	root=$(find_root)
 	cc=${CC:-cc}
@@ -55,6 +55,7 @@ build_xymond_worker() {
 		pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
 	fi
 	[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+	harness_cflags=$(xymon_cflags "$root")
 
 	"$XYMON_MAKE" -C "$root/lib" libxymon.a libxymoncomm.a libxymontime.a >"$outdir/libbuild.log" 2>&1 \
 		|| { cat "$outdir/libbuild.log" >&2; fail "the xymon libraries do not build in this configured tree"; }
@@ -63,7 +64,7 @@ build_xymond_worker() {
 	for src in "$@"; do srcs+=("$root/$src"); done
 
 	# Archives listed twice rather than --start-group, which is GNU ld only.
-	"$cc" -iquote "$root/include" -iquote "$root/lib" -iquote "$root/xymond" -o "$outdir/$prog" \
+	"$cc" $harness_cflags -iquote "$root/xymond" -o "$outdir/$prog" \
 		"${srcs[@]}" \
 		"$root/lib/libxymon.a" "$root/lib/libxymoncomm.a" "$root/lib/libxymontime.a" \
 		"$root/lib/libxymon.a" \

--- a/tests/lib/svcstatus-cgi.sh
+++ b/tests/lib/svcstatus-cgi.sh
@@ -103,7 +103,7 @@ svcstatus_setup() {
 # libxymon.h, ...) changes, bumping its mtime. So any code change in the tree
 # is newer than the cache and forces a rebuild; the cache never hides one.
 svcstatus_build() {
-	local flagkey bin
+	local flagkey bin harness_cflags
 	flagkey=$(printf '%s' "$*" | tr -c 'A-Za-z0-9' '_')
 	bin="${TMPDIR:-/tmp}/xymon-svcstatus-cache.$(id -u)/$(printf '%s' "$ROOT" | tr -c 'A-Za-z0-9' '_').${flagkey:-plain}"
 	mkdir -p "$(dirname "$bin")"
@@ -116,7 +116,8 @@ svcstatus_build() {
 		return 0
 	fi
 
-	"$CC" "$@" -iquote "$ROOT/include" -iquote "$ROOT/lib" -iquote "$ROOT/web" -o "$work/svcstatus" \
+	harness_cflags=$(xymon_cflags "$ROOT")
+	"$CC" "$@" $harness_cflags -iquote "$ROOT/web" -o "$work/svcstatus" \
 		"$ROOT/web/svcstatus.c" "$ROOT/web/svcstatus-info.c" "$ROOT/web/svcstatus-trends.c" \
 		"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
 		$pcre_libs $ssllibs $netlibs $librtdef 2>"$work/cc.log" || return 1

--- a/tests/network/netrc-password.sh
+++ b/tests/network/netrc-password.sh
@@ -86,7 +86,8 @@ EOF
 
 # lib/url.c goes before the archive so its fresh objects satisfy the netrc
 # symbols and the archive's (possibly stale) url.o is never pulled in.
-"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
+harness_cflags=$(xymon_cflags "$ROOT")
+"$CC" $harness_cflags -o "$work/harness" \
 	"$work/harness.c" "$SRC" "$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "netrc harness does not compile"; }
 

--- a/tests/server/analysis-ds-firstmatch.sh
+++ b/tests/server/analysis-ds-firstmatch.sh
@@ -65,7 +65,8 @@ if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
 fi
 [ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
 
-"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -iquote "$ROOT/xymond" -o "$work/harness" \
+harness_cflags=$(xymon_cflags "$ROOT")
+"$CC" $harness_cflags -iquote "$ROOT/xymond" -o "$work/harness" \
 	"$here/analysis-ds-firstmatch-harness.c" "$CLIENT_CONFIG_C" \
 	"$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/server/config-include-dir.sh
+++ b/tests/server/config-include-dir.sh
@@ -88,7 +88,8 @@ if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
 fi
 [ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
 
-"$CC" -DSTANDALONE -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/stackio" \
+harness_cflags=$(xymon_cflags "$ROOT")
+"$CC" -DSTANDALONE $harness_cflags -o "$work/stackio" \
 	"$ROOT/lib/stackio.c" "$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "standalone stackio does not compile"; }
 

--- a/tests/server/namematch-case.sh
+++ b/tests/server/namematch-case.sh
@@ -81,7 +81,8 @@ int main(void)
 }
 EOF
 
-"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
+harness_cflags=$(xymon_cflags "$ROOT")
+"$CC" $harness_cflags -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 

--- a/tests/server/notbefore-notafter.sh
+++ b/tests/server/notbefore-notafter.sh
@@ -162,7 +162,8 @@ EOF
 # --no-ssl build, and carries the -L a non-standard OpenSSL prefix needs.
 ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 
-"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
+harness_cflags=$(xymon_cflags "$ROOT")
+"$CC" $harness_cflags -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
 	$ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/server/xmh-item-names.sh
+++ b/tests/server/xmh-item-names.sh
@@ -62,7 +62,8 @@ cat > "$work/hosts.cfg" <<'EOF'
 127.0.0.1 plainhost.example.com # conn
 EOF
 
-"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
+harness_cflags=$(xymon_cflags "$ROOT")
+"$CC" $harness_cflags -o "$work/harness" \
 	"$here/xmh-item-names-harness.c" "$ROOT/lib/libxymoncomm.a" \
 	$ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/server/xymond-noflap-list.sh
+++ b/tests/server/xymond-noflap-list.sh
@@ -74,7 +74,8 @@ cat > "$work/hosts.cfg" <<'EOF'
 127.0.0.1 recordhost.example.com # conn noflap=web,cpu
 EOF
 
-"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
+harness_cflags=$(xymon_cflags "$ROOT")
+"$CC" $harness_cflags -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
 	$ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/server/xymond-noflap-prefix.sh
+++ b/tests/server/xymond-noflap-prefix.sh
@@ -108,7 +108,8 @@ EOF
 # --no-ssl build, and carries the -L a non-standard OpenSSL prefix needs.
 ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 
-"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
+harness_cflags=$(xymon_cflags "$ROOT")
+"$CC" $harness_cflags -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
 	$ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/web/history-reportlog-reject.sh
+++ b/tests/web/history-reportlog-reject.sh
@@ -38,13 +38,14 @@ svcstatus_setup
 # this test hunts for. Without it, build plain and keep the weaker check.
 cflags="-g -O1 -fsanitize=address,undefined"
 asan_usable || cflags=""
+harness_cflags=$(xymon_cflags "$ROOT")
 export ASAN_OPTIONS="exitcode=99${ASAN_OPTIONS:+:$ASAN_OPTIONS}"
 for cgi in history reportlog; do
-	"$CC" $cflags -iquote "$ROOT/include" -iquote "$ROOT/lib" -iquote "$ROOT/web" -o "$work/$cgi" \
+	"$CC" $cflags $harness_cflags -iquote "$ROOT/web" -o "$work/$cgi" \
 		"$ROOT/web/$cgi.c" \
 		"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
 		$pcre_libs $ssllibs $netlibs $librtdef 2>"$work/cc-$cgi.log" \
-	|| { "$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -iquote "$ROOT/web" -o "$work/$cgi" \
+	|| { "$CC" $harness_cflags -iquote "$ROOT/web" -o "$work/$cgi" \
 			"$ROOT/web/$cgi.c" \
 			"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
 			$pcre_libs $ssllibs $netlibs $librtdef 2>"$work/cc-$cgi.log" \

--- a/tests/web/html-log-custom-graphs.sh
+++ b/tests/web/html-log-custom-graphs.sh
@@ -35,7 +35,8 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 	|| skip "tree not built (run make first; the post-build CI suite covers this)"
 build_xymon_libs "$ROOT" "$work/libbuild.log" libxymoncomm.a
 
-"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
+harness_cflags=$(xymon_cflags "$ROOT")
+"$CC" $harness_cflags -o "$work/harness" \
 	"$here/html-log-custom-graphs-harness.c" "$ROOT/lib/libxymoncomm.a" \
 	$pcre_libs -lssl -lcrypto 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/web/showgraph-exec-title.sh
+++ b/tests/web/showgraph-exec-title.sh
@@ -39,7 +39,8 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 "$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
-"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" $rrddef -o "$work/showgraph" \
+harness_cflags=$(xymon_cflags "$ROOT")
+"$CC" $harness_cflags $rrddef -o "$work/showgraph" \
 	"$ROOT/web/showgraph.c" "$ROOT/lib/libxymoncomm.a" \
 	$pcre_libs $rrdlibs $ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "showgraph does not compile"; }

--- a/tests/web/showgraph-single-service.sh
+++ b/tests/web/showgraph-single-service.sh
@@ -44,7 +44,8 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 "$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
-"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" $rrddef -o "$work/showgraph" \
+harness_cflags=$(xymon_cflags "$ROOT")
+"$CC" $harness_cflags $rrddef -o "$work/showgraph" \
 	"$ROOT/web/showgraph.c" "$ROOT/lib/libxymoncomm.a" \
 	$pcre_libs $rrdlibs $ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "showgraph does not compile"; }


### PR DESCRIPTION
Closes #327.

Harnesses that include `libxymon.h` need `<pcre2.h>` whether or not they use
PCRE — `libxymon.h` pulls in `lib/loadalerts.h`, which includes it. They
resolved the PCRE *libraries* through an env override and pkg-config, then
compiled with no matching include path. That works on Linux only because
`/usr/include/pcre2.h` is already on the default search path; where PCRE lives
under a prefix it does not:

```
lib/loadalerts.h:20:10: fatal error: 'pcre2.h' file not found
FAIL: netrc harness does not compile
```

on every FreeBSD lane, in tests that have nothing to do with PCRE.

`pcre_cflags()` resolves it in the order the link flags already use, most
specific first: `$PCRECFLAGS`, then the configured tree's `PCREINCDIR` — by
definition what the library being linked was built against, and it already
carries its `-I` — then `pkg-config --cflags`, then nothing, which is correct
where the header is already found.

**Three call sites, not the two the issue lists.** `tests/lib/build-worker.sh`
compiles xymond sources through the same include chain and would have hit this
next, once #326 lets the BSD lanes get far enough to compile at all.

## Verified

Linux server build: `passed: 53  skipped: 0  failed: 0`, unchanged from the
`main` baseline. Here `pcre_cflags` resolves to the empty string — the header is
in `/usr/include` — so the no-op path is the one CI exercises today.

Each source in turn:

```
default:      []
env override: [-I/opt/pcre/include]        # PCRECFLAGS
makefile:     [-I/from/the/configured/tree] # PCREINCDIR appended to a scratch Makefile
```

That the flag reaches the compiler, and takes precedence, is shown with a decoy
header — a directory holding a `pcre2.h` that is nothing but `#error decoy
pcre2.h was used`, pointed at with `PCRECFLAGS`:

```
$ PCRECFLAGS=-I.../decoy ./tests/network/netrc-password.sh
.../decoy/pcre2.h:1:2: error: #error decoy pcre2.h was used
```

Same for `config-include-dir.sh` (4 hits) and, through `build-worker.sh`,
`hostdata-save-throttle.sh` (8 hits). A prefixed `pcre2.h` is now found for the
same reason the decoy is.

## What this does not prove

The failing platform is not reachable from `main`'s CI, which is
`ubuntu-latest` only. The decoy stands in for `/usr/local/include/pcre2.h`;
real confirmation needs a FreeBSD run after this merges.

## Merge order

`tests/lib/assert.sh`, `tests/lib/build-worker.sh`,
`tests/network/netrc-password.sh` and `tests/server/config-include-dir.sh` are
also touched by the PRs for #326 and #328. Whichever merges second needs a
rebase.
