### PR TITLE
tests: name the sysctl when xymond cannot attach its channels (#345)

### DIFF
--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -287,6 +287,33 @@ xymon_cflags() {
 	printf '%s' "-iquote $root/include -iquote $root/lib $(pcre_cflags "$root")"
 }
 
+# require_shm_segments N -- skip unless one process may attach N SysV
+# shared-memory segments. xymond attaches one per channel, and macOS ships
+# kern.sysv.shmseg=8 against the nine channels xymond sets up, so a stock Mac
+# cannot start xymond at all.
+#
+# Worth a named check rather than letting the run fail: shmat() reports the
+# limit as EMFILE, which strerror() renders "Too many open files", so the
+# error points at file descriptors and says nothing about the sysctl actually
+# responsible. The skip names the knob and the value so it is actionable.
+#
+# Linux has no comparable per-process cap (SHMSEG is effectively unlimited)
+# and exposes no such sysctl, so an absent knob means "no limit to check".
+require_shm_segments() {
+	local want=$1 have knob found=
+
+	for knob in kern.sysv.shmseg kern.ipc.shmseg; do
+		have=$(sysctl -n "$knob" 2>/dev/null) || continue
+		case $have in ''|*[!0-9]*) continue ;; esac
+		found=$knob
+		break
+	done
+	[ -n "$found" ] || return 0
+	[ "$have" -ge "$want" ] && return 0
+
+	skip "$found is $have, need >= $want (xymond attaches one shared-memory segment per channel) -- raise it with: sudo sysctl -w $found=$want"
+}
+
 # ---- repo location -----------------------------------------------------------
 
 # find_root -- print the absolute path of the repo root, derived from the

--- a/tests/server/hostdata-save-next.sh
+++ b/tests/server/hostdata-save-next.sh
@@ -10,6 +10,11 @@ require_bin XYMOND_CHANNEL xymond/xymond_channel
 require_bin XYMOND_HOSTDATA xymond/xymond_hostdata
 require_bin XYMON common/xymon
 
+# This is the only test that starts a real xymond, so it is the only one that
+# needs the channel shared-memory segments. The count is read from the source
+# rather than hardcoded, so adding a channel cannot silently outgrow the check.
+require_shm_segments "$(grep -c 'setup_channel(C_[A-Z_]*, CHAN_MASTER)' "$(find_root)/xymond/xymond.c")"
+
 work=$(mktempdir)
 port=$((20000 + ($$ % 20000)))
 mkdir -p "$work"/{home/etc,home/tmp,var,logs,hostdata}


### PR DESCRIPTION
xymond attaches one SysV shared-memory segment per channel and sets up
nine (C_STATUS through C_USER, xymond.c). macOS ships
kern.sysv.shmseg=8, so on a stock Mac the ninth attach fails and xymond
never starts:

    Setting up xymond channels
    Could not attach shm Too many open files
    Cannot setup user channel

tests/server/hostdata-save-next.sh is the only test that starts a real
xymond rather than a stub, so it is the only one affected, and it fails
on every macOS lane.

The message is what makes this worth a named check. shmat() reports the
limit as EMFILE, which strerror() renders "Too many open files" -- so the
error points at file descriptors and never mentions the sysctl actually
responsible. require_shm_segments() skips instead, naming the knob, the
current value, the value needed and the command to raise it.

The required count is read out of xymond.c rather than hardcoded, so
adding a channel cannot silently outgrow the check.

Linux has no comparable per-process cap and exposes no such sysctl, so
an absent knob is treated as "nothing to check" and the guard is inert
there: suite 57 passed, 0 skipped, 0 failed, unchanged. Verified in both
directions with a sysctl stub reporting 8, which produces

    SKIP: kern.sysv.shmseg is 8, need >= 9 (xymond attaches one shared-
    memory segment per channel) -- raise it with: sudo sysctl -w
    kern.sysv.shmseg=9

This is the developer-facing half of #345. The other half -- raising the
limit in the macOS lane so CI executes the test instead of skipping it --
belongs with the lane definition, which lives on cmake/bootstrap and not
on main.

Refs #345