### PR TITLE
docs: regenerate xymonserver.cfg.5.html after the instances-per-image rewording

### DIFF
--- a/docs/manpages/man5/xymonserver.cfg.5.html
+++ b/docs/manpages/man5/xymonserver.cfg.5.html
@@ -673,7 +673,7 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     GRAPHS_&lt;COLUMNNAME&gt; changes only what graphs are shown on that
     column's status page. GRAPHS defines the graph list and order on the
     &quot;trends&quot; page, and also stores graph-display metadata such as the
-    per-image split size.</p>
+    maximum number of instances (RRD files) shown per graph image.</p>
 <p class="Pp"></p>
 <dl class="Bl-tag">
   <dt id="TEST2RRD"><a class="permalink" href="#TEST2RRD"><b>TEST2RRD</b></a></dt>
@@ -709,36 +709,36 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       and in what order. The matching RRD files are selected by the
       corresponding graph definitions in <i><a href="../man5/graphs.cfg.5.html">graphs.cfg</a>(5).</i> Each entry is
       either &quot;name&quot; or &quot;name::N&quot;: &quot;name&quot; is the
-      graph name, and N is the maximum number of RRD files drawn per graph image
-      after the graph has been split; the default is 5 per image. The double
-      colon is literal, so &quot;mrtg::1&quot; draws one file per image. N
-      counts RRD files, not lines: each RRD file may hold several data sets
-      (DS), each drawn as its own curve, so an image showing N files can contain
-      several times N lines. Choose N with the per-file DS count in mind - a
-      2-DS graph at &quot;::2&quot; draws 4 lines, while a 1-DS graph at
-      &quot;::5&quot; draws 5. A legacy middle field is accepted by the parser
-      for compatibility, but it is ignored and should not be used in new
-      configurations. The N value belongs in GRAPHS, not in
+      graph name, and N is the maximum number of instances (RRD files) drawn per
+      graph image after the graph has been split; the default is 5 per image.
+      The double colon is literal, so &quot;mrtg::1&quot; draws one file per
+      image. N counts instances (RRD files), not lines: each RRD file may hold
+      several data sets (DS), each drawn as its own curve, so an image showing N
+      files can contain several times N lines. Choose N with the per-file DS
+      count in mind - a 2-DS graph at &quot;::2&quot; draws 4 lines, while a
+      1-DS graph at &quot;::5&quot; draws 5. A legacy middle field is accepted
+      by the parser for compatibility, but it is ignored and should not be used
+      in new configurations. The N value belongs in GRAPHS, not in
       GRAPHS_&lt;COLUMNNAME&gt;, and is used whenever graph links are generated
       for that graph. This includes the &quot;trends&quot; page, a test column's
       default status-page graph from TEST2RRD, and status-page
       GRAPHS_&lt;COLUMNNAME&gt; entries that name the same graph definition. If
       a graph is used only from GRAPHS_&lt;COLUMNNAME&gt; and has no matching
-      entry in GRAPHS, it uses the default split size. On the &quot;trends&quot;
-      page, the RRD file count is known automatically. On status pages,
-      splitting only happens when <i><a href="../man1/svcstatus.cgi.1.html">svcstatus.cgi</a>(1)</i> has an instance count
-      for the graph. A status message can provide this explicitly with a
-      &quot;&lt;!-- linecount=N --&gt;&quot; marker. If no marker is present,
-      <i><a href="../man1/svcstatus.cgi.1.html">svcstatus.cgi</a>(1)</i> computes the count automatically only for columns
-      listed in the &quot;--multigraphs&quot; option (built-in default: disk,
-      inode, qtree, quotas, snapshot, TblSpace, if_load); any other column draws
-      all matching RRD files in one image. Exception: entries with an explicit
-      graph list in a host's TRENDS tag (e.g. &quot;disk:disk1|disk2&quot;, see
-      <i><a href="../man5/hosts.cfg.5.html">hosts.cfg</a>(5))</i> ignore N and use the default of 5. Note: a &quot;DISK
-      filesystem IGNORE&quot; rule in <i><a href="../man5/analysis.cfg.5.html">analysis.cfg</a>(5)</i> removes a
-      filesystem from the status, the alerts and the graphs. This is usually the
-      preferred replacement for the deprecated NORRDDISKS/RRDDISKS settings
-      below.
+      entry in GRAPHS, it uses the default limit of instances per image. On the
+      &quot;trends&quot; page, the RRD file count is known automatically. On
+      status pages, splitting only happens when <i><a href="../man1/svcstatus.cgi.1.html">svcstatus.cgi</a>(1)</i> has an
+      instance count for the graph. A status message can provide this explicitly
+      with a &quot;&lt;!-- linecount=N --&gt;&quot; marker. If no marker is
+      present, <i><a href="../man1/svcstatus.cgi.1.html">svcstatus.cgi</a>(1)</i> computes the count automatically only for
+      columns listed in the &quot;--multigraphs&quot; option (built-in default:
+      disk, inode, qtree, quotas, snapshot, TblSpace, if_load); any other column
+      draws all matching RRD files in one image. Exception: entries with an
+      explicit graph list in a host's TRENDS tag (e.g.
+      &quot;disk:disk1|disk2&quot;, see <i><a href="../man5/hosts.cfg.5.html">hosts.cfg</a>(5))</i> ignore N and use
+      the default of 5. Note: a &quot;DISK filesystem IGNORE&quot; rule in
+      <i><a href="../man5/analysis.cfg.5.html">analysis.cfg</a>(5)</i> removes a filesystem from the status, the alerts
+      and the graphs. This is usually the preferred replacement for the
+      deprecated NORRDDISKS/RRDDISKS settings below.
     <p class="Pp"></p>
   </dd>
   <dt id="NORRDDISKS"><a class="permalink" href="#NORRDDISKS"><b>NORRDDISKS</b></a></dt>


### PR DESCRIPTION
4c1f842d9 (#262) reworded the GRAPHS entry in common/xymonserver.cfg.5 but
did not regenerate the committed HTML, so docs/manpages has been out of
step with its roff source since that merge.

CI catches this -- the "manual pages match their sources" job copies
docs/manpages aside, re-runs build/makehtml.sh and diffs -- and main has
been failing it since 4c1f842d9. This is that regeneration and nothing
else; the only change is the wording #262 already made in the source.

Verified with the job's own procedure: after this commit, regenerating
produces no diff.