### PR TITLE
xymond_alert: FOR=N, an alerts.cfg criterion for the colour's own age (#229 step 3)

### DIFF
--- a/docs/manpages/man5/alerts.cfg.5.html
+++ b/docs/manpages/man5/alerts.cfg.5.html
@@ -139,7 +139,34 @@ group Production databases
       given duration. E.g. DURATION&gt;1h (lasted longer than 1 hour) or
       DURATION&lt;30 (only sends alerts the first 30 minutes). The duration is
       specified as a number, optionally followed by 'm' (minutes, default), 'h'
-      (hours), 'd' (days) or 'w' (weeks).</dd>
+      (hours), 'd' (days) or 'w' (weeks). Note that this is the age of the alert
+      <i>event</i>, not of the current colour: the event begins when the status
+      first goes into an alerting colour and deliberately survives a later
+      yellow&#x2192;red change. A status that has been yellow for two hours
+      therefore matches DURATION&gt;10 the instant it turns red. Use <b>FOR</b>
+      when you mean the colour's own age.</dd>
+  <dt id="FOR"><a class="permalink" href="#FOR"><b>FOR=</b><i>time</i></a></dt>
+  <dd>Rule matching an alert only once the rule's colour has held continuously
+      for at least the given time - the counterpart of DURATION for damping
+      short-lived transitions. E.g. COLOR=red FOR=10 alerts on a red that has
+      lasted ten minutes, whether it arrived from green or from yellow. The time
+      is specified as for DURATION.
+    <p class="Pp">The effective colour - the rule's and the recipient's together
+        - must be a single one: with several, a later generalisation of FOR to
+        whole-condition hold time would not be compatible, so such a rule is
+        reported and the FOR ignored. A FOR on the rule line with COLOR= on the
+        recipient is therefore accepted: the recipient names the colour.</p>
+    <p class="Pp">Where both the rule and a recipient set FOR, the longer
+        applies, as for the other filters: a recipient narrows what the rule
+        lets through, it never widens it. There is no FOR&lt; - damping needs
+        only a lower bound, and DURATION&lt; already covers early-window
+        routing.</p>
+    <p class="Pp">A period where the test stopped reporting counts towards the
+        hold time only if the status comes back the same colour, and only up to
+        four times the report validity that applied when the silence began (two
+        hours by default). A test absent for a month therefore does not return
+        claiming a month-long hold time.</p>
+  </dd>
   <dt id="RECOVERED"><a class="permalink" href="#RECOVERED"><b>RECOVERED</b></a></dt>
   <dd>Send recovery and disabled-state messages to matching recipients. This can
       be set on a rule or on an individual recipient.</dd>

--- a/lib/loadalerts.c
+++ b/lib/loadalerts.c
@@ -51,6 +51,7 @@ static rule_t *ruletail = NULL;
 static int cfid = 0;
 static char cfline[256];
 static int printmode = 0;
+static int ignoreholdtime = 0;
 static rule_t *printrule = NULL;
 
 static enum { P_NONE, P_RULE, P_RECIP } pstate = P_NONE;
@@ -146,9 +147,66 @@ static char *preprocess(char *buf)
 	return STRBUF(result);
 }
 
+/*
+ * FOR=N only has one meaning when the rule names exactly one color: red for 3
+ * then yellow for 8 satisfies neither for 10, yet the rule matched throughout.
+ *
+ * Bit 30 marks "an explicit COLOR= was given" and is not a color itself; with
+ * no COLOR= the effective set is the default one, never a single color.
+ */
+static void check_holdtime_colors(criteria_t *crit, int cfid, int rulecolors)
+{
+	int colors, explicitcolors, n, i;
+
+	if (!crit || !crit->minholdtime) return;
+
+	/*
+	 * Count what the runtime matches on: rule and recipient are matched in
+	 * turn, so the effective set is their intersection, with the default set
+	 * standing in for a side that names no COLOR=. print_alert_recipients()
+	 * builds it the same way.
+	 */
+	explicitcolors = ((crit->colors | rulecolors) & (1 << 30));
+	colors = ((crit->colors  ? crit->colors  : defaultcolors) &
+		  (rulecolors    ? rulecolors    : defaultcolors)) & ~(1 << 30);
+	for (i = n = 0; (i < COL_COUNT); i++) if (colors & (1 << i)) n++;
+	if (n == 1) return;
+
+	if (!explicitcolors)
+		errprintf("Ignoring FOR at line %d: it needs an explicit single COLOR=\n", cfid);
+	else if (colors == 0)
+		errprintf("Ignoring FOR at line %d: its COLOR= has nothing in common with the rule's\n", cfid);
+	else
+		errprintf("Ignoring FOR at line %d: it needs a single COLOR=, not %d\n", cfid, n);
+	crit->minholdtime = 0;
+}
+
 static void flush_rule(rule_t *currule)
 {
+	recip_t *rwalk;
+	int rulecolors;
+
 	if (currule == NULL) return;
+
+	rulecolors = (currule->criteria ? currule->criteria->colors : 0);
+
+	/*
+	 * The rule's own FOR is judged against each recipient, not against the
+	 * rule line alone: a recipient's COLOR= narrows the effective set, so
+	 * "FOR=10" on the rule with "MAIL x COLOR=red" under it names exactly one
+	 * colour at match time. Judged in isolation it named none, and the FOR was
+	 * dropped - the alert then went out immediately, which is the opposite of
+	 * what was asked for.
+	 */
+	for (rwalk = currule->recipients; (rwalk); rwalk = rwalk->next)
+		check_holdtime_colors(currule->criteria, currule->cfid,
+				      (rwalk->criteria && rwalk->criteria->colors) ?
+					rwalk->criteria->colors : defaultcolors);
+
+	if (currule->recipients == NULL) check_holdtime_colors(currule->criteria, currule->cfid, 0);
+
+	for (rwalk = currule->recipients; (rwalk); rwalk = rwalk->next)
+		check_holdtime_colors(rwalk->criteria, rwalk->cfid, rulecolors);
 
 	currule->next = NULL;
 
@@ -517,6 +575,31 @@ int load_alertconfig(char *configfn, int defcolors, int defaultinterval)
 				else errprintf("Ignoring invalid DURATION at line %d: %s\n",cfid, p);
 				firsttoken = 0;
 			}
