### PR TITLE
showgraph: read an RRD's own update time, not its file's (supersedes TBT 215)

### DIFF
--- a/build/test-rrd.c
+++ b/build/test-rrd.c
@@ -24,7 +24,6 @@ int main(void)
 	double ymin, ymax;
 
 	for (pcount = 0; (rrdargs[pcount]); pcount++);
-	rrd_clear_error();
 	result = xymon_rrd_graph(pcount, rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
 	(void)result;
 

--- a/lib/rrd_api_compat.h
+++ b/lib/rrd_api_compat.h
@@ -1,7 +1,12 @@
 #ifndef __RRD_API_COMPAT_H__
 #define __RRD_API_COMPAT_H__
 
+#include <unistd.h>	/* optind/opterr: librrd parses these argv forms with getopt() */
 #include <rrd.h>
+
+/* A strictly-conforming <unistd.h> (e.g. plain -std=c99) keeps the getopt
+ * globals to itself; librrd uses them regardless. */
+extern int optind, opterr;
 
 /*
  * RRDtool changed the argv parameter of its public API from "char **" to
@@ -18,39 +23,61 @@
 
 #if RRD_CONST_ARGS
 typedef const char *xymon_rrd_argv_item_t;
-static const char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
+static inline const char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
 {
 	return (const char **)argv;
 }
 #else
 typedef char *xymon_rrd_argv_item_t;
-static char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
+static inline char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
 {
 	return argv;
 }
 #endif
 
-static int xymon_rrd_update(int argc, xymon_rrd_argv_item_t *argv)
+/*
+ * librrd parses these argv forms with getopt(): reset its globals and the
+ * error state before every call; the state after a call is the caller's.
+ * optind=0 is the GNU re-init - moot on RRDtool >= 1.7, whose private
+ * optparse ignores the getopt globals. That version is the supported floor.
+ */
+static inline void xymon_rrd_call_setup(void)
 {
+	optind = opterr = 0;
+	rrd_clear_error();
+}
+
+static inline int xymon_rrd_update(int argc, xymon_rrd_argv_item_t *argv)
+{
+	xymon_rrd_call_setup();
 	return rrd_update(argc, xymon_rrd_api_argv(argv));
 }
 
-static int xymon_rrd_create(int argc, xymon_rrd_argv_item_t *argv)
+static inline int xymon_rrd_create(int argc, xymon_rrd_argv_item_t *argv)
 {
+	xymon_rrd_call_setup();
 	return rrd_create(argc, xymon_rrd_api_argv(argv));
 }
 
-static int xymon_rrd_fetch(int argc, xymon_rrd_argv_item_t *argv,
+static inline int xymon_rrd_fetch(int argc, xymon_rrd_argv_item_t *argv,
 				  time_t *start, time_t *end, unsigned long *step,
 				  unsigned long *dscount, char ***dsnames, rrd_value_t **data)
 {
+	xymon_rrd_call_setup();
 	return rrd_fetch(argc, xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
 }
 
-static int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv,
+static inline time_t xymon_rrd_last(int argc, xymon_rrd_argv_item_t *argv)
+{
+	xymon_rrd_call_setup();
+	return rrd_last(argc, xymon_rrd_api_argv(argv));
+}
+
+static inline int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv,
 				  char ***calcpr, int *xsize, int *ysize,
 				  void *prdata, double *ymin, double *ymax)
 {
+	xymon_rrd_call_setup();
 	return rrd_graph(argc, xymon_rrd_api_argv(argv), calcpr, xsize, ysize, prdata, ymin, ymax);
 }
 

--- a/lib/rrd_api_compat.h
+++ b/lib/rrd_api_compat.h
@@ -36,10 +36,13 @@ static inline char **xymon_rrd_api_argv(xymon_rrd_argv_item_t *argv)
 #endif
 
 /*
- * librrd parses these argv forms with getopt(): reset its globals and the
- * error state before every call; the state after a call is the caller's.
- * optind=0 is the GNU re-init - moot on RRDtool >= 1.7, whose private
- * optparse ignores the getopt globals. That version is the supported floor.
+ * The option-parsing entry points (create/update/fetch/graph) run getopt()
+ * over their argv: reset its globals and the error state before every call;
+ * the state after a call is the caller's. optind=0 is the GNU re-init that
+ * an option-parsing RRDtool before 1.7 relies on to re-scan; RRDtool >= 1.7
+ * uses a private optparse that ignores the getopt globals, so the reset is a
+ * harmless no-op there. This resets unconditionally rather than asserting a
+ * version floor, which the build does not probe for.
  */
 static inline void xymon_rrd_call_setup(void)
 {

--- a/tests/buildsystem/rrd-api-compat.sh
+++ b/tests/buildsystem/rrd-api-compat.sh
@@ -42,6 +42,8 @@ int rrd_create(int, $argv);
 int rrd_fetch(int, $argv, time_t *, time_t *, unsigned long *,
               unsigned long *, char ***, rrd_value_t **);
 int rrd_graph(int, $argv, char ***, int *, int *, void *, double *, double *);
+time_t rrd_last(int, $argv);
+void rrd_clear_error(void);
 #endif
 EOF
 }
@@ -65,6 +67,7 @@ int main(void)
 			      &dsnames, &data);
 	(void)xymon_rrd_graph(1, argv, &calcpr, &xsize, &ysize, 0,
 			      &ymin, &ymax);
+	(void)xymon_rrd_last(1, argv);
 	return 0;
 }
 EOF

