### PR TITLE
tests: record why showgraph's exec-title injection checks are decidable

### DIFF
--- a/tests/web/showgraph-exec-title.sh
+++ b/tests/web/showgraph-exec-title.sh
@@ -68,6 +68,14 @@ cat >>"$work/graphs.cfg" <<EOF
 	LINE2:p@RRDIDX@#@COLOR@:x
 EOF
 
+# The SIDEEFFECT assertions below are checks that a file does *not* exist, so
+# they are only decidable because showgraph has finished with the title script
+# by the time this returns: it runs it under popen() and then pclose()s, and
+# pclose() waits for the child (web/showgraph.c). Reading the title off the
+# pipe would not be enough -- that proves the script wrote, not that it exited.
+# If that pclose() ever goes away, or the child is abandoned on a timeout, an
+# injected "touch" could land after the check and every one of those
+# assertions would start passing while the injection actually worked.
 render() {  # render <disp-value>
 	rm -f "$work/SIDEEFFECT" "$work/args.out"
 	REQUEST_METHOD=GET \


### PR DESCRIPTION
showgraph-exec-title.sh asserts four times that a file does *not* exist,
which is how it proves an injected touch never ran. An absence check is
only meaningful once whatever would create the file has finished, and
here that is not this shell's child: showgraph runs the title script
under popen(), and the wait happens in pclose() (web/showgraph.c).

Reading the title off the pipe would not be enough on its own -- that
proves the script wrote a line, not that it exited. So the four
assertions rest on that pclose(): in another file, incidental to why it
is there, and written down nowhere.

Remove it, or abandon the child on a timeout, and an injected touch can
land after the check. The assertions keep passing while the injection
actually works. A false pass in an injection guard is silent, which is
the direction nobody re-reads.

Comment only, no behaviour change. Test still passes.