### PR TITLE
tests: fix OpenBSD fixture portability

### DIFF
--- a/tests/client/fs-filter-linux.sh
+++ b/tests/client/fs-filter-linux.sh
@@ -314,6 +314,9 @@ for prog in sh bash awk sed; do
 		|| fail "inode-drop test needs a real '$prog' on PATH"
 	ln -s "$p" "$INODEDIR/$prog"
 done
+printf_path=$(PATH="$REALPATH" type -P printf) \
+	|| fail "inode-drop test needs a real 'printf' on PATH"
+ln -s "$printf_path" "$INODEDIR/printf"
 
 inode_out=$(
 	cd "$TMP"

--- a/tests/server/history-tail-resync.sh
+++ b/tests/server/history-tail-resync.sh
@@ -34,7 +34,7 @@ HISTFILE="$WORK/hist/junk,host.disk"
 
 # Valid open record, then a malformed suffix shorter than the scan window.
 printf 'Mon Apr  6 22:37:31 2020 green 1586205451\n' > "$HISTFILE"
-head -c 300 /dev/zero | tr '\0' 'G' >> "$HISTFILE"
+dd if=/dev/zero bs=300 count=1 2>/dev/null | tr '\0' 'G' >> "$HISTFILE"
 
 # Two consecutive status changes: green->red, then red->yellow.
 printf '@@stachg#1|1586206051.00000|127.0.0.1|xymond|junk.host|disk|1586206351|red|green|1586205451|0||0|0|\nbody\n@@\n@@stachg#2|1586209651.00000|127.0.0.1|xymond|junk.host|disk|1586209951|yellow|red|1586206051|0||0|0|\nbody\n@@\n' \


### PR DESCRIPTION
# tests: fix OpenBSD fixture portability

## Summary

- add external `printf` to the restricted filesystem-test `PATH`
- replace GNU-specific `head -c` with portable `dd`

## Problem

Two test fixtures failed on OpenBSD 7.9:

- `fs-filter-linux.sh` could not run `printf` because OpenBSD `/bin/sh`
  does not provide it as a builtin and the fixture's restricted `PATH`
  omitted `/usr/bin/printf`
- `history-tail-resync.sh` used the unsupported GNU `head -c` option

These failures were found while validating #331 but are unrelated to its
`-iquote` changes.

## Validation

| Platform | Passed | Skipped | Failed |
|---|---:|---:|---:|
| Linux | 54 | 0 | 0 |
| FreeBSD 14.3 | 53 | 1 | 0 |
| NetBSD 11.0 | 51 | 3 | 0 |
| OpenBSD 7.9 | 51 | 3 | 0 |

All skips are platform capability skips.