--- a/tests/rrd/rrdcached-relative-path-key.sh
+++ b/tests/rrd/rrdcached-relative-path-key.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/rrd/rrdcached-relative-path-key.sh
+#
+# showgraph's nostale filter asks rrd_last() how fresh an RRD is, and passes
+# the filename as "./<name>" -- the "./" keeps a "-"-prefixed name out of
+# option parsing while staying a plain operand for a legacy rrd_last() that
+# opens argv[1] directly (web/showgraph.c). Every rrd_* call honours
+# RRDCACHED_ADDRESS, and rrdcached keys its pending-update cache by the
+# filename string it is handed. So the "./" prefix is only safe if the daemon
+# resolves "./name" and the bare "name" to the *same* cache entry: otherwise a
+# reading still sitting in the daemon would not be flushed for the probe, and
+# an RRD kept fresh only in the cache could read as stale.
+#
+# This drives rrdcached directly (no Xymon binary): queue an update under the
+# bare name so it sits in the cache unwritten, then read the last-update time
+# back through the daemon as "./name". If "./name" keyed a different entry the
+# flush would be a no-op and the read would return the stale on-disk time; it
+# returns the freshly cached one, so the two forms are the same key.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+command -v rrdtool   >/dev/null 2>&1 || skip "rrdtool not in PATH"
+command -v rrdcached >/dev/null 2>&1 || skip "rrdcached not in PATH (optional rrdtool daemon)"
+
+work=$(mktempdir)
+# rrdcached refuses a base directory reached through a symlink (e.g. macOS
+# /tmp -> /private/tmp, /var -> /private/var), so hand it the resolved path.
+base=$(cd "$work" && pwd -P)
+sock="$base/rc.sock"
+pidf="$base/rc.pid"
+
+rrdcached -l "unix:$sock" -b "$base" -B -w 3600 -f 7200 -p "$pidf" -m 0700 \
+	2>"$base/rc.err" || { cat "$base/rc.err" >&2; skip "rrdcached would not start here"; }
+register_cleanup "[ -f '$pidf' ] && kill \"\$(cat '$pidf')\" 2>/dev/null || true"
+
+# Wait for the socket rather than sleeping a fixed time.
+for _ in 1 2 3 4 5 6 7 8 9 10; do [ -S "$sock" ] && break; sleep 0.2; done
+[ -S "$sock" ] || { cat "$base/rc.err" >&2; skip "rrdcached socket never appeared"; }
+
+daemon="unix:$sock"
+now=$(date +%s)
+start=$((now - 600))
+
+cd "$base"
+rrdtool create test.rrd --start "$start" --step 300 \
+	DS:x:GAUGE:600:U:U RRA:LAST:0.5:1:10
+
+pre=$(rrdtool last test.rrd)   # on-disk last-update, before any update
+
+# Queue an update under the BARE name. With -w 3600 it stays in the daemon's
+# cache, unwritten to disk.
+rrdtool update --daemon "$daemon" test.rrd "$now:42"
+
+# The file on disk must still show the old time -- proves the update is
+# cache-only, so a later "last" that returns the new time can only have got
+# it by flushing the cached entry.
+ondisk=$(rrdtool last test.rrd)
+assert_equal "$pre" "$ondisk" \
+	"queued update was written to disk immediately -- test cannot distinguish the cache"
+
+# THE ASSERTION: read last-update through the daemon as "./test.rrd", before
+# any bare-name read has had a chance to flush. It must reflect the queued
+# update (newer than on disk), which is only possible if "./test.rrd" keys the
+# same cache entry the bare name was queued under.
+dot=$(rrdtool last --daemon "$daemon" ./test.rrd)
+[ "$dot" != "$pre" ] || fail \
+	"rrdcached did not flush the queued update for './test.rrd' (last=$dot, on-disk=$pre) -- './name' keys a different cache entry than the bare name"
+
+# And the bare name agrees (now reading the just-flushed value from disk).
+bare=$(rrdtool last --daemon "$daemon" test.rrd)
+assert_equal "$dot" "$bare" \
+	"'./test.rrd' and 'test.rrd' disagree through the daemon"
+
+pass "rrdcached keys './name' and 'name' to the same cache entry"

