### PR TITLE
tests: read line lists without mapfile, which needs bash 4

### DIFF
--- a/tests/rrd/inode-unix-columns.sh
+++ b/tests/rrd/inode-unix-columns.sh
@@ -23,7 +23,10 @@ inode-test-flags:
 		'rrddef=$(RRDDEF)' 'rrdincdir=$(RRDINCDIR)' 'rrdlibs=$(RRDLIBS)'
 EOF
 ) || fail "cannot read configured RRD build flags"
-mapfile -t buildflags <<< "$buildflags_output"
+# Read the lines into an array without mapfile: that is a bash 4 builtin
+# and macOS ships bash 3.2, where the suite runs under /usr/bin/env bash.
+buildflags=()
+while IFS= read -r line; do buildflags+=("$line"); done <<< "$buildflags_output"
 [ "${#buildflags[@]}" -eq 5 ] || fail "configured RRD build flags are incomplete"
 ldflags=${buildflags[0]#ldflags=}
 rpathopt=${buildflags[1]#rpathopt=}

--- a/tests/server/client-msgs-sections.sh
+++ b/tests/server/client-msgs-sections.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 . "$(dirname "$0")/../lib/assert.sh"
 
 CLIENT_DIR=$(find_root)/xymond/client
-mapfile -t handlers < <(grep -l 'msgs_report(' "$CLIENT_DIR"/*.c | sort)
+# No mapfile here: it is a bash 4 builtin and macOS ships bash 3.2.
+handlers=()
+while IFS= read -r line; do handlers+=("$line"); done \
+	< <(grep -l 'msgs_report(' "$CLIENT_DIR"/*.c | sort)
 ((${#handlers[@]} > 0)) || fail "no client handlers call msgs_report"
 
 for handler in "${handlers[@]}"; do


### PR DESCRIPTION
macOS ships bash 3.2 and the suite runs under /usr/bin/env bash, so the
two tests using the mapfile builtin die before they test anything:

    ./tests/rrd/inode-unix-columns.sh: line 26: mapfile: command not found
    ./tests/server/client-msgs-sections.sh: line 9: mapfile: command not found

Both report rc=127 on every macOS lane -- 14, 15 and 26.

Both uses read a short list of lines into an array, which a read loop
does the same way on any bash. Done inline at the two sites rather than
behind a helper: bash 3.2 has no namerefs, so a shared version would
have to eval the array name, which is worse than three plain lines.

These two were the whole exposure. A sweep of tests/ for constructs
newer than bash 3.2 finds mapfile twice and nothing else -- no
readarray, no declare -A or local -A, no ${var^^} / ${var,,}; the one
negative array subscript is in C.

Verified by disabling the builtin, which reproduces macOS exactly:

    $ cat nomapfile.sh
    enable -n mapfile
    $ BASH_ENV=nomapfile.sh ./tests/rrd/inode-unix-columns.sh
    ./tests/rrd/inode-unix-columns.sh: line 26: mapfile: command not found   <- before
    PASS: UNIX inode columns reach the shared RRD pipeline                   <- after

Suite: 57 passed, 0 skipped, 0 failed, both normally and with the
builtin disabled. No new shellcheck findings.

macOS will not ship a newer bash -- the 3.2 pin is a GPLv3 licensing
decision -- so the suite has to stay within it rather than wait.

Closes #338