### PR TITLE
xymond: stop checkpointing a gap that can no longer bridge

### DIFF
--- a/common/xymon.1
+++ b/common/xymon.1
@@ -206,7 +206,8 @@ Status color (green, yellow, red, blue, clear, purple)
 .IP "\fBtestflags\fR"
 For network tests, the flags indicating details about the test (used by xymongen).
 .IP "\fBlastchange\fR"
-Unix timestamp when the status color last changed.
+Unix timestamp when the current status color began, i.e. the hold-time of
+the color shown. See "Hold-time and no-data gaps" below.
 .IP "\fBlogtime\fR"
 Unix timestamp when the log message was received.
 .IP "\fBvalidtime\fR"
@@ -292,6 +293,21 @@ and with the following inequalities:  >= > <= < = !=
 
 These filters are: lastchange, logtime, validtime, acktime, disabletime
 
+Hold-time and no-data gaps
+
+\fBlastchange\fR is the hold-time of the color shown: when that color
+began, not when a message last moved it. If a test stops reporting and
+later resumes with the same color, the silence counts as hold-time and the
+value is unchanged across it - the status did not move while it was out of
+sight. A gap longer than four times the report validity is not bridged, and
+a resume with a different color starts a new hold-time. The gap is measured
+from when the status went stale, itself one report validity after the last
+report.
+
+This value can therefore move backwards, which matters for the
+\fBlastchange\fR filter above: a poller asking for changes since its last
+look will not see a bridged recovery.
+
 The response is one line for each status that matches the CRITERIA,
 or all statuses if no criteria is specified. The line is composed of
 a number of fields, separated by a pipe-sign. You can select which
@@ -307,7 +323,8 @@ Status color (green, yellow, red, blue, clear, purple)
 .IP "\fBflags\fR"
 For network tests, the flags indicating details about the test (used by xymongen).
 .IP "\fBlastchange\fR"
-Unix timestamp when the status color last changed.
+Unix timestamp when the current status color began, i.e. the hold-time of
+the color shown. See "Hold-time and no-data gaps" below.
 .IP "\fBlogtime\fR"
 Unix timestamp when the log message was received.
 .IP "\fBvalidtime\fR"

--- a/docs/manpages/man1/xymon.1.html
+++ b/docs/manpages/man1/xymon.1.html
@@ -252,7 +252,8 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
   <dd>For network tests, the flags indicating details about the test (used by
       xymongen).</dd>
   <dt id="lastchange"><a class="permalink" href="#lastchange"><b>lastchange</b></a></dt>
-  <dd>Unix timestamp when the status color last changed.</dd>
+  <dd>Unix timestamp when the current status color began, i.e. the hold-time of
+      the color shown. See &quot;Hold-time and no-data gaps&quot; below.</dd>
   <dt id="logtime"><a class="permalink" href="#logtime"><b>logtime</b></a></dt>
   <dd>Unix timestamp when the log message was received.</dd>
   <dt id="validtime"><a class="permalink" href="#validtime"><b>validtime</b></a></dt>
@@ -344,6 +345,18 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
   !=</p>
 <p class="Pp">These filters are: lastchange, logtime, validtime, acktime,
     disabletime</p>
+<p class="Pp">Hold-time and no-data gaps</p>
+<p class="Pp"><b>lastchange</b> is the hold-time of the color shown: when that
+    color began, not when a message last moved it. If a test stops reporting and
+    later resumes with the same color, the silence counts as hold-time and the
+    value is unchanged across it - the status did not move while it was out of
+    sight. A gap longer than four times the report validity is not bridged, and
+    a resume with a different color starts a new hold-time. The gap is measured
+    from when the status went stale, itself one report validity after the last
+    report.</p>
+<p class="Pp">This value can therefore move backwards, which matters for the
+    <b>lastchange</b> filter above: a poller asking for changes since its last
+    look will not see a bridged recovery.</p>
 <p class="Pp">The response is one line for each status that matches the
     CRITERIA, or all statuses if no criteria is specified. The line is composed
     of a number of fields, separated by a pipe-sign. You can select which fields
@@ -361,7 +374,8 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
   <dd>For network tests, the flags indicating details about the test (used by
       xymongen).</dd>
   <dt id="lastchange~2"><a class="permalink" href="#lastchange~2"><b>lastchange</b></a></dt>
-  <dd>Unix timestamp when the status color last changed.</dd>
+  <dd>Unix timestamp when the current status color began, i.e. the hold-time of
+      the color shown. See &quot;Hold-time and no-data gaps&quot; below.</dd>
   <dt id="logtime~2"><a class="permalink" href="#logtime~2"><b>logtime</b></a></dt>
   <dd>Unix timestamp when the log message was received.</dd>
   <dt id="validtime~2"><a class="permalink" href="#validtime~2"><b>validtime</b></a></dt>

--- a/tests/server/xymond-checkpoint-roundtrip.sh
+++ b/tests/server/xymond-checkpoint-roundtrip.sh
@@ -23,6 +23,11 @@
 #      the file. The file says "flapping when we checkpointed", which after a
 #      long stop is not "flapping now".
 #
+#   4. A no-data gap is carried while it can still bridge a hold-time, and
+#      dropped once it cannot. A gap only ends when the recorded color becomes
+#      the reporter's own again, which never happens while something overrides
+#      it, so without the second half the record is written forever.
+#
 # Needs a built tree: xymond itself and the xymon client.
 
 set -euo pipefail
@@ -195,4 +200,46 @@ esac
 
 stop_xymond
 
-pass "checkpoint round-trip keeps the released status record, carries the flap state, and re-derives flapping"
+# ---- a gap is carried while it can still bridge, and not once it cannot -----
+#
+# The gap fields exist to let a resumed test carry its hold-time across the
+# silence, which holdtime_bridges() refuses past GAPBRIDGE_VALIDITIES report
+# validities. Past that the gap decides nothing, so it must not be written --
+# otherwise a test whose color xymond permanently overrides (an RRDDS modifier,
+# refreshed by xymond_client every client cycle) carries a record in every
+# checkpoint from the first override until the modifier stops.
+#
+# Both halves restore and save without sending a status, so the gap is written
+# back exactly as the daemon holds it. The restored validity is defaultvalidity,
+# 30 minutes, so the window is two hours.
+
+# write_gap_checkpoint GAPSTART -- conn showing the CLEAR xymond invented, with
+# a gap open since GAPSTART carrying a red held from an hour ago.
+write_gap_checkpoint() {
+	local gapstart=$1 held=$(( $(date +%s) - 3600 ))
+
+	printf '@@XYMONDCHK-V1||testhost.example.com|conn|127.0.0.1|clear||red|%s|%s|%s|0|0|0|0|status testhost,example,com.conn clear invented|||0|0\n' \
+		"$held" "$held" "$(( $(date +%s) + 86400 ))" > "$work/chk.gap"
+	printf '@@XYMONDCHK-V1|.flapstate.|testhost.example.com|conn|0|none|none|red|%s|%s|0,0,0,0,0\n' \
+		"$held" "$gapstart" >> "$work/chk.gap"
+}
+
+# saved_gapcolor -- the gap color in the checkpoint xymond just wrote, or
+# "none" when it wrote no .flapstate. record at all.
+saved_gapcolor() {
+	awk -F'|' '$2 == ".flapstate." { print $8; found=1 } END { if (!found) print "none" }' "$work/chk"
+}
+
+write_gap_checkpoint "$(( $(date +%s) - 60 ))"
+start_xymond --restart="$work/chk.gap"
+stop_xymond
+[ "$(saved_gapcolor)" = "red" ] \
+	|| fail "a gap 60s old was not carried through a restart (got $(saved_gapcolor)); the hold-time it would bridge is lost"
+
+write_gap_checkpoint "$(( $(date +%s) - 86400 ))"
+start_xymond --restart="$work/chk.gap"
+stop_xymond
+[ "$(saved_gapcolor)" = "none" ] \
+	|| fail "a day-old gap was written back as $(saved_gapcolor); nothing can bridge it any more, so it is state that never goes away"
+
+pass "checkpoint round-trip keeps the released status record, carries the flap state, re-derives flapping, and drops a gap past its bridge window"

