### PR TITLE
client_config: do not name pcre2 error codes older headers lack

### DIFF
--- a/tests/server/analysis-pattern-error-context.sh
+++ b/tests/server/analysis-pattern-error-context.sh
@@ -79,9 +79,30 @@ assert_contains "at line 2" "$quant_line" \
 assert_contains "at line 3" "$class_line" \
 	"invalid pattern on line 3 is not reported with its config line"
 
+
+# Whether this build could name the two pcre2 error codes the hint is gated on.
+# Both are absent from the pcre2 headers on some older distributions, where the
+# hint is compiled out on purpose -- asserting it there would be failing over a
+# platform limit rather than a regression. Probed with the compiler when there
+# is one; where there is not (an installed-package run), the names are assumed
+# present, which is the case on every platform that ships a current pcre2.
+hint_available=yes
+if command -v "${CC:-cc}" >/dev/null 2>&1; then
+	ROOT=$(find_root)
+	printf '#define PCRE2_CODE_UNIT_WIDTH 8\n#include <pcre2.h>\nint v = PCRE2_ERROR_MISSING_SQUARE_BRACKET + PCRE2_ERROR_MISSING_CLOSING_PARENTHESIS;\n' \
+		>"$work/pcre2probe.c"
+	# shellcheck disable=SC2046,SC2086
+	"${CC:-cc}" $(pcre_cflags "$ROOT") -fsyntax-only "$work/pcre2probe.c" 2>/dev/null || hint_available=no
+fi
+
 # (2) The hint fires for a pattern actually truncated at a space.
-assert_contains "[[:space:]]" "$trunc_line" \
-	"a pattern truncated at a space no longer suggests [[:space:]]"
+if [ "$hint_available" = yes ]; then
+	assert_contains "[[:space:]]" "$trunc_line" \
+		"a pattern truncated at a space no longer suggests [[:space:]]"
+else
+	assert_not_contains "hint" "$trunc_line" \
+		"this pcre2 cannot name the gate's error codes, so no hint may be offered at all"
+fi
 
 # (3) ...and only then. A pattern that is invalid for an unrelated reason gets
 # the location and nothing else.

--- a/xymond/client_config.c
+++ b/xymond/client_config.c
@@ -431,8 +431,22 @@ static exprlist_t *setup_expr(char *ptn, int multiline)
 			 * cut lands inside a group or a character class, pcre2 reports
 			 * exactly one of these two errors. Any other failure is the
 			 * pattern's own doing, so it gets the location only. */
+			/*
+			 * Both names are absent from the pcre2 headers on some older
+			 * distributions -- CentOS 7 and Amazon Linux 2 among them --
+			 * where naming them stops the build outright. Their numeric
+			 * codes are deliberately not hard-coded in their place: nothing
+			 * here can confirm what those headers assign 106 and 114 to, and
+			 * a hint pointing at whitespace for an unrelated failure is worse
+			 * than no hint. Where the codes cannot be named, the pattern and
+			 * its config line are still reported, without the hint.
+			 */
+#if defined(PCRE2_ERROR_MISSING_CLOSING_PARENTHESIS) && defined(PCRE2_ERROR_MISSING_SQUARE_BRACKET)
 			truncated = ((errcode == PCRE2_ERROR_MISSING_CLOSING_PARENTHESIS) ||
 				     (errcode == PCRE2_ERROR_MISSING_SQUARE_BRACKET));
+#else
+			truncated = 0;
+#endif
 
 			errprintf("Invalid pattern '%s' at line %d%s\n", ptn, curparseline,
 				  (truncated ?


### PR DESCRIPTION
`#255`'s whitespace hint is gated on two pcre2 compile-error codes. Naming them stops the build outright where the headers do not declare them:

```
client_config.c:434:29: error: 'PCRE2_ERROR_MISSING_CLOSING_PARENTHESIS' undeclared (first use in this function)
client_config.c:435:22: error: 'PCRE2_ERROR_MISSING_SQUARE_BRACKET' undeclared (first use in this function);
                              did you mean 'PCRE2_ERROR_REPMISSINGBRACE'?
```

**CentOS 7 and Amazon Linux 2 no longer build the server.** Both lanes fail at compile, not at a test. This is a regression from #255, which is mine.

The gate is now compiled only where the codes can be named. The pattern and its config line — the substance of #253 — are reported either way; only the hint is lost.

Their numeric values are deliberately **not** hard-coded in their place. Nothing available here can confirm what those older headers assign 106 and 114 to, and a hint pointing at whitespace for a failure that has nothing to do with whitespace is worse than no hint — which is precisely the regression the delimiter-counting version had, and what the error-code gate replaced.

The test asserted the hint unconditionally, so it would have begun failing on those platforms the moment they built again — over a platform limit rather than a regression. It now probes whether the codes can be named and asserts the matching behaviour. Every other assertion is untouched: the config line, the two patterns that must **not** be hinted, and the valid `[[:space:]]` pattern that must stay silent.

Verified both sides by compiling with the gate forced off and the probe forced negative: the build is clean and the test passes on the no-hint branch.

Full suite: 67 passed, 0 failed, 0 skipped.
