### PR TITLE
web: order install-cgi after install-bin, and stop on a failed link (#350)

### DIFF
--- a/tests/buildsystem/install-cgi-link-failure.sh
+++ b/tests/buildsystem/install-cgi-link-failure.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/buildsystem/install-cgi-link-failure.sh
+#
+# web/Makefile's install-cgi hard-links cgiwrap to every CGI name. make only
+# sees the status of a loop's last iteration, so a link that failed earlier
+# left the package short of a CGI while the build reported success -- and the
+# missing name 404s on a live server, with nothing in the build log.
+#
+# Observed on a Homebrew macOS keg: history.sh and eventlog.sh, the first two
+# names in CGISCRIPTS, were absent while the install reported success.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+[ -f "$ROOT/web/Makefile" ] || skip "web/Makefile absent"
+require_gnu_make
+
+# "-o install-bin": install-cgi depends on install-bin, which chowns and copies
+# the built CGIs. This test is about install-cgi's own recipe and supplies its
+# own cgiwrap, so the prerequisite is declared up to date rather than run - it
+# would otherwise need a built tree and a real XYMONUSER.
+run_install_cgi() {  # run_install_cgi <workdir> -- prints nothing, returns make's status
+	local w=$1
+	"$XYMON_MAKE" -C "$ROOT/web" -o install-bin install-cgi \
+		INSTALLROOT= INSTALLBINDIR="$w/bin" \
+		CGIDIR="$w/cgi" SECURECGIDIR="$w/seccgi" >"$w/make.log" 2>&1
+}
+
+# ---- a link that cannot be made must stop the install ----------------------
+# The first CGI name is obstructed by an unwritable directory, so its ln fails
+# while every later one succeeds -- the shape that used to pass unnoticed.
+work=$(mktempdir)
+mkdir -p "$work/bin" "$work/cgi" "$work/seccgi"
+: >"$work/bin/cgiwrap"
+first=$(sed -n 's/^CGISCRIPTS *= *//p' "$ROOT/web/Makefile" | awk '{print $1}')
+[ -n "$first" ] || fail "could not read the first CGISCRIPTS entry from web/Makefile"
+mkdir "$work/cgi/$first"
+chmod 500 "$work/cgi/$first"
+
+rc=0; run_install_cgi "$work" || rc=$?
+chmod 700 "$work/cgi/$first"
+[ "$rc" -ne 0 ] \
+	|| fail "install-cgi reported success although the link for '$first' could not be made: $(cat "$work/make.log")"
+
+# ---- and an unobstructed run still links every name ------------------------
+# Without this the check above could be satisfied by a rule that always fails.
+work2=$(mktempdir)
+mkdir -p "$work2/bin" "$work2/cgi" "$work2/seccgi"
+: >"$work2/bin/cgiwrap"
+
+run_install_cgi "$work2" \
+	|| fail "install-cgi failed on a clean destination: $(cat "$work2/make.log")"
+
+for v in CGISCRIPTS SECCGISCRIPTS; do
+	case $v in CGISCRIPTS) d=$work2/cgi ;; *) d=$work2/seccgi ;; esac
+	for n in $(sed -n "s/^$v *= *//p" "$ROOT/web/Makefile"); do
+		[ -f "$d/$n" ] || fail "install-cgi did not link $n into $(basename "$d")"
+	done
+done
+
+pass "install-cgi stops when a CGI link cannot be made, and links every name otherwise"

--- a/tests/buildsystem/install-cgi-link-failure.sh
+++ b/tests/buildsystem/install-cgi-link-failure.sh
@@ -38,11 +38,13 @@ mkdir -p "$work/bin" "$work/cgi" "$work/seccgi"
 : >"$work/bin/cgiwrap"
 first=$(sed -n 's/^CGISCRIPTS *= *//p' "$ROOT/web/Makefile" | awk '{print $1}')
 [ -n "$first" ] || fail "could not read the first CGISCRIPTS entry from web/Makefile"
-mkdir "$work/cgi/$first"
-chmod 500 "$work/cgi/$first"
+# The obstruction has to hold for root: the BSD lanes run as one, and a
+# permission bit means nothing there. "ln SRC DIR" resolves to DIR/cgiwrap, so
+# making that an existing directory forces the link to fail whatever the
+# privileges - ln would have to unlink a directory, which only rmdir can do.
+mkdir -p "$work/cgi/$first/cgiwrap"
 
 rc=0; run_install_cgi "$work" || rc=$?
-chmod 700 "$work/cgi/$first"
 [ "$rc" -ne 0 ] \
 	|| fail "install-cgi reported success although the link for '$first' could not be made: $(cat "$work/make.log")"
 

--- a/tests/buildsystem/parallel-make.sh
+++ b/tests/buildsystem/parallel-make.sh
@@ -73,3 +73,26 @@ done
 assert_contains "common-client: lib-client common-build" \
                 "$rules" \
                 "common-client must depend on common-build in the non-CLIENTONLY arm (#91/#92)"
