### PR TITLE
tests: give harnesses the configured link flags, not just libraries (#310)

### DIFF
--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -287,6 +287,50 @@ xymon_cflags() {
 	printf '%s' "-iquote $root/include -iquote $root/lib $(pcre_cflags "$root")"
 }
 
+# xymon_ldflags ROOT -- the configured link flags for a harness built against
+# the in-tree libraries: the library search path, the runtime path, and the
+# libraries libxymoncomm.a itself needs (XYMONCOMMLIBS in xymond/Makefile).
+#
+# The counterpart to xymon_cflags(), and bundled for the same reason: the
+# product build gets all of this from $(CFLAGS) and $(RPATHOPT) on its link
+# line, while each harness spells its own and so far none carried any of it.
+# On the BSDs that costs a link (`ld: cannot find -lpcre2-8`, because
+# build/Makefile.FreeBSD keeps -L/usr/local/lib inside CFLAGS) or a run
+# (`Shared object "libpcre2-8.so.0" not found`, no rpath).
+#
+# Asked of make rather than sed'd out of the Makefile: NETLIBS, ZLIBLIBS and
+# LIBRTDEF live in the per-OS file the toplevel Makefile includes, and the
+# search path has no variable of its own at all - it is embedded in CFLAGS,
+# so the -L tokens are picked out of it.
+xymon_ldflags() {
+	local root=$1 probe out cflags rpath libs tok search=
+
+	[ -f "$root/Makefile" ] || return 0
+	require_gnu_make
+	# shellcheck disable=SC2016  # $(CFLAGS) etc. are make's to expand, not the shell's
+	probe='__xymon_ldflags:
+	@printf "%s\n" "$(CFLAGS)" "$(RPATHOPT)" "$(ZLIBLIBS) $(SSLLIBS) $(NETLIBS) $(LIBRTDEF)"
+'
+	out=$(printf '%s' "$probe" | "$XYMON_MAKE" -s -C "$root" -f Makefile -f - __xymon_ldflags 2>/dev/null) || return 0
+
+	cflags=$(printf '%s\n' "$out" | sed -n 1p)
+	rpath=$(printf '%s\n' "$out" | sed -n 2p)
+	libs=$(printf '%s\n' "$out" | sed -n 3p)
+
+	# Only the search path is wanted from CFLAGS; its -I/-D/-W belong to the
+	# compile side, which xymon_cflags() already covers.
+	for tok in $cflags; do
+		case $tok in -L*) search="$search $tok" ;; esac
+	done
+
+	# RPATHOPT is $(RPATH)$(RPATHVAL); with no RPATHVAL configured it is a bare
+	# "-Wl,--rpath," with nothing after the comma, so drop it rather than hand
+	# the linker a dangling flag.
+	case $rpath in *,) rpath= ;; esac
+
+	printf '%s' "$search $rpath $libs"
+}
+
 # require_shm_segments N -- skip unless one process may attach N SysV
 # shared-memory segments. xymond attaches one per channel, and macOS ships
 # kern.sysv.shmseg=8 against the nine channels xymond sets up, so a stock Mac

