### PR TITLE
client/linux: bound a wedged remote df instead of losing the whole host (#316)

### DIFF
--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -113,11 +113,137 @@ case "$DFLOCALONLY" in
 		DFLOCALONLY=yes
 		;;
 esac
+# XYMONCLIENT_FS_REMOTE_DF_BUDGET: seconds to wait for the remote df probe
+# before giving up for this cycle (default 30, capped at 3600; non-numeric,
+# empty or zero -> 30). A poll BUDGET, not a kill timeout: a df wedged on a
+# dead server sits in uninterruptible D-state where even SIGKILL is ignored,
+# so it is left running and picked up on a later cycle rather than killed.
+DFBUDGET="${XYMONCLIENT_FS_REMOTE_DF_BUDGET:-30}"
+case "$DFBUDGET" in
+	*[!0-9]*|'') DFBUDGET=30 ;;
+	*[1-9]*) ;;
+	*) DFBUDGET=30 ;;
+esac
+[ "$DFBUDGET" -le 3600 ] 2>/dev/null || DFBUDGET=3600
+
+# XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES: the df types whose stat() hard-blocks
+# when the server is unreachable. Shipped as a built-in list so no site has to
+# maintain one; assign the variable to override it. Only consulted with
+# DF_LOCAL_ONLY=no, since df -l keeps these mounts out entirely.
+: "${XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES=nfs nfs4 cifs smb3 ceph glusterfs fuse.glusterfs lustre afs}"
+DFPROBEDIR="${XYMONTMP:-/tmp}"
+
+# probe_dir_is_local DIR : true when DIR is not itself on a hard-blocking
+# filesystem. Decided purely from /proc/mounts (reading it never blocks) by
+# longest mount-point prefix, and deliberately WITHOUT stat()ing DIR: if DIR
+# were on the wedged mount, even `test -w DIR` would block in D-state inside
+# the very fail-safe meant to prevent that. Symlinks are not resolved for the
+# same reason (readlink would stat), so keep XYMONTMP on a real local path.
+probe_dir_is_local()
+{
+	[ -r /proc/mounts ] || return 1
+	awk -v dir="$1" -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+		BEGIN { n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1 }
+		{
+			mp = $2; gsub(/\\040/, " ", mp)
+			if (dir == mp || mp == "/" || substr(dir, 1, length(mp) + 1) == mp "/") {
+				if (length(mp) >= length(best)) { best = mp; besttype = $3 }
+			}
+		}
+		END { exit (besttype in t) ? 1 : 0 }
+	' /proc/mounts
+}
+
+# df_sentinel TAG ARGS... : df for the remote set with at most ONE outstanding
+# probe per TAG. Prints rows (header stripped); returns 0 with data, 124 when
+# unavailable. A wedged df cannot be killed, so it is left running and detected
+# on the next cycle through a pidfile -- orphans never accumulate, and it
+# recovers by itself once the server returns.
+df_sentinel()
+{
+	_tag="$1"; shift
+	_probe="$DFPROBEDIR/df-probe-$_tag"; _pidf="$_probe.pid"
+
+	probe_dir_is_local "$DFPROBEDIR" || return 124
+
+	# Claim the probe before starting it, atomically. Testing for the pidfile
+	# and creating it afterwards let two client cycles both find it absent and
+	# both start a df; only the last pid written was ever recorded, so the
+	# other probe was untracked from then on and more piled up every cycle -
+	# and these are the processes that cannot be killed. Under "set -C" the
+	# create is O_EXCL, so exactly one cycle wins, and winning doubles as the
+	# proof that the pidfile is writable before any df starts.
+	#
+	# A subshell, not a bare ":": ":" is a POSIX special builtin, and a
+	# redirection error on one is fatal to the shell rather than a non-zero
+	# status. Under dash - /bin/sh on Debian and Ubuntu - "return 124" would
+	# never run, the sentinel would die with status 2, and run_df would emit
+	# nothing for the remote set instead of the unavailable rows. It also keeps
+	# noclobber out of the caller.
+	#
+	# The claim names the claiming shell and is replaced by df's pid below, so
+	# a cycle killed in the gap leaves a pid that is simply dead and is
+	# collected like any finished probe, rather than a marker nothing clears.
+	if ! ( set -C; echo "claim:$$" > "$_pidf" ) 2>/dev/null; then
+		_old=$(cat "$_pidf" 2>/dev/null)
+		case "$_old" in
+			claim:*)
+				# Another cycle holds the claim and has not started its df yet.
+				_c=${_old#claim:}
+				[ -n "$_c" ] && kill -0 "$_c" 2>/dev/null && return 124
+				;;
+			?*)
+				# A df we recorded. Still wedged? comm is checked so a recycled
+				# PID does not look like one.
+				if kill -0 "$_old" 2>/dev/null && \
+				   [ "$(cat "/proc/$_old/comm" 2>/dev/null)" = df ]; then
+					return 124
+				fi
+				;;
+		esac
+		# It finished after we stopped waiting. Its output is not usable: we
+		# were not there to see the exit status, so a truncated file is
+		# indistinguishable from a complete one, and its age is unknown.
+		# Discard and re-probe -- fresh data next cycle beats stale or partial
+		# data now. One retry only: if another cycle claims it first, that
+		# cycle owns the probe and this one waits its turn.
+		rm -f "$_pidf" "$_probe"
+		( set -C; echo "claim:$$" > "$_pidf" ) 2>/dev/null || return 124
+	fi
+
+	# Never run a synchronous remote df here: a foreground df would reintroduce
+	# the hang this exists to prevent.
+	( : > "$_probe" ) 2>/dev/null || { rm -f "$_pidf"; return 124; }
+	df "$@" > "$_probe" 2>/dev/null &
+	_pid=$!
+	if ! echo "$_pid" > "$_pidf"; then
+		# The pre-flight passed and this still failed, so a df is running that
+		# the next cycle cannot recognise. Say so: an operator seeing repeated
+		# unavailable rows needs to know a df may be outstanding.
+		echo "xymonclient: cannot record remote df pid in $_pidf" >&2
+	fi
+	_n=0
+	while kill -0 "$_pid" 2>/dev/null; do
+		[ "$_n" -ge "$DFBUDGET" ] && break
+		sleep 1; _n=$((_n + 1))
+	done
+	if kill -0 "$_pid" 2>/dev/null; then
+		return 124			# budget spent; leave it running as the sentinel
+	fi
+	wait "$_pid"; _rc=$?
+	rm -f "$_pidf"
+	if [ "$_rc" -ne 0 ]; then rm -f "$_probe"; return 124; fi
+	sed -e '1d' "$_probe"; rm -f "$_probe"
+	return 0
+}
+
+# run_df INODEFLAG : emit df -P output (header + rows). With DF_LOCAL_ONLY=no
+# the local and remote sets are collected separately, so a wedged remote server
+# can neither block nor stale the local data (df -l cannot stat a remote server).
 run_df()
 {
 	DFINODES="$1"
 	set -- -P
-	[ "$DFLOCALONLY" = yes ] && set -- "$@" -l
 	[ "$DFINODES" = yes ] && set -- "$@" -i
 
 	case $- in
@@ -129,7 +255,71 @@ run_df()
 	done
 	[ "$DFRESTOREGLOB" = yes ] && set +f
 
-	df "$@"
+	if [ "$DFLOCALONLY" = yes ]; then
+		df "$@" -l
+		return
+	fi
+
+	# Everything that cannot hard-block, in one plain df. -x filters the mount
+	# list before df stat()s anything, exactly as -l does, so excluding the
+	# hard-blocking types is enough to keep this call safe - and unlike -l it
+	# still reports healthy remote filesystems, which is what LOCAL_ONLY=no
+	# asks for. The hard-block list decides what needs the sentinel below, not
+	# what is visible.
+	# The hard-blocking exclusions belong to this call and no other. Adding them
+	# to "$@" left them in front of the mount points handed to the guarded
+	# probe below, and an exclusion applies to an explicitly named operand too:
+	# df processed no filesystem at all, exited nonzero, and every one of those
+	# healthy mounts came out unavailable and 100% full. The subshell gets a
+	# copy of the positional parameters, so they stay here.
+	(
+		case $- in *f*) ;; *) set -f ;; esac
+		for t in $XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES; do
+			set -- "$@" -x "$t"
+		done
+		df "$@"
+	)
+
+	# Remote set: pick the hard-blocking mounts out of /proc/mounts (reading it
+	# never blocks), then probe them behind the sentinel. Types are matched by
+	# exact set membership rather than a pattern, so "fuse.glusterfs" compares
+	# literally. Mount points are \040-decoded, and iterated with IFS=newline
+	# so that one containing a space stays a single argument.
+	# A type the admin excluded is not collected, guarded or not: its "-x" is in
+	# "$@" and would exclude the very mount named beside it, which is the same
+	# empty-and-nonzero df as above, reported as unavailable rather than simply
+	# left out.
+	[ -r /proc/mounts ] || return 0
+	_rm=$(awk -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" -v excl="$EXCLUDES" '
+		BEGIN {
+			n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1
+			m = split(excl,  b, /[ \t]+/); for (i = 1; i <= m; i++) x[b[i]] = 1
+		}
+		($3 in t) && !($3 in x) { mp = $2; gsub(/\\040/, " ", mp); print mp }' /proc/mounts)
+	[ -n "$_rm" ] || return 0
+
+	case $- in *f*) _rg=no ;; *) _rg=yes; set -f ;; esac
+	_oifs=$IFS; IFS='
+'
+	# Deliberate split on newline only, so a mount point containing a space
+	# stays one argument. set -f above keeps globbing out of it.
+	# shellcheck disable=SC2086
+	for _m in $_rm; do set -- "$@" "$_m"; done
+	_tag=disk; [ "$DFINODES" = yes ] && _tag=inode
+	_rout=$(df_sentinel "$_tag" "$@")
+	if [ $? -eq 124 ]; then
+		# Unavailable: surface each remote mount as a failed (100%) row rather
+		# than dropping it, since the server reads an absent filesystem as
+		# green. This turns one filesystem red instead of purpling the host.
+		for _m in $_rm; do
+			echo "unavailable:$_m 1 1 0 100% $_m"
+		done
+	else
+		printf '%s\n' "$_rout"
+	fi
+	IFS=$_oifs
+	[ "$_rg" = yes ] && set +f
+	return 0
 }
 # emit_df INODEFLAG LABEL
 # Run df (optionally in inode mode) and reproduce the historical sed join.

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -23,7 +23,9 @@ LOGFETCHOPTS=""
 # mechanisms, matching rules, examples - lives in xymonclient.cfg(5); the
 # blocks below list only each OS's defaults. Unlisted OSes ignore the
 # variables. WARNING: XYMONCLIENT_FS_DF_LOCAL_ONLY=no can hang df on a stale