--- a/tests/server/xymond-rrd-mtime-freshness.sh
+++ b/tests/server/xymond-rrd-mtime-freshness.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-rrd-mtime-freshness.sh
+#
+# showgraph drops an RRD from a graph when "nostale" is set and the file's
+# timestamp is more than a day old (web/showgraph.c), and every graph link
+# Xymon generates carries that flag. The timestamp is therefore part of the
+# writer's contract: it must move whenever xymond_rrd writes a reading, or the
+# graph goes empty a day later with nothing logged anywhere.
+#
+# do_rrd.c stamps the file explicitly because RRDtool writes through mmap,
+# where the kernel does not move the timestamp by itself. That stamp used to
+# be compiled for Linux only, although nothing about mmap is Linux-specific.
+#
+# This pins the contract rather than the workaround, in both directions: a
+# written RRD must come out newer than a marker taken before the write, and an
+# RRD whose reading RRDtool rejected must not. What each case actually catches
+# was measured rather than assumed:
+#
+#   - the accepted-reading case does NOT discriminate on Linux with librrd
+#     1.7.2, where the timestamp moves on its own; it is there for macOS, where
+#     after two hours of updates "rrdtool last" reported 02:00 while the file's
+#     mtime was still 00:02, and for RRDtool versions that behave that way.
+#   - the rejected-reading case discriminates everywhere, including Linux:
+#     nothing but the explicit stamp can move the timestamp when RRDtool has
+#     declined to write.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMOND_RRD "xymond/xymond_rrd"
+
+work=$(mktempdir)
+mkdir -p "$work/rrd" "$work/tmp"
+ts=$(date +%s)
+
+status_msg() {  # status_msg <msg-timestamp>
+	printf '@@status|%s|127.0.0.1|origin|testhost|disk|%s|green||green|%s|0||0||%s|0|linux|/\n' \
+		"$1" $(($1+1800)) "$1" "$1"
+	printf 'disk report\n'
+	printf '/dev/sda1 1000000 400000 600000 40%% /\n'
+	printf '@@\n'
+}
+
+run_worker() {  # run_worker <msg-timestamp>
+	status_msg "$1" | env XYMONHOME="$work" XYMONTMP="$work/tmp" \
+		"$XYMOND_RRD" --rrddir="$work/rrd" --no-cache 2>/dev/null
+}
+
+# --no-cache so the reading is written on the spot: with the cache on nothing
+# reaches the file until a flush, and the test would be timing the flush.
+run_worker "$ts"
+rrd=$(find "$work/rrd" -name '*.rrd' | head -1)
+[ -n "$rrd" ] || fail "xymond_rrd created no RRD from a disk status message"
+
+# Marker taken AFTER creation, so only the second write can make the file
+# newer. Sleep past the coarsest timestamp granularity in play (1s on HFS+).
+touch "$work/marker"
+sleep 1.1
+run_worker $((ts + 300))
+
+[ -n "$(find "$rrd" -newer "$work/marker")" ] \
+	|| fail "the RRD's timestamp did not move when xymond_rrd wrote a new reading -- showgraph's 'nostale' filter drops it from every graph once it is a day old"
+
+# ---- and only then --------------------------------------------------------
+# The other half of the contract. RRDtool refuses a reading that is not newer
+# than the last one and leaves the file untouched; stamping regardless would
+# make an RRD that has stopped being written look fresh to the same 'nostale'
+# check, which is worse than the staleness the stamp is there to prevent.
+# Found by SoundGoof reviewing PR #349, reproduced on FreeBSD and here; the
+# success gate itself is the substance of PR #82.
+touch "$work/marker2"
+sleep 1.1
+run_worker "$ts"   # older than the reading already stored: rejected
+
+[ -z "$(find "$rrd" -newer "$work/marker2")" ] \
+	|| fail "the RRD's timestamp moved for a reading RRDtool rejected -- an RRD that has stopped being written would keep passing showgraph's 'nostale' filter"
+
+pass "a written RRD comes out newer than a marker taken before the write, and a rejected one does not"

--- a/tests/web/showgraph-exec-title.sh
+++ b/tests/web/showgraph-exec-title.sh
@@ -23,6 +23,10 @@ require_gnu_make
 [ -f "$ROOT/web/showgraph.cgi" ] || skip "tree built without RRD support (no showgraph.cgi)"
 
 rrddef=$(sed -n 's/^RRDDEF *= *//p' "$ROOT/Makefile")
+# Where <rrd.h> lives, as configure found it: /usr/include on Linux, but
+# /usr/local/include or /opt/homebrew/include on the BSDs and macOS. Without
+# it, showgraph.c's #include <rrd.h> is not found off the default path.
+rrdinc=$(sed -n 's/^RRDINCDIR *= *//p' "$ROOT/Makefile")
 rrdlibs=$(sed -n 's/^RRDLIBS *= *//p' "$ROOT/Makefile")
 [ -n "$rrdlibs" ] || rrdlibs="-lrrd"
 
