### PR TITLE
xymond_channel: stop instead of spinning on a fatal semaphore error (TBT 177)

### DIFF
--- a/tests/xymond/channel-fatal-semop-harness.c
+++ b/tests/xymond/channel-fatal-semop-harness.c
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * tests/xymond/channel-fatal-semop-harness.c
+ *
+ * Stands in for xymond as the owner of a channel's SysV IPC, so a test can
+ * run the real xymond_channel against a real channel and then tear the
+ * semaphore set out from under it.
+ *
+ * SysV IPC is kernel-persistent: the ids stay valid after the creating
+ * process exits, so "create" can create and return rather than having to
+ * stay alive alongside the test.
+ *
+ *   create <channelname>    create the channel as CHAN_MASTER; print its
+ *                           shmid and semid on stdout as SHMID=/SEMID=
+ *   clients <semid>         print the CLIENTCOUNT semaphore.  A test must not
+ *                           break the channel before xymond_channel has
+ *                           attached to it, or the process exits for the
+ *                           wrong reason and the test passes vacuously;
+ *                           CLIENTCOUNT going to 1 is that readiness gate.
+ *   rmsem <semid>           IPC_RMID the semaphore set.  Every semop already
+ *                           blocked on it returns -1 with EIDRM, and every
+ *                           later one fails the same way: the permanent,
+ *                           fatal error the test is about.
+ *   rmall <shmid> <semid>   remove both, for cleanup.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include <sys/sem.h>
+
+#include "libxymon.h"
+
+/* Same lookup xymond_channel does for --channel= (xymond_channel.c). */
+static int channel_id(char *name)
+{
+	int cnid;
+
+	for (cnid = C_STATUS; (channelnames[cnid] && strcmp(channelnames[cnid], name)); cnid++) ;
+	return (channelnames[cnid] ? cnid : -1);
+}
+
+int main(int argc, char *argv[])
+{
+	if ((argc == 3) && (strcmp(argv[1], "create") == 0)) {
+		int cnid = channel_id(argv[2]);
+		xymond_channel_t *channel;
+
+		if (cnid == -1) {
+			fprintf(stderr, "unknown channel name '%s'\n", argv[2]);
+			return 1;
+		}
+
+		channel = setup_channel(cnid, CHAN_MASTER);
+		if (channel == NULL) {
+			fprintf(stderr, "setup_channel(%s, CHAN_MASTER) failed\n", argv[2]);
+			return 1;
+		}
+
+		printf("SHMID=%d\n", channel->shmid);
+		printf("SEMID=%d\n", channel->semid);
+		return 0;
+	}
+
+	if ((argc == 3) && (strcmp(argv[1], "clients") == 0)) {
+		int n = semctl(atoi(argv[2]), CLIENTCOUNT, GETVAL);
+
+		if (n == -1) {
+			fprintf(stderr, "semctl(%s, CLIENTCOUNT, GETVAL): %s\n", argv[2], strerror(errno));
+			return 1;
+		}
+		printf("%d\n", n);
+		return 0;
+	}
+
+	if ((argc == 3) && (strcmp(argv[1], "rmsem") == 0)) {
+		int semid = atoi(argv[2]);
+
+		if (semctl(semid, 0, IPC_RMID) == -1) {
+			fprintf(stderr, "semctl(%d, IPC_RMID): %s\n", semid, strerror(errno));
+			return 1;
+		}
+		return 0;
+	}
+
+	if ((argc == 4) && (strcmp(argv[1], "rmall") == 0)) {
+		/* Best-effort cleanup: either may already be gone. */
+		shmctl(atoi(argv[2]), IPC_RMID, NULL);
+		semctl(atoi(argv[3]), 0, IPC_RMID);
+		return 0;
+	}
+
+	fprintf(stderr, "usage: %s create <channel> | clients <semid> | rmsem <semid> | rmall <shmid> <semid>\n", argv[0]);
+	return 2;
+}

