### PR TITLE
build: fix malformed flag values in the FreeBSD and NetBSD makefiles

### DIFF
--- a/build/Makefile.FreeBSD
+++ b/build/Makefile.FreeBSD
@@ -10,7 +10,7 @@ CC ?= cc
 CFLAGS = -g -O2 -Wall -Wno-unused -Wno-pointer-sign -D_REENTRANT -I/usr/local/include -L/usr/local/lib $(LFSDEF) $(OSDEF)
 
 
-RPATH = "-Wl,--rpath,"
+RPATH = -Wl,--rpath,
 
 # Compile flags for debugging
 # CFLAGS = -g -DDEBUG -Wall -D_REENTRANT -I/usr/local/include -L/usr/local/lib $(LFSDEF) $(OSDEF)

--- a/build/Makefile.NetBSD
+++ b/build/Makefile.NetBSD
@@ -12,16 +12,16 @@ CC= gcc
 GCCVER := $(shell gcc -dumpversion|cut -d. -f1)
 ifeq ($(GCCVER),4)
    CFLAGS = -g -O2 -Wall -Wno-unused -Wno-pointer-sign -D_REENTRANT $(LFSDEF) $(OSDEF) \
-       -I${PKGDIR}/include -L${PKGDIR}/lib, -Wl,--rpath=${PKGDIR}/lib
+       -I${PKGDIR}/include -L${PKGDIR}/lib -Wl,--rpath=${PKGDIR}/lib
 else
    CFLAGS = -g -O2 -Wall -Wno-unused -D_REENTRANT $(LFSDEF) $(OSDEF) \
-       -I${PKGDIR}/include -L${PKGDIR}/lib, -Wl,--rpath=${PKGDIR}/lib
+       -I${PKGDIR}/include -L${PKGDIR}/lib -Wl,--rpath=${PKGDIR}/lib
 endif
-RPATH = "-Wl,--rpath,"
+RPATH = -Wl,--rpath,
 
 # Compile flags for debugging
 # CFLAGS = -g -DDEBUG -Wall -D_REENTRANT $(LFSDEF) $(OSDEF) \
-       -I${PKGDIR}/include -L${PKGDIR}/lib, -Wl,--rpath=${PKGDIR}/lib
+       -I${PKGDIR}/include -L${PKGDIR}/lib -Wl,--rpath=${PKGDIR}/lib
 
 # Mail program: This must support "CMD -s SUBJECT ADDRESS" to send out a mail with a subject
 # Typically, this will be "mail" or "mailx"


### PR DESCRIPTION
Two values in the per-OS makefiles are written as if they were shell
fragments rather than flag text. The product build survives both because
make hands its recipes to a shell; anything else that reads the values
does not.

RPATH carried literal double quotes on FreeBSD and NetBSD:

    build/Makefile.FreeBSD:13   RPATH = "-Wl,--rpath,"
    build/Makefile.NetBSD:20    RPATH = "-Wl,--rpath,"
    build/Makefile.Linux:18     RPATH = -Wl,--rpath,        <- and GNU, GNU_kFreeBSD

build/Makefile.rules:61 builds RPATHOPT from it. In a recipe the shell
strips the quotes, so the compiler sees the right thing. A test harness
that reads RPATHOPT out of make and word-splits it into argv does not
get that step, and the quotes arrive as literal characters:

    clang: error: no such file or directory: '"-Wl,--rpath,"/usr/local/lib'
    clang: error: no such file or directory: '"-Wl,--rpath,"/usr/pkg/lib'

tests/rrd/inode-unix-columns.sh is the only harness passing RPATHOPT
today and fails on every FreeBSD and NetBSD lane for this. It matters
more than that one test: #310 proposes giving every harness the
configured link flags, and RPATHOPT among them would spread this from
one failure to all of them.

Reproduced and checked both directions with the same make probe the test
uses:

    RPATH = "-Wl,--rpath,"      harness argv: ["-Wl,--rpath,"/usr/local/lib]
                                product:      [-Wl,--rpath,/usr/local/lib]
    RPATH = -Wl,--rpath,        harness argv: [-Wl,--rpath,/usr/local/lib]
                                product:      [-Wl,--rpath,/usr/local/lib]

So the harness is fixed and what the product build sees is unchanged,
which is the point: the quotes were never carrying meaning, and the
three other makefiles that define RPATH already omit them.

Second, NetBSD's CFLAGS had a stray comma after the library search path,
on all three variants (normal, non-pcre, and the commented debug one):

    -I${PKGDIR}/include -L${PKGDIR}/lib, -Wl,--rpath=${PKGDIR}/lib

That makes the search path "/usr/pkg/lib," -- a directory that does not
exist -- rather than /usr/pkg/lib. NetBSD lanes do fail with "ld: cannot
find -lpcre2-8"; I have not confirmed this comma is the whole cause,
since the product build there still links, so treat that as context
rather than a claim.

Neither file is read on Linux (the toplevel Makefile includes only
build/Makefile.Linux), so the local suite cannot exercise either change:
57 passed, 0 skipped, 0 failed, unchanged. The BSD lanes are the check.

Closes #337