@@ -40,7 +44,7 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 
 harness_cflags=$(xymon_cflags "$ROOT")
 harness_ldflags=$(xymon_ldflags "$ROOT")
-"$CC" $harness_cflags $rrddef -o "$work/showgraph" \
+"$CC" $harness_cflags $rrddef $rrdinc -o "$work/showgraph" \
 	"$ROOT/web/showgraph.c" "$ROOT/lib/libxymoncomm.a" \
 	$pcre_libs $rrdlibs $harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "showgraph does not compile"; }

--- a/tests/web/showgraph-stale-filter-harness.c
+++ b/tests/web/showgraph-stale-filter-harness.c
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Creates one RRD whose last reading is at a chosen time, for
+ * tests/web/showgraph-stale-filter.sh. xymond_rrd cannot: only creation
+ * ("-b") can be backdated. The shape matches do_disk.c's, whose "pct" DS
+ * the graph definition under test reads by name.
+ *
+ * usage: harness <file> <epoch-of-last-reading>
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include "rrd_api_compat.h"	/* rrd.h argv is char** or const char** by version */
+
+/* argc for a NULL-terminated argv initializer, so nobody counts by hand */
+#define NARGS(a) ((int)(sizeof(a) / sizeof((a)[0])) - 1)
+
+int main(int argc, char **argv)
+{
+	char start[32], value[64];
+	long last;
+	xymon_rrd_argv_item_t cargv[] = { "rrdcreate", NULL, "-b", start, "-s", "300",
+		"DS:pct:GAUGE:600:0:100", "DS:used:GAUGE:600:0:U",
+		"RRA:AVERAGE:0.5:1:576", "RRA:AVERAGE:0.5:6:576",
+		"RRA:AVERAGE:0.5:24:576", "RRA:AVERAGE:0.5:288:576", NULL };
+	xymon_rrd_argv_item_t uargv[] = { "rrdupdate", NULL, value, NULL };
+
+	if (argc != 3) { fprintf(stderr, "usage: %s <file> <epoch>\n", argv[0]); return 2; }
+	last = atol(argv[2]);
+	cargv[1] = uargv[1] = argv[1];
+	snprintf(start, sizeof(start), "%ld", last - 300);
+	snprintf(value, sizeof(value), "%ld:40:400000", last);
+
+	if (xymon_rrd_create(NARGS(cargv), cargv) != 0) { fprintf(stderr, "create: %s\n", rrd_get_error()); return 1; }
+
+	if (xymon_rrd_update(NARGS(uargv), uargv) != 0) { fprintf(stderr, "update: %s\n", rrd_get_error()); return 1; }
+
+	return 0;
+}