--- a/tests/lib/build-worker.sh
+++ b/tests/lib/build-worker.sh
@@ -21,7 +21,7 @@
 __XYMON_TESTS_BUILD_WORKER_SOURCED=1
 
 build_xymond_worker() {
-	local outdir=$1 prog=$2 root cc treelibs pcre_libs harness_cflags src srcs mkfiles inc
+	local outdir=$1 prog=$2 root cc pcre_libs harness_ldflags harness_cflags src srcs
 	shift 2
 	root=$(find_root)
 	cc=${CC:-cc}
@@ -30,21 +30,6 @@ build_xymond_worker() {
 	require_gnu_make
 	[ -f "$root/include/config.h" ] || skip "tree not configured (no include/config.h)"
 	[ -f "$root/Makefile" ] || skip "tree not configured (no Makefile)"
-
-	# The extra libraries the product link uses (XYMONCOMMLIBS in
-	# xymond/Makefile). Asked of make, not sed from the Makefile: NETLIBS,
-	# ZLIBLIBS and LIBRTDEF live in the per-OS file the Makefile includes.
-	# If make cannot run the stdin-makefile probe, harvest the same four
-	# variables from the Makefile plus the files it includes.
-	treelibs=$(printf '__testlibs:\n\t@echo $(ZLIBLIBS) $(SSLLIBS) $(NETLIBS) $(LIBRTDEF)\n' \
-			| "$XYMON_MAKE" -s -C "$root" -f Makefile -f - __testlibs 2>/dev/null) || {
-		mkfiles="$root/Makefile"
-		while read -r inc; do
-			[ -n "$inc" ] && mkfiles="$mkfiles $root/$inc"
-		done < <(sed -n 's/^include  *//p' "$root/Makefile")
-		# shellcheck disable=SC2086  # mkfiles is a deliberate word-split list
-		treelibs=$(sed -n -E 's/^(ZLIBLIBS|SSLLIBS|NETLIBS|LIBRTDEF) *= *//p' $mkfiles 2>/dev/null | tr '\n' ' ')
-	}
 
 	# PCRELIBS: explicit env override first, then the configured tree's own
 	# setting (which carries any -L for a nonstandard install), then
@@ -56,6 +41,7 @@ build_xymond_worker() {
 	fi
 	[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
 	harness_cflags=$(xymon_cflags "$root")
+	harness_ldflags=$(xymon_ldflags "$root")
 
 	"$XYMON_MAKE" -C "$root/lib" libxymon.a libxymoncomm.a libxymontime.a >"$outdir/libbuild.log" 2>&1 \
 		|| { cat "$outdir/libbuild.log" >&2; fail "the xymon libraries do not build in this configured tree"; }
@@ -68,6 +54,6 @@ build_xymond_worker() {
 		"${srcs[@]}" \
 		"$root/lib/libxymon.a" "$root/lib/libxymoncomm.a" "$root/lib/libxymontime.a" \
 		"$root/lib/libxymon.a" \
-		$pcre_libs $treelibs 2>"$outdir/cc.log" \
+		$pcre_libs $harness_ldflags 2>"$outdir/cc.log" \
 		|| { cat "$outdir/cc.log" >&2; fail "$prog does not build -- cannot run this test"; }
 }

--- a/tests/lib/svcstatus-cgi.sh
+++ b/tests/lib/svcstatus-cgi.sh
@@ -36,9 +36,6 @@ svcstatus_setup() {
 	# from configure's --pcrelib). Omitting them fails the link on a tree
 	# that builds fine. Keep the pkg-config/-lpcre2-8 fallback for a
 	# Makefile without PCRELIBS.
-	ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
-	netlibs=$(sed -n 's/^NETLIBS *= *//p' "$ROOT/Makefile")
-	librtdef=$(sed -n 's/^LIBRTDEF *= *//p' "$ROOT/Makefile")
 	pcre_libs=${PCRELIBS:-$(sed -n 's/^PCRELIBS *= *//p' "$ROOT/Makefile")}
 	if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
 		pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
@@ -103,8 +100,16 @@ svcstatus_setup() {
 # libxymon.h, ...) changes, bumping its mtime. So any code change in the tree
 # is newer than the cache and forces a rebuild; the cache never hides one.
 svcstatus_build() {
-	local flagkey bin harness_cflags
-	flagkey=$(printf '%s' "$*" | tr -c 'A-Za-z0-9' '_')
+	local flagkey bin harness_cflags harness_ldflags
+	harness_cflags=$(xymon_cflags "$ROOT")
+	harness_ldflags=$(xymon_ldflags "$ROOT")
+	# The key has to cover everything that changes the binary, not just the
+	# arguments this was called with: the configured compile and link flags
+	# decide the result too. Keyed on the arguments alone, changing SSLLIBS,
+	# a library search path or the rpath reuses a stale cached binary, and
+	# the test passes without ever exercising the configuration it claims to.
+	# Hashed rather than spelled out because the flags carry absolute paths.
+	flagkey=$(printf '%s' "$* $harness_cflags $harness_ldflags $pcre_libs" | cksum | tr -cd '0-9')
 	bin="${TMPDIR:-/tmp}/xymon-svcstatus-cache.$(id -u)/$(printf '%s' "$ROOT" | tr -c 'A-Za-z0-9' '_').${flagkey:-plain}"
 	mkdir -p "$(dirname "$bin")"
 
@@ -116,11 +121,10 @@ svcstatus_build() {
 		return 0
 	fi
 
-	harness_cflags=$(xymon_cflags "$ROOT")
 	"$CC" "$@" $harness_cflags -iquote "$ROOT/web" -o "$work/svcstatus" \
 		"$ROOT/web/svcstatus.c" "$ROOT/web/svcstatus-info.c" "$ROOT/web/svcstatus-trends.c" \
 		"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
-		$pcre_libs $ssllibs $netlibs $librtdef 2>"$work/cc.log" || return 1
+		$pcre_libs $harness_ldflags 2>"$work/cc.log" || return 1
 	cp "$work/svcstatus" "$bin"
 }
 

--- a/tests/lib/svcstatus-cgi.sh
+++ b/tests/lib/svcstatus-cgi.sh
@@ -100,23 +100,31 @@ svcstatus_setup() {
 # libxymon.h, ...) changes, bumping its mtime. So any code change in the tree
 # is newer than the cache and forces a rebuild; the cache never hides one.
 svcstatus_build() {
-	local flagkey bin harness_cflags harness_ldflags
+	local flagkey bin harness_cflags harness_ldflags ccpath
 	harness_cflags=$(xymon_cflags "$ROOT")
 	harness_ldflags=$(xymon_ldflags "$ROOT")
+	# The compiler decides the binary as much as the flags do. Left out of the
+	# key, a cache filled by one compiler is handed straight to a run that
+	# asked for another, and the test passes without that compiler ever being
+	# invoked -- a gcc-built binary satisfying a run meant to exercise clang.
+	# The resolved path as well as the name: "cc" is a different compiler on
+	# different hosts, and PATH can put another one under the same name.
+	ccpath=$(command -v "${CC%% *}" 2>/dev/null) || ccpath=$CC
 	# The key has to cover everything that changes the binary, not just the
 	# arguments this was called with: the configured compile and link flags
 	# decide the result too. Keyed on the arguments alone, changing SSLLIBS,
 	# a library search path or the rpath reuses a stale cached binary, and
 	# the test passes without ever exercising the configuration it claims to.
 	# Hashed rather than spelled out because the flags carry absolute paths.
-	flagkey=$(printf '%s' "$* $harness_cflags $harness_ldflags $pcre_libs" | cksum | tr -cd '0-9')
+	flagkey=$(printf '%s' "$CC $ccpath $* $harness_cflags $harness_ldflags $pcre_libs" | cksum | tr -cd '0-9')
 	bin="${TMPDIR:-/tmp}/xymon-svcstatus-cache.$(id -u)/$(printf '%s' "$ROOT" | tr -c 'A-Za-z0-9' '_').${flagkey:-plain}"
 	mkdir -p "$(dirname "$bin")"
 
 	if [ -x "$bin" ] && [ -z "$(find \
 			"$ROOT/web/svcstatus.c" "$ROOT/web/svcstatus-info.c" "$ROOT/web/svcstatus-trends.c" \
 			"$ROOT/web/svcstatus-info.h" "$ROOT/web/svcstatus-trends.h" "$ROOT/include/version.h" \
-			"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" -newer "$bin" 2>/dev/null)" ]; then
+			"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" \
+			"$ccpath" -newer "$bin" 2>/dev/null)" ]; then
 		cp "$bin" "$work/svcstatus"
 		return 0
 	fi

--- a/tests/network/netrc-password.sh
+++ b/tests/network/netrc-password.sh
@@ -55,11 +55,9 @@ command -v "$CC" >/dev/null 2>&1 \
 
 work=$(mktempdir)
 
-# Link flags for the prebuilt library. Tolerate an absent top-level Makefile
-# (e.g. only lib/ configured): fall back to no extra SSL flags rather than
-# letting sed abort the script under 'set -e'.
-ssllibs=""
-[ -f "$ROOT/Makefile" ] && ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+# PCRE is a test-specific dependency, so it stays here; the rest of the link
+# flags (search path, rpath, the libraries libxymoncomm.a needs) come from
+# xymon_ldflags below.
 pcre_libs=${PCRELIBS:-}
 if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
 	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
@@ -87,8 +85,9 @@ EOF
 # lib/url.c goes before the archive so its fresh objects satisfy the netrc
 # symbols and the archive's (possibly stale) url.o is never pulled in.
 harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags -o "$work/harness" \
-	"$work/harness.c" "$SRC" "$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
+	"$work/harness.c" "$SRC" "$ROOT/lib/libxymoncomm.a" $harness_ldflags $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "netrc harness does not compile"; }
 
 # A password whose last byte matters: the off-by-one drops the trailing 't'.

--- a/tests/server/analysis-ds-firstmatch.sh
+++ b/tests/server/analysis-ds-firstmatch.sh
@@ -58,7 +58,6 @@ work=$(mktempdir)
 "$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 pcre_libs=${PCRELIBS:-}
 if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
 	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
@@ -66,9 +65,10 @@ fi
 [ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
 
 harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags -iquote "$ROOT/xymond" -o "$work/harness" \
 	"$here/analysis-ds-firstmatch-harness.c" "$CLIENT_CONFIG_C" \
-	"$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
+	"$ROOT/lib/libxymoncomm.a" $harness_ldflags $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 cat >"$work/hosts.cfg" <<'EOF'

--- a/tests/server/config-include-dir.sh
+++ b/tests/server/config-include-dir.sh
@@ -81,7 +81,6 @@ fi
 
 work=$(mktempdir)
 
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 pcre_libs=${PCRELIBS:-}
 if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
 	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
@@ -89,8 +88,9 @@ fi
 [ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
 
 harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" -DSTANDALONE $harness_cflags -o "$work/stackio" \
-	"$ROOT/lib/stackio.c" "$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
+	"$ROOT/lib/stackio.c" "$ROOT/lib/libxymoncomm.a" $harness_ldflags $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "standalone stackio does not compile"; }
 
 # The STANDALONE reader reads argv[1] via stackfgets() (which expands include

--- a/tests/server/namematch-case.sh
+++ b/tests/server/namematch-case.sh
@@ -32,7 +32,6 @@ require_gnu_make
 "$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 pcre_libs=${PCRELIBS:-}
 if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
 	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
@@ -82,8 +81,9 @@ int main(void)
 EOF
 
 harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags -o "$work/harness" \
-	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" $ssllibs $pcre_libs 2>"$work/cc.log" \
+	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" $harness_ldflags $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 "$work/harness" 2>"$work/run.log" \

--- a/tests/server/notbefore-notafter.sh
+++ b/tests/server/notbefore-notafter.sh
@@ -160,12 +160,12 @@ EOF
 
 # Link flags come from the build's own Makefile: SSLLIBS is absent on a
 # --no-ssl build, and carries the -L a non-standard OpenSSL prefix needs.
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 
 harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
-	$ssllibs 2>"$work/cc.log" \
+	$harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 "$work/harness" "$work/hosts.cfg" 2>"$work/stderr.log" \

--- a/tests/server/xmh-item-names.sh
+++ b/tests/server/xmh-item-names.sh
@@ -50,7 +50,6 @@ require_c_buildenv "$ROOT"
 [ -f "$ROOT/lib/libxymoncomm.a" ] \
 	|| skip "tree not built (run make first; the post-build CI suite covers this)"
 
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-xmh-item-names.XXXXXX")
 trap 'rm -rf "$work"' EXIT HUP INT TERM
@@ -63,9 +62,10 @@ cat > "$work/hosts.cfg" <<'EOF'
 EOF
 
 harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags -o "$work/harness" \
 	"$here/xmh-item-names-harness.c" "$ROOT/lib/libxymoncomm.a" \
-	$ssllibs 2>"$work/cc.log" \
+	$harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 "$work/harness" "$work/hosts.cfg" 2>"$work/stderr.log" \

--- a/tests/server/xymond-noflap-list.sh
+++ b/tests/server/xymond-noflap-list.sh
@@ -56,7 +56,6 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 require_gnu_make
 "$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 
 {
 	printf '#include <stdio.h>\n#include <stdlib.h>\n#include <string.h>\n'
@@ -75,9 +74,10 @@ cat > "$work/hosts.cfg" <<'EOF'
 EOF
 
 harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
-	$ssllibs 2>"$work/cc.log" \
+	$harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 "$work/harness" "$work/hosts.cfg" 2>"$work/stderr.log" \

--- a/tests/server/xymond-noflap-prefix.sh
+++ b/tests/server/xymond-noflap-prefix.sh
@@ -106,12 +106,12 @@ EOF
 
 # Link flags come from the build's own Makefile: SSLLIBS is absent on a
 # --no-ssl build, and carries the -L a non-standard OpenSSL prefix needs.
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 
 harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
-	$ssllibs 2>"$work/cc.log" \
+	$harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 "$work/harness" "$work/hosts.cfg" 2>"$work/stderr.log" \

--- a/tests/web/history-reportlog-reject.sh
+++ b/tests/web/history-reportlog-reject.sh
@@ -39,16 +39,17 @@ svcstatus_setup
 cflags="-g -O1 -fsanitize=address,undefined"
 asan_usable || cflags=""
 harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
 export ASAN_OPTIONS="exitcode=99${ASAN_OPTIONS:+:$ASAN_OPTIONS}"
 for cgi in history reportlog; do
 	"$CC" $cflags $harness_cflags -iquote "$ROOT/web" -o "$work/$cgi" \
 		"$ROOT/web/$cgi.c" \
 		"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
-		$pcre_libs $ssllibs $netlibs $librtdef 2>"$work/cc-$cgi.log" \
+		$pcre_libs $harness_ldflags 2>"$work/cc-$cgi.log" \
 	|| { "$CC" $harness_cflags -iquote "$ROOT/web" -o "$work/$cgi" \
 			"$ROOT/web/$cgi.c" \
 			"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
-			$pcre_libs $ssllibs $netlibs $librtdef 2>"$work/cc-$cgi.log" \
+			$pcre_libs $harness_ldflags 2>"$work/cc-$cgi.log" \
 		|| { cat "$work/cc-$cgi.log" >&2; fail "$cgi.cgi does not build"; }; }
 done
 

--- a/tests/web/html-log-custom-graphs.sh
+++ b/tests/web/html-log-custom-graphs.sh
@@ -36,9 +36,10 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 build_xymon_libs "$ROOT" "$work/libbuild.log" libxymoncomm.a
 
 harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags -o "$work/harness" \
 	"$here/html-log-custom-graphs-harness.c" "$ROOT/lib/libxymoncomm.a" \
-	$pcre_libs -lssl -lcrypto 2>"$work/cc.log" \
+	$pcre_libs $harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 XYMONHOME="$work" \

--- a/tests/web/showgraph-exec-title.sh
+++ b/tests/web/showgraph-exec-title.sh
@@ -25,7 +25,6 @@ require_gnu_make
 rrddef=$(sed -n 's/^RRDDEF *= *//p' "$ROOT/Makefile")
 rrdlibs=$(sed -n 's/^RRDLIBS *= *//p' "$ROOT/Makefile")
 [ -n "$rrdlibs" ] || rrdlibs="-lrrd"
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 
 pcre_libs=${PCRELIBS:-}
 if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
@@ -40,9 +39,10 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
 harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags $rrddef -o "$work/showgraph" \
 	"$ROOT/web/showgraph.c" "$ROOT/lib/libxymoncomm.a" \
-	$pcre_libs $rrdlibs $ssllibs 2>"$work/cc.log" \
+	$pcre_libs $rrdlibs $harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "showgraph does not compile"; }
 
 rrds="$work/rrd/testhost"

--- a/tests/web/showgraph-single-service.sh
+++ b/tests/web/showgraph-single-service.sh
@@ -30,7 +30,6 @@ require_gnu_make
 rrddef=$(sed -n 's/^RRDDEF *= *//p' "$ROOT/Makefile")
 rrdlibs=$(sed -n 's/^RRDLIBS *= *//p' "$ROOT/Makefile")
 [ -n "$rrdlibs" ] || rrdlibs="-lrrd"
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 
 pcre_libs=${PCRELIBS:-}
 if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
@@ -45,9 +44,10 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
 
 harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags $rrddef -o "$work/showgraph" \
 	"$ROOT/web/showgraph.c" "$ROOT/lib/libxymoncomm.a" \
-	$pcre_libs $rrdlibs $ssllibs 2>"$work/cc.log" \
+	$pcre_libs $rrdlibs $harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "showgraph does not compile"; }
 
 # Fake RRD directory; selection is by filename, empty stubs suffice


### PR DESCRIPTION
Completes #310. xymon_cflags() covers the compile side; nothing covered
the link side, and that is what the BSD lanes fail on.

Two failure modes, one cause. FreeBSD keeps the library search path
inside CFLAGS (build/Makefile.FreeBSD), which no harness passes, so the
link fails with "ld: cannot find -lpcre2-8" five times per lane. NetBSD
links but will not run: without RPATHOPT the loader cannot find
libpcre2-8.so.0, which is why six hostdata tests fail there and not on
FreeBSD.

xymon_ldflags() emits what the product link line gets: the search path
picked out of CFLAGS, RPATHOPT, and the libraries libxymoncomm.a needs
(XYMONCOMMLIBS). Asked of make rather than parsed out of the Makefile,
since three of those live in the per-OS include and the search path has
no variable of its own. An empty RPATHVAL leaves a bare "-Wl,--rpath,",
which is dropped.

Fourteen harnesses take it, replacing hand-rolled tails; build-worker.sh
drops its own make probe for the shared helper. Test-specific libraries
stay at the call sites, as #310 asked.

The svcstatus cache keyed only on the build arguments, so changing
SSLLIBS or the search path reused a stale binary and the test passed
without exercising the configuration it claims to. Pre-existing -- main
behaves the same -- but this PR widens it, so the key now hashes the
effective flags too.

Verified: 22 of 22 links against libxymoncomm.a now carry the configured
set, against 0 before; a broken SSLLIBS fails the test instead of
passing it, and the cache still reuses a good binary. Suite: 62 passed,
0 skipped, 0 failed.

Linux reproduces neither BSD failure, so those lanes are the check.

Closes #310

