### PR TITLE
tests: reach in-tree headers with -iquote, not -I

### DIFF
--- a/tests/lib/build-worker.sh
+++ b/tests/lib/build-worker.sh
@@ -63,7 +63,7 @@ build_xymond_worker() {
 	for src in "$@"; do srcs+=("$root/$src"); done
 
 	# Archives listed twice rather than --start-group, which is GNU ld only.
-	"$cc" -I"$root/include" -I"$root/lib" -I"$root/xymond" -o "$outdir/$prog" \
+	"$cc" -iquote "$root/include" -iquote "$root/lib" -iquote "$root/xymond" -o "$outdir/$prog" \
 		"${srcs[@]}" \
 		"$root/lib/libxymon.a" "$root/lib/libxymoncomm.a" "$root/lib/libxymontime.a" \
 		"$root/lib/libxymon.a" \

--- a/tests/lib/svcstatus-cgi.sh
+++ b/tests/lib/svcstatus-cgi.sh
@@ -116,7 +116,7 @@ svcstatus_build() {
 		return 0
 	fi
 
-	"$CC" "$@" -I"$ROOT/include" -I"$ROOT/lib" -I"$ROOT/web" -o "$work/svcstatus" \
+	"$CC" "$@" -iquote "$ROOT/include" -iquote "$ROOT/lib" -iquote "$ROOT/web" -o "$work/svcstatus" \
 		"$ROOT/web/svcstatus.c" "$ROOT/web/svcstatus-info.c" "$ROOT/web/svcstatus-trends.c" \
 		"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
 		$pcre_libs $ssllibs $netlibs $librtdef 2>"$work/cc.log" || return 1

--- a/tests/network/netrc-password.sh
+++ b/tests/network/netrc-password.sh
@@ -86,7 +86,7 @@ EOF
 
 # lib/url.c goes before the archive so its fresh objects satisfy the netrc
 # symbols and the archive's (possibly stale) url.o is never pulled in.
-"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
 	"$work/harness.c" "$SRC" "$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "netrc harness does not compile"; }
 

--- a/tests/rrd/inode-unix-columns.sh
+++ b/tests/rrd/inode-unix-columns.sh
@@ -34,7 +34,7 @@ rrdlibs=${buildflags[4]#rrdlibs=}
 
 # Configured flags are deliberate word-split lists.
 # shellcheck disable=SC2086
-"$CC" $ldflags -I"$ROOT/include" $rrddef $rrdincdir \
+"$CC" $ldflags -iquote "$ROOT/include" $rrddef $rrdincdir \
 	-o "$work/rrd-lastupdate" $rpathopt \
 	"$ROOT/tests/rrd/inode-unix-columns-harness.c" $rrdlibs \
 	2>"$work/cc.log" || {

--- a/tests/server/analysis-ds-firstmatch.sh
+++ b/tests/server/analysis-ds-firstmatch.sh
@@ -65,7 +65,7 @@ if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
 fi
 [ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
 
-"$CC" -I"$ROOT/include" -I"$ROOT/lib" -I"$ROOT/xymond" -o "$work/harness" \
+"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -iquote "$ROOT/xymond" -o "$work/harness" \
 	"$here/analysis-ds-firstmatch-harness.c" "$CLIENT_CONFIG_C" \
 	"$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/server/config-include-dir.sh
+++ b/tests/server/config-include-dir.sh
@@ -88,7 +88,7 @@ if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
 fi
 [ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
 
-"$CC" -DSTANDALONE -I"$ROOT/include" -I"$ROOT/lib" -o "$work/stackio" \
+"$CC" -DSTANDALONE -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/stackio" \
 	"$ROOT/lib/stackio.c" "$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "standalone stackio does not compile"; }
 

--- a/tests/server/namematch-case.sh
+++ b/tests/server/namematch-case.sh
@@ -80,7 +80,7 @@ int main(void)
 }
 EOF
 
-"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 

--- a/tests/server/notbefore-notafter.sh
+++ b/tests/server/notbefore-notafter.sh
@@ -161,7 +161,7 @@ EOF
 # --no-ssl build, and carries the -L a non-standard OpenSSL prefix needs.
 ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 
-"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
 	$ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/server/sbuf-define-c90.sh
+++ b/tests/server/sbuf-define-c90.sh
@@ -46,7 +46,7 @@ int check(void)
 EOF
 
 "$CC" -fsyntax-only -Wall -Werror=declaration-after-statement \
-	-I"$ROOT/lib" "$work/sbuf-c90.c" 2>"$work/cc.log" \
+	-iquote "$ROOT/lib" "$work/sbuf-c90.c" 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; \
 	     fail "SBUF_DEFINE followed by a declaration trips -Werror=declaration-after-statement (macro ends in ';'?)"; }
 

--- a/tests/server/xmh-item-names.sh
+++ b/tests/server/xmh-item-names.sh
@@ -62,7 +62,7 @@ cat > "$work/hosts.cfg" <<'EOF'
 127.0.0.1 plainhost.example.com # conn
 EOF
 
-"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
 	"$here/xmh-item-names-harness.c" "$ROOT/lib/libxymoncomm.a" \
 	$ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/server/xtree-destroy.sh
+++ b/tests/server/xtree-destroy.sh
@@ -74,13 +74,13 @@ mkdir -p "$work/shim-tsearch" "$work/shim-fallback"
 echo '#define HAVE_BINARY_TREE 1' >"$work/shim-tsearch/config.h"
 echo '#undef HAVE_BINARY_TREE' >"$work/shim-fallback/config.h"
 
-"$CC" -g -fsanitize=address -I"$work/shim-tsearch" -I"$ROOT/lib" \
+"$CC" -g -fsanitize=address -I"$work/shim-tsearch" -iquote "$ROOT/lib" \
 	-o "$work/t-tsearch" "$work/harness.c" "$ROOT/lib/tree.c" 2>"$work/cc1.log" \
 	|| { cat "$work/cc1.log" >&2; fail "tsearch-variant harness does not compile"; }
 "$work/t-tsearch" >"$work/out1" 2>&1 \
 	|| fail "tsearch variant leaks or fails (rc=$?): $(tail -15 "$work/out1")"
 
-"$CC" -g -fsanitize=address -I"$work/shim-fallback" -I"$ROOT/lib" \
+"$CC" -g -fsanitize=address -I"$work/shim-fallback" -iquote "$ROOT/lib" \
 	-o "$work/t-fallback" "$work/harness.c" "$ROOT/lib/tree.c" 2>"$work/cc2.log" \
 	|| { cat "$work/cc2.log" >&2; fail "fallback-variant harness does not compile"; }
 "$work/t-fallback" >"$work/out2" 2>&1 \

--- a/tests/server/xtree-iterate-deleted.sh
+++ b/tests/server/xtree-iterate-deleted.sh
@@ -112,13 +112,13 @@ mkdir -p "$work/shim-tsearch" "$work/shim-fallback"
 echo '#define HAVE_BINARY_TREE 1' >"$work/shim-tsearch/config.h"
 echo '#undef HAVE_BINARY_TREE' >"$work/shim-fallback/config.h"
 
-"$CC" -g -fsanitize=address -I"$work/shim-tsearch" -I"$ROOT/lib" \
+"$CC" -g -fsanitize=address -I"$work/shim-tsearch" -iquote "$ROOT/lib" \
 	-o "$work/t-tsearch" "$work/harness.c" "$ROOT/lib/tree.c" 2>"$work/cc1.log" \
 	|| { cat "$work/cc1.log" >&2; fail "tsearch-variant harness does not compile"; }
 "$work/t-tsearch" >"$work/out1" 2>&1 \
 	|| fail "tsearch variant visits deleted records (rc=$?): $(tail -15 "$work/out1")"
 
-"$CC" -g -fsanitize=address -I"$work/shim-fallback" -I"$ROOT/lib" \
+"$CC" -g -fsanitize=address -I"$work/shim-fallback" -iquote "$ROOT/lib" \
 	-o "$work/t-fallback" "$work/harness.c" "$ROOT/lib/tree.c" 2>"$work/cc2.log" \
 	|| { cat "$work/cc2.log" >&2; fail "fallback-variant harness does not compile"; }
 "$work/t-fallback" >"$work/out2" 2>&1 \

--- a/tests/server/xymond-noflap-list.sh
+++ b/tests/server/xymond-noflap-list.sh
@@ -73,7 +73,7 @@ cat > "$work/hosts.cfg" <<'EOF'
 127.0.0.1 recordhost.example.com # conn noflap=web,cpu
 EOF
 
-"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
 	$ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/server/xymond-noflap-prefix.sh
+++ b/tests/server/xymond-noflap-prefix.sh
@@ -107,7 +107,7 @@ EOF
 # --no-ssl build, and carries the -L a non-standard OpenSSL prefix needs.
 ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 
-"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
 	$ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/web/cgi-split-hostsvc.sh
+++ b/tests/web/cgi-split-hostsvc.sh
@@ -23,7 +23,7 @@ work=$(mktempdir)
 
 build_xymon_libs "$ROOT" "$work/libbuild.log" libxymon.a
 
-"$CC" -I"$ROOT/include" -o "$work/harness" \
+"$CC" -iquote "$ROOT/include" -o "$work/harness" \
 	"$(dirname "$0")/cgi-split-hostsvc-harness.c" "$ROOT/lib/libxymon.a" \
 	2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/web/history-reportlog-reject.sh
+++ b/tests/web/history-reportlog-reject.sh
@@ -40,11 +40,11 @@ cflags="-g -O1 -fsanitize=address,undefined"
 asan_usable || cflags=""
 export ASAN_OPTIONS="exitcode=99${ASAN_OPTIONS:+:$ASAN_OPTIONS}"
 for cgi in history reportlog; do
-	"$CC" $cflags -I"$ROOT/include" -I"$ROOT/lib" -I"$ROOT/web" -o "$work/$cgi" \
+	"$CC" $cflags -iquote "$ROOT/include" -iquote "$ROOT/lib" -iquote "$ROOT/web" -o "$work/$cgi" \
 		"$ROOT/web/$cgi.c" \
 		"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
 		$pcre_libs $ssllibs $netlibs $librtdef 2>"$work/cc-$cgi.log" \
-	|| { "$CC" -I"$ROOT/include" -I"$ROOT/lib" -I"$ROOT/web" -o "$work/$cgi" \
+	|| { "$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -iquote "$ROOT/web" -o "$work/$cgi" \
 			"$ROOT/web/$cgi.c" \
 			"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
 			$pcre_libs $ssllibs $netlibs $librtdef 2>"$work/cc-$cgi.log" \

--- a/tests/web/html-log-custom-graphs.sh
+++ b/tests/web/html-log-custom-graphs.sh
@@ -35,7 +35,7 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 	|| skip "tree not built (run make first; the post-build CI suite covers this)"
 build_xymon_libs "$ROOT" "$work/libbuild.log" libxymoncomm.a
 
-"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" -o "$work/harness" \
 	"$here/html-log-custom-graphs-harness.c" "$ROOT/lib/libxymoncomm.a" \
 	$pcre_libs -lssl -lcrypto 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/web/showgraph-exec-title.sh
+++ b/tests/web/showgraph-exec-title.sh
@@ -39,7 +39,7 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
-"$CC" -I"$ROOT/include" -I"$ROOT/lib" $rrddef -o "$work/showgraph" \
+"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" $rrddef -o "$work/showgraph" \
 	"$ROOT/web/showgraph.c" "$ROOT/lib/libxymoncomm.a" \
 	$pcre_libs $rrdlibs $ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "showgraph does not compile"; }

--- a/tests/web/showgraph-single-service.sh
+++ b/tests/web/showgraph-single-service.sh
@@ -44,7 +44,7 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 make -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
-"$CC" -I"$ROOT/include" -I"$ROOT/lib" $rrddef -o "$work/showgraph" \
+"$CC" -iquote "$ROOT/include" -iquote "$ROOT/lib" $rrddef -o "$work/showgraph" \
 	"$ROOT/web/showgraph.c" "$ROOT/lib/libxymoncomm.a" \
 	$pcre_libs $rrdlibs $ssllibs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "showgraph does not compile"; }


### PR DESCRIPTION
Closes #328.

The harnesses put the tree's own source directories on the **angle-bracket**
include path. On macOS, whose filesystem is case-insensitive, `-I$ROOT/lib`
then answers the SDK's own `#include <Availability.h>` with xymon's
`lib/availability.h`. `__OSX_AVAILABLE_STARTING` and `__API_AVAILABLE` are
never defined, and every system prototype carrying one fails to parse:

```
lib/Availability.h:53:53: error: unknown type name 'time_t'
   53 | extern int history_color(FILE *fd, time_t snapshot, ...);
sys/stdio.h:48:56: error: expected function body after function declarator
```

The first line names it: clang prints the path as spelled in the `#include`,
but line 53 is `history_color()` — ours. All sixteen affected tests fail; the
macOS lanes report `27 passed, 26 failed`.

The real build is immune because it never passes the flag —
`build/Makefile.rules:11` adds `-I$(BUILDTOPDIR)/include` and nothing else.

`-iquote` grants exactly what the harnesses use. Every in-tree header they
reach is reached through `#include "..."`, and no source in the tree — product
or test — includes an in-tree header with angle brackets. So the SDK gets its
`Availability.h` back and the harnesses lose nothing.

Applied to all four in-tree directories (`include`, `lib`, `web`, `xymond`)
rather than `lib` alone: the collision is a property of putting the tree's
sources on the angle-bracket path at all, and `lib/availability.h` is only
where it landed first. 42 flags across 19 files.

## Verified

Linux server build: `passed: 53  skipped: 0  failed: 0`, unchanged from the
`main` baseline, and no in-tree `-I` left in `tests/`.

Linux is case-sensitive, so the collision itself cannot be reproduced here. What
can be isolated is the compiler semantics the fix turns on — a directory holding
an empty `availability.h`, reached both ways, on both compilers:

| | `#include <availability.h>` | `#include "availability.h"` |
| --- | --- | --- |
| `-I dir` | **found** — the macOS hazard | found |
| `-iquote dir` | **not found** | **found** |

gcc 12 and clang 14, identical results. The middle cell is the bug; the right
column is why nothing breaks.

Also checked before converting: nothing in the tree does `#include <libxymon.h>`
or the equivalent for any other in-tree header, and the only angle-bracket
includes in test harness sources are system headers
(`<netinet/in.h>`, `<arpa/inet.h>`).

## What this does not prove

That macOS goes green. `main`'s CI is `ubuntu-latest` only; real confirmation
needs a macOS run after this merges. One macOS failure is also **not** fixed
here and needs its own change: `tests/server/client-msgs-sections.sh:9` uses
`mapfile`, a bash 4 builtin, and macOS ships bash 3.2 (`rc=127`). Noted in #328.

## Merge order

Overlaps the PRs for #326 (nine files) and #327 (three files). Whichever merges
second needs a rebase; in `tests/lib/build-worker.sh` all three PRs touch the
compile line.