--- a/tests/server/xymond-checkpoint-roundtrip.sh
+++ b/tests/server/xymond-checkpoint-roundtrip.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-checkpoint-roundtrip.sh
+#
+# Drives a real xymond through save and restore of its checkpoint file.
+#
+# Three things this pins, all of which are invisible to a compile and to any
+# source-level check:
+#
+#   1. The status record keeps the field count every released xymond expects.
+#      Its reader errors on a field it does not know and skips the whole line,
+#      so one extra field costs an older build the entire board -- statuses,
+#      acknowledgements and disables -- the first time someone rolls back.
+#      Flap and hold-time state therefore rides in its own ".flapstate."
+#      record, which unrecognised-record skipping already swallows.
+#
+#   2. Both flap colours survive a restart. Left at the calloc default the
+#      first update after startup compares a real colour against a fabricated
+#      green and records a status change that never happened.
+#
+#   3. The flapping flag is re-derived from the restored ring, not taken from
+#      the file. The file says "flapping when we checkpointed", which after a
+#      long stop is not "flapping now".
+#
+# Needs a built tree: xymond itself and the xymon client.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+require_bin XYMOND xymond/xymond
+require_bin XYMONCLIENT common/xymon
+
+command -v sed >/dev/null 2>&1 || skip "sed not available"
+
+work=$(mktempdir)
+
+XYMOND_PID=""
+stop_xymond() {
+	[ -n "$XYMOND_PID" ] || return 0
+	kill "$XYMOND_PID" 2>/dev/null || true
+	# xymond writes its checkpoint during shutdown; wait for it to finish.
+	local i=0
+	while kill -0 "$XYMOND_PID" 2>/dev/null && [ "$i" -lt 100 ]; do
+		sleep 0.1
+		i=$((i+1))
+	done
+	XYMOND_PID=""
+}
+register_cleanup stop_xymond
+
+printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.cfg"
+
+# xymond refuses to start unless XYMONHOME names a real directory, so the
+# stock xymonserver.cfg -- which points at the install prefix -- only works on
+# a machine that already has Xymon installed. Point it at the test's own
+# directory instead, and create what xymond expects to find under it.
+mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
+    -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
+	"$ROOT/xymond/etcfiles/xymonserver.cfg" > "$work/xymonserver.cfg" \
+	|| skip "no xymonserver.cfg to run against"
+
+# free_port -- a 127.0.0.1 port nothing is listening on. Racy in principle;
+# the window is a few milliseconds and only this test uses the port.
+free_port() {
+	local p tries=0
+	while [ "$tries" -lt 50 ]; do
+		p=$(( 20000 + (RANDOM % 20000) ))
+		"$XYMONCLIENT" "127.0.0.1:$p" "ping" >/dev/null 2>&1 || { printf '%s' "$p"; return 0; }
+		tries=$((tries+1))
+	done
+	return 1
+}
+
+# start_xymond [extra args...] -- boot xymond on a fresh port and wait for it
+# to answer. Sets PORT.
+start_xymond() {
+	local i=0
+	PORT=$(free_port) || fail "no free port for xymond"
+	"$XYMOND" --no-daemon --listen="127.0.0.1:$PORT" \
+		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
+		--pidfile="$work/xymond.pid" --checkpoint-file="$work/chk" \
+		--flap-count=2 --flap-seconds=3600 "$@" \
+		> "$work/xymond.log" 2>&1 &
+	XYMOND_PID=$!
+
+	while [ "$i" -lt 100 ]; do
+		"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 && return 0
+		kill -0 "$XYMOND_PID" 2>/dev/null || { cat "$work/xymond.log" >&2; fail "xymond exited during startup"; }
+		sleep 0.1
+		i=$((i+1))
+	done
+	cat "$work/xymond.log" >&2
+	fail "xymond did not answer on 127.0.0.1:$PORT"
+}
+
+# The host part of a status message spells dots as commas.
+send_status() {
+	"$XYMONCLIENT" "127.0.0.1:$PORT" "status testhost,example,com.conn $1 msg-$1" \
+		|| fail "cannot send a $1 status to xymond"
+}
+
+board() {
+	"$XYMONCLIENT" "127.0.0.1:$PORT" "xymondboard fields=$1" 2>/dev/null
+}
+
+# conn_field N -- field N (1-based) of the conn row of a board response.
+conn_field() {
+	board "$1" | awk -F'|' -v col="$2" '$2 == "conn" { print $col }'
+}
+
+# ---- save --------------------------------------------------------------------
+
+start_xymond
+
+# Two colour changes with --flap-count=2 puts the test into the flapping state,
+# so there is flap state worth checkpointing.
+for colour in red green red yellow; do
+	send_status "$colour"
+	sleep 0.3
+done
+
+flapinfo=$(conn_field "hostname,testname,flapinfo" 3)
+[ -n "$flapinfo" ] || fail "conn test never reached the board"
+case "$flapinfo" in
+  1/*) ;;
+  *) fail "expected the conn test to be flapping before the checkpoint, got flapinfo=$flapinfo" ;;
+esac
+
+stop_xymond
+[ -s "$work/chk" ] || fail "xymond wrote no checkpoint file"
+
+# 1. The status record must still carry exactly the field count released
+#    versions parse. This is the check that would have caught appending the
+#    flap fields to it.
+statusfields=$(awk -F'|' '$2 !~ /^\./ { print NF; exit }' "$work/chk")
+[ "$statusfields" = "20" ] \
+	|| fail "status record has $statusfields fields, expected the released 20 -- an older xymond would reject it and drop the whole board:
+$(grep -v '|\.' "$work/chk" | head -1)"
+
+# 2. The flap state went somewhere an older reader skips.
+flapline=$(grep '^@@XYMONDCHK-V1|\.flapstate\.|' "$work/chk" | head -1)
+[ -n "$flapline" ] \
+	|| fail "no .flapstate. record written for a flapping test:
+$(cat "$work/chk")"
+
+# Both flap colours must be in it, or there is nothing to restore in step 2.
+savedcolours=$(printf '%s' "$flapline" | awk -F'|' '{ print $6 "/" $7 }')
+[ "$savedcolours" = "red/yellow" ] \
+	|| fail "expected the saved flap colours red/yellow, got $savedcolours"
+
+# ---- restore -----------------------------------------------------------------
+
+start_xymond --restart="$work/chk"
+
+restored=$(conn_field "hostname,testname,flapinfo" 3)
+[ -n "$restored" ] \
+	|| fail "the status record did not survive the restart -- the whole board was dropped:
+$(cat "$work/chk")"
+
+restoredcolours=$(printf '%s' "$restored" | awk -F'/' '{ print $4 "/" $5 }')
+[ "$restoredcolours" = "red/yellow" ] \
+	|| fail "flap colours came back as $restoredcolours, expected red/yellow (green/green means they were never restored)"
+
+case "$restored" in
+  1/*) ;;
+  *) fail "a checkpoint inside the flap window should restore as flapping, got flapinfo=$restored" ;;
+esac
+
+stop_xymond
+
+# ---- restore from a checkpoint older than the flap window --------------------
+#
+# Same file, with the change ring backdated well past --flap-seconds. The saved
+# flag still says "flapping"; the ring says the test has been quiet for a day,
+# and the ring is what counts.
+
+awk -F'|' -v OFS='|' '$2 == ".flapstate." { $NF = "1000000,1000000" } { print }' \
+	"$work/chk" > "$work/chk.stale"
+grep -q '^@@XYMONDCHK-V1|\.flapstate\.|.*|1000000,1000000$' "$work/chk.stale" \
+	|| fail "could not backdate the flap ring; the .flapstate. record format changed"
+
+start_xymond --restart="$work/chk.stale"
+
+stale=$(conn_field "hostname,testname,flapinfo" 3)
+[ -n "$stale" ] || fail "status record did not survive the restart from the backdated checkpoint"
+case "$stale" in
+  0/*) ;;
+  *) fail "a checkpoint older than the flap window must not restore as flapping, got flapinfo=$stale" ;;
+esac
+
+stop_xymond
+
+pass "checkpoint round-trip keeps the released status record, carries the flap state, and re-derives flapping"

--- a/tests/server/xymond-flap-purple-pin-harness.c
+++ b/tests/server/xymond-flap-purple-pin-harness.c
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later                                  */
+/*
+ * Behavioural half of tests/server/xymond-flap-purple-pin.sh.
+ *
+ * While a test is flapping, xymond holds it at the most critical level it
+ * reported instead of following every oscillation. Purple is not a level --
+ * it means "no data" -- so it must not take part in that comparison in either
+ * direction.
+ *
+ * The direction this guards is purple as the RECORDED color. Purple (3)
+ * outranks green (0), clear (1) and blue (2), so a rule that only exempts the
+ * incoming color still rewrites every report from a resumed test back to
+ * purple, and holds it there for the rest of the flap window -- displaying and
+ * (purple being an alert color by default) paging "no data" for a test that is
+ * actively reporting.
+ *
+ * The companion shell test prepends xymond/xymond.c's real static
+ * flap_pinned_color() when it builds this harness; this file only drives it.
+ */
+static int failures = 0;
+
+static const char *cname(int c)
+{
+	switch (c) {
+	  case COL_GREEN:  return "green";
+	  case COL_CLEAR:  return "clear";
+	  case COL_BLUE:   return "blue";
+	  case COL_PURPLE: return "purple";
+	  case COL_YELLOW: return "yellow";
+	  case COL_RED:    return "red";
+	}
+	return "?";
+}
+
+static void expect(int newcolor, int logcolor, int want)
+{
+	int got = flap_pinned_color(newcolor, logcolor);
+
+	if (got != want) {
+		fprintf(stderr, "incoming=%s recorded=%s: expected %s, got %s\n",
+			cname(newcolor), cname(logcolor), cname(want), cname(got));
+		failures++;
+	}
+}
+
+int main(void)
+{
+	int levels[] = { COL_GREEN, COL_CLEAR, COL_BLUE, COL_YELLOW, COL_RED };
+	int i, j;
+
+	/*
+	 * The regression: a test recorded purple that reports again keeps the
+	 * color it actually sent, whatever that is.
+	 */
+	for (i = 0; i < (int)(sizeof(levels)/sizeof(levels[0])); i++)
+		expect(levels[i], COL_PURPLE, levels[i]);
+
+	/* Purple arriving is recorded as purple, never pinned up to the old level. */
+	for (i = 0; i < (int)(sizeof(levels)/sizeof(levels[0])); i++)
+		expect(COL_PURPLE, levels[i], COL_PURPLE);
+
+	/* Purple on both sides stays purple. */
+	expect(COL_PURPLE, COL_PURPLE, COL_PURPLE);
+
+	/*
+	 * Everything else is unchanged: between two real levels the more
+	 * critical one wins, whichever side it is on.
+	 */
+	for (i = 0; i < (int)(sizeof(levels)/sizeof(levels[0])); i++) {
+		for (j = 0; j < (int)(sizeof(levels)/sizeof(levels[0])); j++) {
+			int newcolor = levels[i], logcolor = levels[j];
+			int want = (newcolor < logcolor) ? logcolor : newcolor;
+
+			expect(newcolor, logcolor, want);
+		}
+	}
+
+	/* A worked example of the reported failure, spelled out. */
+	expect(COL_GREEN, COL_PURPLE, COL_GREEN);
+
+	if (failures) {
+		fprintf(stderr, "%d flap-pin assertion(s) failed\n", failures);
+		return 1;
+	}
+
+	return 0;
+}

