### PR TITLE
xymonlaunch: refuse a tasklist config that was read short

### DIFF
--- a/common/xymonlaunch.c
+++ b/common/xymonlaunch.c
@@ -87,6 +87,48 @@ volatile int forcereload=0;
 # define xfreeassign(k,p) { if (k) { xfree(k); } k=p; }
 # define xfreedup(k,p) { if (k) { xfree(k); } k=strdup(p); }
 
+/* Release what a re-read parsed into a task, leaving its key and its place in
+   the list alone. */
+static void free_task_config(tasklist_t *t)
+{
+	xfreenull(t->cmd);
+	xfreenull(t->logfile);
+	xfreenull(t->envfile);
+	xfreenull(t->envarea);
+	xfreenull(t->onhostptn);
+	xfreenull(t->cronstr);
+	if (t->crondate) { crondatefree(t->crondate); t->crondate = NULL; }
+}
+
+/*
+ * Put a task back the way it was before the re-read cleared it. Nothing was
+ * lost on the way: the clearing loop NULLs the fields before parsing, so
+ * xfreedup() only ever replaced a NULL. Field by field rather than a memcpy,
+ * whose blanked next/copy pointers would cut the task out of the list.
+ */
+static void restore_task(tasklist_t *twalk)
+{
+	tasklist_t *saved = twalk->copy;
+
+	free_task_config(twalk);
+
+	twalk->disabled   = saved->disabled;
+	twalk->cmd        = saved->cmd;
+	twalk->interval   = saved->interval;
+	twalk->maxruntime = saved->maxruntime;
+	twalk->group      = saved->group;
+	twalk->logfile    = saved->logfile;
+	twalk->envfile    = saved->envfile;
+	twalk->envarea    = saved->envarea;
+	twalk->onhostptn  = saved->onhostptn;
+	twalk->cronstr    = saved->cronstr;
+	twalk->crondate   = saved->crondate;
+	twalk->depends    = saved->depends;
+
+	twalk->cfload = 0;
+	xfreenull(twalk->copy);
+}
+
 void load_config(char *conffn)
 {
 	static void *configfiles = NULL;
@@ -95,6 +137,11 @@ void load_config(char *conffn)
 	strbuffer_t *inbuf;
 	char *p;
 	char myhostname[256];
+	/* Nothing is running yet on the first load, so there is nothing to protect
+	   and an incomplete read is handled differently - see below. */
+	int firstload = (taskhead == NULL);
+	int incomplete = 0;
+	grouplist_t *groupmark;
 
 	/* First check if there were no modifications at all */
 	if (configfiles) {
@@ -109,15 +156,39 @@ void load_config(char *conffn)
 	}
 
 	errprintf("Loading tasklist configuration from %s\n", conffn);
+
 	if (gethostname(myhostname, sizeof(myhostname)) != 0) {
 		errprintf("Cannot get the local hostname, using 'localhost' (error: %s)\n", strerror(errno));
 		strcpy(myhostname, "localhost");
 	}
 
+	/*
+	 * Open the file before touching the task list. The clearing below throws
+	 * away every task's settings so that the re-read can detect what changed;
+	 * doing that first and then bailing out here left every task with a NULL
+	 * cmd and no way back, so each task crashed as soon as it was restarted.
+	 */
+	fd = stackfopen(conffn, "r", &configfiles);
+	if (fd == NULL) {
+		errprintf("Cannot open configuration file %s: %s\n", conffn, strerror(errno));
+		return;
+	}
+
 	/* The cfload flag: -1=delete task, 0=old task unchanged, 1=new/changed task */
+	/*
+	 * The group list is global and outlives the read, so the rollback has to
+	 * put it back too: a refused config that declared a group left it behind
+	 * with its own limit, and a later valid declaration of the same name
+	 * finds the existing entry instead of creating one (@SoundGoof).
+	 */
+	groupmark = grouphead;
+
 	for (twalk = taskhead; (twalk); twalk = twalk->next) {
 		twalk->cfload = -1;
-		twalk->group = NULL;
+		/* The group is cleared below, with the other settings and *after* the
+		   copy: cleared first, the copy held a NULL and a refused read gave
+		   every task back without its group - no limit applied to it, and no
+		   decrement when it exits. */
 		/* Create a copy, but retain the settings and pointers are the same */
 		twalk->copy = xmalloc(sizeof(tasklist_t));
 		memcpy(twalk->copy,twalk,sizeof(tasklist_t));
@@ -137,12 +208,6 @@ void load_config(char *conffn)
 		twalk->cronstr = NULL;
 		twalk->crondate = NULL;
 		twalk->depends = NULL;
-	}
-
-	fd = stackfopen(conffn, "r", &configfiles);
-	if (fd == NULL) {
-		errprintf("Cannot open configuration file %s: %s\n", conffn, strerror(errno));
-		return;
 	}
 
 	inbuf = newstrbuffer(0);
@@ -335,8 +400,76 @@ void load_config(char *conffn)
 	stackfclose(fd);
 	freestrbuffer(inbuf);
 
+	/*
+	 * A task back without a command marks a read that did not see the whole
+	 * file: no valid config drops a CMD (DISABLED is how a task is switched
+	 * off), but one caught mid-rewrite has that shape. Such a task cannot run
+	 * - the forked child hands the NULL to expand_env() and dies before exec.
+	 */
+	for (twalk = taskhead; (twalk); twalk = twalk->next) {
+		if ((twalk->cfload != -1) && (twalk->cmd == NULL)) {
+			errprintf("Configuration error, no command for task %s\n", twalk->key);
+			incomplete = 1;
+		}
+	}
+
+	/*
+	 * Do not apply a short read: every section it did not reach looks deleted,
+	 * so the tasks below the cut - xymond among them - would be killed off
+	 * silently. The file list is dropped so the next pass re-reads
+	 * unconditionally rather than trusting a timestamp taken mid-write.
+	 *
+	 * The first load has nothing to protect and nothing running, so refusing
+	 * outright would start nothing at all: there, drop just the tasks with no
+	 * command.
+	 */
+	if (incomplete && !firstload) {
+		errprintf("Incomplete tasklist configuration - keeping the previous one\n");
+
+		/*
+		 * Unlink first, restore second: the copy is what tells a pre-existing
+		 * task from one this read created, and restore_task() releases it.
+		 * The other way round every task looked new, and the whole list was
+		 * freed while its children ran on unsupervised. Groups go the same
+		 * way, down to the mark; entries below it were there before the read.
+		 * Nothing unlinked here was ever started, so there is no pid to see to.
+		 */
+		while (grouphead && (grouphead != groupmark)) {
+			grouplist_t *gtmp = grouphead;
+			grouphead = grouphead->next;
+			if (gtmp->groupname) xfree(gtmp->groupname);
+			xfree(gtmp);
+		}
+
+		while (taskhead && (taskhead->copy == NULL)) {
+			tasklist_t *tmp = taskhead;
+			taskhead = taskhead->next;
+			free_task_config(tmp); xfreenull(tmp->key); xfree(tmp);
+		}
+		twalk = taskhead;
+		while (twalk && twalk->next) {
+			if (twalk->next->copy == NULL) {
+				tasklist_t *tmp = twalk->next;
+				twalk->next = tmp->next;
+				free_task_config(tmp); xfreenull(tmp->key); xfree(tmp);
+			}
+			else twalk = twalk->next;
+		}
+		for (tasktail = taskhead; (tasktail && tasktail->next); tasktail = tasktail->next);
+
+		for (twalk = taskhead; (twalk); twalk = twalk->next) {
+			if (twalk->copy) restore_task(twalk);
+		}
+
+		stackfclist(&configfiles);
+		configfiles = NULL;
+		return;
+	}
+
 	/* Running tasks that have been deleted or changed are killed off now. */
 	for (twalk = taskhead; (twalk); twalk = twalk->next) {
+		if ((twalk->cfload != -1) && (twalk->cmd == NULL)) twalk->cfload = -1;
+
 		/* compare the current settings with the copy - if we have one */
 		if (twalk->cfload == 0) {
 			if (twalk->copy) {

--- a/common/xymonlaunch.c
+++ b/common/xymonlaunch.c
@@ -87,6 +87,51 @@ volatile int forcereload=0;
 # define xfreeassign(k,p) { if (k) { xfree(k); } k=p; }
 # define xfreedup(k,p) { if (k) { xfree(k); } k=strdup(p); }
 
+/* Release what a re-read parsed into a task, leaving its key and its place in
+   the list alone. */
+static void free_task_config(tasklist_t *t)
+{
+	xfreenull(t->cmd);
+	xfreenull(t->logfile);
+	xfreenull(t->envfile);
+	xfreenull(t->envarea);
+	xfreenull(t->onhostptn);
+	xfreenull(t->cronstr);
+	if (t->crondate) { crondatefree(t->crondate); t->crondate = NULL; }
+}
+
+/*
+ * Put a task back the way it was before the re-read cleared it, and throw away
+ * what the re-read parsed. Nothing of the old configuration was lost along the
+ * way: the clearing loop sets the fields to NULL *before* parsing, so xfreedup()
+ * only ever replaced a NULL and never freed the values held in the copy.
+ *
+ * Field by field rather than a memcpy of the copy, whose next/copy pointers were
+ * blanked when it was taken and would cut the task out of the list.
+ */
+static void restore_task(tasklist_t *twalk)
+{
+	tasklist_t *saved = twalk->copy;
+
+	free_task_config(twalk);
+
+	twalk->disabled   = saved->disabled;
+	twalk->cmd        = saved->cmd;
+	twalk->interval   = saved->interval;
+	twalk->maxruntime = saved->maxruntime;
+	twalk->group      = saved->group;
+	twalk->logfile    = saved->logfile;
+	twalk->envfile    = saved->envfile;
+	twalk->envarea    = saved->envarea;
+	twalk->onhostptn  = saved->onhostptn;
+	twalk->cronstr    = saved->cronstr;
+	twalk->crondate   = saved->crondate;
+	twalk->depends    = saved->depends;
+
+	twalk->cfload = 0;
+	xfreenull(twalk->copy);
+}
+
 void load_config(char *conffn)
 {
 	static void *configfiles = NULL;
@@ -95,6 +140,10 @@ void load_config(char *conffn)
 	strbuffer_t *inbuf;
 	char *p;
 	char myhostname[256];
+	/* Nothing is running yet on the first load, so there is nothing to protect
+	   and an incomplete read is handled differently - see below. */
+	int firstload = (taskhead == NULL);
+	int incomplete = 0;
 
 	/* First check if there were no modifications at all */
 	if (configfiles) {
@@ -112,6 +161,18 @@ void load_config(char *conffn)
 	if (gethostname(myhostname, sizeof(myhostname)) != 0) {
 		errprintf("Cannot get the local hostname, using 'localhost' (error: %s)\n", strerror(errno));
 		strcpy(myhostname, "localhost");
+	}
+
+	/*
+	 * Open the file before touching the task list. The clearing below throws
+	 * away every task's settings so that the re-read can detect what changed;
+	 * doing that first and then bailing out here left every task with a NULL
+	 * cmd and no way back, so each task crashed as soon as it was restarted.
+	 */
+	fd = stackfopen(conffn, "r", &configfiles);
+	if (fd == NULL) {
+		errprintf("Cannot open configuration file %s: %s\n", conffn, strerror(errno));
+		return;
 	}
 
 	/* The cfload flag: -1=delete task, 0=old task unchanged, 1=new/changed task */
@@ -137,12 +198,6 @@ void load_config(char *conffn)
 		twalk->cronstr = NULL;
 		twalk->crondate = NULL;
 		twalk->depends = NULL;
-	}
-
-	fd = stackfopen(conffn, "r", &configfiles);
-	if (fd == NULL) {
-		errprintf("Cannot open configuration file %s: %s\n", conffn, strerror(errno));
-		return;
 	}
 
 	inbuf = newstrbuffer(0);
@@ -335,8 +390,75 @@ void load_config(char *conffn)
 	stackfclose(fd);
 	freestrbuffer(inbuf);
 
+	/*
+	 * A configured task that came back without a command is the mark of a read
+	 * that did not see the whole file. No valid configuration has a section
+	 * without a CMD - a task is switched off with DISABLED, not by taking its
+	 * command away - but a config file caught halfway through being rewritten
+	 * has exactly that shape, and the re-read is driven by the file's
+	 * timestamp rather than by whoever is writing it.
+	 *
+	 * Such a task cannot be run at all: setup_commandargs() would hand the NULL
+	 * to expand_env() in the forked child, which dies before it can exec.
+	 */
+	for (twalk = taskhead; (twalk); twalk = twalk->next) {
+		if ((twalk->cfload != -1) && (twalk->cmd == NULL)) {
+			errprintf("Configuration error, no command for task %s\n", twalk->key);
+			incomplete = 1;
+		}
+	}
+
+	/*
+	 * Do not apply a read that came up short. Trusting it costs more than the
+	 * missing command: every section the read did not reach looks deleted, so
+	 * the tasks below the cut - xymond among them - would be killed off as if
+	 * that had been asked for, and nothing in the log would say why.
+	 *
+	 * Put everything back the way it was and wait. The file's timestamp has
+	 * already changed, so the next pass reads it again 30 seconds later, by
+	 * which time whoever was writing it is done. Dropping the file list makes
+	 * that re-read unconditional rather than trusting the timestamp of a file
+	 * that was still being written when we stat'ed it.
+	 *
+	 * On the first load there is no previous state to protect and nothing is
+	 * running yet, so refusing outright would mean starting nothing at all
+	 * because one section out of nineteen is malformed. Drop just the tasks
+	 * that have no command and start the rest.
+	 */
+	if (incomplete && !firstload) {
+		errprintf("Incomplete tasklist configuration - keeping the previous one\n");
+
+		for (twalk = taskhead; (twalk); twalk = twalk->next) {
+			if (twalk->copy) restore_task(twalk);
+		}
+
+		/* Entries this read created were never started, so there is no pid to
+		   see to; they are simply unlinked and released. */
+		while (taskhead && (taskhead->copy == NULL)) {
+			tasklist_t *tmp = taskhead;
+			taskhead = taskhead->next;
+			free_task_config(tmp); xfreenull(tmp->key); xfree(tmp);
+		}
+		twalk = taskhead;
+		while (twalk && twalk->next) {
+			if (twalk->next->copy == NULL) {
+				tasklist_t *tmp = twalk->next;
+				twalk->next = tmp->next;
+				free_task_config(tmp); xfreenull(tmp->key); xfree(tmp);
+			}
+			else twalk = twalk->next;
+		}
+		for (tasktail = taskhead; (tasktail && tasktail->next); tasktail = tasktail->next);
+
+		stackfclist(&configfiles);
+		configfiles = NULL;
+		return;
+	}
+
 	/* Running tasks that have been deleted or changed are killed off now. */
 	for (twalk = taskhead; (twalk); twalk = twalk->next) {
+		if ((twalk->cfload != -1) && (twalk->cmd == NULL)) twalk->cfload = -1;
+
 		/* compare the current settings with the copy - if we have one */
 		if (twalk->cfload == 0) {
 			if (twalk->copy) {

--- a/tests/server/xymonlaunch-partial-config.sh
+++ b/tests/server/xymonlaunch-partial-config.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymonlaunch-partial-config.sh
+#
+# xymonlaunch re-reads its config whenever the file's timestamp changes, and
+# the re-read begins by clearing every task's settings so that it can tell
+# afterwards what actually changed. Nothing checked that it had read a whole
+# file before acting on it, and a config file being rewritten in place - by a
+# package upgrade, say - is readable in that state, because the re-read is
+# driven by the timestamp and not by whoever is writing.
+#
+# Acting on a short read costs two different things:
+#
+#   (A) a section read without its CMD line leaves a task with no command,
+#       which is fatal - the forked child hands the NULL to expand_env(), which
+#       strdup()s it and dies before it can exec, so the task never reaches the
+#       point where a failure would be reported. Restoring only the command is
+#       not enough either: a task that also lost its ENVFILE gets bounced and
+#       restarted without its environment.
+#   (B) every section the read did not reach looks deleted, so the tasks below
+#       the cut - xymond among them - are killed as if that had been asked for.
+#
+#   (C) a config file that cannot be opened at all on the re-read, which used
+#       to return after the clearing loop had already run.
+#
+# All three are driven against a live xymonlaunch. SIGHUP forces the re-read
+# (sig_handler sets nextcfgload = 0) so the test does not wait out the
+# 30-second poll, and each supervised task appends a line every second so that
+# "is it still running" is a question the test can answer by watching a file.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMONLAUNCH "common/xymonlaunch"
+
+work=$(mktempdir)
+cfg="$work/tasks.cfg"
+log="$work/launch.log"
+
+# beat refuses to run without the variable its ENVFILE provides, so "still
+# ticking" proves the whole configuration survived, not just the command.
+printf 'BEAT_OK=1\n' >"$work/beat.env"
+cat >"$work/beat.sh" <<EOF
+#!/bin/sh
+[ -n "\$BEAT_OK" ] || exit 42
+while :; do echo tick >>"$work/beat"; sleep 1; done
+EOF
+cat >"$work/beat2.sh" <<EOF
+#!/bin/sh
+while :; do echo tick >>"$work/beat2"; sleep 1; done
+EOF
+chmod +x "$work/beat.sh" "$work/beat2.sh"
+
+good_config() {
+	cat >"$cfg" <<EOF
+[beat]
+	CMD $work/beat.sh
+	ENVFILE $work/beat.env
+
+[beat2]
+	CMD $work/beat2.sh
+EOF
+}
+
+# ---- helpers ---------------------------------------------------------------
+# Poll rather than sleep a fixed time, so a slow machine gets its chance and a
+# fast one does not pay for it.
+wait_for() {
+	local deadline=$((SECONDS + $1)); shift
+	while [ "$SECONDS" -lt "$deadline" ]; do
+		if eval "$@"; then return 0; fi
+		sleep 0.2
+	done
+	return 1
+}
+lines()     { [ -f "$1" ] && wc -l <"$1" || echo 0; }
+# restart_beat MESSAGE -- kill the supervised task and require xymonlaunch to
+# bring it back. The file is emptied *after* the child is gone, so a tick the
+# dying child still had in flight cannot be mistaken for the new one's first:
+# comparing counts across the kill let the old process satisfy the assertion.
+restart_beat() {
+	pkill -f "$work/beat.sh" 2>/dev/null || true
+	wait_for 15 '! pgrep -f "$work/beat.sh" >/dev/null' \
+		|| fail "the supervised task would not die, so nothing here is about a restart"
+	: > "$work/beat"
+	wait_for 30 '[ -s "$work/beat" ]' || fail "$1"
+}
+grew()      { [ "$(lines "$1")" -gt "$2" ]; }
+loadcount() { grep -c 'Loading tasklist configuration' "$log" || true; }
+loads_gt()  { [ "$(loadcount)" -gt "$1" ]; }
+# Force a re-read and wait until it has actually been attempted, so what
+# follows cannot race the SIGHUP.
+reload() {
+	local n; n=$(loadcount)
+	kill -HUP "$launcher"
+	wait_for 15 "loads_gt $n" || fail "xymonlaunch did not re-read its config after SIGHUP"
+}
+
+good_config
+"$XYMONLAUNCH" --config="$cfg" --no-daemon >"$log" 2>&1 &
+launcher=$!
+register_cleanup "kill $launcher 2>/dev/null || true; pkill -f ${work}/beat.sh 2>/dev/null || true; pkill -f ${work}/beat2.sh 2>/dev/null || true"
+
+wait_for 20 '[ -s "$work/beat" ] && [ -s "$work/beat2" ]' \
+	|| fail "the supervised tasks never started: $(cat "$log")"
+
+# ---- (A) + (B) a read that stopped in the middle of the first section ------
+# [beat] loses its CMD and its ENVFILE; [beat2] is not in the file at all.
+# Both must come through untouched, and neither may be restarted: beat would
+# come back without BEAT_OK and exit 42, beat2 would be killed as deleted.
+#
+# What protects beat2 here is the *first* section being incomplete: a task with
+# no command is the only mark of a short read this can see. So (B) is asserted
+# as a consequence of (A), not on its own, and it cannot be otherwise -- a cut
+# landing exactly on a section boundary leaves a well-formed prefix, which is
+# the known undetectable case. Read this as "a detected short read protects the
+# sections below the cut", not as "an absent section is always protected".
+b1=$(lines "$work/beat"); b2=$(lines "$work/beat2")
+printf '[beat]\n' >"$cfg"
+reload
+
+assert_contains "no command for task beat" "$(cat "$log")" \
+	"the short read did not report the task it left without a command"
+assert_contains "keeping the previous one" "$(cat "$log")" \
+	"the short read was applied instead of being refused"
+assert_not_contains "terminated" "$(cat "$log")" \
+	"a task was killed or exited over a config read that did not see the whole file"
+
+wait_for 20 "grew $work/beat $b1" \
+	|| fail "the task whose section lost its CMD line stopped: $(cat "$log")"
+wait_for 20 "grew $work/beat2 $b2" \
+	|| fail "the task that was simply absent from the short read was killed as deleted: $(cat "$log")"
+
+# Running tasks proving nothing by themselves is the point: a child that was
+# already started keeps running whether or not xymonlaunch still knows about
+# it. What the rollback has to leave behind is the task list, and it is the
+# next restart that reads a command back out of it. So force one.
+#
+# Restoring the tasks before deciding which ones the read had created lost the
+# whole list here: restore_task() releases the copy that tells the two apart,
+# so every task then looked newly created and was unlinked. Nothing died and
+# nothing was logged - the children ran on unsupervised, and never came back
+# (@SoundGoof, on Debian 13 and four BSDs).
+restart_beat "a task did not restart after a refused read -- the rollback dropped it from the task list, leaving its child running unsupervised: $(cat "$log")"
+
+# A good config is picked up again straight away - refusing one read must not
+# wedge the launcher into ignoring the file.
+logmark=$(lines "$log")
+good_config
+reload
+# Only what this re-read logged: the restart forced just above is a
+# termination the test asked for, and predates the mark.
+assert_not_contains "terminated" "$(tail -n +$((logmark + 1)) "$log")" \
+	"the re-read of a restored config bounced tasks that had not changed"
+
+# ---- (C) a config that cannot be opened on the re-read ---------------------
+rm -f "$cfg"
+reload
+assert_contains "Cannot open configuration file" "$(cat "$log")" \
+	"a re-read that could not open the config did not report it"
+
+# Nothing proves the task list survived while the tasks keep running -- it is
+# the *next* restart that reads the command back. So force one.
+restart_beat "the task did not restart after a re-read that could not open its config: $(cat "$log")"
+
+pass "a config read that stopped short, or could not be opened, is refused whole and leaves every running task alone"

--- a/tests/server/xymonlaunch-partial-config.sh
+++ b/tests/server/xymonlaunch-partial-config.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymonlaunch-partial-config.sh
+#
+# xymonlaunch re-reads its config whenever the file's timestamp changes, and
+# the re-read begins by clearing every task's settings so that it can tell
+# afterwards what actually changed. Nothing checked that it had read a whole
+# file before acting on it, and a config file being rewritten in place - by a
+# package upgrade, say - is readable in that state, because the re-read is
+# driven by the timestamp and not by whoever is writing.
+#
+# Acting on a short read costs two different things:
+#
+#   (A) a section read without its CMD line leaves a task with no command,
+#       which is fatal - the forked child hands the NULL to expand_env(), which
+#       strdup()s it and dies before it can exec, so the task never reaches the
+#       point where a failure would be reported. Restoring only the command is
+#       not enough either: a task that also lost its ENVFILE gets bounced and
+#       restarted without its environment.
+#   (B) every section the read did not reach looks deleted, so the tasks below
+#       the cut - xymond among them - are killed as if that had been asked for.
+#
+#   (C) a config file that cannot be opened at all on the re-read, which used
+#       to return after the clearing loop had already run.
+#
+# All three are driven against a live xymonlaunch. SIGHUP forces the re-read
+# (sig_handler sets nextcfgload = 0) so the test does not wait out the
+# 30-second poll, and each supervised task appends a line every second so that
+# "is it still running" is a question the test can answer by watching a file.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMONLAUNCH "common/xymonlaunch"
+
+work=$(mktempdir)
+cfg="$work/tasks.cfg"
+log="$work/launch.log"
+
+# beat refuses to run without the variable its ENVFILE provides, so "still
+# ticking" proves the whole configuration survived, not just the command.
+printf 'BEAT_OK=1\n' >"$work/beat.env"
+cat >"$work/beat.sh" <<EOF
+#!/bin/sh
+[ -n "\$BEAT_OK" ] || exit 42
+while :; do echo tick >>"$work/beat"; sleep 1; done
+EOF
+cat >"$work/beat2.sh" <<EOF
+#!/bin/sh
+while :; do echo tick >>"$work/beat2"; sleep 1; done
+EOF
+chmod +x "$work/beat.sh" "$work/beat2.sh"
+
+good_config() {
+	cat >"$cfg" <<EOF
+[beat]
+	CMD $work/beat.sh
+	ENVFILE $work/beat.env
+
+[beat2]
+	CMD $work/beat2.sh
+EOF
+}
+
+# ---- helpers ---------------------------------------------------------------
+# Poll rather than sleep a fixed time, so a slow machine gets its chance and a
+# fast one does not pay for it.
+wait_for() {
+	local deadline=$((SECONDS + $1)); shift
+	while [ "$SECONDS" -lt "$deadline" ]; do
+		if eval "$@"; then return 0; fi
+		sleep 0.2
+	done
+	return 1
+}
+lines()     { [ -f "$1" ] && wc -l <"$1" || echo 0; }
+grew()      { [ "$(lines "$1")" -gt "$2" ]; }
+loadcount() { grep -c 'Loading tasklist configuration' "$log" || true; }
+loads_gt()  { [ "$(loadcount)" -gt "$1" ]; }
+# Force a re-read and wait until it has actually been attempted, so what
+# follows cannot race the SIGHUP.
+reload() {
+	local n; n=$(loadcount)
+	kill -HUP "$launcher"
+	wait_for 15 "loads_gt $n" || fail "xymonlaunch did not re-read its config after SIGHUP"
+}
+
+good_config
+"$XYMONLAUNCH" --config="$cfg" --no-daemon >"$log" 2>&1 &
+launcher=$!
+register_cleanup "kill $launcher 2>/dev/null || true; pkill -f ${work}/beat.sh 2>/dev/null || true; pkill -f ${work}/beat2.sh 2>/dev/null || true"
+
+wait_for 20 '[ -s "$work/beat" ] && [ -s "$work/beat2" ]' \
+	|| fail "the supervised tasks never started: $(cat "$log")"
+
+# ---- (A) + (B) a read that stopped in the middle of the first section ------
+# [beat] loses its CMD and its ENVFILE; [beat2] is not in the file at all.
+# Both must come through untouched, and neither may be restarted: beat would
+# come back without BEAT_OK and exit 42, beat2 would be killed as deleted.
+b1=$(lines "$work/beat"); b2=$(lines "$work/beat2")
+printf '[beat]\n' >"$cfg"
+reload
+
+assert_contains "no command for task beat" "$(cat "$log")" \
+	"the short read did not report the task it left without a command"
+assert_contains "keeping the previous one" "$(cat "$log")" \
+	"the short read was applied instead of being refused"
+assert_not_contains "terminated" "$(cat "$log")" \
+	"a task was killed or exited over a config read that did not see the whole file"
+
+wait_for 20 "grew $work/beat $b1" \
+	|| fail "the task whose section lost its CMD line stopped: $(cat "$log")"
+wait_for 20 "grew $work/beat2 $b2" \
+	|| fail "the task that was simply absent from the short read was killed as deleted: $(cat "$log")"
+
+# A good config is picked up again straight away - refusing one read must not
+# wedge the launcher into ignoring the file.
+good_config
+reload
+assert_not_contains "terminated" "$(cat "$log")" \
+	"the re-read of a restored config bounced tasks that had not changed"
+
+# ---- (C) a config that cannot be opened on the re-read ---------------------
+rm -f "$cfg"
+reload
+assert_contains "Cannot open configuration file" "$(cat "$log")" \
+	"a re-read that could not open the config did not report it"
+
+# Nothing proves the task list survived while the tasks keep running -- it is
+# the *next* restart that reads the command back. So force one.
+b1=$(lines "$work/beat")
+pkill -f "$work/beat.sh"
+wait_for 30 "grew $work/beat $b1" \
+	|| fail "the task did not restart after a re-read that could not open its config: $(cat "$log")"
+
+pass "a config read that stopped short, or could not be opened, is refused whole and leaves every running task alone"


### PR DESCRIPTION
`load_config()` clears every task's settings before re-reading the file, so the comparison afterwards can tell what changed — and nothing checked that it had read a whole file first. A config being rewritten in place is readable in that state: the re-read is driven by the file's timestamp, not by whoever is writing.

Acting on a short read costs two things:

- **a section read without its `CMD`** leaves a task with no command, which is fatal — the forked child hands the NULL to `expand_env()` and dies before `execvp()`, so it never reaches the point where a failure would be reported;
- **every section the read did not reach looks deleted**, so the tasks below the cut — `xymond` among them — are killed as if that had been asked for, with nothing in the log to say why.

A task with no command is the mark of a short read: no valid config drops a `CMD`, since a task is switched off with `DISABLED`. So when one turns up, put everything back and wait — the next pass re-reads 30 s later, unconditionally, rather than trusting a timestamp taken mid-write.

| mutation | result |
|---|---|
| no check at all | no report, task left with no command |
| restore only the command | `Task beat terminated by signal 15` — a task that lost its `ENVFILE` is restarted without it |
| open the file after clearing, not before | a config that cannot be opened leaves every task with a NULL command |
| restore before classifying | the task never restarts: `restore_task()` releases the copy that tells a pre-existing task from a new one, so the whole list was freed |
| leave the group list out of the rollback | *(not observable — see below)* |

The last two are @SoundGoof's, from two review rounds. The group one is real — the list is global, and a refused config that declared a group left the entry behind — but it has **no test**, and nothing outside the process can observe it: `dump_config()` prints only groups with `maxuse > 1`, and #376 means no group ever has one. It becomes testable when #376 is fixed, and the regression belongs there.

**Three limits, stated rather than papered over:**

- a cut landing **exactly on a section boundary** yields a well-formed prefix and is not detectable this way — so the "absent section" half of the test is asserted as a consequence of the first section being incomplete, not on its own;
- on the **first load** there is no previous state and nothing running, so refusing outright would start nothing at all; only the tasks with no command are dropped;
- `devel` carries the same `load_config()` and the same defect. No separate port is planned — noted so that whoever absorbs devel's xymonlaunch work does not bring the old version back with it.

`tests/server/xymonlaunch-partial-config.sh` drives a live xymonlaunch, forcing re-reads with SIGHUP, and each case above is verified by mutation. Suite on a built tree: 0 failed, 0 skipped.