--- a/tests/web/showgraph-stale-filter.sh
+++ b/tests/web/showgraph-stale-filter.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/showgraph-stale-filter.sh
+#
+# Every generated graph link carries "nostale", which drops an RRD not updated
+# for a day. That was read off the file's mtime, which is not the same fact:
+# RRDtool writes through mmap, and only a Linux-only utimes() in do_rrd.c kept
+# the mtime moving. On a macOS server every mtime froze at creation time while
+# readings kept arriving, and a day later every FNPATTERN multi-graph (disk,
+# tcp) rendered empty.
+#
+# The two cases are that divergence, deterministic on any platform: an RRD
+# written now whose file looks ancient must be graphed, one last written three
+# days ago whose file is new must not. Both fail on the old code.
+#
+# Drives the real CGI with --debug, like showgraph-single-service.sh, and reads
+# the RRD names out of the rrd_graph argument dump.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+require_c_buildenv "$ROOT"
+
+[ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+[ -f "$ROOT/web/showgraph.cgi" ] || skip "tree built without RRD support (no showgraph.cgi)"
+require_bin XYMOND_RRD xymond/xymond_rrd
+
+rrddef=$(sed -n 's/^RRDDEF *= *//p' "$ROOT/Makefile")
+# Where <rrd.h> lives, as configure found it: /usr/include on Linux, but
+# /usr/local/include or /opt/homebrew/include on the BSDs and macOS, and the
+# product Makefiles pass it for every RRD-using object.
+rrdinc=$(sed -n 's/^RRDINCDIR *= *//p' "$ROOT/Makefile")
+rrdlibs=$(sed -n 's/^RRDLIBS *= *//p' "$ROOT/Makefile")
+[ -n "$rrdlibs" ] || rrdlibs="-lrrd"
+
+# PCRELIBS: explicit env override first, else the configured tree's own
+# setting (which carries any -L for a nonstandard install). The tree is
+# required to be built by now, so the Makefile always carries one.
+pcre_libs=${PCRELIBS:-}
+[ -n "$pcre_libs" ] || pcre_libs=$(sed -n 's/^PCRELIBS *= *//p' "$ROOT/Makefile")
+
+work=$(mktempdir)
+
+build_xymon_libs "$ROOT" "$work/libbuild.log" libxymoncomm.a
+
+harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
+"$CC" $harness_cflags $rrddef $rrdinc -o "$work/showgraph" \
+	"$ROOT/web/showgraph.c" "$ROOT/lib/libxymoncomm.a" \
+	$pcre_libs $rrdlibs $harness_ldflags 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "showgraph does not compile"; }
+
+"$CC" $harness_cflags $rrddef $rrdinc -o "$work/mkrrd" \
+	"$(dirname "$0")/showgraph-stale-filter-harness.c" $rrdlibs $harness_ldflags 2>"$work/cc2.log" \
+	|| { cat "$work/cc2.log" >&2; fail "the RRD-building harness does not compile"; }
+
+mkdir -p "$work/rrd" "$work/tmp"
+now=$(date +%s)
+rrds="$work/rrd/testhost"
+
+# The fresh RRD comes from production: a disk status message through
+# xymond_rrd. The stale one cannot -- only creation ("-b") can be backdated,
+# which is what the harness beside this file does.
+{
+	printf '@@status|%s|127.0.0.1|origin|testhost|disk|%s|green||green|%s|0||0||%s|0|linux|/\n' \
+		"$now" "$((now+1800))" "$now" "$now"
+	printf 'disk report\n'
+	printf '/dev/sda1 1000000 400000 600000 40%% /fresh\n'
+	printf '@@\n'
+} | env XYMONHOME="$work" XYMONTMP="$work/tmp" \
+	"$XYMOND_RRD" --rrddir="$work/rrd" --no-cache 2>/dev/null
+
+fresh="$rrds/disk,fresh.rrd"
+old="$rrds/disk,old.rrd"
+# The || true keeps set -e from killing the group at ls (no directory at
+# all) before fail can say what happened.
+[ -f "$fresh" ] || { ls -l "$rrds" >&2 || true; fail "xymond_rrd created no RRD from a disk status message"; }
+"$work/mkrrd" "$old" "$((now - 3*86400))" || fail "cannot build the stale RRD"
+
+# The divergence, set up so that neither case can be answered from the mtime:
+#
+#   fresh.rrd  written now,          file backdated to 2020  -> must be graphed
+#   old.rrd    written 3 days ago,   file created just now   -> must not be
+#
+# The second needs no help: an RRD built from an old reading is a new file.
+touch -t 202001010000 "$fresh"
+
+# The whole answer is kept, and only the DEF lines are handed back: the image
+# follows the argument dump on the same stream, and its NULs have no business
+# in a shell variable. What was kept is asserted on separately below.
+render() {	# render <extra query args>
+	REQUEST_METHOD=GET \
+	QUERY_STRING="host=testhost&service=disk&graph=hourly&action=view$1" \
+	XYMONHOME="$work" TEST2RRD="disk=disk" \
+		"$work/showgraph" --debug --config="$ROOT/xymond/etcfiles/graphs.cfg.DIST" \
+		--rrddir="$rrds" >"$work/answer" 2>/dev/null || true
+	# -a and LC_ALL=C: the answer carries the PNG's bytes, and a grep that
+	# goes binary-mode returns nothing instead of the DEF lines.
+	LC_ALL=C grep -a 'DEF:' "$work/answer" || true
+}
+
+# Without the flag both are drawn: whatever the test observes below is the
+# staleness filter, and not the file selection that precedes it.
+out=$(render "")
+assert_contains "disk,fresh.rrd" "$out" "an unfiltered graph must carry the freshly written RRD"
+assert_contains "disk,old.rrd"   "$out" "an unfiltered graph must carry the stale RRD too"
+
+out=$(render "&nostale")
+assert_contains "disk,fresh.rrd" "$out" \
+	"an RRD written this second was dropped because its file looks old -- this is the macOS blank-graph failure, where mmap leaves the mtime behind"
+assert_not_contains "disk,old.rrd" "$out" \
+	"an RRD last written three days ago was graphed because its file is new -- a decommissioned host keeps its line on every multi-display"
+
+# The graph is drawn after the dump the assertions above read, so require the
+# image: it is the only sign rrd_graph() ran. -a/LC_ALL=C because the answer
+# carries PNG bytes; no producer pipeline (grep's early exit SIGPIPEs it under
+# pipefail, seen on FreeBSD).
+LC_ALL=C grep -aq 'IHDR' "$work/answer" \
+	|| { sed -n '1,12p' "$work/answer" >&2
+	     fail "the request selected its RRD and then produced no image -- rrd_graph() failed after the staleness probe"; }
+
+pass "the nostale filter reads when the RRD was last written, not when its file was touched"