+			else if (strncasecmp(p, "FOR=", 4) == 0) {
+				criteria_t *crit;
+
+				if (firsttoken) { flush_rule(currule); currule = NULL; currcp = NULL; pstate = P_NONE; }
+				crit = setup_criteria(&currule, &currcp);
+				/*
+				 * durationseconds(), not 60*durationvalue(): the
+				 * multiplication is not the only place a duration overflows.
+				 * durationvalue() accumulates minutes in an int, so
+				 * "FOR=426089w" wrapped to 9824 minutes and would have loaded
+				 * clean as a hold time of under seven days - a config that
+				 * silently means something other than what it says. Bounding
+				 * the minutes closes both.
+				 */
+				{
+					int secs;
+
+					if (durationseconds(p+4, &secs)) crit->minholdtime = secs;
+					else {
+						errprintf("Ignoring invalid FOR at line %d: %s\n", cfid, p);
+						crit->minholdtime = 0;
+					}
+				}
+				firsttoken = 0;
+			}
 			else if (strncasecmp(p, "RECOVERED", 9) == 0) {
 				criteria_t *crit;
 
@@ -751,6 +834,7 @@ static void dump_criteria(criteria_t *crit, int isrecip)
 
 	if (crit->timespec) printf("TIME=%s ", crit->timespec);
 	if (crit->extimespec) printf("EXTIME=%s ", crit->extimespec);
+	if (crit->minholdtime) printf("FOR=%d ", (crit->minholdtime / 60));
 	if (crit->minduration) printf("DURATION>%d ", (crit->minduration / 60));
 	if (crit->maxduration) printf("DURATION<%d ", (crit->maxduration / 60));
 	if (isrecip) {
@@ -816,7 +900,8 @@ static int criteriamatch(activealerts_t *alert, criteria_t *crit, criteria_t *ru
 	static char *pgnames = NULL;
 	const char *dgname = NULL;
 	int pgmatchres, pgexclres;
-	time_t duration = (getcurrenttime(NULL) - alert->eventstart);
+	time_t now = getcurrenttime(NULL);
+	time_t duration = (now - alert->eventstart);
 	int result, cfid = 0;
 	char *pgtok, *cfline = NULL;
 	void *hinfo = hostinfo(alert->hostname);
@@ -842,7 +927,7 @@ static int criteriamatch(activealerts_t *alert, criteria_t *crit, criteria_t *ru
 	if (alert->state == A_PAGING) {
 		/* Check max-duration now - it's fast and easy. */
 		if (crit && crit->maxduration && (duration > crit->maxduration)) { 
-			traceprintf("Failed '%s' (max. duration %d>%d)\n", cfline, duration, crit->maxduration);
+			traceprintf("Failed '%s' (max. duration %d>%d)\n", cfline, (int)duration, crit->maxduration);
 			if (!printmode) return 0; 
 		}
 	}
@@ -1000,7 +1085,7 @@ static int criteriamatch(activealerts_t *alert, criteria_t *crit, criteria_t *ru
 
 				if ((*nexttime == -1) || (*nexttime > mynext)) *nexttime = mynext;
 			}
-			traceprintf("Failed '%s' (min. duration %d<%d)\n", cfline, duration, crit->minduration);
+			traceprintf("Failed '%s' (min. duration %d<%d)\n", cfline, (int)duration, crit->minduration);
 			if (!printmode) return 0; 
 		}
 	}
@@ -1033,6 +1118,39 @@ static int criteriamatch(activealerts_t *alert, criteria_t *crit, criteria_t *ru
 	if (!result) {
 		traceprintf("Failed '%s' (color)\n", cfline);
 		return result;
+	}
+
+	/*
+	 * FOR=N: the color's own age, where duration is the event's. Below the
+	 * color check so the color is the one the rule names, and in the recipient
+	 * pass only: failing in the rule pass takes the whole rule out, and with
+	 * nothing matching anywhere xymond_alert goes A_NORECIP and discards the
+	 * repeat state - losing the recovery for an alert already sent.
+	 */
+	if ((alert->state == A_PAGING) && rulecrit && !ignoreholdtime) {
+		/*
+		 * The larger of the two, not the recipient's instead of the rule's.
+		 * Every other criterion is checked in both passes, so a rule and a
+		 * recipient that both set one must both be satisfied; FOR is checked
+		 * in the recipient pass alone, and taking the recipient's value there
+		 * made it the one criterion a recipient could loosen.
+		 */
+		int minhold = (crit && (crit->minholdtime > rulecrit->minholdtime)) ?
+				crit->minholdtime : rulecrit->minholdtime;
+
+		if (minhold) {
+			time_t holdtime = (now - alert->colorstart);
+
+			if (holdtime < minhold) {
+				if (nexttime) {
+					time_t mynext = alert->colorstart + minhold;
+
+					if ((*nexttime == -1) || (*nexttime > mynext)) *nexttime = mynext;
+				}
+				traceprintf("Failed '%s' (min. hold time %d<%d)\n", cfline, (int)holdtime, minhold);
+				if (!printmode) return 0;
+			}
+		}
 	}
 
 	if ((alert->state == A_RECOVERED) || (alert->state == A_DISABLED)) {
@@ -1135,6 +1253,15 @@ void alert_printmode(int on)
 	printmode = on;
 }
 
+/*
+ * FOR= holds an alert back from being sent; it must not hold back a walk that
+ * only invalidates state. See clear_interval().
+ */
+void alert_ignore_holdtime(int on)
+{
+	ignoreholdtime = on;
+}
+
 void print_alert_recipients(activealerts_t *alert, strbuffer_t *buf)
 {
 	char *normalfont = "COLOR=\"#FFFFCC\" FACE=\"Tahoma, Arial, Helvetica\"";
@@ -1159,7 +1286,7 @@ void print_alert_recipients(activealerts_t *alert, strbuffer_t *buf)
 	fontspec = normalfont;
 	stoprulefound = 0;
 	while ((recip = next_recipient(alert, &first, NULL, NULL)) != NULL) {
-		int mindur = 0, maxdur = INT_MAX;
+		int mindur = 0, maxdur = INT_MAX, minhold = 0;
 		char *timespec = NULL; char *extimespec = NULL;
 		int colors = defaultcolors;
 		int i, firstcolor = 1;
@@ -1187,6 +1314,14 @@ void print_alert_recipients(activealerts_t *alert, strbuffer_t *buf)
 		if (recip->criteria && recip->criteria->minduration && (recip->criteria->minduration > mindur)) mindur = recip->criteria->minduration;
 		if (printrule->criteria && printrule->criteria->maxduration) maxdur = printrule->criteria->maxduration;
 		if (recip->criteria && recip->criteria->maxduration && (recip->criteria->maxduration < maxdur)) maxdur = recip->criteria->maxduration;
+		/*
+		 * FOR= holds an alert back exactly as DURATION> does, so the delay
+		 * column must show it or the report says "no delay" about a rule
+		 * that has one -- and it must show the value criteriamatch() applies,
+		 * which is the larger of the two, as minduration just above.
+		 */
+		if (printrule->criteria && printrule->criteria->minholdtime) minhold = printrule->criteria->minholdtime;
+		if (recip->criteria && recip->criteria->minholdtime && (recip->criteria->minholdtime > minhold)) minhold = recip->criteria->minholdtime;
 		if (printrule->criteria && printrule->criteria->timespec) timespec = printrule->criteria->timespec;
 		if (printrule->criteria && printrule->criteria->extimespec) extimespec = printrule->criteria->extimespec;
 		if (recip->criteria && recip->criteria->timespec) {
@@ -1232,7 +1367,8 @@ void print_alert_recipients(activealerts_t *alert, strbuffer_t *buf)
 			snprintf(l, sizeof(l), "<td><font %s>%s (%s)</font></td>", fontspec, recip->recipient, codes);
 		addtobuffer(buf, l);
 
-		snprintf(l, sizeof(l), "<td align=center>%s</td>", durationstring(mindur));
+		snprintf(l, sizeof(l), "<td align=center>%s</td>",
+			 durationstring((minhold > mindur) ? minhold : mindur));
 		addtobuffer(buf, l);
 
 		/* maxdur=INT_MAX means "no max duration". So set it to 0 for durationstring() to do the right thing */

--- a/lib/loadalerts.h
+++ b/lib/loadalerts.h
@@ -36,6 +36,9 @@ typedef struct activealerts_t {
 	unsigned char *pagemessage;
 	unsigned char *ackmessage;
 	time_t eventstart;
+	time_t colorstart;	/* When the current color was entered, from the
+				   page channel's lastchange. eventstart survives
+				   yellow->red; this does not. */
 	time_t nextalerttime;
 	astate_t state;
 	int cookie;
@@ -78,6 +81,9 @@ typedef struct criteria_t {
 	char *timespec;
 	char *extimespec;
 	int minduration, maxduration;	/* In seconds */
+	int minholdtime;		/* FOR=N, in seconds. Hold time of the rule's
+					   color, where minduration is the age of the
+					   alert event. Single-color rules only. */
 	enum recovermsg_t sendrecovered, sendnotice;
 } criteria_t;
 
@@ -103,6 +109,7 @@ extern recip_t *next_recipient(activealerts_t *alert, int *first, int *anymatch,
 extern int have_recipient(activealerts_t *alert, int *anymatch);
 
 extern void alert_printmode(int on);
+extern void alert_ignore_holdtime(int on);
 extern void print_alert_recipients(activealerts_t *alert, strbuffer_t *buf);
 #endif
 

--- a/lib/timefunc.c
+++ b/lib/timefunc.c
@@ -17,6 +17,8 @@ static char rcsid[] = "$Id$";
 #include <sys/time.h>
 #include <string.h>
 #include <ctype.h>
+#include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -408,14 +410,21 @@ char *histlogtime(time_t histtime)
 }
 
 
-int durationvalue(char *dur)
+static long long durationminutes(char *dur)
 {
-	/* 
+	/*
 	 * Calculate a duration, taking special modifiers into consideration.
-	 * Return the duration as number of minutes.
+	 * Return the exact duration as number of minutes, or DUR_UNPARSED when a
+	 * single component does not fit an int - the width the callers below work
+	 * in, and where the original int arithmetic here was undefined anyway.
+	 *
+	 * The sum itself cannot overflow a long long: a component is at most
+	 * INT_MAX weeks, or 2.2e13 minutes, and a config line bounds how many of
+	 * them there can be.
 	 */
+#define DUR_UNPARSED LLONG_MIN
 
-	int result = 0;
+	long long result = 0;
 	char *startofval;
 	char *endpos;
 	char savedelim;
@@ -430,13 +439,16 @@ int durationvalue(char *dur)
 	while (startofval && (isdigit((int)*startofval))) {
 		char *p;
 		char modifier;
-		int oneval = 0;
+		long long oneval;
 
 		p = startofval + strspn(startofval, "0123456789");
 		modifier = *p;
 		*p = '\0';
-		oneval = atoi(startofval);
+		errno = 0;
+		oneval = strtoll(startofval, NULL, 10);
 		*p = modifier;
+
+		if ((errno == ERANGE) || (oneval > INT_MAX)) { result = DUR_UNPARSED; break; }
 
 		switch (modifier) {
 		  case '\0': break;			/* No delimiter = minutes */
@@ -454,6 +466,44 @@ int durationvalue(char *dur)
 	*endpos = savedelim;
 
 	return result;
+}
+
+
+int durationvalue(char *dur)
+{
+	/*
+	 * Minutes, narrowed to an int, with no way to tell a value that did not
+	 * fit from one that did. Kept deliberately: eight of the seventeen call
+	 * sites compute 60*durationvalue() in an int, where a saturated INT_MAX
+	 * comes back as -60. New code calls durationseconds(); converting the
+	 * rest is a separate sweep.
+	 */
+	long long result = durationminutes(dur);
+
+	return ((result == DUR_UNPARSED) ? 0 : (int)result);
+}
+
+
+int durationseconds(char *dur, int *secs)
+{
+	/*
+	 * Seconds, refusing what will not fit: 1 and stores, or 0 when absent,
+	 * unparseable or too large. A duration overflows twice - the minutes
+	 * accumulate, then the caller multiplies by 60 - so the bound is on the
+	 * minutes. An unknown unit is a typo, not a delimiter ("10x" would read as
+	 * ten minutes); durationvalue() keeps its lax parsing and installed base.
+	 */
+	long long result;
+
+	if (!dur || (*dur == '\0')) return 0;
+	if (dur[strspn(dur, "0123456789mhdw")] != '\0') return 0;
+
+	result = durationminutes(dur);
+
+	if ((result <= 0) || (result > (INT_MAX / 60))) return 0;
+
+	*secs = (int)(result * 60);
+	return 1;
 }
 
 char *durationstring(time_t secs)

--- a/lib/timefunc.h
+++ b/lib/timefunc.h
@@ -24,6 +24,7 @@ extern int within_sla(char *holidaykey, char *timespec, int defresult);
 extern int periodcoversnow(char *tag);
 extern char *histlogtime(time_t histtime);
 extern int durationvalue(char *dur);
+extern int durationseconds(char *dur, int *secs);
 extern char *durationstring(time_t secs);
 extern char *agestring(time_t secs);
 extern time_t timestr2timet(char *s);

--- a/tests/server/alert-escalation-repeat-harness.c
+++ b/tests/server/alert-escalation-repeat-harness.c
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * tests/server/alert-escalation-repeat-harness.c
+ *
+ * Driver for clear_interval() at a severity increase, used by
+ * alert-escalation-repeat.sh.
+ *
+ * A repeat interval is keyed by hostname|testname|method|recipient
+ * (do_alert.c), not by the rule that produced it, so the same MAIL address
+ * under a yellow rule and under a red one shares ONE record. When the colour
+ * escalates, xymond_alert calls clear_interval() so the interval left by the
+ * old colour does not hold back the new one.
+ *
+ * clear_interval() finds its recipients through next_recipient(), which is
+ * also what decides whether an alert may be sent -- and FOR= makes that answer
+ * "not yet". Without alert_ignore_holdtime() the walk therefore returns
+ * nobody at the very moment the state has to be invalidated, the record
+ * survives, and the red alert is dropped until the yellow's interval comes
+ * due: the transition FOR= exists to damp is the one it delays.
+ *
+ * do_alert.c is #included rather than linked: find_repeatinfo() and the repeat
+ * list are static, and this test is about what happens to a record inside it.
+ *
+ * usage: harness <hosts.cfg> <alerts.cfg> <repeat-due-in-sec>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "libxymon.h"
+
+#include "do_alert.c"
+
+int main(int argc, char *argv[])
+{
+	activealerts_t alert;
+	time_t now = getcurrenttime(NULL);
+	recip_t *recip;
+	repeat_t *rpt;
+	int first = 1, duein;
+
+	if (argc < 4) {
+		fprintf(stderr, "usage: %s <hosts.cfg> <alerts.cfg> <repeat-due-in-sec>\n", argv[0]);
+		return 2;
+	}
+
+	load_hostnames(argv[1], NULL, get_fqdn());
+	if (load_alertconfig(argv[2], (1 << COL_RED) | (1 << COL_YELLOW) | (1 << COL_PURPLE), 0) == 0) {
+		fprintf(stderr, "cannot load %s\n", argv[2]);
+		return 2;
+	}
+	duein = atoi(argv[3]);
+
+	memset(&alert, 0, sizeof(alert));
+	alert.hostname   = strdup("testhost");
+	alert.testname   = strdup("conn");
+	alert.location   = strdup("");
+	alert.osname     = strdup("");
+	alert.classname  = strdup("");
+	alert.groups     = strdup("");
+	strcpy(alert.ip, "127.0.0.1");
+	alert.state      = A_PAGING;
+
+	/* The yellow alert: it went out a while ago and set a repeat interval. */
+	alert.color = alert.maxcolor = COL_YELLOW;
+	alert.eventstart = alert.colorstart = now - 3600;
+	stoprulefound = 0;
+	recip = next_recipient(&alert, &first, NULL, NULL);
+	if (!recip) {
+		fprintf(stderr, "no recipient for the yellow rule -- the fixture is wrong\n");
+		return 2;
+	}
+	rpt = find_repeatinfo(&alert, recip, 1);
+	if (!rpt) {
+		fprintf(stderr, "no repeat record created\n");
+		return 2;
+	}
+	rpt->nextalert = now + duein;
+
+	/*
+	 * Now red begins. colorstart moves to this instant, as xymond_alert sets
+	 * it from the message's lastchange, so a FOR= on the red rule is not
+	 * satisfied yet. This is the escalation path: severity increased, so the
+	 * repeat interval must be cleared.
+	 */
+	alert.color = alert.maxcolor = COL_RED;
+	alert.colorstart = now;
+	clear_interval(&alert);
+
+	printf("nextalert=%s\n", ((rpt->nextalert == 0) ? "cleared" : "kept"));
+	return 0;
+}

--- a/tests/server/alert-escalation-repeat.sh
+++ b/tests/server/alert-escalation-repeat.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/alert-escalation-repeat.sh
+#
+# A severity increase must clear the repeat interval left by the colour it came
+# from, even when the new colour carries FOR= and is not due to be sent yet.
+#
+# The two are separate questions that used to share one walk. FOR= holds an
+# alert back from being SENT; clear_interval() asks who the alert could reach,
+# so that a repeat record from the previous colour is forgotten. Both went
+# through next_recipient(), so a red rule with FOR= returned nobody at the
+# instant of escalation, the yellow's record survived, and the red was then
+# dropped until that record came due -- delaying the very transition FOR=
+# exists to damp.
+#
+# Repeat records are keyed hostname|testname|method|recipient (do_alert.c), not
+# by rule, so one MAIL address named under both rules shares one record. That
+# is what makes the two rules interact at all.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+here=$(dirname "$0")
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+require_gnu_make
+
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+
+work=$(mktempdir)
+harness="$work/harness"
+
+"$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+pcre_libs=${PCRELIBS:-}
+if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+fi
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+# -iquote xymond: the harness #includes do_alert.c for its static repeat list.
+harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
+# shellcheck disable=SC2086  # deliberate word-splitting, as the neighbouring tests do
+"$CC" $harness_cflags -iquote "$ROOT/xymond" -o "$harness" "$here/alert-escalation-repeat-harness.c" \
+	"$ROOT/lib/libxymoncomm.a" $harness_ldflags $pcre_libs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+cat >"$work/hosts.cfg" <<'EOF'
+127.0.0.1  testhost  # conn
+EOF
+
+# The shape that fails: one address, two rules, FOR= on the escalated one.
+cat >"$work/alerts.cfg" <<'EOF'
+HOST=testhost SERVICE=conn COLOR=yellow
+	MAIL admin@example.com REPEAT=60
+HOST=testhost SERVICE=conn COLOR=red FOR=10
+	MAIL admin@example.com REPEAT=60
+EOF
+
+got=$("$harness" "$work/hosts.cfg" "$work/alerts.cfg" 3600 2>"$work/run.err") \
+	|| { cat "$work/run.err" >&2; fail "harness did not run"; }
+assert_equal "nextalert=cleared" "$got" \
+	"escalating to a colour whose FOR= is not up yet must still clear the previous colour's repeat interval"
+
+# Without FOR= the walk never had anything to skip: this is the control, and it
+# fails if the harness stopped exercising clear_interval() at all.
+cat >"$work/alerts-nofor.cfg" <<'EOF'
+HOST=testhost SERVICE=conn COLOR=yellow
+	MAIL admin@example.com REPEAT=60
+HOST=testhost SERVICE=conn COLOR=red
+	MAIL admin@example.com REPEAT=60
+EOF
+
+got=$("$harness" "$work/hosts.cfg" "$work/alerts-nofor.cfg" 3600 2>"$work/run.err") \
+	|| { cat "$work/run.err" >&2; fail "harness did not run for the control case"; }
+assert_equal "nextalert=cleared" "$got" \
+	"the same escalation without FOR= must clear it too -- otherwise this test proves nothing"
+
+pass "a severity increase clears the previous colour's repeat interval, FOR= or not"

--- a/tests/server/alert-for-holdtime-harness.c
+++ b/tests/server/alert-for-holdtime-harness.c
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * tests/server/alert-for-holdtime-harness.c
+ *
+ * Driver for the FOR=N alerts.cfg criterion (issue #229, step 3), used by
+ * alert-for-holdtime.sh.
+ *
+ * FOR=N matches when the rule's colour has held for N minutes. It is the
+ * counterpart of DURATION>N, which measures the age of the alert *event* and
+ * deliberately survives yellow->red -- so a red arriving after two hours of
+ * yellow satisfies DURATION>10 immediately, and FOR=10 must not.
+ *
+ * The harness builds one activealerts_t with the two timestamps set
+ * independently, loads the alerts.cfg passed on argv, and prints MATCH or
+ * NOMATCH from have_recipient(). Setting eventstart and colorstart apart is
+ * the whole point: a build that reads eventstart where it should read
+ * colorstart prints MATCH for the yellow->red case, and the shell names it.
+ *
+ * With "report" as a sixth argument it prints what the config report shows
+ * for the same alert instead (svcstatus.cgi, confreport.cgi), which is where
+ * a hold time computed one way and displayed another becomes visible.
+ *
+ * usage: harness <hosts.cfg> <alerts.cfg> <color> <colorage-sec> <eventage-sec> [report]
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "libxymon.h"
+
+int main(int argc, char *argv[])
+{
+	activealerts_t alert;
+	time_t now = getcurrenttime(NULL);
+	int colorage, eventage;
+	int anymatch = 0, matched;
+
+	if (argc < 6) {
+		fprintf(stderr, "usage: %s <hosts.cfg> <alerts.cfg> <color> <colorage-sec> <eventage-sec>\n", argv[0]);
+		return 2;
+	}
+
+	load_hostnames(argv[1], NULL, get_fqdn());
+
+	/*
+	 * alertcolors: the set a rule matches when it names no COLOR= of its own.
+	 * red|yellow|purple is what xymond_alert defaults to, and FOR must refuse
+	 * that set rather than pick one of them.
+	 */
+	/* Returns 1 when it loaded, 0 when it could not open the file (the
+	   "unchanged, skipped" 0 needs a second call in one process). */
+	if (load_alertconfig(argv[2], (1 << COL_RED) | (1 << COL_YELLOW) | (1 << COL_PURPLE), 0) == 0) {
+		fprintf(stderr, "cannot load %s\n", argv[2]);
+		return 2;
+	}
+
+	colorage = atoi(argv[4]);
+	eventage = atoi(argv[5]);
+
+	memset(&alert, 0, sizeof(alert));
+	alert.hostname   = strdup("testhost");
+	alert.testname   = strdup("conn");
+	alert.location   = strdup("");
+	alert.osname     = strdup("");
+	alert.classname  = strdup("");
+	alert.groups     = strdup("");
+	strcpy(alert.ip, "127.0.0.1");
+	alert.color      = alert.maxcolor = parse_color(argv[3]);
+	alert.eventstart = now - eventage;
+	alert.colorstart = now - colorage;
+	alert.state      = A_PAGING;
+	alert.next       = NULL;
+
+	/*
+	 * anymatch is what tells "nobody is due yet" from "no rule covers this
+	 * alert at all". xymond_alert (xymond_alert.c:941-948) sends an alert
+	 * with no recipient AND no match to A_NORECIP and calls cleanup_alert(),
+	 * discarding the repeat state -- and with it the recovery message. A
+	 * criterion that merely defers must leave it set, so the shell asserts
+	 * on it and not only on the verdict.
+	 */
+	if ((argc > 6) && (strcmp(argv[6], "report") == 0)) {
+		/*
+		 * printmode is what the CGIs set, and it is the mode in which an
+		 * unsatisfied hold time reports the delay instead of withholding
+		 * the row (loadalerts.c:1151) -- so this prints the same recipient
+		 * a deferred alert has, with the delay it is waiting on.
+		 */
+		strbuffer_t *buf = newstrbuffer(0);
+
+		alert_printmode(1);
+		print_alert_recipients(&alert, buf);
+		fputs(STRBUF(buf), stdout);
+		return 0;
+	}
+
+	/* Sequenced deliberately: argument evaluation order is unspecified, so
+	   reading anymatch inside the same printf() can print it before the call
+	   that sets it. */
+	matched = have_recipient(&alert, &anymatch);
+	printf("%s anymatch=%d\n", (matched ? "MATCH" : "NOMATCH"), anymatch);
+	return 0;
+}

--- a/tests/server/alert-for-holdtime.sh
+++ b/tests/server/alert-for-holdtime.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/alert-for-holdtime.sh
+#
+# Behavioural guard for the FOR=N alerts.cfg criterion (issue #229, step 3).
+#
+# FOR=N matches when the rule's colour has held for N minutes, where
+# DURATION>N measures the age of the alert event and deliberately survives
+# yellow->red. The pair is what makes "delay this colour transition"
+# expressible, so the tests below check both halves of the distinction and
+# not merely that FOR counts minutes:
+#
+#   - below and above the threshold, the obvious cases;
+#   - a red that arrived after two hours of yellow: DURATION>10 matches it,
+#     FOR=10 must not. A build reading eventstart where it should read
+#     colorstart passes every other case and fails this one;
+#   - rules FOR cannot mean: several colours, or none named at all.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+here=$(dirname "$0")
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+require_gnu_make
+
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+
+work=$(mktempdir)
+harness="$work/harness"
+
+"$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+pcre_libs=${PCRELIBS:-}
+if [ -z "$pcre_libs" ] && command -v pkg-config >/dev/null 2>&1; then
+	pcre_libs=$(pkg-config --libs libpcre2-8 2>/dev/null || true)
+fi
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+# The configured flags, not a hand-picked SSLLIBS: xymon_ldflags() carries the
+# library search path and the rpath, without which the harness links on NetBSD
+# and then cannot run, pkgsrc putting libpcre2-8.so under /usr/pkg/lib. PCRE
+# itself is not in there -- it is not one of libxymoncomm's own libraries --
+# so it stays beside it, as the other alerts harnesses spell it.
+harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
+# shellcheck disable=SC2086  # deliberate word-splitting, as the neighbouring tests do
+"$CC" $harness_cflags -o "$harness" "$here/alert-for-holdtime-harness.c" \
+	"$ROOT/lib/libxymoncomm.a" $harness_ldflags $pcre_libs 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+cat >"$work/hosts.cfg" <<'EOF'
+127.0.0.1  testhost  # conn
+EOF
+
+# run <alerts.cfg-body> <color> <colorage-sec> <eventage-sec> [report]
+run() {
+	printf '%s\n' "$1" >"$work/alerts.cfg"
+	"$harness" "$work/hosts.cfg" "$work/alerts.cfg" "$2" "$3" "$4" "${5:-}" 2>"$work/run.err"
+}
+
+RULE_FOR10='HOST=testhost SERVICE=conn COLOR=red FOR=10
+	MAIL admin@example.com'
+
+# ---- the threshold itself ---------------------------------------------------
+
+got=$(run "$RULE_FOR10" red 300 300)
+assert_equal "NOMATCH anymatch=1" "$got" "red held 5 minutes must not satisfy FOR=10"
+
+got=$(run "$RULE_FOR10" red 900 900)
+assert_equal "MATCH anymatch=1" "$got" "red held 15 minutes must satisfy FOR=10"
+
+# ---- FOR is not DURATION ----------------------------------------------------
+
+# Two hours of yellow, then red 5 minutes ago. The event is old, the colour is
+# young. This is the case the criterion exists for.
+got=$(run "$RULE_FOR10" red 300 7200)
+assert_equal "NOMATCH anymatch=1" "$got" \
+	"a red 5 minutes old must not satisfy FOR=10 because its event is 2 hours old"
+
+# A blocked FOR must mean "nobody is due yet", never "no rule covers this
+# alert". xymond_alert (xymond_alert.c:941-948) reacts to the second by going
+# A_NORECIP and calling cleanup_alert(), which discards the repeat state and
+# with it the recovery message for an alert it already sent. anymatch is what
+# separates the two, so every expectation above carries it -- evaluating FOR
+# on the rule pass, where criteriamatch is called with anymatch=NULL
+# (loadalerts.c:1147,1172), prints anymatch=0 and the assertions name it.
+
+# FOR written on a recipient line, inheriting the rule's single COLOR=.
+got=$(run 'HOST=testhost SERVICE=conn COLOR=red
+	MAIL oncall@example.com FOR=10' red 300 300)
+assert_equal "NOMATCH anymatch=1" "$got" \
+	"a recipient-level FOR must defer without repeating COLOR= on its line"
+assert_not_contains "Ignoring FOR" "$(cat "$work/run.err")" \
+	"a recipient FOR must inherit the colour its rule already pins"
+
+got=$(run 'HOST=testhost SERVICE=conn COLOR=red
+	MAIL oncall@example.com FOR=10' red 900 900)
+assert_equal "MATCH anymatch=1" "$got" \
+	"the same recipient must be due once the colour has held long enough"
+
+RULE_DUR10='HOST=testhost SERVICE=conn COLOR=red DURATION>10
+	MAIL admin@example.com'
+got=$(run "$RULE_DUR10" red 300 7200)
+assert_equal "MATCH anymatch=1" "$got" \
+	"the same alert must satisfy DURATION>10 -- otherwise the case proves nothing"
+
+# ---- rules FOR cannot mean --------------------------------------------------
+
+# Several colours: "the colour has held 10 minutes" has no single referent.
+got=$(run 'HOST=testhost SERVICE=conn COLOR=red,yellow FOR=10
+	MAIL admin@example.com' red 60 60)
+assert_contains "needs a single COLOR=" "$(cat "$work/run.err")" \
+	"a multi-colour FOR rule must be reported at load time"
+assert_equal "MATCH anymatch=1" "$got" \
+	"a rejected FOR must leave the rest of the rule matching, not silently drop it"
+
+# No COLOR= at all: the effective set is the default one, never a single colour.
+got=$(run 'HOST=testhost SERVICE=conn FOR=10
+	MAIL admin@example.com' red 60 60)
+assert_contains "needs an explicit single COLOR=" "$(cat "$work/run.err")" \
+	"a FOR rule without COLOR= must be reported at load time"
+assert_equal "MATCH anymatch=1" "$got" \
+	"a rejected FOR must leave the rest of the rule matching here too"
+
+# The colour a recipient can actually alert on is what the rule and the
+# recipient BOTH name: criteriamatch() is run for each in turn. So COLOR= sets
+# that overlap in exactly one colour leave FOR with a single referent, and must
+# be accepted -- counting the recipient's own two colours rejected this and sent
+# the alert immediately.
+got=$(run 'HOST=testhost SERVICE=conn COLOR=red
+	MAIL oncall@example.com COLOR=red,yellow FOR=10' red 300 300)
+assert_not_contains "Ignoring FOR" "$(cat "$work/run.err")" \
+	"overlapping COLOR= sets naming one colour between them must not reject FOR"
+assert_equal "NOMATCH anymatch=1" "$got" \
+	"and that FOR must actually defer: red held 5 minutes does not satisfy FOR=10"
+
+got=$(run 'HOST=testhost SERVICE=conn COLOR=red
+	MAIL oncall@example.com COLOR=red,yellow FOR=10' red 900 900)
+assert_equal "MATCH anymatch=1" "$got" \
+	"red held 15 minutes satisfies it, so the deferral is the threshold and not a block"
+
+# No colour in common: the recipient can never fire, FOR or no FOR. Say that,
+# rather than "it needs an explicit single COLOR=", which it has.
+got=$(run 'HOST=testhost SERVICE=conn COLOR=red
+	MAIL oncall@example.com COLOR=yellow FOR=10' red 900 900)
+assert_contains "nothing in common with the rule" "$(cat "$work/run.err")" \
+	"a recipient whose COLOR= cannot overlap its rule must be reported at load time"
+
+# A unit we do not know is a typo, not a delimiter. The parser stops at the
+# first character outside 0123456789mhdw, so "10x" used to read as ten minutes
+# and load clean -- a hold time that is not what the line says.
+got=$(run 'HOST=testhost SERVICE=conn COLOR=red FOR=10x
+	MAIL admin@example.com' red 60 60)
+assert_contains "Ignoring invalid FOR" "$(cat "$work/run.err")" \
+	"a FOR with an unknown unit must be reported, not read as minutes"
+assert_equal "MATCH anymatch=1" "$got" \
+	"and the rest of the rule must keep matching"
+
+# ---- a duration that does not fit ------------------------------------------
+#
+# A duration overflows in two places, and the interesting one is not the
+# obvious one. durationvalue() accumulates minutes in an int, so "426089w" --
+# well within what the syntax accepts -- wrapped to 9824 minutes and would
+# have loaded clean as a hold time of under seven days: a config silently
+# meaning something other than what it says. Multiplying wide at the call site
+# cannot see that, because the wrap already happened inside.
+#
+# Both are closed by bounding the minutes, so what this case pins is the
+# reported input, not just a large one (@SoundGoof).
+
+got=$(run 'HOST=testhost SERVICE=conn COLOR=red FOR=426089w
+	MAIL admin@example.com' red 300 300)
+assert_contains "Ignoring invalid FOR" "$(cat "$work/run.err")" \
+	"a FOR that does not fit must be reported at load time, not wrapped into a short one"
+assert_equal "MATCH anymatch=1" "$got" \
+	"a rejected FOR must leave the rest of the rule matching, as the other rejections do"
+
+# The bound is on the minutes, so it lands one multiplication earlier than a
+# reader expects: INT_MAX/60 minutes is the largest hold time there is. Both
+# sides of it are pinned, or an off-by-one either way would go unnoticed.
+got=$(run 'HOST=testhost SERVICE=conn COLOR=red FOR=35791394
+	MAIL admin@example.com' red 300 300)
+assert_not_contains "Ignoring invalid FOR" "$(cat "$work/run.err")" \
+	"INT_MAX/60 minutes is representable and must be accepted"
+assert_equal "NOMATCH anymatch=1" "$got" \
+	"a hold time of INT_MAX/60 minutes must be applied, not ignored"
+
+got=$(run 'HOST=testhost SERVICE=conn COLOR=red FOR=35791395
+	MAIL admin@example.com' red 300 300)
+assert_contains "Ignoring invalid FOR" "$(cat "$work/run.err")" \
+	"one minute past INT_MAX/60 must be refused"
+
+# ---- the rule sets the threshold, the recipient names the colour ------------
+#
+# The effective colour set is the rule's and the recipient's together, so a FOR
+# on the rule line with "MAIL x COLOR=red" under it names exactly one colour at
+# match time. Judged against the rule line alone it named none, the FOR was
+# dropped, and the alert went out at once -- the opposite of what was asked.
+RULE_SPLIT='HOST=testhost SERVICE=conn FOR=10
+	MAIL admin@example.com COLOR=red'
+got=$(run "$RULE_SPLIT" red 300 300)
+assert_equal "NOMATCH anymatch=1" "$got" \
+	"a FOR on the rule line was dropped because the colour is on the recipient"
+assert_not_contains "Ignoring FOR" "$(cat "$work/run.err")" \
+	"the rule's FOR was refused although the recipient names a single colour"
+got=$(run "$RULE_SPLIT" red 900 900)
+assert_equal "MATCH anymatch=1" "$got" \
+	"the same rule must alert once the colour has held long enough"
+
+# ---- a threshold on both lines takes the stricter one -----------------------
+#
+# Every other criterion is checked in both passes, so a rule and a recipient
+# that both set one must both be satisfied. FOR is checked in the recipient
+# pass alone, where taking the recipient's value made it the one criterion a
+# recipient could loosen.
+RULE_BOTH='HOST=testhost SERVICE=conn COLOR=red FOR=60
+	MAIL admin@example.com FOR=10'
+assert_equal "NOMATCH anymatch=1" "$(run "$RULE_BOTH" red 900 900)" \
+	"a recipient loosened the rule's FOR instead of adding to it"
+assert_equal "MATCH anymatch=1" "$(run "$RULE_BOTH" red 4200 4200)" \
+	"the stricter of the two thresholds was never satisfied"
+
+# And the config report must say the same thing the engine does. It computes
+# the delay column a second time, on its own, so the two can disagree: taking
+# the recipient's 10m there told an operator "first alert after 10 minutes"
+# about an alert xymond_alert holds for an hour.
+report=$(run "$RULE_BOTH" red 300 300 report)
+assert_contains "center>1h <" "$report" \
+	"the report shows the recipient's FOR where the engine applies the rule's"
+assert_not_contains "center>10m <" "$report" \
+	"the delay column names a threshold that will not be the one applied"
+
+pass "FOR=N measures the hold time of the rule's colour, not the age of the event"

--- a/tests/server/alert-test-mode-holdtime.sh
+++ b/tests/server/alert-test-mode-holdtime.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/alert-test-mode-holdtime.sh
+#
+# "xymond_alert --test" must answer for FOR= the way the daemon would.
+#
+# The mode exists to check an alerts.cfg without waiting for a real alert, so
+# it is the one place a wrong answer is taken at face value. It builds its
+# alert record with calloc and fills in the ages by hand, and colorstart -- the
+# field FOR= measures -- was left at zero there while the three other
+# constructors set it (from the message's lastchange, or from the checkpoint,
+# or not at all for @@notify, which never reaches FOR=). Zero means 1970, so
+# every FOR= looked satisfied and --test recommended an alert the daemon would
+# have held back.
+#
+# --test models one colour held for --duration: there is no earlier colour to
+# have escalated from, so the colour is as old as the event.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+ALERT=${XYMOND_ALERT:-$ROOT/xymond/xymond_alert}
+
+[ -x "$ALERT" ] || skip "$ALERT not built or not executable"
+
+work=$(mktempdir)
+cat >"$work/hosts.cfg" <<'EOF'
+127.0.0.1  testhost  # conn
+EOF
+cat >"$work/alerts.cfg" <<'EOF'
+HOST=testhost SERVICE=conn COLOR=red FOR=10
+	MAIL admin@example.com
+EOF
+
+# --test talks to xymond first and falls back to the file; the connection
+# refusal is noise here, so only stdout is read.
+run() {
+	env XYMONHOME="$work" XYMONTMP="$work" HOSTSCFG="$work/hosts.cfg" \
+	    MACHINE=testhost MACHINEDOTS=testhost \
+	    XYMONSERVERS=127.0.0.1 XYMSRV=127.0.0.1 XYMON=/bin/true \
+	    "$ALERT" --config="$work/alerts.cfg" --test testhost conn \
+	    --color=red --duration="$1" 2>/dev/null
+}
+
+got=$(run 5)
+assert_contains "min. hold time" "$got" \
+	"--test must report a red held 5 minutes as not yet satisfying FOR=10"
+assert_not_contains "Mail alert with command" "$got" \
+	"and must not recommend an alert the daemon would hold back"
+
+got=$(run 15)
+assert_contains "Mail alert with command" "$got" \
+	"--test must recommend the alert once the colour has held long enough"
+
+pass "xymond_alert --test measures FOR= against the colour age it was given"

--- a/xymond/alerts.cfg.5
+++ b/xymond/alerts.cfg.5
@@ -96,6 +96,29 @@ Rule matching an alert by the time-of-day. This is specified as the DOWNTIME tim
 Rule excluding an alert by the time-of-day. This is specified as the DOWNTIME timespecification in the hosts.cfg file.
 .IP "\fBDURATION>\fR\fItime\fR, \fBDURATION>=\fR\fItime\fR, \fBDURATION<\fR\fItime\fR, \fBDURATION<=\fR\fItime\fR"
 Rule matching an alert if the event has lasted longer/shorter than the given duration. E.g. DURATION>1h (lasted longer than 1 hour) or DURATION<30 (only sends alerts the first 30 minutes). The duration is specified as a number, optionally followed by 'm' (minutes, default), 'h' (hours), 'd' (days) or 'w' (weeks).
+Note that this is the age of the alert \fIevent\fR, not of the current colour: the event
+begins when the status first goes into an alerting colour and deliberately survives a
+later yellow\(->red change. A status that has been yellow for two hours therefore matches
+DURATION>10 the instant it turns red. Use \fBFOR\fR when you mean the colour's own age.
+.IP "\fBFOR=\fR\fItime\fR"
+Rule matching an alert only once the rule's colour has held continuously for at least the
+given time \- the counterpart of DURATION for damping short-lived transitions. E.g.
+COLOR=red FOR=10 alerts on a red that has lasted ten minutes, whether it arrived from
+green or from yellow. The time is specified as for DURATION.
+.sp
+The effective colour \- the rule's and the recipient's together \- must be a single one:
+with several, a later generalisation of FOR to whole-condition hold time would not be
+compatible, so such a rule is reported and the FOR ignored. A FOR on the rule line with
+COLOR= on the recipient is therefore accepted: the recipient names the colour.
+.sp
+Where both the rule and a recipient set FOR, the longer applies, as for the other filters:
+a recipient narrows what the rule lets through, it never widens it. There is no FOR< \-
+damping needs only a lower bound, and DURATION< already covers early-window routing.
+.sp
+A period where the test stopped reporting counts towards the hold time only if the status
+comes back the same colour, and only up to four times the report validity that applied when
+the silence began (two hours by default). A test absent for a month therefore does not
+return claiming a month-long hold time.
 .IP "\fBRECOVERED\fR"
 Send recovery and disabled-state messages to matching recipients. This can be set on a rule or on an individual recipient.
 .IP "\fBNORECOVERED\fR"

--- a/xymond/do_alert.c
+++ b/xymond/do_alert.c
@@ -799,6 +799,12 @@ void clear_interval(activealerts_t *alert)
 
 	alert->nextalerttime = 0;
 	stoprulefound = 0;
+	/*
+	 * Past FOR=: this walk clears state, it sends nothing. A recipient whose
+	 * hold time is not up yet still carries the previous colour's interval,
+	 * and that interval is what would delay the next alert.
+	 */
+	alert_ignore_holdtime(1);
 	while (!stoprulefound && ((recip = next_recipient(alert, &first, NULL, NULL)) != NULL)) {
 		rpt = find_repeatinfo(alert, recip, 0);
 		if (rpt) {
@@ -806,6 +812,7 @@ void clear_interval(activealerts_t *alert)
 			rpt->nextalert = 0;
 		}
 	}
+	alert_ignore_holdtime(0);
 }
 
 void save_state(char *filename)

--- a/xymond/etcfiles/alerts.cfg.DIST
+++ b/xymond/etcfiles/alerts.cfg.DIST
@@ -91,7 +91,20 @@
 #                longer or shorter than the given duration. The operators
 #                are >, >=, < and <=. A duration is a number optionally
 #                followed by m (minutes, default), h (hours), d (days),
-#                or w (weeks).
+#                or w (weeks). This is the age of the alert EVENT, which
+#                survives a yellow->red change: a status yellow for two
+#                hours matches DURATION>10 the moment it turns red. For
+#                the age of the colour itself, use FOR.
+#    FOR       - Rule matching only once the rule's colour has held for
+#                at least the given time, written as for DURATION. Use it
+#                to damp short-lived transitions:
+#
+#                    HOST=db1 SERVICE=disk COLOR=red FOR=10
+#                        MAIL admin@example.com
+#
+#                alerts on a red that has lasted ten minutes, whether it
+#                arrived from green or from yellow. The rule must name
+#                exactly one COLOR.
 #    RECOVERED - send recovery and disabled-state messages to matching
 #                recipients. This can be set on a rule or recipient.
 #    NORECOVERED

--- a/xymond/xymond_alert.c
+++ b/xymond/xymond_alert.c
@@ -256,7 +256,16 @@ void save_checkpoint(char *filename)
 		if (awalk->pagemessage) pgmsg = nlencode(awalk->pagemessage);
 		fprintf(fd, "%s|", pgmsg);
 		if (awalk->ackmessage) ackmsg = nlencode(awalk->ackmessage);
-		fprintf(fd, "%s\n", ackmsg);
+		fprintf(fd, "%s|", ackmsg);
+		/*
+		 * colorstart goes last because the record is read by position, not by
+		 * name: anywhere else shifts every following field, and a file written
+		 * by the previous version would be restored with nextalerttime read as
+		 * the state. Appended, an older file simply lacks it (see below), and
+		 * an older binary ignores it. nlencode() escapes '|' as "\p", so the
+		 * message fields above cannot fake a separator and move this one.
+		 */
+		fprintf(fd, "%d\n", (int) awalk->colorstart);
 	}
 	fclose(fd);
 
@@ -330,6 +339,22 @@ int load_checkpoint(char *filename)
 			newalert->color = newalert->maxcolor = parse_color(item[4]);
 			newalert->eventstart = (time_t) atoi(item[5]);
 			newalert->nextalerttime = (time_t) atoi(item[6]);
+			/*
+			 * Written by versions that know about FOR=. Without it the color
+			 * hold time is unknown, and eventstart is the closest honest
+			 * answer: equal for an alert that never changed color, and too
+			 * early - so FOR fires sooner, never later - for one that did.
+			 * The next report from the test replaces it with the real value.
+			 */
+			newalert->colorstart = (time_t) ((i > 10) ? atoi(item[10]) : 0);
+			/*
+			 * Zero is not a hold time. It is what an older file has (no such
+			 * field), what a record created for an @@notify alert carries,
+			 * and what a truncated line yields -- and taken literally it
+			 * makes every FOR= rule match at once, defeating the damping in
+			 * exactly the window after a restart.
+			 */
+			if (newalert->colorstart <= 0) newalert->colorstart = newalert->eventstart;
 			newalert->state = A_PAGING;
 
 			if (statusbuf) {
@@ -499,6 +524,12 @@ int main(int argc, char *argv[])
 			awalk->color = awalk->maxcolor = parse_color(testcolor);
 			awalk->pagemessage = "Test of the alert configuration";
 			awalk->eventstart = getcurrenttime(NULL) - testdur*60;
+			/*
+			 * --test models one colour held for --duration, with nothing to
+			 * have escalated from. Left at the calloc'd zero, FOR= would
+			 * measure now-1970 and always look satisfied.
+			 */
+			awalk->colorstart = awalk->eventstart;
 			awalk->groups = (testgroups ? strdup(testgroups) : NULL);
 			awalk->state = A_PAGING;
 			awalk->cookie = 12345;
@@ -686,6 +717,14 @@ int main(int argc, char *argv[])
 				add_active(awalk->hostname, awalk);
 				traceprintf("New record\n");
 			}
+
+			/*
+			 * lastchange, unlike eventstart above, is taken from every
+			 * message: it is the hold time of the color now being reported,
+			 * which is what FOR= measures. eventstart deliberately survives
+			 * yellow->red; this must not.
+			 */
+			awalk->colorstart = (time_t) atoi(metadata[9]);
 
 			newcolor = parse_color(metadata[7]);
 			oldalertstatus = ((alertcolors & (1 << awalk->color)) != 0);


### PR DESCRIPTION
Step 3 of #229. `DURATION` measures the age of the alert *event*, and eventstart deliberately survives a yellow→red change — so a status yellow for two hours matches `COLOR=red DURATION>10` the instant it turns red, and "delay this colour transition" is not expressible. `delayred` is the only thing that covers it today, and it does so by rewriting the state of record, leaking the deferral into history, events and SLA.

**`FOR=N` matches once the rule's colour has held N minutes.** Same incident, seen by both:

| jaune 30 min, puis rouge… | `DURATION>10` | `FOR=10` |
|---|---|---|
| rouge depuis 2 min | alerte | silence |
| rouge depuis 12 min | alerte | alerte |

They agree while the status keeps one colour; they part only in the minutes after a colour change. In one line: **`FOR` is `DURATION` with the clock restarted on each colour change.**

No protocol change — the page channel already carries `log->lastchange`, read now into a second per-record timestamp. `colorstart` is checkpointed as a new **last** field, so a file from the previous version simply lacks it and falls back to eventstart.

**How it combines with the rule it sits under** — the same way as every other filter: a recipient narrows what the rule lets through, never widens it. Sets intersect (`COLOR`), bounds take the stricter (`DURATION`, `FOR`). A `FOR` on the rule line with `COLOR=` on the recipient is therefore accepted: the recipient names the colour.

**Two restrictions from the RFC:** no `FOR<` (damping needs a lower bound; `DURATION<` covers early-window routing), and a single effective colour — not because the meaning would be ambiguous (the colour is matched first, so there is always exactly one at match time), but to keep a later generalisation to whole-condition hold time compatible. A refused `FOR` is reported and dropped; the rest of the rule keeps working.

Evaluated in the recipient pass only. Failing in the rule pass takes the whole rule out, and with nothing matching anywhere `xymond_alert` goes A_NORECIP and discards the repeat state — losing the recovery message for an alert already sent.

| evidence | |
|---|---|
| tests | `alert-for-holdtime.sh`, `alert-test-mode-holdtime.sh`, `alert-escalation-repeat.sh`, driving the real `have_recipient()` |
| mutations that fail them | eventstart instead of colorstart · check moved to the rule pass · `int` accumulator restored · recipient loosening the rule's `FOR` · rule `FOR` judged without its recipients · the report's delay column computed the other way |
| bound | `FOR=35791394` accepted, `35791395` refused; `10s`, `10xyz`, `10h5x` refused |
| suite | 0 failed, 0 skipped |

Converting the other seventeen `durationvalue()` callers to the bounded parser is #368.

Not covered, said rather than implied: the checkpoint round-trip of colorstart, and `alert-escalation-repeat.sh` passes with `FOR` ignored — it pins the escalation, not the hold time.

Refs #229


