### PR TITLE
xymond: let xymondboard select oldcolor, and add previouscolor (#229 step 4)

### DIFF
--- a/common/xymon.1
+++ b/common/xymon.1
@@ -203,6 +203,20 @@ The name of the host
 The name of the test
 .IP "\fBcolor\fR"
 Status color (green, yellow, red, blue, clear, purple)
+.IP "\fBprevreportcolor\fR"
+The color xymond recorded at the previous report, whether or not it differed:
+a test repeating its color reports that same color here. Also accepted as
+\fBoldcolor\fR, the name it has inside xymond. It is the color xymond
+\fIrecorded\fR, which is not always the one the test sent \- a disabled or
+in-downtime test is recorded blue whatever it reports. \fBnone\fR until a
+status has been reported twice.
+.IP "\fBprevchangecolor\fR"
+The color this test held before its most recent change. Also accepted as
+\fBpreviouscolor\fR. It moves only when the
+color changes, so a test that went green, red, red reports color=red,
+prevreportcolor=red, prevchangecolor=green \- it answers "what was this before
+it went bad". \fBnone\fR until the first change, and it survives a xymond
+restart.
 .IP "\fBtestflags\fR"
 For network tests, the flags indicating details about the test (used by xymongen).
 .IP "\fBlastchange\fR"
@@ -320,6 +334,20 @@ The name of the host
 The name of the test
 .IP "\fBcolor\fR"
 Status color (green, yellow, red, blue, clear, purple)
+.IP "\fBprevreportcolor\fR"
+The color xymond recorded at the previous report, whether or not it differed:
+a test repeating its color reports that same color here. Also accepted as
+\fBoldcolor\fR, the name it has inside xymond. It is the color xymond
+\fIrecorded\fR, which is not always the one the test sent \- a disabled or
+in-downtime test is recorded blue whatever it reports. \fBnone\fR until a
+status has been reported twice.
+.IP "\fBprevchangecolor\fR"
+The color this test held before its most recent change. Also accepted as
+\fBpreviouscolor\fR. It moves only when the
+color changes, so a test that went green, red, red reports color=red,
+prevreportcolor=red, prevchangecolor=green \- it answers "what was this before
+it went bad". \fBnone\fR until the first change, and it survives a xymond
+restart.
 .IP "\fBflags\fR"
 For network tests, the flags indicating details about the test (used by xymongen).
 .IP "\fBlastchange\fR"

--- a/docs/manpages/man1/xymon.1.html
+++ b/docs/manpages/man1/xymon.1.html
@@ -248,6 +248,20 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
   <dd>The name of the test</dd>
   <dt id="color"><a class="permalink" href="#color"><b>color</b></a></dt>
   <dd>Status color (green, yellow, red, blue, clear, purple)</dd>
+  <dt id="prevreportcolor"><a class="permalink" href="#prevreportcolor"><b>prevreportcolor</b></a></dt>
+  <dd>The color xymond recorded at the previous report, whether or not it
+      differed: a test repeating its color reports that same color here. Also
+      accepted as <b>oldcolor</b>, the name it has inside xymond. It is the
+      color xymond <i>recorded</i>, which is not always the one the test sent -
+      a disabled or in-downtime test is recorded blue whatever it reports.
+      <b>none</b> until a status has been reported twice.</dd>
+  <dt id="prevchangecolor"><a class="permalink" href="#prevchangecolor"><b>prevchangecolor</b></a></dt>
+  <dd>The color this test held before its most recent change. Also accepted as
+      <b>previouscolor</b>. It moves only when the color changes, so a test that
+      went green, red, red reports color=red, prevreportcolor=red,
+      prevchangecolor=green - it answers &quot;what was this before it went
+      bad&quot;. <b>none</b> until the first change, and it survives a xymond
+      restart.</dd>
   <dt id="testflags"><a class="permalink" href="#testflags"><b>testflags</b></a></dt>
   <dd>For network tests, the flags indicating details about the test (used by
       xymongen).</dd>
@@ -370,6 +384,20 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
   <dd>The name of the test</dd>
   <dt id="color~3"><a class="permalink" href="#color~3"><b>color</b></a></dt>
   <dd>Status color (green, yellow, red, blue, clear, purple)</dd>
+  <dt id="prevreportcolor~2"><a class="permalink" href="#prevreportcolor~2"><b>prevreportcolor</b></a></dt>
+  <dd>The color xymond recorded at the previous report, whether or not it
+      differed: a test repeating its color reports that same color here. Also
+      accepted as <b>oldcolor</b>, the name it has inside xymond. It is the
+      color xymond <i>recorded</i>, which is not always the one the test sent -
+      a disabled or in-downtime test is recorded blue whatever it reports.
+      <b>none</b> until a status has been reported twice.</dd>
+  <dt id="prevchangecolor~2"><a class="permalink" href="#prevchangecolor~2"><b>prevchangecolor</b></a></dt>
+  <dd>The color this test held before its most recent change. Also accepted as
+      <b>previouscolor</b>. It moves only when the color changes, so a test that
+      went green, red, red reports color=red, prevreportcolor=red,
+      prevchangecolor=green - it answers &quot;what was this before it went
+      bad&quot;. <b>none</b> until the first change, and it survives a xymond
+      restart.</dd>
   <dt id="flags"><a class="permalink" href="#flags"><b>flags</b></a></dt>
   <dd>For network tests, the flags indicating details about the test (used by
       xymongen).</dd>

--- a/tests/server/xymond-checkpoint-roundtrip.sh
+++ b/tests/server/xymond-checkpoint-roundtrip.sh
@@ -184,9 +184,14 @@ stop_xymond
 # flag still says "flapping"; the ring says the test has been quiet for a day,
 # and the ring is what counts.
 
-awk -F'|' -v OFS='|' '$2 == ".flapstate." { $NF = "1000000,1000000" } { print }' \
-	"$work/chk" > "$work/chk.stale"
-grep -q '^@@XYMONDCHK-V1|\.flapstate\.|.*|1000000,1000000$' "$work/chk.stale" \
+# The ring is field 11, named rather than taken as the last one: fields have
+# been appended after it (previouscolor), and $NF then rewrites the wrong one
+# while still producing a line that ends in the value written -- the edit reads
+# as applied and changes nothing.
+awk -F'|' -v OFS='|' '$2 == ".flapstate." { if (NF < 11) exit 3; $11 = "1000000,1000000" } { print }' \
+	"$work/chk" > "$work/chk.stale" \
+	|| fail "the .flapstate. record has fewer fields than the flap ring's position; the format changed"
+grep -q '^@@XYMONDCHK-V1|\.flapstate\.|\([^|]*|\)\{8\}1000000,1000000\(|.*\)\?$' "$work/chk.stale" \
 	|| fail "could not backdate the flap ring; the .flapstate. record format changed"
 
 start_xymond --restart="$work/chk.stale"

--- a/tests/server/xymondboard-color-history.sh
+++ b/tests/server/xymondboard-color-history.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymondboard-color-history.sh
+#
+# The two colors a board consumer can ask for, and the difference between them:
+#
+#   prevreportcolor   the color of the previous report, assigned on every message
+#   prevchangecolor   the color held before the most recent change
+#
+# They are the same only until a test repeats itself. A test that goes green,
+# red, red reports color=red prevreportcolor=red prevchangecolor=green -- and it is
+# prevchangecolor that answers "what was it before this went bad", which is what
+# a display or an alert rule wants (@SoundGoof, #355).
+#
+# Both are selectable fields now. They were carried on xymond's internal
+# channels before this, so a module could see them and a `fields=` consumer
+# could not.
+#
+# Needs a built tree: xymond itself and the xymon client.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+require_bin XYMOND xymond/xymond
+require_bin XYMONCLIENT common/xymon
+
+work=$(mktempdir)
+
+XYMOND_PID=""
+stop_xymond() {
+	[ -n "$XYMOND_PID" ] || return 0
+	kill "$XYMOND_PID" 2>/dev/null || true
+	local i=0
+	while kill -0 "$XYMOND_PID" 2>/dev/null && [ "$i" -lt 100 ]; do
+		sleep 0.1
+		i=$((i+1))
+	done
+	XYMOND_PID=""
+}
+register_cleanup stop_xymond
+
+printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.cfg"
+
+mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
+    -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
+	"$ROOT/xymond/etcfiles/xymonserver.cfg" > "$work/xymonserver.cfg" \
+	|| skip "no xymonserver.cfg to run against"
+
+free_port() {
+	local p tries=0
+	while [ "$tries" -lt 50 ]; do
+		p=$(( 20000 + (RANDOM % 20000) ))
+		"$XYMONCLIENT" "127.0.0.1:$p" "ping" >/dev/null 2>&1 || { printf '%s' "$p"; return 0; }
+		tries=$((tries+1))
+	done
+	return 1
+}
+
+start_xymond() {
+	local i=0
+	PORT=$(free_port) || fail "no free port for xymond"
+	"$XYMOND" --no-daemon --listen="127.0.0.1:$PORT" \
+		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
+		--pidfile="$work/xymond.pid" --checkpoint-file="$work/chk.out" \
+		"$@" \
+		> "$work/xymond.log" 2>&1 &
+	XYMOND_PID=$!
+
+	while [ "$i" -lt 100 ]; do
+		"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 && return 0
+		kill -0 "$XYMOND_PID" 2>/dev/null || { cat "$work/xymond.log" >&2; fail "xymond exited during startup"; }
+		sleep 0.1
+		i=$((i+1))
+	done
+	cat "$work/xymond.log" >&2
+	fail "xymond did not answer on 127.0.0.1:$PORT"
+}
+
+send() { "$XYMONCLIENT" "127.0.0.1:$PORT" "$1" || fail "xymond rejected: $1"; }
+status() { send "status testhost,example,com.conn $1 msg"; sleep 0.4; }
+
+# board FIELD -- one field of the conn status, through the fields= selector a
+# consumer uses. An unknown field name yields an empty column, which is exactly
+# what this test is here to catch.
+board() {
+	"$XYMONCLIENT" "127.0.0.1:$PORT" "xymondboard fields=testname,$1" 2>/dev/null \
+		| awk -F'|' '$1 == "conn" { print $2 }'
+}
+
+assert_colors() {
+	local wantcolor=$1 wantold=$2 wantprev=$3 label=$4
+	local gotcolor gotold gotprev
+	gotcolor=$(board color); gotold=$(board prevreportcolor); gotprev=$(board prevchangecolor)
+	[ "$gotcolor" = "$wantcolor" ] && [ "$gotold" = "$wantold" ] && [ "$gotprev" = "$wantprev" ] \
+		|| fail "$label: expected color=$wantcolor prevreportcolor=$wantold prevchangecolor=$wantprev, got color=$gotcolor prevreportcolor=$gotold prevchangecolor=$gotprev"
+}
+
+start_xymond
+
+# --- a status nobody has seen change ------------------------------------------
+# "none" is the no-previous-color sentinel, and it is not a transition. It
+# stands for prevreportcolor only until the second report: prevreportcolor is assigned on
+# every message, so a repeated green makes it green while prevchangecolor is
+# still none -- nothing has changed yet.
+status green
+assert_colors green none none "first report"
+
+status green
+assert_colors green green none "a repeated color moves prevreportcolor, not prevchangecolor"
+
+# --- restored from a checkpoint that predates the field -----------------------
+# An upgrade restores a file written by a xymond that had no color history to
+# save: the status record without the ".prevchangecolor." record beside it. The restore path fills
+# the field from a calloc'ed struct, where 0 is COL_GREEN -- so without an
+# explicit default every restored test claims it was green before a change it
+# never had. Written by hand because this xymond always writes the sidecar.
+stop_xymond
+[ -s "$work/chk.out" ] || fail "xymond wrote no checkpoint file"
+grep -v '^@@XYMONDCHK-V1|\.prevchangecolor\.|' "$work/chk.out" > "$work/chk.old"
+grep -q '^@@XYMONDCHK-V1||testhost' "$work/chk.old" \
+	|| fail "no status record left after dropping the record; the checkpoint format changed"
+start_xymond --restart="$work/chk.old"
+assert_colors green green none "a status restored without color history must not invent one"
+
+# --- the case the field exists for --------------------------------------------
+status red
+assert_colors red green green "the change itself"
+
+status red
+assert_colors red red green "a repeat after the change keeps what came before it"
+
+# --- and it follows the next change, not the reports in between ---------------
+status yellow
+assert_colors yellow red red "the next change moves prevchangecolor to the color that was held"
+
+# --- across a restart ----------------------------------------------------------
+# A monitoring server restarts, often during the incident the operator is
+# looking at. A field whose whole job is to say what came before is worth
+# nothing if it forgets exactly then, so it rides the checkpoint.
+stop_xymond   # xymond writes its checkpoint while shutting down
+[ -s "$work/chk.out" ] || fail "xymond wrote no checkpoint file"
+
+grep -q '^@@XYMONDCHK-V1|\.prevchangecolor\.|testhost\.example\.com|conn|red$' "$work/chk.out" \
+	|| fail "the checkpoint carries no .prevchangecolor. record for a status that has one"
+start_xymond --restart="$work/chk.out"
+assert_colors yellow red red "a restored status keeps the color it held before the change"
+
+# oldcolor is kept as an alias for prevreportcolor: it is the name inside
+# xymond and the one a script reaches for first. An alias nothing exercises is
+# an alias that quietly stops resolving.
+[ "$(board oldcolor)" = "$(board prevreportcolor)" ] \
+	|| fail "the oldcolor alias must resolve to the same field as prevreportcolor"
+[ "$(board previouscolor)" = "$(board prevchangecolor)" ] \
+	|| fail "the previouscolor alias must resolve to the same field as prevchangecolor"
+
+pass "xymondboard exposes prevreportcolor (alias oldcolor) and prevchangecolor, and prevchangecolor survives a restart"

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -132,6 +132,7 @@ typedef struct xymond_log_t {
 	time_t *flapchange;	/* Table of the most recent status-change times, used for flap detection */
 	time_t pregaplastchange;	/* The "lastchange" saved when a no-data gap began */
 	time_t gapstart;	/* When that gap began; bounds how far a resume may bridge */
+	int prevchangecolor;	/* The color held before the most recent change, or NO_COLOR before the first one */
 	int pregapcolor;	/* The color recorded before the gap, or NO_COLOR when not in one */
 	int pregapvalidity;	/* The report validity in force when the gap began, in minutes */
 	int validity;		/* Minutes this test's reports stay valid; sizes the bridge bound */
@@ -309,7 +310,8 @@ xymond_statistics_t xymond_stats[] = {
 	{ NULL, 0 }
 };
 
-enum boardfield_t { F_NONE, F_IP, F_HOSTNAME, F_TESTNAME, F_MATCHEDTAG, F_COLOR, F_FLAGS, 
+enum boardfield_t { F_NONE, F_IP, F_HOSTNAME, F_TESTNAME, F_MATCHEDTAG, F_COLOR,
+		    F_PREVREPORTCOLOR, F_PREVCHANGECOLOR, F_FLAGS, 
 		    F_LASTCHANGE, F_LOGTIME, F_VALIDTIME, F_ACKTIME, F_DISABLETIME,
 		    F_SENDER, F_COOKIE, F_LINE1,
 		    F_ACKMSG, F_DISMSG, F_MSG, F_CLIENT, F_CLIENTTSTAMP,
@@ -332,6 +334,13 @@ boardfieldnames_t boardfieldnames[] = {
 	{ "matchedtags", F_MATCHEDTAG },
 	{ "testname", F_TESTNAME },
 	{ "color", F_COLOR },
+	/* The canonical names say when each one moves; the aliases are the names
+	 * xymond uses internally and the ones the first consumer of these fields
+	 * already queries (axians/xymon#10). Same precedent as matchedtag(s). */
+	{ "prevreportcolor", F_PREVREPORTCOLOR },
+	{ "oldcolor", F_PREVREPORTCOLOR },
+	{ "prevchangecolor", F_PREVCHANGECOLOR },
+	{ "previouscolor", F_PREVCHANGECOLOR },
 	{ "flags", F_FLAGS },
 	{ "lastchange", F_LASTCHANGE },
 	{ "logtime", F_LOGTIME },
@@ -1349,7 +1358,7 @@ void get_hts(char *msg, char *sender, char *origin,
 			lwalk->pregapcolor = NO_COLOR;
 			lwalk->pregapvalidity = defaultvalidity;
 			lwalk->validity = defaultvalidity;
-			lwalk->color = lwalk->oldcolor = NO_COLOR;
+			lwalk->color = lwalk->oldcolor = lwalk->prevchangecolor = NO_COLOR;
 			lwalk->host = hwalk;
 			lwalk->test = twalk;
 			lwalk->origin = owalk;
@@ -1913,6 +1922,10 @@ void handle_status(unsigned char *msg, char *sender, char *hostname, char *testn
 	 * are about to stop seeing began, not when we stopped seeing it. */
 	prevlastchange = log->lastchange;
 
+	/* oldcolor is the previous report; prevchangecolor is the color held before
+	 * the most recent change. A test repeating a color moves the first and not
+	 * the second, which is what "what was it before this" asks for. */
+	if (newcolor != log->color) log->prevchangecolor = log->color;
 	log->oldcolor = log->color;
 	log->color = newcolor;
 	oldalertstatus = decide_alertstate(log->oldcolor);
@@ -3602,6 +3615,8 @@ strbuffer_t *generate_outbuf(strbuffer_t **prebuf, boardfield_t *boardfields, xy
 		  case F_HOSTNAME: addtobuffer(buf, hwalk->hostname); break;
 		  case F_TESTNAME: addtobuffer(buf, lwalk->test->name); break;
 		  case F_COLOR: addtobuffer(buf, colnames[lwalk->color]); break;
+		  case F_PREVREPORTCOLOR: addtobuffer(buf, colnames[lwalk->oldcolor]); break;
+		  case F_PREVCHANGECOLOR: addtobuffer(buf, colnames[lwalk->prevchangecolor]); break;
 		  case F_FLAGS: if (lwalk->testflags) addtobuffer(buf, lwalk->testflags); break;
 		  case F_LASTCHANGE: snprintf(l, sizeof(l), "%d", (int)lwalk->lastchange); addtobuffer(buf, l); break;
 		  case F_LOGTIME: snprintf(l, sizeof(l), "%d", (int)lwalk->logtime); addtobuffer(buf, l); break;
@@ -5169,6 +5184,18 @@ void save_checkpoint(void)
 				if (iores >= 0) iores = fprintf(fd, "\n");
 			}
 
+			/* Own record rather than a field on one that exists: ".flapstate."
+			 * is read by position, so a field appended there rides on its
+			 * write condition and on every reader counting to the same place.
+			 * An unrecognised ".name." record is skipped, so this one costs an
+			 * older xymond nothing, and a file without it restores as "no
+			 * previous color" -- which is what those statuses had. */
+			if ((iores >= 0) && (lwalk->prevchangecolor != NO_COLOR)) {
+				iores = fprintf(fd, "@@XYMONDCHK-V1|.prevchangecolor.|%s|%s|%s\n",
+						hwalk->hostname, lwalk->test->name,
+						colnames[lwalk->prevchangecolor]);
+			}
+
 			for (awalk = lwalk->acklist; (awalk && (iores >= 0)); awalk = awalk->next) {
 				iores = fprintf(fd, "@@XYMONDCHK-V1|.acklist.|%s|%s|%d|%d|%d|%d|%s|%s\n",
 						hwalk->hostname, lwalk->test->name,
@@ -5413,6 +5440,39 @@ void load_checkpoint(char *fn)
 			continue;
 		}
 
+		if (strncmp(STRBUF(inbuf), "@@XYMONDCHK-V1|.prevchangecolor.|", 33) == 0) {
+			xymond_log_t *log = NULL;
+			int prevchangecolor = NO_COLOR;
+
+			hitem = NULL; t = NULL;
+
+			item = gettok(STRBUF(inbuf), "|\n"); i = 0;
+			while (item) {
+				switch (i) {
+				  case 0: break;
+				  case 1: break;
+				  case 2:
+					hosthandle = xtreeFind(rbhosts, item);
+					hitem = (hosthandle == xtreeEnd(rbhosts)) ? NULL : xtreeData(rbhosts, hosthandle);
+					break;
+				  case 3:
+					testhandle = xtreeFind(rbtests, item);
+					t = (testhandle == xtreeEnd(rbtests)) ? NULL : xtreeData(rbtests, testhandle);
+					break;
+				  case 4: prevchangecolor = restore_color(item); break;
+				  default: break;
+				}
+				item = gettok(NULL, "|\n"); i++;
+			}
+
+			if (hitem && t) {
+				for (log = hitem->logs; (log && (log->test != t)); log = log->next) ;
+			}
+			if (log) log->prevchangecolor = prevchangecolor;
+
+			continue;
+		}
+
 		if ((strncmp(STRBUF(inbuf), "@@XYMONDCHK-V1|.", 16) == 0) || (strncmp(STRBUF(inbuf), "@@HOBBITDCHK-V1|.", 17) == 0)) continue;
 
 		item = gettok(STRBUF(inbuf), "|\n"); i = 0;
@@ -5525,8 +5585,12 @@ void load_checkpoint(char *fn)
 		 * A ".flapstate." record, when one follows, overwrites this.
 		 */
 		if (flapcount > 0) ltail->flapchange[0] = lastchange;
-		/* The rest of the flap and hold-time state arrives in that record. */
+		/* The rest of the flap and hold-time state arrives in that record.
+		 * prevchangecolor needs the default too: calloc leaves it 0, which is
+		 * COL_GREEN, so a file written before the field existed would restore
+		 * every test as "was green before". */
 		ltail->pregapcolor = NO_COLOR;
+		ltail->prevchangecolor = NO_COLOR;
 		/* Not checkpointed: the test's next report sets its real validity,
 		 * which arrives within one validity period by definition. */
 		ltail->validity = defaultvalidity;


### PR DESCRIPTION
**Rewritten.** This PR documented `oldcolor` as a `xymondboard` field; it is not one, so it now makes it one, adds the second color, and corrects two claims the old text made. **1 commit.**

`boardfieldnames[]` has no entry for `oldcolor`, so `fields=hostname,testname,color,oldcolor` returns an empty column, and `xymondlog`'s default list does not carry it either. It has been on xymond's internal channels forever, which is where the modules see it.

Both are selectable now, under names that say when each moves:

| field | assigned | after green, red, red |
|---|---|---|
| `prevreportcolor` | every message | `red` |
| `prevchangecolor` | only on a real change | `green` |

`oldcolor` and `previouscolor` are accepted as aliases, the way `matchedtag` and `matchedtags` share a field: they are the names xymond uses internally and the ones the first consumer already queries (axians/xymon#10), so that dashboard keeps working unchanged.

The canonical names exist because `oldcolor` already means the *other* thing one layer down — in `lib/eventlog.h` it is the color before a transition, which is what `prevchangecolor` holds here. A consumer reading both `allevents` and the board meets the same word with two meanings; no wording in the manual repairs that.

**Checkpoint.** `prevchangecolor` gets a record of its own, `@@XYMONDCHK-V1|.prevchangecolor.|host|test|color`, following axians/xymon#10 rather than riding `.flapstate.`. That record is read by position, so a field appended to it depends on its write condition and on every reader counting to the same place; an unrecognised `.name.` record is skipped instead. A checkpoint without the record restores as "no previous color", which is what those statuses had — and the restore path sets that default explicitly, next to `pregapcolor`: `calloc` leaves 0, which is `COL_GREEN`, so an older file would otherwise restore every test as "was green before" a change it never had.

| mutation | caught by |
|---|---|
| `prevchangecolor` assigned on every message | `a repeated color moves prevreportcolor, not prevchangecolor: expected none, got green` |
| the restore handler dropped | `a restored status keeps the color it held before the change: expected red, got none` |
| the restore default dropped | `a status restored without color history must not invent one: expected none, got green` |

**The manual page drops two claims the code contradicts**, both from the text approved earlier:

- "a status whose color has never changed reports `none`" — only its *first* report does. Send green twice and the value is green, though nothing ever changed.
- "the color this test reported" — it is the color xymond *recorded*. A disabled or in-downtime test reports green and is recorded blue.

`xymond-checkpoint-roundtrip.sh` now backdates the flap ring by naming field 11 rather than `$NF`. Nothing forces that any more, but `$NF` only worked while the ring was last, and it failed silently when it was not — the edit landed elsewhere and still left a line ending in the value written, so the guard passed over an edit that changed nothing.

Suite: 76 passed, 0 skipped, 0 failed on a built tree. Manual page HTML regenerated with `build/makehtml.sh`.