--- a/tests/web/showgraph-stale-filter.sh
+++ b/tests/web/showgraph-stale-filter.sh
@@ -98,7 +98,7 @@ render() {	# render <extra query args>
 	QUERY_STRING="host=testhost&service=disk&graph=hourly&action=view$1" \
 	XYMONHOME="$work" TEST2RRD="disk=disk" \
 		"$work/showgraph" --debug --config="$ROOT/xymond/etcfiles/graphs.cfg.DIST" \
-		--rrddir="$rrds" >"$work/answer" 2>/dev/null || true
+		--rrddir="$rrds" >"$work/answer" 2>"$work/errors" || true
 	# -a and LC_ALL=C: the answer carries the PNG's bytes, and a grep that
 	# goes binary-mode returns nothing instead of the DEF lines.
 	LC_ALL=C grep -a 'DEF:' "$work/answer" || true
@@ -123,5 +123,18 @@ assert_not_contains "disk,old.rrd" "$out" \
 LC_ALL=C grep -aq 'IHDR' "$work/answer" \
 	|| { sed -n '1,12p' "$work/answer" >&2
 	     fail "the request selected its RRD and then produced no image -- rrd_graph() failed after the staleness probe"; }
+
+# When every matching file is dropped as stale, the empty answer must say so
+# (#377) -- not silence, and not the FNPATTERN blame that misdirects to
+# graphs.cfg.
+mv "$fresh" "$work/fresh.aside"
+out=$(render "&nostale")
+assert_not_contains "disk," "$out" "with every matching RRD stale, nothing may be graphed"
+errs=$(cat "$work/errors")
+assert_contains "no RRD for service 'disk' - 1 matching file(s) dropped by the nostale filter" "$errs" \
+	"an all-stale result must name the service, the count and the staleness drops in the log"
+assert_not_contains "FNPATTERN" "$errs" \
+	"an all-stale result must not blame the FNPATTERN capture -- that red herring is issue #377"
+mv "$work/fresh.aside" "$fresh"
 
 pass "the nostale filter reads when the RRD was last written, not when its file was touched"

--- a/web/perfdata.c
+++ b/web/perfdata.c
@@ -112,7 +112,6 @@ int oneset(char *hostname, char *rrdname, char *starttime, char *endtime, char *
 	rrdargs[6] = "-e"; rrdargs[7] = endtimedate; rrdargs[8] = endtimehm;
 	rrdargs[9] = NULL;
 
-	optind = opterr = 0; rrd_clear_error();
 	result = xymon_rrd_fetch(9, rrdargs, &start, &end, &step, &dscount, &dsnames, &data);
 
 	if (result != 0) {

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -1061,14 +1061,20 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 			 * Ask the RRD, not the filesystem: mmap writes do not move
 			 * the mtime everywhere (tests/web/showgraph-stale-filter.sh).
 			 * The argv form: the wrappers own the "char **" versus
-			 * "const char **" divergence. "--" keeps a "-"-prefixed
-			 * filename out of option parsing.
+			 * "const char **" divergence. The "./" prefix keeps a
+			 * "-"-prefixed filename out of option parsing while staying
+			 * a plain operand for a legacy rrd_last() that opens argv[1]
+			 * directly rather than parsing options (RRDtool < 1.4). We
+			 * are chdir'd into the RRD directory, so "./name" resolves
+			 * identically to the bare name.
 			 */
 			if (ignorestalerrds) {
-				xymon_rrd_argv_item_t lastargv[] = { "last", "--", d->d_name, NULL };
+				char dotpath[PATH_MAX];
+				xymon_rrd_argv_item_t lastargv[] = { "last", dotpath, NULL };
 				time_t lastupd;
 
-				lastupd = xymon_rrd_last(3, lastargv);
+				snprintf(dotpath, sizeof(dotpath), "./%s", d->d_name);
+				lastupd = xymon_rrd_last(2, lastargv);
 
 				if (lastupd == (time_t)-1) {
 					/* Unreadable: rrd_graph would fail the whole image

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -986,7 +986,6 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 		int err, result;
 		PCRE2_SIZE errofs;
 		pcre2_match_data *ovector;
-		struct stat st;
 		time_t now = getcurrenttime(NULL);
 
 		/* Scan the directory to see what RRD files are there that match */
@@ -1057,12 +1056,28 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 				if (strstr(d->d_name, service) == NULL) { svcrejects++; continue; }
 			}
 
-			/* 
-			 * Has it been updated recently (within the past 24 hours) ? 
-			 * We don't want old graphs to mess up multi-displays.
+			/*
+			 * Drop RRDs not updated for a day from multi-displays.
+			 * Ask the RRD, not the filesystem: mmap writes do not move
+			 * the mtime everywhere (tests/web/showgraph-stale-filter.sh).
+			 * The argv form: the wrappers own the "char **" versus
+			 * "const char **" divergence. "--" keeps a "-"-prefixed
+			 * filename out of option parsing.
 			 */
-			if (ignorestalerrds && (stat(d->d_name, &st) == 0) && ((now - st.st_mtime) > 86400)) {
-				continue;
+			if (ignorestalerrds) {
+				xymon_rrd_argv_item_t lastargv[] = { "last", "--", d->d_name, NULL };
+				time_t lastupd;
+
+				lastupd = xymon_rrd_last(3, lastargv);
+
+				if (lastupd == (time_t)-1) {
+					/* Unreadable: rrd_graph would fail the whole image
+					 * on it. Drop it and say so; without nostale the
+					 * error still reaches the page. */
+					errprintf("nostale filter drops %s: rrd_last: %s\n", d->d_name, rrd_get_error());
+					continue;
+				}
+				if ((now - lastupd) > 86400) continue;
 			}
 
 			/* We have a matching file! */
@@ -1269,8 +1284,6 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	}
 
 	/* All set - generate the graph */
-	rrd_clear_error();
-
 	result = xymon_rrd_graph(rrdargcount, rrdargs, &calcpr, &xsize, &ysize, NULL, &ymin, &ymax);
 
 	/*

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -821,7 +821,7 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	gdef_t *gdef = NULL, *gdefuser = NULL;
 	int wantsingle = 0;
 	int rrdparamisservice = 0;
-	int svcrejects = 0;
+	int svcrejects = 0, staledrops = 0;
 	DIR *dir;
 	time_t now = getcurrenttime(NULL);
 
@@ -1075,9 +1075,10 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 					 * on it. Drop it and say so; without nostale the
 					 * error still reaches the page. */
 					errprintf("nostale filter drops %s: rrd_last: %s\n", d->d_name, rrd_get_error());
+					staledrops++;
 					continue;
 				}
-				if ((now - lastupd) > 86400) continue;
+				if ((now - lastupd) > 86400) { staledrops++; continue; }
 			}
 
 			/* We have a matching file! */
@@ -1127,11 +1128,17 @@ void generate_graph(char *gdeffn, char *rrddir, char *graphfn)
 	}
 	rrddbs[rrddbcount].key = rrddbs[rrddbcount].rrdfn = rrddbs[rrddbcount].rrdparam = NULL;
 
-	if ((rrddbcount == 0) && svcrejects) {
-		if (rrdparamisservice)
-			errprintf("showgraph: no RRD file matched service '%s' - check that FNPATTERN group 1 captures the service component\n", service);
-		else
-			errprintf("showgraph: no RRD file matched service '%s'\n", service);
+	if (rrddbcount == 0) {
+		/* Name the real reason (#377): a stale drop is neither silence
+		 * nor an FNPATTERN problem. */
+		if (staledrops)
+			errprintf("showgraph: no RRD for service '%s' - %d matching file(s) dropped by the nostale filter\n", service, staledrops);
+		else if (svcrejects) {
+			if (rrdparamisservice)
+				errprintf("showgraph: no RRD file matched service '%s' - check that FNPATTERN group 1 captures the service component\n", service);
+			else
+				errprintf("showgraph: no RRD file matched service '%s'\n", service);
+		}
 	}
 
 	/* Sort them so the display looks prettier. */

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -11,7 +11,6 @@
 static char rcsid[] = "$Id$";
 
 #include <sys/types.h>
-#include <sys/time.h>
 #include <sys/stat.h>
 #include <stdio.h>
 #include <string.h>
@@ -20,7 +19,6 @@ static char rcsid[] = "$Id$";
 #include <limits.h>
 #include <ctype.h>
 #include <errno.h>
-#include <utime.h>
 
 #include <rrd.h>
 #define PCRE2_CODE_UNIT_WIDTH 8
@@ -258,17 +256,7 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 	}
 
 	for (pcount = 0; (updparams[pcount]); pcount++);
-	optind = opterr = 0; rrd_clear_error();
 	result = xymon_rrd_update(pcount, updparams);
-
-#if defined(LINUX)
-	/*
-	 * RRDtool 1.2+ uses mmap'ed I/O, but the Linux kernel does not update timestamps when
-	 * doing file I/O on mmap'ed files. This breaks our check for stale/nostale RRD's.
-	 * So do an explicit timestamp update on the file here.
-	 */
-	utimes(filedir, NULL);
-#endif
 
 	/* Clear the cached data */
 	for (i=0; (i < cacheitem->valcount); i++) {
@@ -412,11 +400,6 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 			}
 		}
 