--- a/tests/xymond/channel-fatal-semop.sh
+++ b/tests/xymond/channel-fatal-semop.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/channel-fatal-semop.sh
+#
+# xymond_channel waits for work by blocking on the GOCLIENT semaphore. If the
+# channel's semaphore set goes away under it -- xymond torn down, a stale set
+# cleared by hand, ipcrm -- that semop stops blocking and starts failing
+# immediately and permanently with EIDRM. The "Semaphore wait aborted" branch
+# only continue'd, and the continue skips the rest of the loop body including
+# its one blocking call, so an idle waiter turned into a full-core busy-loop
+# that ran until someone killed it. It must stop instead.
+#
+# Driven against the real thing: the harness creates the channel's IPC the way
+# xymond does (CHAN_MASTER), and removes the semaphore set once xymond_channel
+# has attached to it.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/build-worker.sh
+. "$(dirname "$0")/../lib/build-worker.sh"
+
+require_bin XYMOND_CHANNEL xymond/xymond_channel
+
+work=$(mktempdir)
+# setup_channel() keys the IPC off ftok(XYMONHOME), so a per-test directory
+# keeps this run's channel distinct from a real Xymon on the same host and
+# from another copy of this test running beside it.
+mkdir -p "$work/home"
+
+build_xymond_worker "$work" channel-harness tests/xymond/channel-fatal-semop-harness.c
+
+ids=$(XYMONHOME="$work/home" "$work/channel-harness" create status) \
+	|| fail "the harness could not create the status channel"
+eval "$ids"
+if [ -z "${SEMID:-}" ] || [ -z "${SHMID:-}" ]; then
+	fail "the harness did not report the channel ids"
+fi
+register_cleanup "'$work/channel-harness' rmall '$SHMID' '$SEMID' >/dev/null 2>&1 || true"
+
+XYMONHOME="$work/home" "$XYMOND_CHANNEL" --channel=status /bin/cat \
+	>"$work/channel.log" 2>&1 &
+worker=$!
+register_cleanup "kill -9 $worker 2>/dev/null || true"
+
+# Breaking the channel before xymond_channel has attached would make it fail
+# during startup instead, and the test would pass without ever reaching the
+# loop under test. setup_channel() registers a client by raising CLIENTCOUNT,
+# so wait for that -- the condition, not a duration.
+attached=no
+for _ in $(seq 1 100); do
+	[ "$("$work/channel-harness" clients "$SEMID" 2>/dev/null || echo 0)" -ge 1 ] \
+		&& { attached=yes; break; }
+	sleep 0.1
+done
+[ "$attached" = yes ] || {
+	cat "$work/channel.log" >&2
+	fail "xymond_channel never attached to the channel"
+}
+
+# It is now blocked in semop(GOCLIENT). Take the semaphore set away: that wait
+# fails with EIDRM, and so will every retry.
+"$work/channel-harness" rmsem "$SEMID" >/dev/null \
+	|| fail "the harness could not remove the semaphore set"
+
+stopped=no
+for _ in $(seq 1 100); do
+	kill -0 "$worker" 2>/dev/null || { stopped=yes; break; }
+	sleep 0.1
+done
+
+if [ "$stopped" != yes ]; then
+	# Report what it is doing with the CPU where that is readable: the burn
+	# is the symptom operators actually see. Linux-only, so best-effort.
+	ticks=$(awk '{print $14+$15}' "/proc/$worker/stat" 2>/dev/null || echo "unavailable")
+	cat "$work/channel.log" >&2
+	fail "xymond_channel kept running after its semaphore set was removed (cpu ticks used: $ticks) -- the fatal semop error spins instead of stopping"
+fi
+
+rc=0
+wait "$worker" 2>/dev/null || rc=$?
+
+log=$(cat "$work/channel.log")
+
+# Stopped by the intended route, not by dying: a signal death would show up
+# here as 128+n, and the diagnostic pins which branch ran.
+assert_equal "0" "$rc" "xymond_channel shuts down cleanly on a fatal semaphore error"
+assert_contains "cannot continue" "$log" \
+	"the fatal semaphore error is reported before exiting"
+
+pass "xymond_channel exits when its semaphore set is removed"

--- a/xymond/xymond_channel.c
+++ b/xymond/xymond_channel.c
@@ -601,6 +601,12 @@ int main(int argc, char *argv[])
 		s.sem_num = GOCLIENT; s.sem_op  = -1; s.sem_flg = ((pendingcount > 0) ? IPC_NOWAIT : 0);
 		n = semop(channel->semid, &s, 1);
 