--- a/tests/server/xymond-flap-purple-pin.sh
+++ b/tests/server/xymond-flap-purple-pin.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-flap-purple-pin.sh
+#
+# While a test is flapping, xymond records the most critical level it reported
+# rather than following every oscillation. Purple is not a level -- it means
+# "no data" -- so it must stay out of that comparison on both sides.
+#
+# Exempting only the incoming color is not enough. Purple (3) outranks green
+# (0), clear (1) and blue (2), so once a flapping test has been recorded purple
+# (its client went quiet and check_purple_status() said so), the pin rewrites
+# every subsequent report from the resumed client back to purple. The test then
+# displays "no data" -- and pages for it, purple being an alert color by
+# default -- while it is talking to us, until the flap window expires.
+#
+# This drives xymond's real flap_pinned_color() over every color pair.
+#
+# Source-only apart from libxymoncomm.a, which supplies nothing here but keeps
+# the harness link identical to its siblings.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+here=$(dirname "$0")
+
+XYMOND_C="$ROOT/xymond/xymond.c"
+[ -f "$XYMOND_C" ] || skip "xymond/xymond.c not present in this checkout"
+
+body=$(awk '/^static int flap_pinned_color/,/^}/' "$XYMOND_C")
+[ -n "$body" ] || fail "could not locate flap_pinned_color() in xymond/xymond.c"
+
+require_cc
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+
+work=$(mktempdir)
+
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+
+{
+	printf '#include <stdio.h>\n#include <stdlib.h>\n#include <string.h>\n'
+	printf '#include "libxymon.h"\n'
+	printf '%s\n' "$body"
+	cat "$here/xymond-flap-purple-pin-harness.c"
+} > "$work/harness.c"
+
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
+	$ssllibs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+"$work/harness" 2>"$work/stderr.log" \
+	|| fail "flap colour-pin assertions failed:
+$(cat "$work/stderr.log")"
+
+pass "a flapping test recorded purple keeps the colour it reports when it resumes"

--- a/tests/server/xymond-holdtime-bridge-harness.c
+++ b/tests/server/xymond-holdtime-bridge-harness.c
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later                                  */
+/*
+ * Behavioural half of tests/server/xymond-holdtime-bridge.sh.
+ *
+ * When a test stops reporting, xymond invents a status for it and the real
+ * one is lost from view. If the test comes back wearing the colour it left
+ * with, the problem plainly did not go away while we were blind, so the
+ * hold-time carries across the silence -- which is what alerts.cfg DURATION
+ * rules read.
+ *
+ * Two things bound that inference, and this drives both:
+ *
+ *   - the colour must match. Coming back a different colour means something
+ *     did happen while we could not see it, so the clock starts fresh.
+ *   - the silence must be short. Nothing caps how long a status may sit
+ *     stale, so without a limit a host absent for a month would return
+ *     claiming a month-long hold-time and page at full escalation the moment
+ *     it reappeared.
+ *
+ * The companion shell test prepends xymond/xymond.c's real
+ * GAPBRIDGE_VALIDITIES and holdtime_bridges() when it builds this harness.
+ */
+static int failures = 0;
+
+static void expect(const char *label, int got, int want)
+{
+	if (got != want) {
+		fprintf(stderr, "%s: expected %s, got %s\n", label,
+			(want ? "bridge" : "fresh hold-time"),
+			(got ? "bridge" : "fresh hold-time"));
+		failures++;
+	}
+}
+
+int main(void)
+{
+	const int validity = 30;			/* minutes; xymond's default */
+	const time_t limit = GAPBRIDGE_VALIDITIES * validity * 60;
+
+	/* No gap at all: an ordinary colour change starts a fresh hold-time. */
+	expect("no gap recorded",
+	       holdtime_bridges(COL_RED, NO_COLOR, 0, validity), 0);
+
+	/* Came back as it left, well inside the limit: bridge. */
+	expect("same colour, brief silence",
+	       holdtime_bridges(COL_RED, COL_RED, 60, validity), 1);
+
+	/* Came back different: something moved while we were blind. */
+	expect("colour changed during the silence",
+	       holdtime_bridges(COL_GREEN, COL_RED, 60, validity), 0);
+
+	/* The bound, from both sides and exactly on it. */
+	expect("silence just under the limit",
+	       holdtime_bridges(COL_RED, COL_RED, limit - 1, validity), 1);
+	expect("silence exactly at the limit",
+	       holdtime_bridges(COL_RED, COL_RED, limit, validity), 1);
+	expect("silence just over the limit",
+	       holdtime_bridges(COL_RED, COL_RED, limit + 1, validity), 0);
+
+	/* The case the bound exists for: gone a month, back red. */
+	expect("gone a month, back the same colour",
+	       holdtime_bridges(COL_RED, COL_RED, 30*24*3600, validity), 0);
+
+	/*
+	 * The bound scales with how often the test reports, so a test that
+	 * checks in rarely is allowed a proportionally longer silence.
+	 */
+	expect("slow test, silence inside its own limit",
+	       holdtime_bridges(COL_RED, COL_RED, 10*3600, 240), 1);
+	expect("fast test, same silence is far outside its limit",
+	       holdtime_bridges(COL_RED, COL_RED, 10*3600, 5), 0);
+
+	/*
+	 * The bound must be computed at time_t width. validity is whatever the
+	 * reporter asked for with "status+NNN", and 4 * 10000000 * 60 overflows a
+	 * 32-bit int to a negative number -- which silently refuses to bridge even
+	 * a one-minute gap for that test.
+	 */
+	expect("huge validity, brief silence",
+	       holdtime_bridges(COL_RED, COL_RED, 60, 10000000), 1);
+
+	/* Every colour bridges, not just purple -- clear and blue gaps too. */
+	expect("green held across a clear gap",
+	       holdtime_bridges(COL_GREEN, COL_GREEN, 60, validity), 1);
+	expect("yellow held across a gap",
+	       holdtime_bridges(COL_YELLOW, COL_YELLOW, 60, validity), 1);
+
+	if (failures) {
+		fprintf(stderr, "%d hold-time bridge assertion(s) failed\n", failures);
+		return 1;
+	}
+
+	return 0;
+}

--- a/tests/server/xymond-holdtime-bridge.sh
+++ b/tests/server/xymond-holdtime-bridge.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-holdtime-bridge.sh
+#
+# "lastchange" is the hold-time of the recorded colour -- how long the test has
+# been this colour -- and alerts.cfg DURATION rules read it, through
+# xymond_alert's eventstart. When a test stops reporting, xymond invents a
+# status for it; if the test comes back wearing the colour it left with, the
+# problem did not go away while we were blind, so the hold-time carries across.
+#
+# Two bounds keep that inference honest, and this drives both: the colour must
+# match, and the silence must be short relative to how often the test reports.
+# The second one matters because nothing caps how long a status may sit stale --
+# check_purple_status() only ever deletes summaries -- so without a limit a host
+# absent for a month would come back claiming a month-long hold-time and page at
+# full DURATION escalation the moment it reappeared.
+#
+# Source-only apart from libxymoncomm.a, which supplies nothing here but keeps
+# the harness link identical to its siblings.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+here=$(dirname "$0")
+
+XYMOND_C="$ROOT/xymond/xymond.c"
+[ -f "$XYMOND_C" ] || skip "xymond/xymond.c not present in this checkout"
+
+limit=$(sed -n 's/^#define GAPBRIDGE_VALIDITIES *\([0-9][0-9]*\).*/\1/p' "$XYMOND_C")
+[ -n "$limit" ] || fail "could not read GAPBRIDGE_VALIDITIES from xymond/xymond.c"
+
+body=$(awk '/^static int holdtime_bridges/,/^}/' "$XYMOND_C")
+[ -n "$body" ] || fail "could not locate holdtime_bridges() in xymond/xymond.c"
+
+require_cc
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+
+work=$(mktempdir)
+
+ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+
+{
+	printf '#include <stdio.h>\n#include <stdlib.h>\n#include <string.h>\n'
+	printf '#include "libxymon.h"\n'
+	printf '#define NO_COLOR (COL_COUNT)\n'
+	printf '#define GAPBRIDGE_VALIDITIES %s\n' "$limit"
+	printf '%s\n' "$body"
+	cat "$here/xymond-holdtime-bridge-harness.c"
+} > "$work/harness.c"
+
+"$CC" -I"$ROOT/include" -I"$ROOT/lib" -o "$work/harness" \
+	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
+	$ssllibs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+"$work/harness" 2>"$work/stderr.log" \
+	|| fail "hold-time bridge assertions failed:
+$(cat "$work/stderr.log")"
+
+pass "hold-time bridges a short same-colour silence, and only that"

--- a/tests/server/xymond-holdtime-bridge.sh
+++ b/tests/server/xymond-holdtime-bridge.sh
@@ -32,6 +32,11 @@ XYMOND_C="$ROOT/xymond/xymond.c"
 limit=$(sed -n 's/^#define GAPBRIDGE_VALIDITIES *\([0-9][0-9]*\).*/\1/p' "$XYMOND_C")
 [ -n "$limit" ] || fail "could not read GAPBRIDGE_VALIDITIES from xymond/xymond.c"
 
+# Both halves of the rule: holdtime_bridges() decides the colour and defers the
+# length to gap_within_window(), which save_checkpoint() also asks on its own.
+window=$(awk '/^static int gap_within_window/,/^}/' "$XYMOND_C")
+[ -n "$window" ] || fail "could not locate gap_within_window() in xymond/xymond.c"
+
 body=$(awk '/^static int holdtime_bridges/,/^}/' "$XYMOND_C")
 [ -n "$body" ] || fail "could not locate holdtime_bridges() in xymond/xymond.c"
 
@@ -48,6 +53,7 @@ ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 	printf '#include "libxymon.h"\n'
 	printf '#define NO_COLOR (COL_COUNT)\n'
 	printf '#define GAPBRIDGE_VALIDITIES %s\n' "$limit"
+	printf '%s\n' "$window"
 	printf '%s\n' "$body"
 	cat "$here/xymond-holdtime-bridge-harness.c"
 } > "$work/harness.c"