+
+# --- install-cgi vs install-bin ----------------------------------------------
+
+WEB="$ROOT/web/Makefile"
+[ -f "$WEB" ] || skip "web/Makefile absent"
+web=$(cat "$WEB")
+
+# install-cgi hardlinks $(INSTALLBINDIR)/cgiwrap into the CGI dirs, and
+# install-bin is what puts cgiwrap there. Listing both as prerequisites of
+# "install" does not order them, so -jN can start install-cgi first and its
+# very first ln fails on a missing source. Observed on a Homebrew build (which
+# exports -j by default): history.sh, the first entry of CGISCRIPTS, absent
+# from an otherwise complete install, giving a 404 on the history CGI.
+assert_contains "install-cgi: install-bin" "$web" \
+                "install-cgi must depend on install-bin so cgiwrap exists before it is linked"
+
+# The link loops must also stop on a failed ln. A shell "for" reports only its
+# last iteration's status, so without this a failure on any earlier name leaves
+# make exiting 0 with a CGI missing -- which is why the race went unnoticed.
+assert_not_contains 'cgiwrap $(INSTALLROOT)$(CGIDIR)/$$F; done' "$web" \
+                    "the CGI link loop must not swallow a failed ln (needs '|| exit 1')"
+assert_not_contains 'cgiwrap $(INSTALLROOT)$(SECURECGIDIR)/$$F; done' "$web" \
+                    "the secure CGI link loop must not swallow a failed ln (needs '|| exit 1')"

--- a/web/Makefile
+++ b/web/Makefile
@@ -164,6 +164,15 @@ clean:
 
 install: install-bin install-cgi install-man
 
+# install-cgi hardlinks $(INSTALLBINDIR)/cgiwrap, which install-bin is what
+# puts there. Listing both as prerequisites of "install" does not order them,
+# so a parallel make can start install-cgi first and the very first ln fails
+# on a missing source -- silently, because a shell "for" reports only its last
+# iteration's status. Observed with make -j: history.sh, the first entry of
+# CGISCRIPTS, absent from an otherwise complete install, giving a 404 on the
+# history CGI.
+install-cgi: install-bin
+
 install-bin:
 ifndef PKGBUILD
 	chown $(XYMONUSER) $(PROGRAMS)
@@ -175,13 +184,8 @@ endif
 install-cgi:
 	mkdir -p $(INSTALLROOT)$(CGIDIR)
 	mkdir -p $(INSTALLROOT)$(SECURECGIDIR)
-ifndef PKGBUILD
-	for F in $(CGISCRIPTS); do ln -f $(INSTALLROOT)$(INSTALLBINDIR)/cgiwrap $(INSTALLROOT)$(CGIDIR)/$$F; done
-	for F in $(SECCGISCRIPTS); do ln -f $(INSTALLROOT)$(INSTALLBINDIR)/cgiwrap $(INSTALLROOT)$(SECURECGIDIR)/$$F; done
-else
-	for F in $(CGISCRIPTS); do ln -f $(INSTALLROOT)$(INSTALLBINDIR)/cgiwrap $(INSTALLROOT)$(CGIDIR)/$$F; done
-	for F in $(SECCGISCRIPTS); do ln -f $(INSTALLROOT)$(INSTALLBINDIR)/cgiwrap $(INSTALLROOT)$(SECURECGIDIR)/$$F; done
-endif
+	for F in $(CGISCRIPTS); do ln -f $(INSTALLROOT)$(INSTALLBINDIR)/cgiwrap $(INSTALLROOT)$(CGIDIR)/$$F || exit 1; done
+	for F in $(SECCGISCRIPTS); do ln -f $(INSTALLROOT)$(INSTALLBINDIR)/cgiwrap $(INSTALLROOT)$(SECURECGIDIR)/$$F || exit 1; done
 
 install-man:
 ifndef PKGBUILD


### PR DESCRIPTION
`install-cgi` hardlinks `$(INSTALLBINDIR)/cgiwrap`; `install-bin` is what puts cgiwrap there. Listing both under `install:` does not order them, so `make -jN` runs them concurrently.

Measured on a Homebrew build of `main`, which exports `-j` by default:

```
ln: .../server/bin/cgiwrap: No such file or directory
```

Once, on the first iteration — by the second, cgiwrap had landed. The install ended with **25 of 26** wrappers and a 404 on the history CGI. Silent, because a shell `for` returns only its last iteration's status, so `make install` exits 0. Any `make -jN install` from source can hit it, non-deterministically.

| | fix |
|---|---|
| the race | `install-cgi: install-bin` |
| the swallowed status | `\|\| exit 1` on the link loops |
| identical `ifndef PKGBUILD` / `else` branches | removed |

Two tests, because they catch different halves:

| mutation | behavioural | static |
|---|---|---|
| remove `\|\| exit 1` | fails | fails |
| remove the dependency | passes | **fails** |

The behavioural one obstructs the first CGI name and requires a non-zero exit, then checks an unobstructed run still links every name — without which a rule that always failed would pass. The static one guards the ordering, which no test reproduces deterministically.

Consolidates #358. Closes #350