+		/* This is where we'll first find some fatal errors */
+		if ((n == -1) && (errno != EAGAIN) && (errno != EINTR) ) {
+			dbgprintf("xymond_channel: Semaphore wait failed; can't continue: %s\n", strerror(errno));
+			running = 0;
+		} 
+
 		if (n == 0) {
 			/*
 			 * GOCLIENT went high, and so we got alerted about a new

--- a/xymond/xymond_channel.c
+++ b/xymond/xymond_channel.c
@@ -601,11 +601,18 @@ int main(int argc, char *argv[])
 		s.sem_num = GOCLIENT; s.sem_op  = -1; s.sem_flg = ((pendingcount > 0) ? IPC_NOWAIT : 0);
 		n = semop(channel->semid, &s, 1);
 
-		/* This is where we'll first find some fatal errors */
-		if ((n == -1) && (errno != EAGAIN) && (errno != EINTR) ) {
-			dbgprintf("xymond_channel: Semaphore wait failed; can't continue: %s\n", strerror(errno));
+		/*
+		 * EAGAIN is the IPC_NOWAIT "nothing pending" answer and EINTR a
+		 * signal; both are normal and the loop retries. Anything else is
+		 * permanent - EIDRM or EINVAL once the semaphore set is gone -
+		 * and the "Semaphore wait aborted" path below just continues,
+		 * which turns a blocking wait into a full-core busy-loop that
+		 * runs until the process is killed. Stop instead.
+		 */
+		if ((n == -1) && (errno != EAGAIN) && (errno != EINTR)) {
+			errprintf("Semaphore wait failed, cannot continue: %s\n", strerror(errno));
 			running = 0;
-		} 
+		}
 
 		if (n == 0) {
 			/*


### PR DESCRIPTION
`xymond_channel` idles by blocking on `semop(GOCLIENT)`. When the channel's semaphore set goes away under it — xymond torn down, a stale set cleared by hand, `ipcrm` — that call stops blocking and starts failing immediately and *permanently* with `EIDRM`.

`main` handles that in the "Semaphore wait aborted" branch, which logs at debug level and `continue`s. The `continue` is what makes it expensive: it skips the rest of the loop body, including the `select()` in the peer-write section that is the cycle's only other blocking call. Nothing touches `running`, and the error is permanent, so the next iteration fails identically. An idle waiter becomes a busy-loop that runs until someone kills it.

### Measured, not assumed

Driving the real binary against a real channel and removing the semaphore set, before the fix:

| | state | CPU |
|---|---|---|
| blocked on `semop` | `S` | 0.0% |
| semaphore set removed | `R` | 322 ticks (3.2 s) per 3 s wall — a saturated core |

It never exited.

### The fix

Test the `semop` result where the error first surfaces, between the call and the `n == 0` branch. Anything that is not `EAGAIN` (the `IPC_NOWAIT` "nothing pending" answer) or `EINTR` (a signal) is permanent, so clear `running` and let the existing loop condition end the process through its normal shutdown path. No new exit route.

### Structure

Two commits, as with the other Terabithia ports (#200, #221, #225):

1. **`xymond_channel: exit when fatal semaphore errors are encountered`** — devel `7ffd904b103838a193d73e4fc08a3692ab7d63f7` (TBT 177) applied verbatim, authored by J.C. Cleaver with the original 2015-11-29 author date and a `cherry picked from` trailer.
2. **`xymond_channel: correct and cover the TBT 177 fatal-semop stop`** — our corrections and the test, so the correction diff reads against the port rather than against `main`.

The corrections in (2):

- `dbgprintf` → `errprintf`. As ported, a worker dying on a fatal IPC error leaves no trace unless someone happened to be running with `--debug`. This is a death notice, and it now goes where this file's other death notices go ("Child process %d died").
- Message reworded to match those, without the redundant program-name prefix `errprintf` does not need.
- The comment says which errnos are the normal ones and why the existing "Semaphore wait aborted" `continue` is the expensive path.
- Dropped the stray trailing whitespace and the extra space in the condition.

The resulting tree is byte-identical to the previous single-commit revision of this PR; only the history changed.

### Test

`tests/xymond/channel-fatal-semop.sh` drives the real `xymond_channel` against a real channel. The harness creates the channel's IPC the way xymond does (`setup_channel` with `CHAN_MASTER`; SysV IPC is kernel-persistent, so it can create and exit rather than live alongside the test). The test waits for `xymond_channel` to register itself by raising `CLIENTCOUNT` — without that gate it could break the channel before the process reached the loop under test and pass for the wrong reason — then `IPC_RMID`s the semaphore set and requires the process to exit.

- Passes in 0.17 s with the fix.
- Fails on the unfixed binary in ~12 s, reporting the burn it measured: `cpu ticks used: 1083` across the poll window.
- Exit status **and** the diagnostic are asserted, so a crash cannot pass as a clean stop.
- The channel is keyed off `ftok(XYMONHOME)`, so the test's private `XYMONHOME` keeps it clear of a real Xymon on the same host and of a parallel copy of itself. Cleanup removes both ids; the runs leave no IPC behind.

Suite: 54 passed, 0 skipped, 0 failed on a built server tree.

### Merge note

#172 / #173 insert a `hupchildren` block immediately **above** the same `semop` this touches. Different lines, shared context — adjacent hunks, so expect a trivial context resolution for whichever lands second rather than a surprise. No dependency either way.

Refs #29 (TBT `177` = `7ffd904b1`), #106