--- a/tests/server/xymond-holdtime-gap.sh
+++ b/tests/server/xymond-holdtime-gap.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-holdtime-gap.sh
+#
+# Drives a real xymond over the gap bookkeeping that decides what `lastchange`
+# says -- the field the board shows as "red for 3 days" and the one
+# xymond_alert turns into `eventstart`, which alerts.cfg DURATION reads.
+#
+# The companion test xymond-holdtime-bridge.sh drives the pure predicate.
+# Nothing there reaches the code that opens and closes a gap, so this drives
+# the whole path in the daemon: a gap is set up by restoring a checkpoint that
+# carries one, then real messages decide what happens to it.
+#
+# Restoring the state beats producing it: a real no-data gap needs xymond to
+# notice a test has gone stale, which cannot happen faster than its report
+# validity.
+#
+# What it pins:
+#
+#   1. A test that resumes with the color it left with keeps its hold-time.
+#   2. A test that resumes with a different color starts a fresh one.
+#   3. A genuine report ENDS the gap even when it does not change the color.
+#      Closing only on a color change leaves the gap open, and a later change
+#      then bridges across a period the test was demonstrably reporting.
+#   4. A disable landing inside a gap does not destroy it. The BLUE of a
+#      disable is xymond's choice, not the test reporting, so the gap must
+#      survive to be resolved by the report that eventually arrives.
+#   5. Both of those on a running daemon, where a report that changes nothing
+#      reaches no part of the status-change path -- a restored log is the one
+#      case that does not exercise.
+#
+# Needs a built tree: xymond itself and the xymon client.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+require_bin XYMOND xymond/xymond
+require_bin XYMONCLIENT common/xymon
+
+work=$(mktempdir)
+
+XYMOND_PID=""
+stop_xymond() {
+	[ -n "$XYMOND_PID" ] || return 0
+	kill "$XYMOND_PID" 2>/dev/null || true
+	local i=0
+	while kill -0 "$XYMOND_PID" 2>/dev/null && [ "$i" -lt 100 ]; do
+		sleep 0.1
+		i=$((i+1))
+	done
+	XYMOND_PID=""
+}
+register_cleanup stop_xymond
+
+printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.cfg"
+
+# xymond will not start unless XYMONHOME is a real directory, and the shipped
+# xymonserver.cfg names the install prefix, which need not exist here.
+mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
+    -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
+	"$ROOT/xymond/etcfiles/xymonserver.cfg" > "$work/xymonserver.cfg" \
+	|| skip "no xymonserver.cfg to run against"
+
+free_port() {
+	local p tries=0
+	while [ "$tries" -lt 50 ]; do
+		p=$(( 20000 + (RANDOM % 20000) ))
+		"$XYMONCLIENT" "127.0.0.1:$p" "ping" >/dev/null 2>&1 || { printf '%s' "$p"; return 0; }
+		tries=$((tries+1))
+	done
+	return 1
+}
+
+# write_checkpoint HELDCOLOR HELDSINCE GAPCOLOR GAPSTART -- a checkpoint where
+# conn currently shows HELDCOLOR (since HELDSINCE) with a gap open: xymond
+# invented HELDCOLOR, and the color before the gap was GAPCOLOR, held from
+# HELDSINCE. Field order matches save_checkpoint().
+write_checkpoint() {
+	local shown=$1 shownsince=$2 gapcolor=$3 gapstart=$4
+	local valid=$(( $(date +%s) + 86400 ))
+
+	printf '@@XYMONDCHK-V1||testhost.example.com|conn|127.0.0.1|%s||%s|%s|%s|%s|0|0|0|0|status testhost,example,com.conn %s invented|||0|0\n' \
+		"$shown" "$gapcolor" "$shownsince" "$shownsince" "$valid" "$shown" > "$work/chk"
+	printf '@@XYMONDCHK-V1|.flapstate.|testhost.example.com|conn|0|none|none|%s|%s|%s|0,0,0,0,0\n' \
+		"$gapcolor" "$HELDSINCE" "$gapstart" >> "$work/chk"
+}
+
+# start_xymond [extra xymond arguments] -- the cases that need a gap already in
+# place pass --restart; the ones that build it from live messages do not.
+start_xymond() {
+	local i=0
+	PORT=$(free_port) || fail "no free port for xymond"
+	"$XYMOND" --no-daemon --listen="127.0.0.1:$PORT" \
+		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
+		--pidfile="$work/xymond.pid" --checkpoint-file="$work/chk.out" \
+		"$@" \
+		> "$work/xymond.log" 2>&1 &
+	XYMOND_PID=$!
+
+	while [ "$i" -lt 100 ]; do
+		"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 && return 0
+		kill -0 "$XYMOND_PID" 2>/dev/null || { cat "$work/xymond.log" >&2; fail "xymond exited during startup"; }
+		sleep 0.1
+		i=$((i+1))
+	done
+	cat "$work/xymond.log" >&2
+	fail "xymond did not answer on 127.0.0.1:$PORT"
+}
+
+send() { "$XYMONCLIENT" "127.0.0.1:$PORT" "$1" || fail "xymond rejected: $1"; }
+status() { send "status testhost,example,com.conn $1 msg"; sleep 0.4; }
+
+lastchange() {
+	"$XYMONCLIENT" "127.0.0.1:$PORT" "xymondboard fields=testname,lastchange" 2>/dev/null \
+		| awk -F'|' '$1 == "conn" { print $2 }'
+}
+
+xymondboard_color() {
+	"$XYMONCLIENT" "127.0.0.1:$PORT" "xymondboard fields=testname,color" 2>/dev/null \
+		| awk -F'|' '$1 == "conn" { print $2 }'
+}
+
+# assert_held WHEN LABEL -- lastchange must be WHEN (the hold-time carried).
+assert_held() {
+	local got; got=$(lastchange)
+	[ "$got" = "$1" ] || fail "$2: expected lastchange=$1 (hold-time carried), got $got"
+}
+
+# assert_moved WHEN LABEL -- lastchange must have left WHEN. The live cases
+# build their own hold-times seconds ago, which assert_fresh cannot tell from a
+# carried one; they separate the two by a sleep and compare exactly.
+assert_moved() {
+	local got; got=$(lastchange)
+	[ "$got" != "$1" ] \
+		|| fail "$2: lastchange is still $1, carried across a gap the test had already ended"
+}
+
+# assert_fresh LABEL -- lastchange must be recent (a new hold-time started).
+assert_fresh() {
+	local got age; got=$(lastchange)
+	[ -n "$got" ] || fail "$2${1}: conn is not on the board"
+	age=$(( $(date +%s) - got ))
+	[ "$age" -ge 0 ] && [ "$age" -lt 300 ] \
+		|| fail "$1: expected a fresh lastchange, got one ${age}s old (hold-time was carried when it should not be)"
+}
+
+# ---- 1. resume with the same color: the hold-time carries -------------------
+
+HELDSINCE=$(( $(date +%s) - 86400 ))
+write_checkpoint clear "$(( $(date +%s) - 60 ))" red "$(( $(date +%s) - 60 ))"
+start_xymond --restart="$work/chk"
+status red
+assert_held "$HELDSINCE" "same-color resume"
+stop_xymond
+
+# ---- 2. resume with a different color: a fresh hold-time -------------------
+
+HELDSINCE=$(( $(date +%s) - 86400 ))
+write_checkpoint clear "$(( $(date +%s) - 60 ))" red "$(( $(date +%s) - 60 ))"
+start_xymond --restart="$work/chk"
+status yellow
+assert_fresh "different-color resume"
+stop_xymond
+
+# ---- 3. a genuine report ends the gap even without a color change ----------
+#
+# xymond invented CLEAR while the test was quiet. The test comes back and
+# genuinely reports CLEAR, and only later goes red. That red began just now; it
+# must not inherit the hold-time from before a silence the test has already
+# ended.
+#
+# A restored log has histsynced == 0, so its first report enters the
+# status-change path whatever color it carries. Case 6 drives the same sequence
+# on a running daemon, where it does not.
+
+HELDSINCE=$(( $(date +%s) - 86400 ))
+write_checkpoint clear "$(( $(date +%s) - 60 ))" red "$(( $(date +%s) - 60 ))"
+start_xymond --restart="$work/chk"
+status clear
+status red
+assert_fresh "report matching the invented color must end the gap"
+stop_xymond
+
+# ---- 4. a disable inside the gap must not destroy it ------------------------
+#
+# The BLUE of a disable is xymond's choice, not the test reporting, so it must
+# leave the gap alone; the report that arrives after the enable is what
+# resolves it.
+
+HELDSINCE=$(( $(date +%s) - 86400 ))
+write_checkpoint clear "$(( $(date +%s) - 60 ))" red "$(( $(date +%s) - 60 ))"
+start_xymond --restart="$work/chk"
+send "disable testhost.example.com.conn 5 investigating"
+sleep 0.4
+send "enable testhost.example.com.conn"
+sleep 0.4
+status red
+assert_held "$HELDSINCE" "disable inside a gap"
+stop_xymond
+
+# ---- 5. a DOWNTIME window hides the real color, so it opens a gap ----------
+#
+# During DOWNTIME the test keeps reporting but xymond records BLUE, so the real
+# color is just as hidden as during a silence. The gap bookkeeping used to sit
+# inside the "not in DOWNTIME" guard, so no window could ever open one and the
+# hold-time was lost when the window ended.
+#
+# The window cannot be ended from here (it is a hosts.cfg tag), so this checks
+# the half that is observable: the gap opens, carrying the color and hold-time
+# from before the window.
+
+HELDSINCE=$(( $(date +%s) - 86400 ))
+printf 'page test Test\n127.0.0.1 testhost.example.com # conn DOWNTIME=*:*:0000:2359:Maint\n' > "$work/hosts.cfg"
+printf '@@XYMONDCHK-V1||testhost.example.com|conn|127.0.0.1|red||red|%s|%s|%s|0|0|0|0|status testhost,example,com.conn red held|||0|0\n' \
+	"$HELDSINCE" "$HELDSINCE" "$(( $(date +%s) + 86400 ))" > "$work/chk"
+
+start_xymond --restart="$work/chk"
+status red
+[ "$(xymondboard_color)" = "blue" ] || fail "DOWNTIME did not force the status blue; the tag was not applied"
+stop_xymond
+
+flapstate=$(grep '^@@XYMONDCHK-V1|\.flapstate\.|' "$work/chk.out" || true)
+[ -n "$flapstate" ] \
+	|| fail "a DOWNTIME window opened no gap, so the hold-time is lost when it ends"
+gapcolor=$(printf '%s' "$flapstate" | awk -F'|' '{ print $8 }')
+gapheld=$(printf '%s' "$flapstate" | awk -F'|' '{ print $9 }')
+[ "$gapcolor" = "red" ] \
+	|| fail "gap opened by DOWNTIME recorded the color as $gapcolor, expected the pre-window red"
+[ "$gapheld" = "$HELDSINCE" ] \
+	|| fail "gap opened by DOWNTIME recorded hold-time $gapheld, expected $HELDSINCE"
+
+# ---- 6. the same, on a running daemon --------------------------------------
+#
+# Cases 1-5 restore their gap, and a restored log takes the status-change path
+# on its first report whatever that report says. A running xymond has
+# histsynced == 1, and there a report that changes nothing takes no path at
+# all -- so the gap has to end outside that one. The disable opens the gap
+# because a no-data gap needs the purple sweep, which does not run until ten
+# minutes after startup.
+
+printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.cfg"
+rm -f "$work/chk"
+start_xymond
+status red
+HELDSINCE=$(lastchange)
+sleep 2
+send "disable testhost.example.com.conn 5 investigating"
+sleep 0.4
+send "enable testhost.example.com.conn"
+sleep 0.4
+status blue	# genuine, and BLUE is exactly what the disable invented
+status red
+assert_moved "$HELDSINCE" "genuine report of the invented color must end the gap on a running daemon"
+stop_xymond
+
+# ---- 7. reports that arrive during a disable do not end the gap ------------
+#
+# They are genuine, but xymond records BLUE for them, so they say nothing about
+# the color the test is in and the gap must survive them: the test never
+# stopped being red, so the red after the enable still holds from before.
+# Case 4 does not reach this -- handle_enadis() posts a status for the disable
+# but not for the enable, so nothing reports inside its window.
+
+rm -f "$work/chk"
+start_xymond
+status red
+HELDSINCE=$(lastchange)
+sleep 2
+send "disable testhost.example.com.conn 5 investigating"
+sleep 0.4
+status red	# genuine, but recorded as the disable's BLUE
+send "enable testhost.example.com.conn"
+sleep 0.4
+status red
+assert_held "$HELDSINCE" "reports arriving during a disable must not end the gap"
+stop_xymond
+
+pass "hold-time survives a same-color resume, and only that: a different color, an ended gap on a restored and on a running daemon, a disable with and without reports inside it, and a DOWNTIME window are each handled"

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -126,7 +126,12 @@ typedef struct xymond_log_t {
 	char *testflags;
 	char *grouplist;        /* For extended status reports (e.g. from xymond_client) */
 	char sender[IP_ADDR_STRLEN];
-	time_t *lastchange;	/* Table of times when the currently logged status began */
+	time_t lastchange;	/* When the currently recorded color began: its hold-time */
+	time_t *flapchange;	/* Table of the most recent status-change times, used for flap detection */
+	time_t pregaplastchange;	/* The "lastchange" saved when a no-data gap began */
+	time_t gapstart;	/* When that gap began; bounds how far a resume may bridge */
+	int pregapcolor;	/* The color recorded before the gap, or NO_COLOR when not in one */
+	int validity;		/* Minutes this test's reports stay valid; sizes the bridge bound */
 	time_t logtime;		/* time when last update was received */
 	time_t validtime;	/* time when status is no longer valid */
 	time_t enabletime;	/* time when test auto-enables after a disable */
@@ -738,7 +743,7 @@ void posttochannel(xymond_channel_t *channel, char *channelmarker,
 				colnames[log->color], 				/*  7 */
 				(log->testflags ? log->testflags : ""),		/*  8 */
 				colnames[log->oldcolor], 			/*  9 */
-				(int) log->lastchange[0]); 			/* 10 */
+				(int) log->lastchange); 			/* 10 */
 			if (n < (bufsz-5)) {
 				n += snprintf(channel->channelbuf+n, (bufsz-n-5), "|%d|%s",	/* 11+12 */
 					(int)log->acktime, nlencode(log->ackmsg));
@@ -796,7 +801,7 @@ void posttochannel(xymond_channel_t *channel, char *channelmarker,
 				(int) log->validtime,				/*  6 */ 
 				colnames[log->color],				/*  7 */ 
 				colnames[log->oldcolor],			/*  8 */ 
-				(int) log->lastchange[0])			/*  9 */;
+				(int) log->lastchange)			/*  9 */;
 			if (n < (bufsz-5)) {
 				n += snprintf(channel->channelbuf+n, (bufsz-n-5), "|%d|%s",	/* 10+11 */
 					(int)log->enabletime, nlencode(log->dismsg));
@@ -867,7 +872,7 @@ void posttochannel(xymond_channel_t *channel, char *channelmarker,
 					channelmarker, channel->seq, hostname, (int) tstamp.tv_sec, (int) tstamp.tv_usec,
 					sender, hostname, 
 					log->test->name, log->host->ip, (int) log->validtime, 
-					colnames[log->color], colnames[log->oldcolor], (int) log->lastchange[0],
+					colnames[log->color], colnames[log->oldcolor], (int) log->lastchange,
 					pagepath, 
 					(log->cookie ? log->cookie : ""), 
 					osname, classname, 
@@ -1313,8 +1318,16 @@ void get_hts(char *msg, char *sender, char *origin,
 		for (lwalk = hwalk->logs; (lwalk && ((lwalk->test != twalk) || (lwalk->origin != owalk))); lwalk = lwalk->next);
 		if (createlog && (lwalk == NULL)) {
 			lwalk = (xymond_log_t *)calloc(1, sizeof(xymond_log_t));
-			lwalk->lastchange = (time_t *)calloc((flapcount > 0) ? flapcount : 1, sizeof(time_t));
-			lwalk->lastchange[0] = getcurrenttime(NULL);
+			lwalk->lastchange = getcurrenttime(NULL);
+			lwalk->flapchange = (flapcount > 0) ? (time_t *)calloc(flapcount, sizeof(time_t)) : NULL;
+			/*
+			 * Seed with the creation time, which the ring used to get free
+			 * from the shared array; without it detection needs one more
+			 * colour change and a new test gets an extra alert out first.
+			 */
+			if (flapcount > 0) lwalk->flapchange[0] = getcurrenttime(NULL);
+			lwalk->pregapcolor = NO_COLOR;
+			lwalk->validity = defaultvalidity;
 			lwalk->color = lwalk->oldcolor = NO_COLOR;
 			lwalk->host = hwalk;
 			lwalk->test = twalk;
@@ -1421,6 +1434,41 @@ static int changedelay(void *hinfo, int newcolor, char *testname, int currcolor)
 	return result;
 }
 
+/*
+ * flap_pinned_color -- hold a flapping test at the most critical level it
+ * reported, so the display does not follow every oscillation.
+ *
+ * Purple is exempt on both sides: it is "no data", not a level. Incoming, it
+ * would record a status never sent. Recorded, it outranks green/clear/blue, so
+ * it would rewrite every report from a resumed test back to no-data -- and page
+ * for it -- until the flap window expired.
+ */
+/*
+ * record_flapchange -- push NOW onto the ring flap detection reads. Both the
+ * flapping and the ordinary status-change paths record into it; written out
+ * separately they drifted, one growing a DOWNTIME guard the other lacked.
+ */
+static void record_flapchange(xymond_log_t *log, time_t now)
+{
+	int i;
+
+	if (flapcount <= 0) return;
+
+	for (i = flapcount-1; (i > 0); i--)
+		log->flapchange[i] = log->flapchange[i-1];
+	log->flapchange[0] = now;
+}
+
+
+static int flap_pinned_color(int newcolor, int logcolor)
+{
+	if (newcolor == COL_PURPLE) return newcolor;
+	if (logcolor == COL_PURPLE) return newcolor;
+
+	return (newcolor < logcolor) ? logcolor : newcolor;
+}
+
+
 static int isset_noflap(void *hinfo, char *testname, char *hostname)
 {
 	char *tok, *dstr, *dbuf;
@@ -1456,14 +1504,48 @@ static int isset_noflap(void *hinfo, char *testname, char *hostname)
 	return 1;
 }
 
-void handle_status(unsigned char *msg, char *sender, char *hostname, char *testname, char *grouplist, 
-		   xymond_log_t *log, int newcolor, char *downcause, int modifyonly)
+/*
+ * Longest gap we will bridge, in report-validity periods -- two hours at the
+ * default, measured from when the status went stale rather than from the last
+ * report, so the silence tolerated is one validity longer again. Nothing caps
+ * how long a status may sit stale, and the longer the silence the likelier
+ * "red, gone, red" is two incidents, not one.
+ */
+#define GAPBRIDGE_VALIDITIES 4
+
+/*
+ * holdtime_bridges -- may a test that is reporting again carry its hold-time
+ * across the silence? Only if nothing suggests the status moved while we were
+ * blind: same color as before, and not gone long. PREGAPCOLOR is NO_COLOR when
+ * there was no gap; VALIDITY is the test's report validity in minutes.
+ */
+static int holdtime_bridges(int newcolor, int pregapcolor, time_t gaplen, int validity)
+{
+	if (pregapcolor == NO_COLOR) return 0;		/* no gap to bridge */
+	if (newcolor != pregapcolor) return 0;		/* it changed while we were blind */
+
+	/* time_t, not int: validity comes from the reporter ("status+NNN"), and a
+	 * large one overflows an int product and wraps. */
+	return (gaplen <= (time_t)GAPBRIDGE_VALIDITIES * validity * 60);
+}
+
+
+void handle_status(unsigned char *msg, char *sender, char *hostname, char *testname, char *grouplist,
+		   xymond_log_t *log, int reportedcolor, char *downcause, int modifyonly, int synthetic)
 {
 	int validity = defaultvalidity;
 	time_t now = getcurrenttime(NULL);
+	time_t prevlastchange;
 	int msglen, issummary;
 	enum alertstate_t oldalertstatus, newalertstatus;
 	int delayval = 0;
+	/*
+	 * "reportedcolor" is what the reporter said; "newcolor" is what we decide
+	 * to record. A disable, a change delay, the flap pin and a modifier all
+	 * rewrite the latter below, and the gap bookkeeping needs to tell the two
+	 * apart -- see there.
+	 */
+	int newcolor = reportedcolor;
 	void *hinfo = hostinfo(hostname);
 
 	dbgprintf("->handle_status\n");
@@ -1552,10 +1634,10 @@ void handle_status(unsigned char *msg, char *sender, char *hostname, char *testn
 	if (modifyonly || issummary) {
 		/* Nothing */
 	}
-	else if ((flapcount > 0) && ((now - log->lastchange[flapcount-1]) < flapthreshold) && (!isset_noflap(hinfo, testname, hostname))) {
+	else if ((flapcount > 0) && ((now - log->flapchange[flapcount-1]) < flapthreshold) && (!isset_noflap(hinfo, testname, hostname))) {
 		if (!log->flapping) {
-			errprintf("Flapping detected for %s:%s - %d changes in %d seconds\n",
-				  hostname, testname, flapcount, (now - log->lastchange[flapcount-1]));
+			errprintf("Flapping detected for %s:%s - %d changes in %ld seconds\n",
+				  hostname, testname, flapcount, (long)(now - log->flapchange[flapcount-1]));
 			log->flapping = 1;
 			log->oldflapcolor = log->color;
 			log->currflapcolor = newcolor;
@@ -1565,20 +1647,20 @@ void handle_status(unsigned char *msg, char *sender, char *hostname, char *testn
 			log->currflapcolor = newcolor;
 		}
 
-		/* Make sure we maintain the most critical level reported by the flapping unit */
-		if (newcolor < log->color) newcolor = log->color;
+		/* Maintain the most critical level reported by the flapping unit. */
+		newcolor = flap_pinned_color(newcolor, log->color);
 
-		/* 
+		/*
 		 * If the status is actually changing, but we've detected it's a
-		 * flap and therefore suppress atatus change events, then we must
-		 * update the lastchange-times here because it won't be done in
-		 * the status-change handler.
+		 * flap and therefore suppress status change events, then we must
+		 * record the change-time here because it won't be done in
+		 * the status-change handler. Note that "lastchange" is NOT
+		 * updated: the recorded color does not change, so its hold-time
+		 * keeps running. Like the status-change handler, don't record
+		 * anything while DOWNTIME is active.
 		 */
-		if ((log->oldflapcolor != log->currflapcolor) && (newcolor == log->color)) {
-			int i;
-			for (i=flapcount-1; (i > 0); i--)
-				log->lastchange[i] = log->lastchange[i-1];
-			log->lastchange[0] = now;
+		if (!log->downtimeactive && (log->oldflapcolor != log->currflapcolor) && (newcolor == log->color)) {
+			record_flapchange(log, now);
 		}
 	}
 	else {
@@ -1654,6 +1736,7 @@ void handle_status(unsigned char *msg, char *sender, char *hostname, char *testn
 		 *
 		 * Same tweak must be done for disabled tests.
 		 */
+		log->validity = validity;
 		log->validtime = now + validity*60;
 		if (log->acktime    && (log->acktime > log->validtime))    log->validtime = log->acktime;
 		if (log->enabletime) {
@@ -1737,6 +1820,10 @@ void handle_status(unsigned char *msg, char *sender, char *hostname, char *testn
 		if ((now - log->yellowstart) < delayval) newcolor = log->color; /* Keep current color */
 	}
 
+
+	/* For the gap bookkeeping below: opening a gap records when the color we
+	 * are about to stop seeing began, not when we stopped seeing it. */
+	prevlastchange = log->lastchange;
 
 	log->oldcolor = log->color;
 	log->color = newcolor;
@@ -1856,19 +1943,59 @@ void handle_status(unsigned char *msg, char *sender, char *hostname, char *testn
 		 * (It is only seen as active if the color has been forced BLUE).
 		 */
 		if (!log->downtimeactive && (log->oldcolor != newcolor)) {
-			int i;
 			if (log->host->clientmsgs && (newalertstatus == A_ALERT) && log->test->clientsave) {
-				posttochannel(clichgchn, channelnames[C_CLICHG], msg, sender, 
+				posttochannel(clichgchn, channelnames[C_CLICHG], msg, sender,
 						hostname, log, NULL);
 			}
 
-			if (flapcount > 0) {
-				/* We keep track of flaps, so update the lastchange table */
-				for (i=flapcount-1; (i > 0); i--)
-					log->lastchange[i] = log->lastchange[i-1];
-			}
-			log->lastchange[0] = now;
+			/* We keep track of flaps, so update the change-time table */
+			record_flapchange(log, now);
+
+			log->lastchange = now;
 			log->statuschangecount++;
+		}
+	}
+
+	/*
+	 * Deliberately outside the test above: whether we can see the reporter's
+	 * own color has nothing to do with whether that color changed, nor with
+	 * DOWNTIME, which hides it just as a silence does. Keying the gap on a
+	 * color change leaves it open when a test resumes with the color xymond
+	 * invented -- that report moves nothing, so nothing in there runs -- and
+	 * a later change then bridges across a period the test was demonstrably
+	 * reporting.
+	 */
+	if (!issummary) {
+		if (synthetic || log->downtimeactive || (newcolor != reportedcolor)) {
+			/*
+			 * xymond chose this color, not the reporter: it invented one
+			 * because no data arrived (synthetic), get_hts() rewrote it for
+			 * DOWNTIME before we were called, or a disable, a change delay,
+			 * the flap pin or a modifier rewrote it above. Only the first
+			 * such update opens the gap; a later one would overwrite the
+			 * color to resume to with one xymond invented, which no real
+			 * report could match.
+			 */
+			if ((log->pregapcolor == NO_COLOR) && (log->oldcolor >= 0) && (log->oldcolor < COL_COUNT)) {
+				/* The range test keeps COL_CLIENT (99), which parse_color()
+				 * accepts, out of colnames[] at checkpoint time. */
+				log->pregapcolor = log->oldcolor;
+				log->pregaplastchange = prevlastchange;
+				log->gapstart = now;
+			}
+		}
+		else if (log->pregapcolor != NO_COLOR) {
+			/*
+			 * What we are recording is the reporter's own color again, so the
+			 * gap ends whatever that color is.
+			 *
+			 * Same color as before, after a short enough gap: the problem did
+			 * not go away while we could not see it, so the hold-time carries
+			 * across. alerts.cfg DURATION reads this.
+			 */
+			if (holdtime_bridges(newcolor, log->pregapcolor, (now - log->gapstart), log->validity))
+				log->lastchange = log->pregaplastchange;
+			log->pregapcolor = NO_COLOR;
 		}
 	}
 
@@ -2016,8 +2143,8 @@ void handle_modify(char *msg, xymond_log_t *log, int color)
 
 		if (newcolor != log->color) {
 			/* Color change - trigger a status update */
-			handle_status(log->message, log->sender, 
-				log->host->hostname, log->test->name, log->grouplist, log, newcolor, NULL, 1);
+			handle_status(log->message, log->sender,
+				log->host->hostname, log->test->name, log->grouplist, log, newcolor, NULL, 1, 1);
 		}
 	}
 
@@ -2204,7 +2331,7 @@ void handle_enadis(int enabled, conn_t *msg, char *sender)
 				}
 				posttochannel(enadischn, channelnames[C_ENADIS], msg->buf, sender, log->host->hostname, log, NULL);
 				/* Trigger an immediate status update */
-				handle_status(log->message, sender, log->host->hostname, log->test->name, log->grouplist, log, COL_BLUE, NULL, 0);
+				handle_status(log->message, sender, log->host->hostname, log->test->name, log->grouplist, log, COL_BLUE, NULL, 0, 1);
 			}
 		}
 		else {
@@ -2219,7 +2346,7 @@ void handle_enadis(int enabled, conn_t *msg, char *sender)
 				posttochannel(enadischn, channelnames[C_ENADIS], msg->buf, sender, log->host->hostname, log, NULL);
 
 				/* Trigger an immediate status update */
-				handle_status(log->message, sender, log->host->hostname, log->test->name, log->grouplist, log, COL_BLUE, NULL, 0);
+				handle_status(log->message, sender, log->host->hostname, log->test->name, log->grouplist, log, COL_BLUE, NULL, 0, 1);
 			}
 		}
 
@@ -2327,7 +2454,7 @@ void handle_ackinfo(char *msg, char *sender, xymond_log_t *log)
 			fprintf(ackinfologfd, "%s %s %s %s %d %d %d %d %s\n",
 				timestamp, log->host->hostname, log->test->name,
 				newack->ackedby, newack->level, 
-				(int)log->lastchange[0], (int)newack->received, (int)newack->validuntil, 
+				(int)log->lastchange, (int)newack->received, (int)newack->validuntil,
 				nlencode(newack->msg));
 			fflush(ackinfologfd);
 		}
@@ -2523,7 +2650,7 @@ void free_log_t(xymond_log_t *zombie)
 	if (zombie->dismsg) xfree(zombie->dismsg);
 	if (zombie->ackmsg) xfree(zombie->ackmsg);
 	if (zombie->grouplist) xfree(zombie->grouplist);
-	if (zombie->lastchange) xfree(zombie->lastchange);
+	if (zombie->flapchange) xfree(zombie->flapchange);
 	if (zombie->testflags) xfree(zombie->testflags);
 	flush_acklist(zombie, 1);
 	xfree(zombie);
@@ -3348,7 +3475,7 @@ int match_test_filter(xymond_log_t *log, hostfilter_rec_t *filter)
 
 		  case FILTER_FIELDTIME:
 			switch (fwalk->boardfield) {
-			  case F_LASTCHANGE: testedval = log->lastchange[0]; break;
+			  case F_LASTCHANGE: testedval = log->lastchange; break;
 			  case F_LOGTIME: testedval = log->logtime; break;
 			  case F_VALIDTIME: testedval = log->validtime; break;
 			  case F_ACKTIME: testedval = log->acktime; break;
@@ -3411,7 +3538,7 @@ strbuffer_t *generate_outbuf(strbuffer_t **prebuf, boardfield_t *boardfields, xy
 		  case F_TESTNAME: addtobuffer(buf, lwalk->test->name); break;
 		  case F_COLOR: addtobuffer(buf, colnames[lwalk->color]); break;
 		  case F_FLAGS: if (lwalk->testflags) addtobuffer(buf, lwalk->testflags); break;
-		  case F_LASTCHANGE: snprintf(l, sizeof(l), "%d", (int)lwalk->lastchange[0]); addtobuffer(buf, l); break;
+		  case F_LASTCHANGE: snprintf(l, sizeof(l), "%d", (int)lwalk->lastchange); addtobuffer(buf, l); break;
 		  case F_LOGTIME: snprintf(l, sizeof(l), "%d", (int)lwalk->logtime); addtobuffer(buf, l); break;
 		  case F_VALIDTIME: snprintf(l, sizeof(l), "%d", (int)lwalk->validtime); addtobuffer(buf, l); break;
 		  case F_ACKTIME: snprintf(l, sizeof(l), "%d", (int)lwalk->acktime); addtobuffer(buf, l); break;
@@ -3446,9 +3573,16 @@ strbuffer_t *generate_outbuf(strbuffer_t **prebuf, boardfield_t *boardfields, xy
 			break;
 
 		  case F_FLAPINFO:
-			snprintf(l, sizeof(l), "%d/%ld/%ld/%s/%s", 
-				 lwalk->flapping, 
-				 lwalk->lastchange[0], (flapcount > 0) ? lwalk->lastchange[flapcount-1] : 0,
+			/*
+			 * xymon.1 defines these as the latest and the first status
+			 * change: both ends of the flap ring. lastchange is neither
+			 * any more, and using it could invert the pair. Cast rather
+			 * than assume time_t is long, or the two %s shift.
+			 */
+			snprintf(l, sizeof(l), "%d/%ld/%ld/%s/%s",
+				 lwalk->flapping,
+				 (long)((flapcount > 0) ? lwalk->flapchange[0] : 0),
+				 (long)((flapcount > 0) ? lwalk->flapchange[flapcount-1] : 0),
 				 colnames[lwalk->oldflapcolor], colnames[lwalk->currflapcolor]);
 			addtobuffer(buf, l);
 			break;
@@ -3698,7 +3832,7 @@ void do_message(conn_t *msg, char *origin)
 					update_statistics(currmsg);
 
 					if (h && t && log && (color != -1)) {
-						handle_status(currmsg, sender, h->hostname, t->name, grouplist, log, color, downcause, 0);
+						handle_status(currmsg, sender, h->hostname, t->name, grouplist, log, color, downcause, 0, 0);
 					}
 					break;
 				}
@@ -3771,7 +3905,7 @@ void do_message(conn_t *msg, char *origin)
 
 		  default:
 			if (h && t && log && (color != -1)) {
-				handle_status(msg->buf, sender, h->hostname, t->name, grouplist, log, color, downcause, 0);
+				handle_status(msg->buf, sender, h->hostname, t->name, grouplist, log, color, downcause, 0, 0);
 			}
 			break;
 		}
@@ -3839,7 +3973,7 @@ void do_message(conn_t *msg, char *origin)
 		/* Summaries are always allowed. Or should we ? */
 		get_hts(msg->buf, sender, origin, &h, &t, NULL, &log, &color, NULL, NULL, 1, 1);
 		if (h && t && log && (color != -1)) {
-			handle_status(msg->buf, sender, h->hostname, t->name, NULL, log, color, NULL, 0);
+			handle_status(msg->buf, sender, h->hostname, t->name, NULL, log, color, NULL, 0, 0);
 		}
 	}
 	else if ((strncmp(msg->buf, "notes", 5) == 0) || (strncmp(msg->buf, "usermsg", 7) == 0)) {
@@ -4041,7 +4175,7 @@ void do_message(conn_t *msg, char *origin)
 				"  <Type>", 		log->test->name, 			"</Type>\n",
 				"  <Status>", 		colnames[log->color], 			"</Status>\n",
 				"  <TestFlags>", 	(log->testflags ? log->testflags : ""), "</TestFlags>\n",
-				"  <LastChange>", 	timestr(log->lastchange[0]), 		"</LastChange>\n",
+				"  <LastChange>", 	timestr(log->lastchange), 		"</LastChange>\n",
 				"  <LogTime>", 		timestr(log->logtime), 			"</LogTime>\n",
 				"  <ValidTime>", 	timestr(log->validtime), 		"</ValidTime>\n",
 				"  <AckTime>", 		timestr(log->acktime), 			"</AckTime>\n",
@@ -4125,7 +4259,8 @@ void do_message(conn_t *msg, char *origin)
 			clientlogrec.message = infologrec.message = trendslogrec.message = "";
 			faketestinit = 1;
 		}
-		clientlogrec.lastchange = infologrec.lastchange = trendslogrec.lastchange = dummytimes;
+		clientlogrec.lastchange = infologrec.lastchange = trendslogrec.lastchange = 0;
+		clientlogrec.flapchange = infologrec.flapchange = trendslogrec.flapchange = dummytimes;
 
 
 		for (hosthandle = xtreeFirst(rbhosts); (hosthandle != xtreeEnd(rbhosts)); hosthandle = xtreeNext(rbhosts, hosthandle)) {
@@ -4259,7 +4394,7 @@ void do_message(conn_t *msg, char *origin)
 					"    <Type>", lwalk->test->name, "</Type>\n",
 					"    <Status>", colorname(lwalk->color), "</Status>\n",
 					"    <TestFlags>", (lwalk->testflags ? lwalk->testflags : ""), "</TestFlags>\n",
-					"    <LastChange>", timestr(lwalk->lastchange[0]), "</LastChange>\n",
+					"    <LastChange>", timestr(lwalk->lastchange), "</LastChange>\n",
 					"    <LogTime>", timestr(lwalk->logtime), "</LogTime>\n",
 					"    <ValidTime>", timestr(lwalk->validtime), "</ValidTime>\n",
 					"    <AckTime>", timestr(lwalk->acktime), "</AckTime>\n",
@@ -4850,7 +4985,7 @@ void save_checkpoint(void)
 				colnames[lwalk->color], 
 				(lwalk->testflags ? lwalk->testflags : ""),
 				colnames[lwalk->oldcolor],
-				(int)lwalk->logtime, (int) lwalk->lastchange[0], (int) lwalk->validtime, 
+				(int)lwalk->logtime, (int) lwalk->lastchange, (int) lwalk->validtime,
 				(int) lwalk->enabletime, (int) lwalk->acktime, 
 				(lwalk->cookie ? lwalk->cookie : ""), (int) lwalk->cookieexpires,
 				nlencode(lwalk->message));
@@ -4860,6 +4995,36 @@ void save_checkpoint(void)
 			if (iores >= 0) iores = fprintf(fd, "|%s", msgstr);
 			if (iores >= 0) iores = fprintf(fd, "|%d|%d", (int)lwalk->redstart, (int)lwalk->yellowstart);
 			if (iores >= 0) iores = fprintf(fd, "\n");
+
+			/*
+			 * Own record, not extra fields on the status record: that one is
+			 * positional and its reader errors on any field it does not know,
+			 * so appending would make an older xymond discard the whole board
+			 * on a rollback. Unrecognised ".name." records are already skipped
+			 * by every released reader. Written only when there is state.
+			 */
+			/*
+			 * flapchange[0] alone is not state worth carrying -- every log is
+			 * seeded with its creation time, on both paths -- and testing it
+			 * would put a record after every status. Real history means two.
+			 */
+			if ((iores >= 0) && (lwalk->flapping || (lwalk->pregapcolor != NO_COLOR) ||
+					     ((flapcount > 1) && lwalk->flapchange[1]))) {
+				int fi;
+
+				/* long, not int: truncating these to 32 bits would
+				 * return negative after 2038, giving hold-times in 1901
+				 * and silently disabling flap detection. */
+				iores = fprintf(fd, "@@XYMONDCHK-V1|.flapstate.|%s|%s|%d|%s|%s|%s|%ld|%ld|",
+						hwalk->hostname, lwalk->test->name,
+						lwalk->flapping,
+						colnames[lwalk->oldflapcolor], colnames[lwalk->currflapcolor],
+						colnames[lwalk->pregapcolor], (long)lwalk->pregaplastchange,
+						(long)lwalk->gapstart);
+				for (fi = 0; ((fi < flapcount) && (iores >= 0)); fi++)
+					iores = fprintf(fd, "%s%ld", ((fi == 0) ? "" : ","), (long)lwalk->flapchange[fi]);
+				if (iores >= 0) iores = fprintf(fd, "\n");
+			}
 
 			for (awalk = lwalk->acklist; (awalk && (iores >= 0)); awalk = awalk->next) {
 				iores = fprintf(fd, "@@XYMONDCHK-V1|.acklist.|%s|%s|%d|%d|%d|%d|%s|%s\n",
@@ -4897,6 +5062,20 @@ void save_checkpoint(void)
 }
 
 
+/*
+ * restore_color -- a checkpoint color name, as an index safe for colnames[].
+ * parse_color() answers -1 for an unknown name and COL_CLIENT (99) for
+ * "client"; colnames[] holds COL_COUNT+1 entries, so either would read past
+ * its end on the next save. Anything that is not a status color reads as none.
+ */
+static int restore_color(char *name)
+{
+	int c = parse_color(name);
+
+	return ((c >= 0) && (c <= NO_COLOR)) ? c : NO_COLOR;
+}
+
+
 void load_checkpoint(char *fn)
 {
 	FILE *fd;
@@ -4909,7 +5088,7 @@ void load_checkpoint(char *fn)
 	testinfo_t *t = NULL;
 	char *origin = NULL;
 	xymond_log_t *ltail = NULL;
-	char *originname, *hostname, *testname, *sender, *testflags, *statusmsg, *disablemsg, *ackmsg, *cookie; 
+	char *originname, *hostname, *testname, *sender, *testflags, *statusmsg, *disablemsg, *ackmsg, *cookie;
 	time_t logtime, lastchange, validtime, enabletime, acktime, cookieexpires, yellowstart, redstart;
 	int color = COL_GREEN, oldcolor = COL_GREEN;
 	int count = 0;
@@ -5002,6 +5181,77 @@ void load_checkpoint(char *fn)
 				if (newack->ackedby) xfree(newack->ackedby);
 				if (newack->msg) xfree(newack->msg);
 				xfree(newack);
+			}
+
+			continue;
+		}
+
+		if (strncmp(STRBUF(inbuf), "@@XYMONDCHK-V1|.flapstate.|", 27) == 0) {
+			xymond_log_t *log = NULL;
+			int flapping = 0, oldflapcolor = NO_COLOR, currflapcolor = NO_COLOR;
+			int pregapcolor = NO_COLOR;
+			time_t pregaplastchange = 0, gapstart = 0;
+			char *flapchangestr = NULL;
+
+			hitem = NULL; t = NULL;
+
+			item = gettok(STRBUF(inbuf), "|\n"); i = 0;
+			while (item) {
+				switch (i) {
+				  case 0: break;
+				  case 1: break;
+				  case 2:
+					hosthandle = xtreeFind(rbhosts, item);
+					hitem = (hosthandle == xtreeEnd(rbhosts)) ? NULL : xtreeData(rbhosts, hosthandle);
+					break;
+				  case 3:
+					testhandle = xtreeFind(rbtests, item);
+					t = (testhandle == xtreeEnd(rbtests)) ? NULL : xtreeData(rbtests, testhandle);
+					break;
+				  case 4: flapping = atoi(item); break;
+				  case 5: oldflapcolor = restore_color(item); break;
+				  case 6: currflapcolor = restore_color(item); break;
+				  case 7: pregapcolor = restore_color(item); break;
+				  case 8: pregaplastchange = (time_t)strtol(item, NULL, 10); break;
+				  case 9: gapstart = (time_t)strtol(item, NULL, 10); break;
+				  case 10: flapchangestr = item; break;
+				  default: break;
+				}
+				item = gettok(NULL, "|\n"); i++;
+			}
+
+			if (hitem && t) {
+				for (log = hitem->logs; (log && (log->test != t)); log = log->next) ;
+			}
+
+			if (log) {
+				/*
+				 * Both flap colors, or the first update after a restart
+				 * compares a real color against the "none" they start as
+				 * and records a status change that never happened.
+				 */
+				log->oldflapcolor = oldflapcolor;
+				log->currflapcolor = currflapcolor;
+				log->pregapcolor = pregapcolor;
+				log->pregaplastchange = pregaplastchange;
+				log->gapstart = gapstart;
+				if (flapchangestr && (flapcount > 0) && log->flapchange) {
+					char *fp = flapchangestr;
+					int fi = 0;
+
+					while (fp && (fi < flapcount)) {
+						log->flapchange[fi++] = (time_t)strtol(fp, NULL, 10);
+						fp = strchr(fp, ','); if (fp) fp++;
+					}
+				}
+
+				/*
+				 * The saved flag means "flapping when we checkpointed", not
+				 * "flapping now" -- xymond may have been down for hours. Re-derive
+				 * from the restored ring, the same test handle_status() runs.
+				 */
+				log->flapping = (flapping && (flapcount > 0) && log->flapchange &&
+						 ((getcurrenttime(NULL) - log->flapchange[flapcount-1]) < flapthreshold));
 			}
 
 			continue;
@@ -5110,8 +5360,23 @@ void load_checkpoint(char *fn)
 		ltail->testflags = ( (testflags && strlen(testflags)) ? strdup(testflags) : NULL);
 		strcpy(ltail->sender, sender);
 		ltail->logtime = logtime;
-		ltail->lastchange = (time_t *)calloc((flapcount > 0) ? flapcount : 1, sizeof(time_t));
-		ltail->lastchange[0] = lastchange;
+		ltail->lastchange = lastchange;
+		ltail->flapchange = (flapcount > 0) ? (time_t *)calloc(flapcount, sizeof(time_t)) : NULL;
+		/*
+		 * Seed the ring as get_hts() does: a checkpoint written before the ring
+		 * existed carries no ".flapstate." record to fill it, and an all-zero
+		 * ring costs one extra colour change before detection can trigger.
+		 * A ".flapstate." record, when one follows, overwrites this.
+		 */
+		if (flapcount > 0) ltail->flapchange[0] = lastchange;
+		/* The rest of the flap and hold-time state arrives in that record. */
+		ltail->pregapcolor = NO_COLOR;
+		/* Not checkpointed: the test's next report sets its real validity,
+		 * which arrives within one validity period by definition. */
+		ltail->validity = defaultvalidity;
+		/* Same default a fresh log gets from calloc, so flapinfo reads the
+		 * same for a never-flapped test either side of a restart. */
+		ltail->oldflapcolor = ltail->currflapcolor = COL_GREEN;
 		ltail->validtime = validtime;
 		ltail->enabletime = enabletime;
 		if (ltail->enabletime == DISABLED_UNTIL_OK) ltail->validtime = INT_MAX;
@@ -5230,8 +5495,8 @@ void check_purple_status(void)
 						if (!lwalk->dismsg) lwalk->dismsg = strdup(cause);                                         
 					}
 
-					handle_status(lwalk->message, "xymond", 
-						hwalk->hostname, lwalk->test->name, lwalk->grouplist, lwalk, newcolor, NULL, 0);
+					handle_status(lwalk->message, "xymond",
+						hwalk->hostname, lwalk->test->name, lwalk->grouplist, lwalk, newcolor, NULL, 0, 1);
 					lwalk = lwalk->next;
 				}
 			}
@@ -5794,7 +6059,7 @@ int main(int argc, char *argv[])
 					  xgetenv("MACHINE"));
 			}
 			else {
-				handle_status(buf, "xymond", h->hostname, t->name, NULL, log, color, NULL, 0);
+				handle_status(buf, "xymond", h->hostname, t->name, NULL, log, color, NULL, 0, 0);
 			}
 			last_stats_time = now;
 			flush_errbuf();

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -1514,19 +1514,30 @@ static int isset_noflap(void *hinfo, char *testname, char *hostname)
 #define GAPBRIDGE_VALIDITIES 4
 
 /*
+ * gap_within_window -- is a gap still short enough to carry a hold-time across?
+ * Split out from the test below because a gap that fails this one can no longer
+ * affect any decision, whatever color arrives next. VALIDITY is the test's
+ * report validity in minutes.
+ */
+static int gap_within_window(time_t gaplen, int validity)
+{
+	/* time_t, not int: validity comes from the reporter ("status+NNN"), and a
+	 * large one overflows an int product and wraps. */
+	return (gaplen <= (time_t)GAPBRIDGE_VALIDITIES * validity * 60);
+}
+
+/*
  * holdtime_bridges -- may a test that is reporting again carry its hold-time
  * across the silence? Only if nothing suggests the status moved while we were
  * blind: same color as before, and not gone long. PREGAPCOLOR is NO_COLOR when
- * there was no gap; VALIDITY is the test's report validity in minutes.
+ * there was no gap.
  */
 static int holdtime_bridges(int newcolor, int pregapcolor, time_t gaplen, int validity)
 {
 	if (pregapcolor == NO_COLOR) return 0;		/* no gap to bridge */
 	if (newcolor != pregapcolor) return 0;		/* it changed while we were blind */
 
-	/* time_t, not int: validity comes from the reporter ("status+NNN"), and a
-	 * large one overflows an int product and wraps. */
-	return (gaplen <= (time_t)GAPBRIDGE_VALIDITIES * validity * 60);
+	return gap_within_window(gaplen, validity);
 }
 
 
@@ -4950,6 +4961,7 @@ void save_checkpoint(void)
 	scheduletask_t *swalk;
 	ackinfo_t *awalk;
 	int iores = 0;
+	int gapopen = 0;
 
 	if (checkpointfn == NULL) return;
 
@@ -5007,8 +5019,19 @@ void save_checkpoint(void)
 			 * flapchange[0] alone is not state worth carrying -- every log is
 			 * seeded with its creation time, on both paths -- and testing it
 			 * would put a record after every status. Real history means two.
+			 *
+			 * A gap past its bridge window is not state either: no color can
+			 * carry a hold-time across it any more, so it is over whatever
+			 * happens next. Saying so here is what keeps it from being saved
+			 * for as long as the override lasts -- xymond_client refreshes an
+			 * RRDDS modifier every client cycle, and while one is in force the
+			 * color being recorded is never the reporter's, so nothing ever
+			 * closes the gap.
 			 */
-			if ((iores >= 0) && (lwalk->flapping || (lwalk->pregapcolor != NO_COLOR) ||
+			gapopen = ((lwalk->pregapcolor != NO_COLOR) &&
+				   gap_within_window(now - lwalk->gapstart, lwalk->validity));
+
+			if ((iores >= 0) && (lwalk->flapping || gapopen ||
 					     ((flapcount > 1) && lwalk->flapchange[1]))) {
 				int fi;
 
@@ -5019,8 +5042,9 @@ void save_checkpoint(void)
 						hwalk->hostname, lwalk->test->name,
 						lwalk->flapping,
 						colnames[lwalk->oldflapcolor], colnames[lwalk->currflapcolor],
-						colnames[lwalk->pregapcolor], (long)lwalk->pregaplastchange,
-						(long)lwalk->gapstart);
+						colnames[gapopen ? lwalk->pregapcolor : NO_COLOR],
+						(long)(gapopen ? lwalk->pregaplastchange : 0),
+						(long)(gapopen ? lwalk->gapstart : 0));
 				for (fi = 0; ((fi < flapcount) && (iores >= 0)); fi++)
 					iores = fprintf(fd, "%s%ld", ((fi == 0) ? "" : ","), (long)lwalk->flapchange[fi]);
 				if (iores >= 0) iores = fprintf(fd, "\n");


### PR DESCRIPTION
Closes #332.

**Stacked on #250** — the gap fields do not exist before it. Until #250 merges this
PR shows its commit too; that drops out of the diff once it lands.

A no-data gap ends when the color being recorded becomes the reporter's own again.
While something overrides that color it never does, so the gap stays open and its
`.flapstate.` record is written in every checkpoint from the first override onward.
`xymond_client` refreshes an RRDDS modifier every client cycle, so on a server using
DS rules that is every one of those logs, forever.

Past `GAPBRIDGE_VALIDITIES` report validities the gap decides nothing —
`holdtime_bridges()` refuses it whatever color arrives next. This splits that length
test out as `gap_within_window()` and asks it at save time as well.

Runtime behavior is unchanged: nothing else reads the gap, and one the saver drops is
one the loader could only restore to have refused. The single visible difference is
across a restart — validity is not checkpointed, so a restored log falls back to
`defaultvalidity`, and a gap long expired against its own `status+1` window would
otherwise come back bridgeable against a 30-minute one.

### Tests

`xymond-checkpoint-roundtrip.sh` gains both halves, driven without sending a status so
the gap is written back exactly as the daemon holds it: sixty seconds old it must
survive the round trip, a day old it must not. Reintroducing the defect fails it:

```
FAIL: a day-old gap was written back as red; nothing can bridge it any more,
      so it is state that never goes away
```

`xymond-holdtime-bridge.sh` extracts both halves of the rule now, so splitting the pair
without updating it fails to link rather than silently testing half the rule.

All 22 tests in `tests/server/` pass.