-# remote mount and turn the whole host purple - see the manual first.
+# remote mount and turn the whole host purple - see the manual first. On Linux
+# that hang is bounded by the remote-df sentinel (XYMONCLIENT_FS_REMOTE_DF_BUDGET,
+# XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES); other clients carry it in full.
 #
 # Linux (xymonclient-linux.sh) - excludes nodev pseudo-filesystems and the
 # always-full iso9660/squashfs images:

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -144,11 +144,53 @@ With \fBno\fR, a stale or hard-blocked remote mount can wedge df
 indefinitely (an uninterruptible D-state wait): the client run never
 finishes, so the whole host goes purple \(em no data for all metrics,
 not just disk \(em until the mount recovers or the host reboots.
+On Linux this is bounded by the remote-df sentinel described below; the
+other clients still carry the risk in full.
 .IP
 A df that \fIexits\fR non-zero with no output (a real error, not a hang)
 is marked failed (yellow) rather than left empty, so a failed filesystem
 probe is not silently reported green. This does not cover the hang
 above: a wedged df never exits.
+
+.IP "\fBXYMONCLIENT_FS_REMOTE_DF_BUDGET\fR"
+Linux only. Seconds to wait for the remote df probe before giving up for
+this cycle. Defaults to \fB30\fR, capped at 3600; empty, zero or
+non-numeric values fall back to the default.
+.IP
+This is a poll \fIbudget\fR, not a kill timeout. A df blocked on a dead
+server sits in uninterruptible D-state, where even SIGKILL is ignored, so
+it cannot be killed and is deliberately left running: the next cycle
+finds it through a pidfile in $XYMONTMP and reports the mounts
+unavailable instead of starting a second one. At most one df is ever
+outstanding per report, so nothing accumulates, and collection resumes by
+itself once the server answers.
+.IP
+Only the remote set runs behind the sentinel. The local set is collected
+separately with \fBdf \-l\fR, which never stats a remote server, so
+local filesystems stay fresh throughout an outage instead of being lost
+with the host.
+.IP
+While a remote mount is unreachable its row is reported as 100% full,
+which turns that one filesystem red rather than letting it vanish from
+the report \(em an absent filesystem reads as green. Note that this row
+also reaches the RRD, so the disk graph shows 100% used (and a used-space
+figure of one block) for the duration of the outage.
+.IP
+The sentinel needs a writable probe directory and uses $XYMONTMP. If
+$XYMONTMP is itself on a hard-blocking filesystem the sentinel reports
+the remote mounts unavailable rather than touching it, since even testing
+such a path blocks. Keep $XYMONTMP on local storage. Symbolic links are
+not resolved, for the same reason.
+
+.IP "\fBXYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES\fR"
+Linux only. The df filesystem types whose stat() hard-blocks when the
+server is unreachable, and which are therefore collected behind the
+sentinel. Defaults to
+\fBnfs nfs4 cifs smb3 ceph glusterfs fuse.glusterfs lustre afs\fR.
+Types are matched as exact df type tokens, so \fBfuse.glusterfs\fR is
+compared literally rather than as a pattern. Only consulted with
+\fBXYMONCLIENT_FS_DF_LOCAL_ONLY=no\fR, since \fBdf \-l\fR keeps these
+mounts out entirely otherwise.
 
 .IP "\fBXYMON\fR"
 Full path to the

--- a/docs/manpages/man5/xymonclient.cfg.5.html
+++ b/docs/manpages/man5/xymonclient.cfg.5.html
@@ -169,12 +169,55 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       elsewhere). With <b>no</b>, a stale or hard-blocked remote mount can wedge
       df indefinitely (an uninterruptible D-state wait): the client run never
       finishes, so the whole host goes purple &#x2014; no data for all metrics,
-      not just disk &#x2014; until the mount recovers or the host reboots.</dd>
+      not just disk &#x2014; until the mount recovers or the host reboots. On
+      Linux this is bounded by the remote-df sentinel described below; the other
+      clients still carry the risk in full.</dd>
   <dt></dt>
   <dd>A df that <i>exits</i> non-zero with no output (a real error, not a hang)
       is marked failed (yellow) rather than left empty, so a failed filesystem
       probe is not silently reported green. This does not cover the hang above:
       a wedged df never exits.
+    <p class="Pp"></p>
+  </dd>
+  <dt id="XYMONCLIENT_FS_REMOTE_DF_BUDGET"><a class="permalink" href="#XYMONCLIENT_FS_REMOTE_DF_BUDGET"><b>XYMONCLIENT_FS_REMOTE_DF_BUDGET</b></a></dt>
+  <dd>Linux only. Seconds to wait for the remote df probe before giving up for
+      this cycle. Defaults to <b>30</b>, capped at 3600; empty, zero or
+      non-numeric values fall back to the default.</dd>
+  <dt></dt>
+  <dd>This is a poll <i>budget</i>, not a kill timeout. A df blocked on a dead
+      server sits in uninterruptible D-state, where even SIGKILL is ignored, so
+      it cannot be killed and is deliberately left running: the next cycle finds
+      it through a pidfile in $XYMONTMP and reports the mounts unavailable
+      instead of starting a second one. At most one df is ever outstanding per
+      report, so nothing accumulates, and collection resumes by itself once the
+      server answers.</dd>
+  <dt></dt>
+  <dd>Only the remote set runs behind the sentinel. The local set is collected
+      separately with <b>df -l</b>, which never stats a remote server, so local
+      filesystems stay fresh throughout an outage instead of being lost with the
+      host.</dd>
+  <dt></dt>
+  <dd>While a remote mount is unreachable its row is reported as 100% full,
+      which turns that one filesystem red rather than letting it vanish from the
+      report &#x2014; an absent filesystem reads as green. Note that this row
+      also reaches the RRD, so the disk graph shows 100% used (and a used-space
+      figure of one block) for the duration of the outage.</dd>
+  <dt></dt>
+  <dd>The sentinel needs a writable probe directory and uses $XYMONTMP. If
+      $XYMONTMP is itself on a hard-blocking filesystem the sentinel reports the
+      remote mounts unavailable rather than touching it, since even testing such
+      a path blocks. Keep $XYMONTMP on local storage. Symbolic links are not
+      resolved, for the same reason.
+    <p class="Pp"></p>
+  </dd>
+  <dt id="XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES"><a class="permalink" href="#XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES"><b>XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES</b></a></dt>
+  <dd>Linux only. The df filesystem types whose stat() hard-blocks when the
+      server is unreachable, and which are therefore collected behind the
+      sentinel. Defaults to <b>nfs nfs4 cifs smb3 ceph glusterfs fuse.glusterfs
+      lustre afs</b>. Types are matched as exact df type tokens, so
+      <b>fuse.glusterfs</b> is compared literally rather than as a pattern. Only
+      consulted with <b>XYMONCLIENT_FS_DF_LOCAL_ONLY=no</b>, since <b>df -l</b>
+      keeps these mounts out entirely otherwise.
     <p class="Pp"></p>
   </dd>
   <dt id="XYMON"><a class="permalink" href="#XYMON"><b>XYMON</b></a></dt>

--- a/tests/client/fs-filter-linux.sh
+++ b/tests/client/fs-filter-linux.sh
@@ -186,11 +186,26 @@ args=$(XYMONCLIENT_FS_INCLUDE_TYPES=tmpfs XYMONCLIENT_FS_EXCLUDE_TYPES=tmpfs run
 assert_contains " -x tmpfs " "$args" \
 	"a type in both include and exclude lists must stay excluded (exclude wins)"
 
-# --- XYMONCLIENT_FS_DF_LOCAL_ONLY=no drops the -l flag ----------------------
+# --- XYMONCLIENT_FS_DF_LOCAL_ONLY=no excludes only what can hard-block -------
+# Before the remote-df sentinel (#316), "no" meant one df run over everything,
+# which is what could wedge on a dead server. Collection is now split: this
+# first call drops the hard-blocking types with -x (which filters the mount
+# list before df stat()s anything, exactly as -l does), and those mounts are
+# then probed separately behind the sentinel, covered by fs-sentinel-linux.sh.
+#
+# It deliberately does NOT use -l here: -l would drop every remote filesystem,
+# including healthy types that can be stat()ed safely, which is not what
+# LOCAL_ONLY=no asks for. What must hold is that no hard-blocking type reaches
+# this call.
 
 args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=no run_snippet)
-assert_contains     " -P " "$args" "DF_LOCAL_ONLY=no must still pass -P"
-assert_not_contains " -l " "$args" "DF_LOCAL_ONLY=no must drop -l"
+assert_contains " -P " "$args" "DF_LOCAL_ONLY=no must still pass -P"
+assert_not_contains " -l " "$args" \
+	"DF_LOCAL_ONLY=no must not use -l: that would drop healthy remote filesystems"
+for t in nfs nfs4 cifs smb3 ceph glusterfs fuse.glusterfs lustre afs; do
+	assert_contains " -x $t " "$args" \
+		"DF_LOCAL_ONLY=no must exclude the hard-blocking type '$t' from the unguarded df (#316)"
+done
 
 args=$(XYMONCLIENT_FS_DF_LOCAL_ONLY=yes run_snippet)
 assert_contains " -l " "$args" "DF_LOCAL_ONLY=yes must still pass -l"

--- a/tests/client/fs-sentinel-linux.sh
+++ b/tests/client/fs-sentinel-linux.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-sentinel-linux.sh
+#
+# The remote-df sentinel (#316). With XYMONCLIENT_FS_DF_LOCAL_ONLY=no, df
+# stats remote mounts, and a dead NFS/CIFS/Ceph server leaves it in
+# uninterruptible D-state where even SIGKILL is ignored -- so a foreground
+# `timeout df` cannot help and the whole client cycle hangs until the mount
+# recovers. The host then goes purple and *all* metrics are lost, not just
+# disk.
+#
+# The client therefore splits collection: the local set (df -l, which never
+# stats a remote server) runs plainly, and the remote set runs behind a
+# sentinel that waits a bounded budget and then moves on, leaving the wedged
+# df running to be detected next cycle.
+#
+# Everything here is driven with a df stub and a /proc/mounts fixture: no real
+# remote filesystem is involved, and nothing is ever killed.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"
+
+fsf_setup linux XYMONCLIENT_LINUX
+
+grep -q 'df_sentinel' "$SCRIPT" || fail "remote-df sentinel missing from $SCRIPT (regressed)"
+
+MOUNTS="$TMP/mounts"
+DF_CALLS="$TMP/df.calls"; : > "$DF_CALLS"; export DF_CALLS
+DF_REMOTE="$TMP/df.remote"; : > "$DF_REMOTE"; export DF_REMOTE
+printf 'nodev\tproc\nnodev\tsysfs\n' > "$TMP/filesystems"
+
+# The stub hangs only when asked about a remote mount, which is how a real df
+# wedges: the local set keeps answering throughout.
+cat > "$STUB/df" <<'EOF'
+#!/bin/sh
+echo x >> "$DF_CALLS"
+# Model the parts of df's contract this test depends on: -l keeps local
+# filesystems only, -x TYPE drops that type, and both filter the mount list
+# before anything is stat()ed (which is why neither can hard-block). Named
+# mount points report just those. Without -l or names, df lists everything -
+# that is the call that has to keep reporting healthy remote filesystems.
+_ex=" "; _local_only=; _named=
+_prev=
+for a in "$@"; do
+	case "$_prev" in -x) _ex="$_ex$a " ;; esac
+	case "$a" in
+		-l) _local_only=1 ;;
+		/remote/*) _named="$_named $a" ;;
+	esac
+	_prev=$a
+done
+# Remote probes are counted apart from the per-cycle local df, and each records
+# its own pid so the test can end the ones it starts.
+[ -n "$_named" ] && echo $$ >> "${DF_REMOTE:-/dev/null}"
+[ -n "$_named" ] && [ -n "${DF_HANG:-}" ] && sleep "${DF_HANGTIME:-120}"
+[ -n "${DF_FAIL:-}" ] && exit 1
+if [ -n "$_named" ]; then
+	# An exclusion applies to an explicitly named operand too, and once every
+	# operand is excluded df processes no filesystem and exits nonzero. Not
+	# modelling that hid the guarded probe being handed the exclusions for the
+	# very types it was asked to report.
+	_keep=
+	for a in $_named; do
+		case "$a" in */sshfs) _t=sshfs ;; *) _t=nfs4 ;; esac
+		case "$_ex" in *" $_t "*) ;; *) _keep="$_keep $a" ;; esac
+	done
+	if [ -z "$_keep" ]; then
+		echo "df: no file systems processed" >&2
+		exit 1
+	fi
+	echo "Filesystem 1024-blocks Used Available Capacity Mounted on"
+	for a in $_keep; do echo "srv:/exp 100 50 50 50% $a"; done
+	exit 0
+fi
+echo "Filesystem 1024-blocks Used Available Capacity Mounted on"
+case "$_ex" in *" ext4 "*) ;; *) echo "/dev/sda1 1000 400 600 40% /" ;; esac
+if [ -z "$_local_only" ]; then
+	case "$_ex" in *" nfs4 "*) ;; *) echo "srv:/exp 100 50 50 50% /remote/nfs" ;; esac
+	case "$_ex" in *" sshfs "*) ;; *) echo "usr@h:/d 200 20 180 10% /remote/sshfs" ;; esac
+fi
+EOF
+chmod +x "$STUB/df"
+
+# Extract the [df] block with /proc repointed at the fixtures. /proc/<pid>/comm
+# is deliberately NOT rewritten: the PID-reuse guard must be exercised for real.
+fsf_extract "$TMP/df-section.sh" "s#/proc/mounts#$MOUNTS#g; s#/proc/filesystems#$TMP/filesystems#g" '\[inode\]'
+
+# run_cycle [ENV=VAL ...] -- one client cycle; prints the [df] block.
+run_cycle() {
+	env "$@" \
+		DF_CALLS="$DF_CALLS" \
+		DF_REMOTE="$DF_REMOTE" \
+		XYMONTMP="$TMP/probe" \
+		XYMONCLIENT_FS_DF_LOCAL_ONLY=no \
+		XYMONCLIENT_FS_REMOTE_DF_BUDGET=2 \
+		PATH="$STUB:$PATH" \
+		/bin/sh "$TMP/df-section.sh" 2>/dev/null
+}
+
+mkdir -p "$TMP/probe"
+local_mounts() { printf '/dev/sda1 / ext4 rw 0 0\nsrv:/exp /remote/nfs nfs4 rw 0 0\nusr@h:/d /remote/sshfs sshfs rw 0 0\n' > "$MOUNTS"; }
+local_mounts
+
+# --- healthy -----------------------------------------------------------------
+out=$(run_cycle)
+assert_contains "/remote/sshfs" "$out" \
+	"a remote filesystem whose type is not hard-blocking must still be reported"
+assert_contains '/dev/sda1 1000 400 600 40% /' "$out" "the local set must be reported"
+assert_contains 'srv:/exp 100 50 50 50% /remote/nfs' "$out" "the remote set must be reported"
+# The remote df prints its own header; a second one inside the same [df] block
+# is parsed by the server as a filesystem row (xymond_client.c: the header is
+# recognised only on the first line), inventing a bogus "Mounted" filesystem.
+assert_equal '1' "$(printf '%s\n' "$out" | grep -c '^Filesystem ')" \
+	"the remote df header must be stripped: a second one becomes a phantom filesystem"
+
+# --- wedged: bounded, local stays fresh, remote surfaced ----------------------
+rm -f "$TMP"/probe/*
+out=$(DF_HANG=1 run_cycle DF_HANG=1)
+assert_contains '/dev/sda1 1000 400 600 40% /' "$out" \
+	"a wedged remote server must not stale or block the local set"
+assert_contains 'unavailable:/remote/nfs' "$out" \
+	"an unreachable mount must be surfaced, not dropped (the server reads absent as green)"
+assert_contains ' 100% /remote/nfs' "$out" "the unavailable row must read as full so the column goes red"
+[ -f "$TMP/probe/df-probe-disk.pid" ] || fail "the wedged df must be left recorded as the sentinel"
+
+# --- still wedged: exactly one outstanding df --------------------------------
+# Counted from the stub itself: a system-wide process count would be skewed by
+# anything else running on the machine.
+before=$(wc -l < "$DF_CALLS")
+out=$(DF_HANG=1 run_cycle DF_HANG=1)
+after=$(wc -l < "$DF_CALLS")
+assert_equal "$((before + 1))" "$after" \
+	"while one df is wedged, a cycle must run only the local df -- not a second remote one"
+assert_contains 'unavailable:/remote/nfs' "$out" "the mount stays unavailable while wedged"
+
+# --- recovery ----------------------------------------------------------------
+# End the wedge and wait for it to actually be gone: while the recorded df is
+# still alive the sentinel is *supposed* to keep reporting unavailable, so
+# starting the next cycle too early would assert the wrong thing.
+wedged=$(cat "$TMP/probe/df-probe-disk.pid")
+kill -9 "$wedged" 2>/dev/null || true
+for _ in $(seq 1 100); do
+	kill -0 "$wedged" 2>/dev/null || break
+	sleep 0.1
+done
+kill -0 "$wedged" 2>/dev/null && fail "could not end the simulated wedge (pid $wedged)"
+out=$(run_cycle)
+assert_contains 'srv:/exp 100 50 50 50% /remote/nfs' "$out" \
+	"the remote set must return once the server does"
+assert_equal '0' "$(find "$TMP/probe" -type f | awk 'END { print NR }')" \
+	"the probe files must be cleaned up after a successful cycle"
+
+# --- a type excluded by policy is not probed either --------------------------
+# Its "-x" is in the argument list, so naming its mount beside it is the same
+# empty-and-nonzero df: the mount must simply not be collected, not collected
+# and then reported unavailable.
+rm -f "$TMP"/probe/*
+out=$(run_cycle XYMONCLIENT_FS_EXCLUDE_TYPES=nfs4)
+assert_not_contains 'unavailable:/remote/nfs' "$out" \
+	"an excluded type was probed anyway and its healthy mount reported unavailable"
+assert_not_contains '/remote/nfs' "$out" "an excluded type must not be reported at all"
+assert_contains '/dev/sda1 1000 400 600 40% /' "$out" "the local set must still be reported"
+assert_contains '/remote/sshfs' "$out" \
+	"excluding one type must not take the other remote filesystems with it"
+
+# --- concurrent cycles claim the probe exactly once --------------------------
+# Testing for the pidfile and creating it afterwards let two cycles both find it
+# absent and both start a df. Only the last pid written was recorded, so the
+# other probe was untracked from then on and more accumulated every cycle --
+# the opposite of what the sentinel exists to guarantee.
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+for _ in $(seq 1 20); do
+	run_cycle DF_HANG=1 DF_HANGTIME=5 >/dev/null 2>&1 &
+done
+wait
+assert_equal '1' "$(wc -l < "$DF_REMOTE")" \
+	"concurrent cycles each started a remote df; exactly one may own the probe"
+while read -r _p; do kill -9 "$_p" 2>/dev/null || true; done < "$DF_REMOTE"
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+
+# --- a claim held by another live cycle is respected -------------------------
+# Racing for the window above is probabilistic -- it takes many cycles to land
+# in it -- so the state it produces is set up directly instead: a pidfile
+# naming a live process that is not a df, which is what a cycle between its
+# claim and its fork leaves behind. Without an explicit claim that state does
+# not exist, the entry reads as a stale pid, and the second cycle removes it
+# and starts a probe of its own on top of the first.
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+sleep 30 & holder=$!
+printf 'claim:%s\n' "$holder" > "$TMP/probe/df-probe-disk.pid"
+out=$(run_cycle)
+assert_equal '0' "$(wc -l < "$DF_REMOTE")" \
+	"a probe already claimed by a live cycle was started a second time"
+assert_contains 'unavailable:/remote/nfs' "$out" \
+	"a probe claimed by another cycle must report unavailable, not start a second df"
+kill "$holder" 2>/dev/null || true; wait "$holder" 2>/dev/null || true
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+
+# --- df fails ----------------------------------------------------------------
+out=$(DF_FAIL=1 run_cycle DF_FAIL=1)
+assert_contains 'unavailable:/remote/nfs' "$out" \
+	"a remote df that exits nonzero must report unavailable, not a partial set"
+
+# --- the probe dir is itself on a hard-blocking mount ------------------------
+# Nothing may touch it: `test -w` on a wedged mount blocks in D-state, inside
+# the fail-safe meant to prevent exactly that.
+mkdir -p "$TMP/remoteprobe"
+printf '/dev/sda1 / ext4 rw 0 0\nsrv:/exp /remote/nfs nfs4 rw 0 0\nsrv:/p %s nfs4 rw 0 0\n' \
+	"$TMP/remoteprobe" > "$MOUNTS"
+out=$(DF_HANG=1 env XYMONTMP="$TMP/remoteprobe" \
+	XYMONCLIENT_FS_DF_LOCAL_ONLY=no XYMONCLIENT_FS_REMOTE_DF_BUDGET=2 \
+	DF_HANG=1 DF_CALLS="$DF_CALLS" PATH="$STUB:$PATH" /bin/sh "$TMP/df-section.sh" 2>/dev/null)
+assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
+	"a probe dir on a hard-blocking filesystem must never be touched"
+assert_contains 'unavailable:/remote/nfs' "$out" "the remote set must report unavailable instead"
+local_mounts
+
+# --- the default is unchanged ------------------------------------------------
+rm -f "$TMP"/probe/*
+out=$(env XYMONTMP="$TMP/probe" DF_CALLS="$DF_CALLS" PATH="$STUB:$PATH" /bin/sh "$TMP/df-section.sh" 2>/dev/null)
+assert_contains '/dev/sda1 1000 400 600 40% /' "$out" "the default (local-only) report is unchanged"
+assert_not_contains '/remote/nfs' "$out" "df -l must still keep remote mounts out by default"
+assert_equal '0' "$(find "$TMP/probe" -type f | awk 'END { print NR }')" \
+	"the sentinel must not run at all with DF_LOCAL_ONLY=yes"
+
+
+# --- pidfile unusable --------------------------------------------------------
+# The pid is what lets the next cycle recognise a df that is still wedged, so a
+# df must not be started when it cannot be recorded - otherwise every cycle
+# starts another one, and these are the processes that cannot be killed.
+# A directory in the pidfile's place makes creating it fail while the probe
+# file next to it stays writable.
+mkdir -p "$TMP/probe/df-probe-disk.pid"
+_before=$(wc -l < "$DF_CALLS")
+pidout=$(run_cycle)
+_after=$(wc -l < "$DF_CALLS")
+rmdir "$TMP/probe/df-probe-disk.pid"
+assert_equal 1 "$((_after - _before))" \
+	"an unrecordable pid must stop the remote df from starting (only the plain df may run)"
+assert_contains "unavailable:/remote/nfs" "$pidout" \
+	"an unrecordable pid must report the remote set unavailable, not drop it"
+
+pass "the remote-df sentinel bounds a wedged mount without blocking the client"


### PR DESCRIPTION
With `XYMONCLIENT_FS_DF_LOCAL_ONLY=no`, df stats remote mounts. A dead NFS/CIFS/Ceph server
leaves it in an uninterruptible D-state wait where SIGKILL is ignored, so a foreground
`timeout df` cannot help either: the client cycle never finishes, the host goes purple, and
every metric is lost -- not just disk -- until the mount recovers or the machine reboots.
Today the only mitigation is to not report remote filesystems at all.

Collection is split in two, on type rather than on locality. The plain df drops the
hard-blocking types with `-x` (`XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES`, shipped with a
default so no site has to maintain one); everything else, local or remote, is still
reported, as `LOCAL_ONLY=no` asks. Those types -- found by reading `/proc/mounts`, which
never blocks -- run behind a sentinel: df goes to the background and the client waits at
most `XYMONCLIENT_FS_REMOTE_DF_BUDGET` seconds (default 30). That is a poll budget, not a
kill timeout: a wedged df cannot be killed, so it is left running and recognised next cycle
through a pidfile, and no second one is started. At most one df is ever outstanding per
report, and collection resumes by itself when the server answers. Meanwhile each mount of
the remote set is reported as a 100% row rather than dropped, because the server reads an
absent filesystem as green -- one filesystem red instead of the whole host purple.

Details that are easy to get wrong:

- **`-x` on the plain df, never `-l`.** Both filter the mount list before df `stat()`s
  anything; `-l` would also delete healthy remote filesystems from monitoring.
- **The exclusions stay in a subshell around that df.** `-x` applies to an explicitly named
  operand too: handed both, the guarded probe processes nothing, exits nonzero, and every
  healthy mount comes out unavailable and 100% full.
- **The pidfile is claimed with an O_EXCL create under `set -C`.** Test-then-create let two
  cycles both start a df with only the last pid recorded, so untracked probes -- the
  unkillable kind -- piled up every cycle. Winning also proves the pidfile writable before
  any df starts.
- **Writability is probed with `( : > file )`, never a bare `:`.** A redirection error on a
  POSIX special builtin is fatal to the shell rather than a non-zero status, so under dash
  -- `/bin/sh` on Debian and Ubuntu -- the guard's `return 124` never ran and run_df emitted
  nothing instead of the unavailable rows. Measured: dash 2, bash 124.
- **The remote df's header is stripped.** `unix_disk_report()` recognises one only on the
  first line (xymond_client.c); a second becomes a phantom "Mounted" filesystem that counts
  toward DISKCOUNT and reaches the RRD.
- **The probe dir must be local, decided from `/proc/mounts` without `stat()`ing it.** On
  the wedged mount even `test -w` blocks in D-state, inside the fail-safe meant to prevent
  that. Symlinks are not resolved for the same reason, and that is documented.
- **A probe that finished after the budget is discarded.** Its exit status went unseen, so a
  truncated file is indistinguishable from a complete one, and a partial df silently drops
  mounts -- which reads as green, the failure this exists to prevent.
- **PID reuse is checked against `/proc/PID/comm`**, and mount points are `\040`-decoded and
  iterated with `IFS=newline`, so a recycled pid does not strand a mount and a mount point
  containing a space stays one argument to df.

Known cost, deliberately accepted: the 100% row also reaches the disk RRD, so the graph
shows 100% used for the duration of the outage.

Tests. fs-sentinel-linux.sh drives a df stub and a `/proc/mounts` fixture: a healthy remote
type outside the hard-block list, the wedge (local set stays fresh, one outstanding df,
recovery), a type excluded by policy, an unrecordable pidfile, a probe dir on the wedged
mount, and the concurrent claim twice -- twenty parallel cycles, which land in the window
often but not always, and a deterministic setup of the state that window produces; only the
second reliably fails without the fix. The stub exits nonzero having processed nothing when
an exclusion leaves no operand, which is exactly what hid the exclusion defect.
fs-filter-linux.sh trades its ` -l ` assertion, which encoded the old mechanism, for the
property that matters: no hard-blocking type reaches the unguarded df.

Suite: 63 passed, 0 skipped, 0 failed. Mutations caught: reverting to `df -l`, dropping the
pidfile claim, handing the exclusions to the guarded probe. Not caught, and left as such:
restoring the fatal `:` idiom, because no case makes the probe file itself unwritable.

Closes #316
