### PR TITLE
tests: forbid forcing a failure with a permission bit

### DIFF
--- a/tests/buildsystem/test-suite-portability.sh
+++ b/tests/buildsystem/test-suite-portability.sh
@@ -37,8 +37,16 @@ files=$(
 [ -n "$files" ] || fail "found no test scripts to check"
 
 # report RULE PATTERN WHY -- flag every non-comment line matching PATTERN.
+#
+# Each pattern is kept, and the non-vacuity probe at the end matches with the
+# ones recorded here rather than a copy of them. The copy is how the root-lane
+# rule was widened while its probe still exercised the narrow form, so the
+# probe kept passing over a gap it was there to expose.
+__rule_patterns=()
 report() {
 	local rule=$1 pattern=$2 why=$3 f line
+
+	__rule_patterns[${#__rule_patterns[@]}]=$pattern
 	for f in $files; do
 		# Drop comment lines before matching, keeping real line numbers.
 		# "|| true" twice: a grep with no match exits 1, which set -e and
@@ -65,6 +73,20 @@ report "gnu-only" 'sed +-i|grep +[^|]*--include|grep +-[a-zA-Z]*P|stat +-c|readl
 # file shipped a mapfile rule that tested nothing on OpenBSD.
 report "gnu-regex" '(grep|sed|awk|expr)[^|]*\\(b|<|>|w|W|s|S|d|D)([^[:alnum:]]|$)' \
 	"GNU-only regex escape; POSIX has [[:alnum:]] and (^|[^...])"
+
+# The lanes run as root, where a permission bit stops nothing. A test that
+# takes write access away to force a failure therefore passes on a developer's
+# machine and fails in CI, having proved the opposite of what it claims. Force
+# the failure structurally instead - an existing directory where a file is
+# expected, a path that is not there at all.
+#
+# The owner digit carries it: 6 and 7 are the two that grant both read and
+# write, so [0-5] is exactly the modes that deny one of them, whatever the
+# group and other digits say. Matching only the modes ending in 00 missed
+# "chmod 555 dir", which is how a directory is usually made read-only
+# (@SoundGoof).
+report "root-lane" 'chmod +[-+=rwx]*[0-7]?[0-5][0-7][0-7]([^0-9]|$)|chmod +[ugoa]*-w' \
+	"the lanes run as root; a permission bit will not force this failure"
 
 # Interpreters the BSD runners do not have.
 report "interpreter" '(^|[^-[:alnum:]_])(python3?|perl)[[:space:]]' \
@@ -105,9 +127,12 @@ probe="$work/probe.sh"
 	printf 'sed -i s/a/b/ f\n'
 	printf 'python3 -c pass\n'
 	printf 'grep -E %s x\n' "'\\bword\\b'"
+	printf 'chmod 500 d\n'
+	printf 'chmod 555 d\n'
 } >"$probe"
-hits=$(grep -cE '(^|[^[:alnum:]_])(mapfile|readarray)([^[:alnum:]_]|$)|sed +-i|(^|[^-[:alnum:]_])python3?[[:space:]]|(grep|sed|awk|expr)[^|]*\\(b|<|>|w|W|s|S|d|D)([^[:alnum:]]|$)' "$probe")
-assert_equal "4" "$hits" "the rule patterns no longer match the constructs they are meant to catch"
+probe_pattern=$(IFS='|'; printf '%s' "${__rule_patterns[*]}")
+hits=$(grep -cE "$probe_pattern" "$probe")
+assert_equal "6" "$hits" "the rule patterns no longer match the constructs they are meant to catch"
 
 # The link-flags rule the same way, including the bypass it used to allow: the
 # helpers named in a comment and nowhere else.


### PR DESCRIPTION
Follow-up to #359, kept separate so its approval was not dismissed for a fifth rule
unrelated to the four it carries.

The CI lanes run as **root**, where a permission bit stops nothing. A test that removes
write access to force a failure therefore passes on a developer's machine and fails in CI,
having proved the opposite of what it claims. That is what the `install-cgi` fixture did:
green for an unprivileged Linux user, red for @SoundGoof on NetBSD 9.4 and 11.0,
OpenBSD 7.9 and FreeBSD 14.3 (#351).

The rule says to force the failure structurally instead — an existing directory where a
file is expected, a path that is not there at all:

```sh
mkdir "$dir/history.sh"; chmod 500 …    # root walks straight through
mkdir -p "$dir/history.sh/cgiwrap"      # ln would have to unlink a directory
```

Measured unprivileged, so the difference is the mechanism and not the privilege:

| obstruction | ln says |
|---|---|
| mode 500 | `Permission denied` — a policy root ignores |
| destination is a directory | `cannot overwrite directory` — only `rmdir` removes one |

No occurrence is left in the suite, so this is green today and guards forward.

### After review

The numeric matcher only caught modes ending in `00`, so `chmod 555 dir` -- the usual
way to make a directory read-only -- went through, and root creates files in it
regardless (@SoundGoof). The owner digit carries the rule: 6 and 7 are the only two
granting both read and write, so `[0-5]` is exactly the modes denying one of them,
whatever group and other say. Measured over the whole mode space: `555`, `444`, `0555`
now rejected; `700`, `755`, `644`, `0755`, `4755`, `+x` still accepted.

Looking for that gap did not find it because the non-vacuity probe carried a *copy*
of the patterns, so widening the rule once already had left the probe exercising the
narrow form. It now matches with the patterns the rules were declared with, which
also removes the duplicated 200-character alternation. Narrowing the rule back fails
the probe.

Rebased on `2b2272eb9`. Full suite on a built tree: 73 passed, 0 failed, 0 skipped.

