### PR TITLE
tests: give every harness that links the tree its configured flags

### DIFF
--- a/tests/server/xymond-flap-purple-pin.sh
+++ b/tests/server/xymond-flap-purple-pin.sh
@@ -38,7 +38,11 @@ require_cc
 
 work=$(mktempdir)
 
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+# The configured link flags rather than a hand-picked SSLLIBS: they carry the
+# library search path and the runtime path as well. Without the rpath the
+# harness links on NetBSD and then cannot run -- "Shared object
+# libpcre2-8.so.0 not found", since pkgsrc puts it under /usr/pkg/lib.
+harness_ldflags=$(xymon_ldflags "$ROOT")
 
 {
 	printf '#include <stdio.h>\n#include <stdlib.h>\n#include <string.h>\n'
@@ -56,7 +60,7 @@ harness_cflags=$(xymon_cflags "$ROOT")
 # shellcheck disable=SC2086
 "$CC" $harness_cflags -I"$ROOT/lib" -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
-	$ssllibs 2>"$work/cc.log" \
+	$harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 "$work/harness" 2>"$work/stderr.log" \

--- a/tests/server/xymond-gap-validity.sh
+++ b/tests/server/xymond-gap-validity.sh
@@ -44,7 +44,11 @@ require_cc
 	|| skip "tree not built (run make first; the post-build CI suite covers this)"
 
 work=$(mktempdir)
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+# The configured link flags rather than a hand-picked SSLLIBS: they carry the
+# library search path and the runtime path as well. Without the rpath the
+# harness links on NetBSD and then cannot run -- "Shared object
+# libpcre2-8.so.0 not found", since pkgsrc puts it under /usr/pkg/lib.
+harness_ldflags=$(xymon_ldflags "$ROOT")
 
 # Only the fields the extracted code touches. The real xymond_log_t carries
 # forty more that none of it reads.
@@ -69,7 +73,7 @@ ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
 harness_cflags=$(xymon_cflags "$ROOT")
 # shellcheck disable=SC2086
 "$CC" $harness_cflags -I"$ROOT/lib" -o "$work/harness" \
-	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" $ssllibs 2>"$work/cc.log" \
+	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" $harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 "$work/harness" >"$work/out.log" 2>&1 \

--- a/tests/server/xymond-holdtime-bridge.sh
+++ b/tests/server/xymond-holdtime-bridge.sh
@@ -46,7 +46,11 @@ require_cc
 
 work=$(mktempdir)
 
-ssllibs=$(sed -n 's/^SSLLIBS *= *//p' "$ROOT/Makefile")
+# The configured link flags rather than a hand-picked SSLLIBS: they carry the
+# library search path and the runtime path as well. Without the rpath the
+# harness links on NetBSD and then cannot run -- "Shared object
+# libpcre2-8.so.0 not found", since pkgsrc puts it under /usr/pkg/lib.
+harness_ldflags=$(xymon_ldflags "$ROOT")
 
 {
 	printf '#include <stdio.h>\n#include <stdlib.h>\n#include <string.h>\n'
@@ -67,7 +71,7 @@ harness_cflags=$(xymon_cflags "$ROOT")
 # shellcheck disable=SC2086
 "$CC" $harness_cflags -I"$ROOT/lib" -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
-	$ssllibs 2>"$work/cc.log" \
+	$harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 "$work/harness" 2>"$work/stderr.log" \

--- a/tests/web/cgi-split-hostsvc.sh
+++ b/tests/web/cgi-split-hostsvc.sh
@@ -23,9 +23,16 @@ work=$(mktempdir)
 
 build_xymon_libs "$ROOT" "$work/libbuild.log" libxymon.a
 
-"$CC" -iquote "$ROOT/include" -o "$work/harness" \
+# The configured compile and link flags: libxymon.h pulls in pcre2.h, which
+# sits under /usr/local/include or /usr/pkg/include on the BSDs, and the link
+# needs the matching search path and runtime path.
+harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
+
+# shellcheck disable=SC2086
+"$CC" $harness_cflags -iquote "$ROOT/include" -o "$work/harness" \
 	"$(dirname "$0")/cgi-split-hostsvc-harness.c" "$ROOT/lib/libxymon.a" \
-	2>"$work/cc.log" \
+	$harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 
 "$work/harness" >"$work/run.log" 2>&1 \


### PR DESCRIPTION
Follow-on to #346, which added `xymon_ldflags()` and used it for the svcstatus scaffolding. Four harnesses still scrape `SSLLIBS` out of the Makefile by hand, or pass no link flags at all, which leaves out the library search path and the runtime path.

On NetBSD that is the failure @SoundGoof reported against #204: the harness links and then cannot run —

```
Shared object "libpcre2-8.so.0" not found
```

— because pkgsrc puts it under `/usr/pkg/lib` and nothing records an rpath.

| Harness | Was |
|---|---|
| `xymond-gap-validity.sh` | hand-scraped `SSLLIBS` |
| `xymond-holdtime-bridge.sh` | hand-scraped `SSLLIBS` |
| `xymond-flap-purple-pin.sh` | hand-scraped `SSLLIBS` |
| `cgi-split-hostsvc.sh` | no compile or link flags at all |

**Four is the whole set**, and that is worth stating because the raw count looks alarming: of the thirty tests under `tests/` that invoke a compiler, fifteen do not call `xymon_ldflags()`. Eleven of those link *nothing* — they compile a self-contained snippet, so a search path would have nothing to find. The twelfth, `inode-unix-columns.sh`, asks make for `LDFLAGS`, `RPATHOPT` and `RRDLIBS` itself and already carries what it needs.

Full suite: 67 passed, 0 failed, 0 skipped.