-		/*
-		 * Ugly! RRDtool uses getopt() for parameter parsing, so
-		 * we MUST reset this before every call.
-		 */
-		optind = opterr = 0; rrd_clear_error();
 		result = xymon_rrd_create(4+pcount, rrdcreate_params);
 		xfree(rrdcreate_params);
 		if (rrakey) xfree(rrakey);
@@ -726,7 +709,6 @@ static int rrddatasets(char *hostname, char ***dsnames)
 	if (build_rrd_filedir(filedir, sizeof(filedir), hostname, rrdfn)) return 0;
 	if (stat(filedir, &st) == -1) return 0;
 
-	optind = opterr = 0; rrd_clear_error();
 	result = xymon_rrd_fetch(5, fetch_params, &starttime, &endtime, &steptime, &dscount, dsnames, &rrddata);
 	if (result == -1) {
 		errprintf("Error while retrieving RRD dataset names from %s: %s\n",

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -243,14 +243,25 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 	optind = opterr = 0; rrd_clear_error();
 	result = xymon_rrd_update(pcount, updparams);
 
-#if defined(LINUX)
 	/*
-	 * RRDtool 1.2+ uses mmap'ed I/O, but the Linux kernel does not update timestamps when
-	 * doing file I/O on mmap'ed files. This breaks our check for stale/nostale RRD's.
-	 * So do an explicit timestamp update on the file here.
+	 * showgraph decides from the file's timestamp whether an RRD is still
+	 * live ("nostale" drops anything older than a day), so the timestamp has
+	 * to move whenever we write. RRDtool writes through mmap and the kernel
+	 * does not move it by itself, so stamp the file explicitly.
+	 *
+	 * Only when the update succeeded. RRDtool rejects a duplicate or
+	 * out-of-order reading without touching the file, and stamping anyway
+	 * would keep an RRD that is no longer being written looking fresh to the
+	 * very check this stamp exists to feed.
+	 *
+	 * This was compiled for Linux only, although nothing about mmap is
+	 * Linux-specific. Measured on macOS (Homebrew RRDtool): after two hours
+	 * of updates "rrdtool last" reported 02:00 while the file's mtime was
+	 * still 00:02, so every graph on that server went empty a day after the
+	 * last restart, with nothing logged anywhere. One utimes() is nothing
+	 * next to the update it follows.
 	 */
-	utimes(filedir, NULL);
-#endif
+	if (result == 0) utimes(filedir, NULL);
 
 	/* Clear the cached data */
 	for (i=0; (i < cacheitem->valcount); i++) {


### PR DESCRIPTION
`nostale` — on every generated graph link — drops an RRD not updated for a day. That answer was
read off the file's mtime, which only tracked updates because `do_rrd.c` pushed it with a
Linux-only `utimes()`. On a Homebrew macOS server every mtime froze at creation time, and a day
later every `FNPATTERN` multi-graph (disk, tcp) rendered empty while the data kept arriving.
`showgraph` now asks the RRD itself (`rrd_last`, through the existing argv wrappers), and
`do_rrd.c` loses its stamp.

Deliberate semantics:
- Staleness means the last **successful** sample: an RRD whose every update fails leaves nostale
  views after a day. `xymond_rrd` logs each failed update.
- A file `rrd_last` cannot read is dropped with a log line naming it; one bad file no longer
  fails the whole multi-graph image.
- Data timestamps lagging wall clock by more than a day count as stale even while updates succeed.
- Every nostale request pays one `rrd_last` per pattern-matched file. Measured below; no mtime
  fast path is sound (the stale test case is a fresh file with 3-day-old data).

| measured, 200 disk RRDs | |
|---|---|
| `rrd_last()` warm / cold | 7.5 µs / 116 µs per file |
| filter on a cold 20-RRD render | 2.4 ms of 39.9 ms — 6% |
| removed from the write path | one `utimes()` per RRD per update |

Constraints:
- **This PR imposes no RRDtool version floor, and the build probes for none.** The staleness
  read does not depend on one: `rrd_last` is called with `./<name>` as its sole operand, which
  the legacy direct-`argv[1]` path (1.2.x) and the option-parsing path (>= 1.4) both accept. The
  wrappers reset `optind`/`opterr` before every call for the entry points that *do* parse
  options — create, update, fetch, graph — which is what a pre-1.7 RRDtool needs to re-scan and
  a no-op under 1.7's private optparse. Tested here against librrd 1.7.2.
- `rrd_last` honours `RRDCACHED_ADDRESS`: an rrdcached site needs the daemon reachable from the
  CGI. Unreachable drops every file, each with its log line. Deliberately not unset — `rrd_graph`
  wants the daemon too.
- Release note: the removed `utimes()` also kept mtimes fresh for out-of-tree consumers (rsync
  quick-check, mtime-keyed purge crons) on pre-3.5 Linux kernels — and permanently on macOS,
  where mmap writes never stamp the mtime.

Fixes #377 (second commit): an empty result now names the nostale drops — `no RRD for service
'x' - N matching file(s) dropped by the nostale filter` — instead of silence, or the FNPATTERN
blame that misdirected the original report to graphs.cfg.

`tests/web/showgraph-stale-filter.sh` drives the real CGI on RRDs whose file times contradict
their data:

| case | must | old code |
|---|---|---|
| written now, mtime backdated | be graphed | dropped — the macOS blank graph |
| last written 3 days ago, file just created | not be graphed | graphed |
| every match stale | named in the log, exact message | silence, or FNPATTERN blame |

Follow-up: lift the duplicated disk `@@status` fixture into tests/lib (shared with
xymond-rrd-drophost.sh).


