### PR TITLE
client: bound a wedged remote df on FreeBSD, NetBSD, OpenBSD and macOS (#316)

### DIFF
--- a/client/xymonclient-darwin.sh
+++ b/client/xymonclient-darwin.sh
@@ -72,6 +72,245 @@ _user="${_user#|}"
 # dropping remote mounts regardless of type.
 _localfilter=""
 [ "$DFLOCALONLY" = yes ] && _localfilter='/[(, ]local[,) ]/!d;'
+# XYMONCLIENT_FS_REMOTE_DF_BUDGET: seconds to wait for the remote df probe
+# before giving up for this cycle (default 30, capped at 3600; non-numeric,
+# empty or zero -> 30). A poll BUDGET, not a kill timeout: a df wedged on a
+# dead server sits in uninterruptible D-state where even SIGKILL is ignored,
+# so it is left running and picked up on a later cycle rather than killed.
+DFBUDGET="${XYMONCLIENT_FS_REMOTE_DF_BUDGET:-30}"
+case "$DFBUDGET" in
+	*[!0-9]*|'') DFBUDGET=30 ;;
+	*[1-9]*) ;;
+	*) DFBUDGET=30 ;;
+esac
+[ "$DFBUDGET" -le 3600 ] 2>/dev/null || DFBUDGET=3600
+
+# XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES: the mount types whose stat() hard-blocks
+# when the server is unreachable. Shipped as a built-in list so no site has to
+# maintain one; assign the variable to override it.
+: "${XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES=nfs nfs4 smbfs cifs afpfs webdav ceph glusterfs lustre afs}"
+DFPROBEDIR="${XYMONTMP:-/tmp}"
+
+# fs_mounts : one "TYPE<tab>MOUNTPOINT" line per mount, from mount(8). macOS
+# mount(8) lists from getmntinfo(MNT_NOWAIT) -- verified in the shipped binary,
+# three call sites, all MNT_NOWAIT -- so it never refreshes statfs and cannot
+# block on a dead server, which df would.
+fs_mounts() {
+	mount | awk '
+		{
+			i = index($0, " on ")
+			if (i == 0) next
+			rest = substr($0, i + 4)
+			if (match(rest, / \(/) == 0) next
+			mp = substr(rest, 1, RSTART - 1)
+			split(substr(rest, RSTART + 2), a, /[,)]/)
+			printf "%s\t%s\n", a[1], mp
+		}'
+}
+
+# fs_hardblocking : the mount points whose type hard-blocks, one per line.
+fs_hardblocking() {
+	fs_mounts | awk -F'\t' -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+		BEGIN { n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1 }
+		($1 in t) { print $2 }'
+}
+
+# fs_only IN EXCLUDE-LIST / fs_also IN KEEP-LIST : whole-line set operations, so
+# a mount point containing a space is still matched exactly. The list is fed
+# through the same stream as the input, ahead of a separator line, rather than
+# through "awk -v": an assignment with embedded newlines is not portable, and
+# on a BSD awk it silently yields an empty set.
+fs_setop() {
+	{ printf '%s\n' "$2"; echo '@@'; printf '%s\n' "$1"; } | awk -v want="$3" '
+		$0 == "@@" { split_done = 1; next }
+		!split_done { x[$0] = 1; next }
+		$0 == "" { next }
+		(($0 in x) ? "in" : "out") == want'
+}
+fs_only() { fs_setop "$1" "$2" out; }
+fs_also() { fs_setop "$1" "$2" in; }
+
+# probe_dir_is_local DIR : true when DIR is not itself on a hard-blocking
+# filesystem. Decided purely from the mount list by longest mount-point prefix,
+# and deliberately WITHOUT stat()ing DIR: if DIR were on the wedged mount, even
+# `test -w DIR` would block in D-state inside the very fail-safe meant to
+# prevent that. Symlinks are not resolved for the same reason (readlink would
+# stat), so keep XYMONTMP on a real local path.
+probe_dir_is_local()
+{
+	# The helper's status, not the pipeline's: a pipeline reports its last
+	# command, and awk succeeds on no input at all -- which is what an
+	# unreadable mount list looks like from there. Answering "local" then
+	# sends the probe at a directory that may sit on the wedged mount this
+	# exists to keep away from.
+	_pdlm=$(fs_mounts) || return 1
+	printf '%s\n' "$_pdlm" | awk -F'\t' -v dir="$1" -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+		BEGIN { n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1 }
+		{
+			mp = $2
+			if (dir == mp || mp == "/" || substr(dir, 1, length(mp) + 1) == mp "/") {
+				if (length(mp) >= length(best)) { best = mp; besttype = $1 }
+			}
+		}
+		END { exit (besttype in t) ? 1 : 0 }
+	'
+}
+
+df_sentinel()
+{
+	_tag="$1"; shift
+	_probe="$DFPROBEDIR/df-probe-$_tag"; _pidf="$_probe.pid"
+
+	probe_dir_is_local "$DFPROBEDIR" || return 124
+
+	# Claim the probe before starting it, or two cycles both find no pidfile
+	# and both start a df -- and only the last pid written is recorded, so the
+	# others pile up untracked, and these cannot be killed.
+	#
+	# The claim goes to a private file and is hard-linked into place: link
+	# fails if the target exists, so one cycle wins, and what it publishes is
+	# complete the moment it is visible. "set -C" gave exclusivity but not
+	# that -- O_EXCL makes the create atomic, not the create-and-write, and a
+	# reader in between saw an empty string, took it for a stale entry, and
+	# started a probe on top of the first (@SoundGoof). Winning also proves
+	# the directory is writable before any df runs.
+	#
+	# The redirect is wrapped in a subshell because a redirection error on a
+	# special builtin kills the shell under dash instead of returning non-zero,
+	# and then "return 124" never runs.
+	#
+	# The claim names the claiming shell and is replaced by df's pid below, so
+	# a cycle killed in the gap leaves a dead pid, collected like any finished
+	# probe, rather than a marker nothing clears.
+	_tmpf="$_pidf.$$"
+	if ! ( echo "claim:$$" > "$_tmpf" ) 2>/dev/null; then
+		rm -f "$_tmpf"
+		return 124
+	fi
+	# "-d" first: link into a directory puts the file *inside* it, so a
+	# directory where the pidfile belongs would look like a won claim while
+	# nothing recorded the pid. The old redirect simply failed there, and that
+	# is the behaviour to keep: unclaimable means unavailable, not a probe
+	# nobody tracks.
+	if [ -d "$_pidf" ] || ! ln "$_tmpf" "$_pidf" 2>/dev/null; then
+		_old=$(cat "$_pidf" 2>/dev/null)
+		case "$_old" in
+			claim:*)
+				# Another cycle holds the claim and has not started its df yet.
+				_c=${_old#claim:}
+				[ -n "$_c" ] && kill -0 "$_c" 2>/dev/null && { rm -f "$_tmpf"; return 124; }
+				;;
+			?*)
+				# A df we recorded. Still wedged? The command name is
+				# checked so a recycled PID does not look like one. ps, not
+				# /proc: POSIX, same answer, already a dependency of this
+				# client, and it reads process state only -- it cannot touch
+				# the wedged mount. Basename, because comm is the short name
+				# on Linux and the BSDs and the full path on macOS.
+				_c=$(ps -o comm= -p "$_old" 2>/dev/null | tr -d '[:space:]')
+				_c=${_c##*/}
+				if kill -0 "$_old" 2>/dev/null && [ "$_c" = df ]; then
+					rm -f "$_tmpf"
+					return 124
+				fi
+				;;
+		esac
+		# It finished after we stopped waiting. Its output is not usable: we
+		# were not there to see the exit status, so a truncated file is
+		# indistinguishable from a complete one, and its age is unknown.
+		if [ ! -e "$_pidf" ]; then
+			# The link failed with nothing in its way, so this filesystem does
+			# not do hard links -- XYMONTMP pointed somewhere exotic. Every
+			# cycle then reports the guarded mounts unavailable and never
+			# probes: red rather than a false green, but saying nothing about
+			# why. Say it.
+			echo "xymonclient: cannot claim the remote df probe in $_pidf (does $DFPROBEDIR support hard links?)" >&2
+			rm -f "$_tmpf"
+			return 124
+		fi
+		# Discard and re-probe -- fresh data next cycle beats stale or partial
+		# data now. One retry only: if another cycle claims it first, that
+		# cycle owns the probe and this one waits its turn.
+		rm -f "$_pidf" "$_probe"
+		[ -d "$_pidf" ] && { rm -f "$_tmpf"; return 124; }
+		ln "$_tmpf" "$_pidf" 2>/dev/null || { rm -f "$_tmpf"; return 124; }
+	fi
+	rm -f "$_tmpf"
+
+	# Never run a synchronous remote df here: a foreground df would reintroduce
+	# the hang this exists to prevent.
+	( : > "$_probe" ) 2>/dev/null || { rm -f "$_pidf"; return 124; }
+	df "$@" > "$_probe" 2>/dev/null &
+	_pid=$!
+	# Publish the pid the same way the claim was published: a plain
+	# "> $_pidf" truncates before it writes, and a cycle reading in that
+	# interval sees an empty file, removes it, and starts a second probe --
+	# leaving this one's df running with nothing recording it (@SoundGoof).
+	# A rename within one directory replaces the claim in a single step, so a
+	# reader gets either the whole claim or the whole pid.
+	if ! ( printf '%s\n' "$_pid" > "$_tmpf" ) 2>/dev/null || ! mv -f "$_tmpf" "$_pidf" 2>/dev/null; then
+		rm -f "$_tmpf"
+		# The pre-flight passed and this still failed, so a df is running that
+		# the next cycle cannot recognise. The claim is still in place and this
+		# shell outlives the budget, so no second probe starts meanwhile. Say
+		# so: an operator seeing repeated unavailable rows needs to know a df
+		# may be outstanding.
+		echo "xymonclient: cannot record remote df pid in $_pidf" >&2
+	fi
+	_n=0
+	while kill -0 "$_pid" 2>/dev/null; do
+		[ "$_n" -ge "$DFBUDGET" ] && break
+		sleep 1; _n=$((_n + 1))
+	done
+	if kill -0 "$_pid" 2>/dev/null; then
+		return 124			# budget spent; leave it running as the sentinel
+	fi
+	wait "$_pid"; _rc=$?
+	rm -f "$_pidf"
+	if [ "$_rc" -ne 0 ]; then rm -f "$_probe"; return 124; fi
+	sed -e '1d' "$_probe"; rm -f "$_probe"
+	return 0
+}
+
+# fs_guarded TAG FLAGS MOUNTS : rows for the hard-blocking set, behind the
+# sentinel. Prints nothing when there is nothing to probe; on an unanswering
+# server prints one 100%-full marker row per mount rather than dropping it,
+# since the server reads an absent filesystem as green -- one filesystem red
+# instead of the whole host purple.
+fs_guarded() {
+	_tag="$1"; _flags="$2"; _mounts="$3"
+	[ -n "$_mounts" ] || return 0
+	set -f
+	_oifs=$IFS
+	# The two lists split differently, and the caller has already set IFS to
+	# newline for the mount points: taking that for the flags too would hand df
+	# the single unknown option "-P -H", and every guarded mount would report
+	# unavailable while its server was answering perfectly.
+	IFS=' '
+	# shellcheck disable=SC2086
+	set -- $_flags
+	# The mount points on newline only, so one containing a space stays a
+	# single argument.
+	IFS='
+'
+	# shellcheck disable=SC2086
+	set -- "$@" $_mounts
+	_rout=`df_sentinel "$_tag" "$@"`
+	if [ $? -eq 124 ]; then
+		for _m in $_mounts; do
+			if [ "$_tag" = inode ]; then
+				echo "unavailable:$_m 1 1 0 100% 1 0 100% $_m"
+			else
+				echo "unavailable:$_m 1 1 0 100% $_m"
+			fi
+		done
+	else
+		printf '%s\n' "$_rout"
+	fi
+	IFS=$_oifs
+	set +f
+}
+
 # fs_list [extra-type-excludes...]: mount points surviving the filter, one per
 # line. Extra excludes are per-report (apfs for the inode report) and applied
 # like EXCLUDE_TYPES (unconditional).
@@ -85,6 +324,12 @@ fs_list() {
 	mount | sed -E "${_prog}s/^.* on (.*) \(.*$/\1/"
 }
 FILESYSTEMS=`fs_list`
+# The hard-blocking mounts are collected separately, behind the sentinel: a df
+# on a dead NFS/SMB server sits in uninterruptible D-state where even SIGKILL is
+# ignored, so the per-path loop below must never be handed one (#316).
+FS_HARD_ALL=`fs_hardblocking`
+FILESYSTEMS_REMOTE=`fs_also "$FILESYSTEMS" "$FS_HARD_ALL"`
+FILESYSTEMS=`fs_only "$FILESYSTEMS" "$FS_HARD_ALL"`
 # apfs is excluded from the inode report: its ifree is derived from the shared
 # container free space (identical across a container's volumes, %iused pinned
 # at 0%), so the numbers carry no exhaustion signal - the ZFS situation,
@@ -92,6 +337,8 @@ FILESYSTEMS=`fs_list`
 # [inode] section legitimately so: "nothing inode-limited to monitor" is data,
 # not a failure.
 FILESYSTEMS_INODE=`fs_list apfs`
+FILESYSTEMS_INODE_REMOTE=`fs_also "$FILESYSTEMS_INODE" "$FS_HARD_ALL"`
+FILESYSTEMS_INODE=`fs_only "$FILESYSTEMS_INODE" "$FS_HARD_ALL"`
 # emit_df KIND LABEL: print the table in $_out, or -- when df produced nothing --
 # a one-line marker (no df header) so the server goes yellow not green. macOS df
 # is queried per path (into $_out above), so this only applies the guard; that
@@ -108,18 +355,26 @@ emit_df() {
 # would defeat the filter. An empty list is itself reportable - if a macOS
 # change (or a config mistake) filters everything away, the marker turns the
 # column yellow instead of silently blanking disk monitoring.
-if [ -n "$FILESYSTEMS" ]; then
+if [ -n "$FILESYSTEMS" ] || [ -n "$FILESYSTEMS_REMOTE" ]; then
 	# Render the table by probing each path; emit_df turns empty output (every
-	# probe failed) into a failure marker. A partial run still prints rows.
+	# probe failed) into a failure marker. A partial run still prints rows. The
+	# hard-blocking mounts are appended from the sentinel, headerless -- and
+	# when they are the only ones left, the header has to come from somewhere,
+	# so it is taken from / (the boot volume, which is never a remote mount).
 	_out=$( (IFS=$'\n'
 	 set -f		# a mountpoint containing a glob char must not expand
-	 set $FILESYSTEMS
-	 df -P -H $1; shift
-	 while test $# -gt 0
-	 do
-	   df -P -H $1 | tail -1 | sed 's/\([^ ]\) \([^ ]\)/\1_\2/g'
-	   shift
-	 done) | column -t -s " " | sed -e 's!Mounted *on!Mounted on!' )
+	 if [ -n "$FILESYSTEMS" ]; then
+	   set $FILESYSTEMS
+	   df -P -H $1; shift
+	   while test $# -gt 0
+	   do
+	     df -P -H $1 | tail -1 | sed 's/\([^ ]\) \([^ ]\)/\1_\2/g'
+	     shift
+	   done
+	 elif [ -n "$FILESYSTEMS_REMOTE" ]; then
+	   df -P -H / | head -1
+	 fi
+	 fs_guarded disk "-P -H" "$FILESYSTEMS_REMOTE") | column -t -s " " | sed -e 's!Mounted *on!Mounted on!' )
 else
 	echo "xymonclient-darwin: no filesystems survived the mount filter; check XYMONCLIENT_FS_* settings" >&2
 	_out=""
@@ -129,16 +384,21 @@ emit_df disk Disk
 echo "[inode]"
 # Empty list here is legitimate (all-APFS Mac: nothing inode-limited exists),
 # so unlike the disk report there is no marker - the section stays empty.
-if [ -n "$FILESYSTEMS_INODE" ]; then
+if [ -n "$FILESYSTEMS_INODE" ] || [ -n "$FILESYSTEMS_INODE_REMOTE" ]; then
 	_out=$( (IFS=$'\n'
 	 set -f		# a mountpoint containing a glob char must not expand
-	 set $FILESYSTEMS_INODE
-	 df -P -i $1; shift
-	 while test $# -gt 0
-	 do
-	   df -P -i $1 | tail -1 | sed 's/\([^0123456789% ]\) \([^ ]\)/\1_\2/g'
-	   shift
-	 done) | awk '
+	 if [ -n "$FILESYSTEMS_INODE" ]; then
+	   set $FILESYSTEMS_INODE
+	   df -P -i $1; shift
+	   while test $# -gt 0
+	   do
+	     df -P -i $1 | tail -1 | sed 's/\([^0123456789% ]\) \([^ ]\)/\1_\2/g'
+	     shift
+	   done
+	 elif [ -n "$FILESYSTEMS_INODE_REMOTE" ]; then
+	   df -P -i / | head -1
+	 fi
+	 fs_guarded inode "-P -i" "$FILESYSTEMS_INODE_REMOTE") | awk '
 NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9}
 (NR>=2 && $6>0) {printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}' )
 	emit_df inode Inode

--- a/client/xymonclient-freebsd.sh
+++ b/client/xymonclient-freebsd.sh
@@ -57,12 +57,248 @@ case "$DFLOCALONLY" in
 	*) echo "xymonclient-freebsd: invalid XYMONCLIENT_FS_DF_LOCAL_ONLY '$DFLOCALONLY', using yes" >&2; DFLOCALONLY=yes ;;
 esac
 DFLOCAL=""; [ "$DFLOCALONLY" = yes ] && DFLOCAL="-l"
-# run_df FLAG [extra-excludes...]: df rows for one report behind the FS filter
-# and local-only flag. The seam where the remote-df sentinel will hook.
+# XYMONCLIENT_FS_REMOTE_DF_BUDGET: seconds to wait for the remote df probe
+# before giving up for this cycle (default 30, capped at 3600; non-numeric,
+# empty or zero -> 30). A poll BUDGET, not a kill timeout: a df wedged on a
+# dead server sits in uninterruptible D-state where even SIGKILL is ignored,
+# so it is left running and picked up on a later cycle rather than killed.
+DFBUDGET="${XYMONCLIENT_FS_REMOTE_DF_BUDGET:-30}"
+case "$DFBUDGET" in
+	*[!0-9]*|'') DFBUDGET=30 ;;
+	*[1-9]*) ;;
+	*) DFBUDGET=30 ;;
+esac
+[ "$DFBUDGET" -le 3600 ] 2>/dev/null || DFBUDGET=3600
+
+# XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES: the df types whose stat() hard-blocks
+# when the server is unreachable. Shipped as a built-in list so no site has to
+# maintain one; assign the variable to override it. Only consulted with
+# DF_LOCAL_ONLY=no, since df -l keeps these mounts out entirely.
+: "${XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES=nfs nfs4 smbfs cifs ceph glusterfs fusefs.glusterfs lustre afs}"
+DFPROBEDIR="${XYMONTMP:-/tmp}"
+
+# fs_mounts : one "TYPE<tab>MOUNTPOINT" line per mount, from mount(8).
+# FreeBSD mount(8) lists from getmntinfo(MNT_NOWAIT) unless -v is given,
+# so it never refreshes statfs and cannot block on a dead server. Never -v.
+# df -P would, which is the whole reason this list is read here instead.
+fs_mounts() {
+	mount | awk '
+		{
+			i = index($0, " on ")
+			if (i == 0) next
+			rest = substr($0, i + 4)
+			if (match(rest, / \(/) == 0) next
+			mp = substr(rest, 1, RSTART - 1)
+			split(substr(rest, RSTART + 2), a, /[,)]/)
+			printf "%s\t%s\n", a[1], mp
+		}'
+}
+
+# probe_dir_is_local DIR : true when DIR is not itself on a hard-blocking
+# filesystem. Decided purely from the mount list by longest mount-point prefix,
+# and deliberately WITHOUT stat()ing DIR: if DIR were on the wedged mount, even
+# `test -w DIR` would block in D-state inside the very fail-safe meant to
+# prevent that. Symlinks are not resolved for the same reason (readlink would
+# stat), so keep XYMONTMP on a real local path.
+probe_dir_is_local()
+{
+	# The helper's status, not the pipeline's: a pipeline reports its last
+	# command, and awk succeeds on no input at all -- which is what an
+	# unreadable mount list looks like from there. Answering "local" then
+	# sends the probe at a directory that may sit on the wedged mount this
+	# exists to keep away from.
+	_pdlm=$(fs_mounts) || return 1
+	printf '%s\n' "$_pdlm" | awk -F'\t' -v dir="$1" -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+		BEGIN { n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1 }
+		{
+			mp = $2
+			if (dir == mp || mp == "/" || substr(dir, 1, length(mp) + 1) == mp "/") {
+				if (length(mp) >= length(best)) { best = mp; besttype = $1 }
+			}
+		}
+		END { exit (besttype in t) ? 1 : 0 }
+	'
+}
+
+df_sentinel()
+{
+	_tag="$1"; shift
+	_probe="$DFPROBEDIR/df-probe-$_tag"; _pidf="$_probe.pid"
+
+	probe_dir_is_local "$DFPROBEDIR" || return 124
+
+	# Claim the probe before starting it, or two cycles both find no pidfile
+	# and both start a df -- and only the last pid written is recorded, so the
+	# others pile up untracked, and these cannot be killed.
+	#
+	# The claim goes to a private file and is hard-linked into place: link
+	# fails if the target exists, so one cycle wins, and what it publishes is
+	# complete the moment it is visible. "set -C" gave exclusivity but not
+	# that -- O_EXCL makes the create atomic, not the create-and-write, and a
+	# reader in between saw an empty string, took it for a stale entry, and
+	# started a probe on top of the first (@SoundGoof). Winning also proves
+	# the directory is writable before any df runs.
+	#
+	# The redirect is wrapped in a subshell because a redirection error on a
+	# special builtin kills the shell under dash instead of returning non-zero,
+	# and then "return 124" never runs.
+	#
+	# The claim names the claiming shell and is replaced by df's pid below, so
+	# a cycle killed in the gap leaves a dead pid, collected like any finished
+	# probe, rather than a marker nothing clears.
+	_tmpf="$_pidf.$$"
+	if ! ( echo "claim:$$" > "$_tmpf" ) 2>/dev/null; then
+		rm -f "$_tmpf"
+		return 124
+	fi
+	# "-d" first: link into a directory puts the file *inside* it, so a
+	# directory where the pidfile belongs would look like a won claim while
+	# nothing recorded the pid. The old redirect simply failed there, and that
+	# is the behaviour to keep: unclaimable means unavailable, not a probe
+	# nobody tracks.
+	if [ -d "$_pidf" ] || ! ln "$_tmpf" "$_pidf" 2>/dev/null; then
+		_old=$(cat "$_pidf" 2>/dev/null)
+		case "$_old" in
+			claim:*)
+				# Another cycle holds the claim and has not started its df yet.
+				_c=${_old#claim:}
+				[ -n "$_c" ] && kill -0 "$_c" 2>/dev/null && { rm -f "$_tmpf"; return 124; }
+				;;
+			?*)
+				# A df we recorded. Still wedged? The command name is
+				# checked so a recycled PID does not look like one. ps, not
+				# /proc: POSIX, same answer, already a dependency of this
+				# client, and it reads process state only -- it cannot touch
+				# the wedged mount. Basename, because comm is the short name
+				# on Linux and the BSDs and the full path on macOS.
+				_c=$(ps -o comm= -p "$_old" 2>/dev/null | tr -d '[:space:]')
+				_c=${_c##*/}
+				if kill -0 "$_old" 2>/dev/null && [ "$_c" = df ]; then
+					rm -f "$_tmpf"
+					return 124
+				fi
+				;;
+		esac
+		# It finished after we stopped waiting. Its output is not usable: we
+		# were not there to see the exit status, so a truncated file is
+		# indistinguishable from a complete one, and its age is unknown.
+		if [ ! -e "$_pidf" ]; then
+			# The link failed with nothing in its way, so this filesystem does
+			# not do hard links -- XYMONTMP pointed somewhere exotic. Every
+			# cycle then reports the guarded mounts unavailable and never
+			# probes: red rather than a false green, but saying nothing about
+			# why. Say it.
+			echo "xymonclient: cannot claim the remote df probe in $_pidf (does $DFPROBEDIR support hard links?)" >&2
+			rm -f "$_tmpf"
+			return 124
+		fi
+		# Discard and re-probe -- fresh data next cycle beats stale or partial
+		# data now. One retry only: if another cycle claims it first, that
+		# cycle owns the probe and this one waits its turn.
+		rm -f "$_pidf" "$_probe"
+		[ -d "$_pidf" ] && { rm -f "$_tmpf"; return 124; }
+		ln "$_tmpf" "$_pidf" 2>/dev/null || { rm -f "$_tmpf"; return 124; }
+	fi
+	rm -f "$_tmpf"
+
+	# Never run a synchronous remote df here: a foreground df would reintroduce
+	# the hang this exists to prevent.
+	( : > "$_probe" ) 2>/dev/null || { rm -f "$_pidf"; return 124; }
+	df "$@" > "$_probe" 2>/dev/null &
+	_pid=$!
+	# Publish the pid the same way the claim was published: a plain
+	# "> $_pidf" truncates before it writes, and a cycle reading in that
+	# interval sees an empty file, removes it, and starts a second probe --
+	# leaving this one's df running with nothing recording it (@SoundGoof).
+	# A rename within one directory replaces the claim in a single step, so a
+	# reader gets either the whole claim or the whole pid.
+	if ! ( printf '%s\n' "$_pid" > "$_tmpf" ) 2>/dev/null || ! mv -f "$_tmpf" "$_pidf" 2>/dev/null; then
+		rm -f "$_tmpf"
+		# The pre-flight passed and this still failed, so a df is running that
+		# the next cycle cannot recognise. The claim is still in place and this
+		# shell outlives the budget, so no second probe starts meanwhile. Say
+		# so: an operator seeing repeated unavailable rows needs to know a df
+		# may be outstanding.
+		echo "xymonclient: cannot record remote df pid in $_pidf" >&2
+	fi
+	_n=0
+	while kill -0 "$_pid" 2>/dev/null; do
+		[ "$_n" -ge "$DFBUDGET" ] && break
+		sleep 1; _n=$((_n + 1))
+	done
+	if kill -0 "$_pid" 2>/dev/null; then
+		return 124			# budget spent; leave it running as the sentinel
+	fi
+	wait "$_pid"; _rc=$?
+	rm -f "$_pidf"
+	if [ "$_rc" -ne 0 ]; then rm -f "$_probe"; return 124; fi
+	sed -e '1d' "$_probe"; rm -f "$_probe"
+	return 0
+}
+
+# run_df FLAG [extra-excludes...]: df rows for one report behind the FS filter.
+# With DF_LOCAL_ONLY=no the local and remote sets are collected separately, so a
+# wedged remote server can neither block nor stale the local data.
 run_df() {
 	_flag="$1"; shift
-	_excl=`fs_excl_opt "$@"`
-	df "$_flag" $DFLOCAL $_excl
+	if [ "$DFLOCALONLY" = yes ]; then
+		df "$_flag" $DFLOCAL `fs_excl_opt "$@"`
+		return
+	fi
+
+	# Everything that cannot hard-block, in one plain df. "-t no<csv>" filters
+	# the mount list before df stat()s anything, exactly as -l does, so
+	# excluding the hard-blocking types is enough to keep this call safe -- and
+	# unlike -l it still reports healthy remote filesystems, which is what
+	# LOCAL_ONLY=no asks for. Its status is kept: emit_df turns "no output and
+	# non-zero" into the failure marker that drives the server yellow, and
+	# splitting the collection must not cost that.
+	_plain=`df "$_flag" \`fs_excl_opt "$@" $XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES\``
+	_prc=$?
+	[ -n "$_plain" ] && printf '%s\n' "$_plain"
+
+	# Remote set: the hard-blocking mounts, from mount(8) (which never
+	# refreshes statfs), minus any the admin excluded -- naming a mount whose
+	# type is excluded gives a df with nothing to process, which exits nonzero
+	# and would report every one of those healthy mounts unavailable.
+	_exl=`fs_excl_opt "$@" | sed -e 's/^-tno//' -e 's/,/ /g'`
+	_rm=`fs_mounts | awk -F'\t' -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" -v excl="$_exl" '
+		BEGIN {
+			n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1
+			m = split(excl,  b, /[ \t]+/); for (i = 1; i <= m; i++) x[b[i]] = 1
+		}
+		($1 in t) && !($1 in x) { print $2 }'`
+	[ -n "$_rm" ] || return $_prc
+
+	case $- in *f*) _rg=no ;; *) _rg=yes; set -f ;; esac
+	_oifs=$IFS; IFS='
+'
+	# Deliberate split on newline only, so a mount point containing a space
+	# stays one argument. set -f above keeps globbing out of it.
+	set -- "$_flag"
+	# shellcheck disable=SC2086
+	for _m in $_rm; do set -- "$@" "$_m"; done
+	_tag=disk; [ "$_flag" = -i ] && _tag=inode
+	_rout=`df_sentinel "$_tag" "$@"`
+	if [ $? -eq 124 ]; then
+		# Unavailable: surface each remote mount as a failed (100%) row rather
+		# than dropping it, since the server reads an absent filesystem as
+		# green. This turns one filesystem red instead of purpling the host.
+		# The inode report is read column-wise (iused, ifree and %iused are
+		# fields 6-8), so its marker row carries them too.
+		for _m in $_rm; do
+			if [ "$_flag" = -i ]; then
+				echo "unavailable:$_m 1 1 0 100% 1 0 100% $_m"
+			else
+				echo "unavailable:$_m 1 1 0 100% $_m"
+			fi
+		done
+	else
+		printf '%s\n' "$_rout"
+	fi
+	IFS=$_oifs
+	[ "$_rg" = yes ] && set +f
+	return 0
 }
 # emit_df KIND LABEL FLAG [extra-excludes...]: run_df + failure guard. On a
 # non-zero df with no output, print a one-line marker (no df header) so the

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -166,43 +166,54 @@ df_sentinel()
 
 	probe_dir_is_local "$DFPROBEDIR" || return 124
 
-	# Claim the probe before starting it, atomically. Testing for the pidfile
-	# and creating it afterwards let two client cycles both find it absent and
-	# both start a df; only the last pid written was ever recorded, so the
-	# other probe was untracked from then on and more piled up every cycle -
-	# and these are the processes that cannot be killed. Under "set -C" the
-	# create is O_EXCL, so exactly one cycle wins, and winning doubles as the
-	# proof that the pidfile is writable before any df starts.
+	# Claim the probe before starting it, or two cycles both find no pidfile
+	# and both start a df -- and only the last pid written is recorded, so the
+	# others pile up untracked, and these cannot be killed.
 	#
-	# A subshell, not a bare ":": ":" is a POSIX special builtin, and a
-	# redirection error on one is fatal to the shell rather than a non-zero
-	# status. Under dash - /bin/sh on Debian and Ubuntu - "return 124" would
-	# never run, the sentinel would die with status 2, and run_df would emit
-	# nothing for the remote set instead of the unavailable rows. It also keeps
-	# noclobber out of the caller.
+	# The claim goes to a private file and is hard-linked into place: link
+	# fails if the target exists, so one cycle wins, and what it publishes is
+	# complete the moment it is visible. "set -C" gave exclusivity but not
+	# that -- O_EXCL makes the create atomic, not the create-and-write, and a
+	# reader in between saw an empty string, took it for a stale entry, and
+	# started a probe on top of the first (@SoundGoof). Winning also proves
+	# the directory is writable before any df runs.
+	#
+	# The redirect is wrapped in a subshell because a redirection error on a
+	# special builtin kills the shell under dash instead of returning non-zero,
+	# and then "return 124" never runs.
 	#
 	# The claim names the claiming shell and is replaced by df's pid below, so
-	# a cycle killed in the gap leaves a pid that is simply dead and is
-	# collected like any finished probe, rather than a marker nothing clears.
-	if ! ( set -C; echo "claim:$$" > "$_pidf" ) 2>/dev/null; then
+	# a cycle killed in the gap leaves a dead pid, collected like any finished
+	# probe, rather than a marker nothing clears.
+	_tmpf="$_pidf.$$"
+	if ! ( echo "claim:$$" > "$_tmpf" ) 2>/dev/null; then
+		rm -f "$_tmpf"
+		return 124
+	fi
+	# "-d" first: link into a directory puts the file *inside* it, so a
+	# directory where the pidfile belongs would look like a won claim while
+	# nothing recorded the pid. The old redirect simply failed there, and that
+	# is the behaviour to keep: unclaimable means unavailable, not a probe
+	# nobody tracks.
+	if [ -d "$_pidf" ] || ! ln "$_tmpf" "$_pidf" 2>/dev/null; then
 		_old=$(cat "$_pidf" 2>/dev/null)
 		case "$_old" in
 			claim:*)
 				# Another cycle holds the claim and has not started its df yet.
 				_c=${_old#claim:}
-				[ -n "$_c" ] && kill -0 "$_c" 2>/dev/null && return 124
+				[ -n "$_c" ] && kill -0 "$_c" 2>/dev/null && { rm -f "$_tmpf"; return 124; }
 				;;
 			?*)
-				# A df we recorded. Still wedged? The command name is checked
-				# so a recycled PID does not look like one. Read it with ps,
-				# not /proc/PID/comm: ps is POSIX, gives the same answer, is
-				# already a dependency of this client (the [ps] section), and
-				# reads process state only -- it cannot touch the wedged mount.
-				# Take the basename: comm is the short name on Linux and the
-				# BSDs, but the full path on macOS.
+				# A df we recorded. Still wedged? The command name is
+				# checked so a recycled PID does not look like one. ps, not
+				# /proc: POSIX, same answer, already a dependency of this
+				# client, and it reads process state only -- it cannot touch
+				# the wedged mount. Basename, because comm is the short name
+				# on Linux and the BSDs and the full path on macOS.
 				_c=$(ps -o comm= -p "$_old" 2>/dev/null | tr -d '[:space:]')
 				_c=${_c##*/}
 				if kill -0 "$_old" 2>/dev/null && [ "$_c" = df ]; then
+					rm -f "$_tmpf"
 					return 124
 				fi
 				;;
@@ -210,22 +221,43 @@ df_sentinel()
 		# It finished after we stopped waiting. Its output is not usable: we
 		# were not there to see the exit status, so a truncated file is
 		# indistinguishable from a complete one, and its age is unknown.
+		if [ ! -e "$_pidf" ]; then
+			# The link failed with nothing in its way, so this filesystem does
+			# not do hard links -- XYMONTMP pointed somewhere exotic. Every
+			# cycle then reports the guarded mounts unavailable and never
+			# probes: red rather than a false green, but saying nothing about
+			# why. Say it.
+			echo "xymonclient: cannot claim the remote df probe in $_pidf (does $DFPROBEDIR support hard links?)" >&2
+			rm -f "$_tmpf"
+			return 124
+		fi
 		# Discard and re-probe -- fresh data next cycle beats stale or partial
 		# data now. One retry only: if another cycle claims it first, that
 		# cycle owns the probe and this one waits its turn.
 		rm -f "$_pidf" "$_probe"
-		( set -C; echo "claim:$$" > "$_pidf" ) 2>/dev/null || return 124
+		[ -d "$_pidf" ] && { rm -f "$_tmpf"; return 124; }
+		ln "$_tmpf" "$_pidf" 2>/dev/null || { rm -f "$_tmpf"; return 124; }
 	fi
+	rm -f "$_tmpf"
 
 	# Never run a synchronous remote df here: a foreground df would reintroduce
 	# the hang this exists to prevent.
 	( : > "$_probe" ) 2>/dev/null || { rm -f "$_pidf"; return 124; }
 	df "$@" > "$_probe" 2>/dev/null &
 	_pid=$!
-	if ! echo "$_pid" > "$_pidf"; then
+	# Publish the pid the same way the claim was published: a plain
+	# "> $_pidf" truncates before it writes, and a cycle reading in that
+	# interval sees an empty file, removes it, and starts a second probe --
+	# leaving this one's df running with nothing recording it (@SoundGoof).
+	# A rename within one directory replaces the claim in a single step, so a
+	# reader gets either the whole claim or the whole pid.
+	if ! ( printf '%s\n' "$_pid" > "$_tmpf" ) 2>/dev/null || ! mv -f "$_tmpf" "$_pidf" 2>/dev/null; then
+		rm -f "$_tmpf"
 		# The pre-flight passed and this still failed, so a df is running that
-		# the next cycle cannot recognise. Say so: an operator seeing repeated
-		# unavailable rows needs to know a df may be outstanding.
+		# the next cycle cannot recognise. The claim is still in place and this
+		# shell outlives the budget, so no second probe starts meanwhile. Say
+		# so: an operator seeing repeated unavailable rows needs to know a df
+		# may be outstanding.
 		echo "xymonclient: cannot record remote df pid in $_pidf" >&2
 	fi
 	_n=0
@@ -283,14 +315,19 @@ run_df()
 	# collection must not cost that. Returning 0 unconditionally here left a
 	# failing df with no rows looking like a healthy empty report -- the same
 	# false green the marker exists to prevent, reached from the other side.
+	# The noglob switch is set here, not inside the substitution: bash 3.2 and
+	# OpenBSD's ksh both refuse a case statement inside a $( ) with
+	# "syntax error near unexpected token ;;". This client never runs on those
+	# shells, but this block is extracted and run by a test that does.
+	case $- in *f*) _pg=no ;; *) _pg=yes; set -f ;; esac
 	_plain=$(
-		case $- in *f*) ;; *) set -f ;; esac
 		for t in $XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES; do
 			set -- "$@" -x "$t"
 		done
 		df "$@"
 	)
 	_prc=$?
+	[ "$_pg" = yes ] && set +f
 	[ -n "$_plain" ] && printf '%s\n' "$_plain"
 
 	# Remote set: pick the hard-blocking mounts out of /proc/mounts (reading it

--- a/client/xymonclient-netbsd.sh
+++ b/client/xymonclient-netbsd.sh
@@ -45,10 +45,249 @@ case "$DFLOCALONLY" in
     *) echo "xymonclient-netbsd: invalid XYMONCLIENT_FS_DF_LOCAL_ONLY '$DFLOCALONLY', using yes" >&2; DFLOCALONLY=yes ;;
 esac
 DFLOCAL=""; [ "$DFLOCALONLY" = yes ] && DFLOCAL="-l"
+# XYMONCLIENT_FS_REMOTE_DF_BUDGET: seconds to wait for the remote df probe
+# before giving up for this cycle (default 30, capped at 3600; non-numeric,
+# empty or zero -> 30). A poll BUDGET, not a kill timeout: a df wedged on a
+# dead server sits in uninterruptible D-state where even SIGKILL is ignored,
+# so it is left running and picked up on a later cycle rather than killed.
+DFBUDGET="${XYMONCLIENT_FS_REMOTE_DF_BUDGET:-30}"
+case "$DFBUDGET" in
+	*[!0-9]*|'') DFBUDGET=30 ;;
+	*[1-9]*) ;;
+	*) DFBUDGET=30 ;;
+esac
+[ "$DFBUDGET" -le 3600 ] 2>/dev/null || DFBUDGET=3600
+
+# XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES: the df types whose stat() hard-blocks
+# when the server is unreachable. Shipped as a built-in list so no site has to
+# maintain one; assign the variable to override it. Only consulted with
+# DF_LOCAL_ONLY=no, since df -l keeps these mounts out entirely.
+: "${XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES=nfs nfs4 smbfs cifs ceph glusterfs puffs|nfs lustre afs}"
+DFPROBEDIR="${XYMONTMP:-/tmp}"
+
+# fs_mounts : one "TYPE<tab>MOUNTPOINT" line per mount, from mount(8).
+# NetBSD mount(8) lists from getmntinfo(MNT_NOWAIT), so it never refreshes
+# statfs and cannot block on a dead server.
+# df -P would, which is the whole reason this list is read here instead.
+fs_mounts() {
+	mount | awk '
+		{
+			i = index($0, " on ")
+			if (i == 0) next
+			rest = substr($0, i + 4)
+			if (match(rest, / type [^ ]+ \(/) == 0) next
+			mp = substr(rest, 1, RSTART - 1)
+			type = substr(rest, RSTART + 6)
+			sub(/ \(.*/, "", type)
+			printf "%s\t%s\n", type, mp
+		}'
+}
+
+# probe_dir_is_local DIR : true when DIR is not itself on a hard-blocking
+# filesystem. Decided purely from the mount list by longest mount-point prefix,
+# and deliberately WITHOUT stat()ing DIR: if DIR were on the wedged mount, even
+# `test -w DIR` would block in D-state inside the very fail-safe meant to
+# prevent that. Symlinks are not resolved for the same reason (readlink would
+# stat), so keep XYMONTMP on a real local path.
+probe_dir_is_local()
+{
+	# The helper's status, not the pipeline's: a pipeline reports its last
+	# command, and awk succeeds on no input at all -- which is what an
+	# unreadable mount list looks like from there. Answering "local" then
+	# sends the probe at a directory that may sit on the wedged mount this
+	# exists to keep away from.
+	_pdlm=$(fs_mounts) || return 1
+	printf '%s\n' "$_pdlm" | awk -F'\t' -v dir="$1" -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+		BEGIN { n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1 }
+		{
+			mp = $2
+			if (dir == mp || mp == "/" || substr(dir, 1, length(mp) + 1) == mp "/") {
+				if (length(mp) >= length(best)) { best = mp; besttype = $1 }
+			}
+		}
+		END { exit (besttype in t) ? 1 : 0 }
+	'
+}
+
+df_sentinel()
+{
+	_tag="$1"; shift
+	_probe="$DFPROBEDIR/df-probe-$_tag"; _pidf="$_probe.pid"
+
+	probe_dir_is_local "$DFPROBEDIR" || return 124
+
+	# Claim the probe before starting it, or two cycles both find no pidfile
+	# and both start a df -- and only the last pid written is recorded, so the
+	# others pile up untracked, and these cannot be killed.
+	#
+	# The claim goes to a private file and is hard-linked into place: link
+	# fails if the target exists, so one cycle wins, and what it publishes is
+	# complete the moment it is visible. "set -C" gave exclusivity but not
+	# that -- O_EXCL makes the create atomic, not the create-and-write, and a
+	# reader in between saw an empty string, took it for a stale entry, and
+	# started a probe on top of the first (@SoundGoof). Winning also proves
+	# the directory is writable before any df runs.
+	#
+	# The redirect is wrapped in a subshell because a redirection error on a
+	# special builtin kills the shell under dash instead of returning non-zero,
+	# and then "return 124" never runs.
+	#
+	# The claim names the claiming shell and is replaced by df's pid below, so
+	# a cycle killed in the gap leaves a dead pid, collected like any finished
+	# probe, rather than a marker nothing clears.
+	_tmpf="$_pidf.$$"
+	if ! ( echo "claim:$$" > "$_tmpf" ) 2>/dev/null; then
+		rm -f "$_tmpf"
+		return 124
+	fi
+	# "-d" first: link into a directory puts the file *inside* it, so a
+	# directory where the pidfile belongs would look like a won claim while
+	# nothing recorded the pid. The old redirect simply failed there, and that
+	# is the behaviour to keep: unclaimable means unavailable, not a probe
+	# nobody tracks.
+	if [ -d "$_pidf" ] || ! ln "$_tmpf" "$_pidf" 2>/dev/null; then
+		_old=$(cat "$_pidf" 2>/dev/null)
+		case "$_old" in
+			claim:*)
+				# Another cycle holds the claim and has not started its df yet.
+				_c=${_old#claim:}
+				[ -n "$_c" ] && kill -0 "$_c" 2>/dev/null && { rm -f "$_tmpf"; return 124; }
+				;;
+			?*)
+				# A df we recorded. Still wedged? The command name is
+				# checked so a recycled PID does not look like one. ps, not
+				# /proc: POSIX, same answer, already a dependency of this
+				# client, and it reads process state only -- it cannot touch
+				# the wedged mount. Basename, because comm is the short name
+				# on Linux and the BSDs and the full path on macOS.
+				_c=$(ps -o comm= -p "$_old" 2>/dev/null | tr -d '[:space:]')
+				_c=${_c##*/}
+				if kill -0 "$_old" 2>/dev/null && [ "$_c" = df ]; then
+					rm -f "$_tmpf"
+					return 124
+				fi
+				;;
+		esac
+		# It finished after we stopped waiting. Its output is not usable: we
+		# were not there to see the exit status, so a truncated file is
+		# indistinguishable from a complete one, and its age is unknown.
+		if [ ! -e "$_pidf" ]; then
+			# The link failed with nothing in its way, so this filesystem does
+			# not do hard links -- XYMONTMP pointed somewhere exotic. Every
+			# cycle then reports the guarded mounts unavailable and never
+			# probes: red rather than a false green, but saying nothing about
+			# why. Say it.
+			echo "xymonclient: cannot claim the remote df probe in $_pidf (does $DFPROBEDIR support hard links?)" >&2
+			rm -f "$_tmpf"
+			return 124
+		fi
+		# Discard and re-probe -- fresh data next cycle beats stale or partial
+		# data now. One retry only: if another cycle claims it first, that
+		# cycle owns the probe and this one waits its turn.
+		rm -f "$_pidf" "$_probe"
+		[ -d "$_pidf" ] && { rm -f "$_tmpf"; return 124; }
+		ln "$_tmpf" "$_pidf" 2>/dev/null || { rm -f "$_tmpf"; return 124; }
+	fi
+	rm -f "$_tmpf"
+
+	# Never run a synchronous remote df here: a foreground df would reintroduce
+	# the hang this exists to prevent.
+	( : > "$_probe" ) 2>/dev/null || { rm -f "$_pidf"; return 124; }
+	df "$@" > "$_probe" 2>/dev/null &
+	_pid=$!
+	# Publish the pid the same way the claim was published: a plain
+	# "> $_pidf" truncates before it writes, and a cycle reading in that
+	# interval sees an empty file, removes it, and starts a second probe --
+	# leaving this one's df running with nothing recording it (@SoundGoof).
+	# A rename within one directory replaces the claim in a single step, so a
+	# reader gets either the whole claim or the whole pid.
+	if ! ( printf '%s\n' "$_pid" > "$_tmpf" ) 2>/dev/null || ! mv -f "$_tmpf" "$_pidf" 2>/dev/null; then
+		rm -f "$_tmpf"
+		# The pre-flight passed and this still failed, so a df is running that
+		# the next cycle cannot recognise. The claim is still in place and this
+		# shell outlives the budget, so no second probe starts meanwhile. Say
+		# so: an operator seeing repeated unavailable rows needs to know a df
+		# may be outstanding.
+		echo "xymonclient: cannot record remote df pid in $_pidf" >&2
+	fi
+	_n=0
+	while kill -0 "$_pid" 2>/dev/null; do
+		[ "$_n" -ge "$DFBUDGET" ] && break
+		sleep 1; _n=$((_n + 1))
+	done
+	if kill -0 "$_pid" 2>/dev/null; then
+		return 124			# budget spent; leave it running as the sentinel
+	fi
+	wait "$_pid"; _rc=$?
+	rm -f "$_pidf"
+	if [ "$_rc" -ne 0 ]; then rm -f "$_probe"; return 124; fi
+	sed -e '1d' "$_probe"; rm -f "$_probe"
+	return 0
+}
+
+# run_df FLAG [extra-excludes...]: df rows for one report behind the FS filter.
+# With DF_LOCAL_ONLY=no the local and remote sets are collected separately, so a
+# wedged remote server can neither block nor stale the local data.
 run_df() {
-    _flag="$1"; shift
-    _excl=`fs_excl_opt "$@"`
-    df "$_flag" $DFLOCAL $_excl
+	_flag="$1"; shift
+	if [ "$DFLOCALONLY" = yes ]; then
+		df "$_flag" $DFLOCAL `fs_excl_opt "$@"`
+		return
+	fi
+
+	# Everything that cannot hard-block, in one plain df. "-t no<csv>" filters
+	# the mount list before df stat()s anything, exactly as -l does, so
+	# excluding the hard-blocking types is enough to keep this call safe -- and
+	# unlike -l it still reports healthy remote filesystems, which is what
+	# LOCAL_ONLY=no asks for. Its status is kept: emit_df turns "no output and
+	# non-zero" into the failure marker that drives the server yellow, and
+	# splitting the collection must not cost that.
+	_plain=`df "$_flag" \`fs_excl_opt "$@" $XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES\``
+	_prc=$?
+	[ -n "$_plain" ] && printf '%s\n' "$_plain"
+
+	# Remote set: the hard-blocking mounts, from mount(8) (which never
+	# refreshes statfs), minus any the admin excluded -- naming a mount whose
+	# type is excluded gives a df with nothing to process, which exits nonzero
+	# and would report every one of those healthy mounts unavailable.
+	_exl=`fs_excl_opt "$@" | sed -e 's/^-tno//' -e 's/,/ /g'`
+	_rm=`fs_mounts | awk -F'\t' -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" -v excl="$_exl" '
+		BEGIN {
+			n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1
+			m = split(excl,  b, /[ \t]+/); for (i = 1; i <= m; i++) x[b[i]] = 1
+		}
+		($1 in t) && !($1 in x) { print $2 }'`
+	[ -n "$_rm" ] || return $_prc
+
+	case $- in *f*) _rg=no ;; *) _rg=yes; set -f ;; esac
+	_oifs=$IFS; IFS='
+'
+	# Deliberate split on newline only, so a mount point containing a space
+	# stays one argument. set -f above keeps globbing out of it.
+	set -- "$_flag"
+	# shellcheck disable=SC2086
+	for _m in $_rm; do set -- "$@" "$_m"; done
+	_tag=disk; [ "$_flag" = -i ] && _tag=inode
+	_rout=`df_sentinel "$_tag" "$@"`
+	if [ $? -eq 124 ]; then
+		# Unavailable: surface each remote mount as a failed (100%) row rather
+		# than dropping it, since the server reads an absent filesystem as
+		# green. This turns one filesystem red instead of purpling the host.
+		# The inode report is read column-wise (iused, ifree and %iused are
+		# fields 6-8), so its marker row carries them too.
+		for _m in $_rm; do
+			if [ "$_flag" = -i ]; then
+				echo "unavailable:$_m 1 1 0 100% 1 0 100% $_m"
+			else
+				echo "unavailable:$_m 1 1 0 100% $_m"
+			fi
+		done
+	else
+		printf '%s\n' "$_rout"
+	fi
+	IFS=$_oifs
+	[ "$_rg" = yes ] && set +f
+	return 0
 }
 emit_df() {
     _kind="$1"; _label="$2"; shift 2

--- a/client/xymonclient-openbsd.sh
+++ b/client/xymonclient-openbsd.sh
@@ -53,12 +53,249 @@ case "$DFLOCALONLY" in
 	*) echo "xymonclient-openbsd: invalid XYMONCLIENT_FS_DF_LOCAL_ONLY '$DFLOCALONLY', using yes" >&2; DFLOCALONLY=yes ;;
 esac
 DFLOCAL=""; [ "$DFLOCALONLY" = yes ] && DFLOCAL="-l"
-# run_df FLAG [extra-excludes...]: df rows for one report behind the FS filter
-# and local-only flag. The seam where the remote-df sentinel will hook.
+# XYMONCLIENT_FS_REMOTE_DF_BUDGET: seconds to wait for the remote df probe
+# before giving up for this cycle (default 30, capped at 3600; non-numeric,
+# empty or zero -> 30). A poll BUDGET, not a kill timeout: a df wedged on a
+# dead server sits in uninterruptible D-state where even SIGKILL is ignored,
+# so it is left running and picked up on a later cycle rather than killed.
+DFBUDGET="${XYMONCLIENT_FS_REMOTE_DF_BUDGET:-30}"
+case "$DFBUDGET" in
+	*[!0-9]*|'') DFBUDGET=30 ;;
+	*[1-9]*) ;;
+	*) DFBUDGET=30 ;;
+esac
+[ "$DFBUDGET" -le 3600 ] 2>/dev/null || DFBUDGET=3600
+
+# XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES: the df types whose stat() hard-blocks
+# when the server is unreachable. Shipped as a built-in list so no site has to
+# maintain one; assign the variable to override it. Only consulted with
+# DF_LOCAL_ONLY=no, since df -l keeps these mounts out entirely.
+: "${XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES=nfs nfs4 smbfs cifs ceph glusterfs lustre afs}"
+DFPROBEDIR="${XYMONTMP:-/tmp}"
+
+# fs_mounts : one "TYPE<tab>MOUNTPOINT" line per mount, from mount(8).
+# OpenBSD mount(8) lists from getmntinfo(MNT_NOWAIT), so it never refreshes
+# statfs and cannot block on a dead server.
+# df -P would, which is the whole reason this list is read here instead.
+fs_mounts() {
+	mount | awk '
+		{
+			i = index($0, " on ")
+			if (i == 0) next
+			rest = substr($0, i + 4)
+			if (match(rest, / type [^ ]+ \(/) == 0) next
+			mp = substr(rest, 1, RSTART - 1)
+			type = substr(rest, RSTART + 6)
+			sub(/ \(.*/, "", type)
+			printf "%s\t%s\n", type, mp
+		}'
+}
+
+# probe_dir_is_local DIR : true when DIR is not itself on a hard-blocking
+# filesystem. Decided purely from the mount list by longest mount-point prefix,
+# and deliberately WITHOUT stat()ing DIR: if DIR were on the wedged mount, even
+# `test -w DIR` would block in D-state inside the very fail-safe meant to
+# prevent that. Symlinks are not resolved for the same reason (readlink would
+# stat), so keep XYMONTMP on a real local path.
+probe_dir_is_local()
+{
+	# The helper's status, not the pipeline's: a pipeline reports its last
+	# command, and awk succeeds on no input at all -- which is what an
+	# unreadable mount list looks like from there. Answering "local" then
+	# sends the probe at a directory that may sit on the wedged mount this
+	# exists to keep away from.
+	_pdlm=$(fs_mounts) || return 1
+	printf '%s\n' "$_pdlm" | awk -F'\t' -v dir="$1" -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+		BEGIN { n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1 }
+		{
+			mp = $2
+			if (dir == mp || mp == "/" || substr(dir, 1, length(mp) + 1) == mp "/") {
+				if (length(mp) >= length(best)) { best = mp; besttype = $1 }
+			}
+		}
+		END { exit (besttype in t) ? 1 : 0 }
+	'
+}
+
+df_sentinel()
+{
+	_tag="$1"; shift
+	_probe="$DFPROBEDIR/df-probe-$_tag"; _pidf="$_probe.pid"
+
+	probe_dir_is_local "$DFPROBEDIR" || return 124
+
+	# Claim the probe before starting it, or two cycles both find no pidfile
+	# and both start a df -- and only the last pid written is recorded, so the
+	# others pile up untracked, and these cannot be killed.
+	#
+	# The claim goes to a private file and is hard-linked into place: link
+	# fails if the target exists, so one cycle wins, and what it publishes is
+	# complete the moment it is visible. "set -C" gave exclusivity but not
+	# that -- O_EXCL makes the create atomic, not the create-and-write, and a
+	# reader in between saw an empty string, took it for a stale entry, and
+	# started a probe on top of the first (@SoundGoof). Winning also proves
+	# the directory is writable before any df runs.
+	#
+	# The redirect is wrapped in a subshell because a redirection error on a
+	# special builtin kills the shell under dash instead of returning non-zero,
+	# and then "return 124" never runs.
+	#
+	# The claim names the claiming shell and is replaced by df's pid below, so
+	# a cycle killed in the gap leaves a dead pid, collected like any finished
+	# probe, rather than a marker nothing clears.
+	_tmpf="$_pidf.$$"
+	if ! ( echo "claim:$$" > "$_tmpf" ) 2>/dev/null; then
+		rm -f "$_tmpf"
+		return 124
+	fi
+	# "-d" first: link into a directory puts the file *inside* it, so a
+	# directory where the pidfile belongs would look like a won claim while
+	# nothing recorded the pid. The old redirect simply failed there, and that
+	# is the behaviour to keep: unclaimable means unavailable, not a probe
+	# nobody tracks.
+	if [ -d "$_pidf" ] || ! ln "$_tmpf" "$_pidf" 2>/dev/null; then
+		_old=$(cat "$_pidf" 2>/dev/null)
+		case "$_old" in
+			claim:*)
+				# Another cycle holds the claim and has not started its df yet.
+				_c=${_old#claim:}
+				[ -n "$_c" ] && kill -0 "$_c" 2>/dev/null && { rm -f "$_tmpf"; return 124; }
+				;;
+			?*)
+				# A df we recorded. Still wedged? The command name is
+				# checked so a recycled PID does not look like one. ps, not
+				# /proc: POSIX, same answer, already a dependency of this
+				# client, and it reads process state only -- it cannot touch
+				# the wedged mount. Basename, because comm is the short name
+				# on Linux and the BSDs and the full path on macOS.
+				_c=$(ps -o comm= -p "$_old" 2>/dev/null | tr -d '[:space:]')
+				_c=${_c##*/}
+				if kill -0 "$_old" 2>/dev/null && [ "$_c" = df ]; then
+					rm -f "$_tmpf"
+					return 124
+				fi
+				;;
+		esac
+		# It finished after we stopped waiting. Its output is not usable: we
+		# were not there to see the exit status, so a truncated file is
+		# indistinguishable from a complete one, and its age is unknown.
+		if [ ! -e "$_pidf" ]; then
+			# The link failed with nothing in its way, so this filesystem does
+			# not do hard links -- XYMONTMP pointed somewhere exotic. Every
+			# cycle then reports the guarded mounts unavailable and never
+			# probes: red rather than a false green, but saying nothing about
+			# why. Say it.
+			echo "xymonclient: cannot claim the remote df probe in $_pidf (does $DFPROBEDIR support hard links?)" >&2
+			rm -f "$_tmpf"
+			return 124
+		fi
+		# Discard and re-probe -- fresh data next cycle beats stale or partial
+		# data now. One retry only: if another cycle claims it first, that
+		# cycle owns the probe and this one waits its turn.
+		rm -f "$_pidf" "$_probe"
+		[ -d "$_pidf" ] && { rm -f "$_tmpf"; return 124; }
+		ln "$_tmpf" "$_pidf" 2>/dev/null || { rm -f "$_tmpf"; return 124; }
+	fi
+	rm -f "$_tmpf"
+
+	# Never run a synchronous remote df here: a foreground df would reintroduce
+	# the hang this exists to prevent.
+	( : > "$_probe" ) 2>/dev/null || { rm -f "$_pidf"; return 124; }
+	df "$@" > "$_probe" 2>/dev/null &
+	_pid=$!
+	# Publish the pid the same way the claim was published: a plain
+	# "> $_pidf" truncates before it writes, and a cycle reading in that
+	# interval sees an empty file, removes it, and starts a second probe --
+	# leaving this one's df running with nothing recording it (@SoundGoof).
+	# A rename within one directory replaces the claim in a single step, so a
+	# reader gets either the whole claim or the whole pid.
+	if ! ( printf '%s\n' "$_pid" > "$_tmpf" ) 2>/dev/null || ! mv -f "$_tmpf" "$_pidf" 2>/dev/null; then
+		rm -f "$_tmpf"
+		# The pre-flight passed and this still failed, so a df is running that
+		# the next cycle cannot recognise. The claim is still in place and this
+		# shell outlives the budget, so no second probe starts meanwhile. Say
+		# so: an operator seeing repeated unavailable rows needs to know a df
+		# may be outstanding.
+		echo "xymonclient: cannot record remote df pid in $_pidf" >&2
+	fi
+	_n=0
+	while kill -0 "$_pid" 2>/dev/null; do
+		[ "$_n" -ge "$DFBUDGET" ] && break
+		sleep 1; _n=$((_n + 1))
+	done
+	if kill -0 "$_pid" 2>/dev/null; then
+		return 124			# budget spent; leave it running as the sentinel
+	fi
+	wait "$_pid"; _rc=$?
+	rm -f "$_pidf"
+	if [ "$_rc" -ne 0 ]; then rm -f "$_probe"; return 124; fi
+	sed -e '1d' "$_probe"; rm -f "$_probe"
+	return 0
+}
+
+# run_df FLAG [extra-excludes...]: df rows for one report behind the FS filter.
+# With DF_LOCAL_ONLY=no the local and remote sets are collected separately, so a
+# wedged remote server can neither block nor stale the local data.
 run_df() {
 	_flag="$1"; shift
-	_excl=`fs_excl_opt "$@"`
-	df "$_flag" $DFLOCAL $_excl
+	if [ "$DFLOCALONLY" = yes ]; then
+		df "$_flag" $DFLOCAL `fs_excl_opt "$@"`
+		return
+	fi
+
+	# Everything that cannot hard-block, in one plain df. "-t no<csv>" filters
+	# the mount list before df stat()s anything, exactly as -l does, so
+	# excluding the hard-blocking types is enough to keep this call safe -- and
+	# unlike -l it still reports healthy remote filesystems, which is what
+	# LOCAL_ONLY=no asks for. Its status is kept: emit_df turns "no output and
+	# non-zero" into the failure marker that drives the server yellow, and
+	# splitting the collection must not cost that.
+	_plain=`df "$_flag" \`fs_excl_opt "$@" $XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES\``
+	_prc=$?
+	[ -n "$_plain" ] && printf '%s\n' "$_plain"
+
+	# Remote set: the hard-blocking mounts, from mount(8) (which never
+	# refreshes statfs), minus any the admin excluded -- naming a mount whose
+	# type is excluded gives a df with nothing to process, which exits nonzero
+	# and would report every one of those healthy mounts unavailable.
+	_exl=`fs_excl_opt "$@" | sed -e 's/^-tno//' -e 's/,/ /g'`
+	_rm=`fs_mounts | awk -F'\t' -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" -v excl="$_exl" '
+		BEGIN {
+			n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1
+			m = split(excl,  b, /[ \t]+/); for (i = 1; i <= m; i++) x[b[i]] = 1
+		}
+		($1 in t) && !($1 in x) { print $2 }'`
+	[ -n "$_rm" ] || return $_prc
+
+	case $- in *f*) _rg=no ;; *) _rg=yes; set -f ;; esac
+	_oifs=$IFS; IFS='
+'
+	# Deliberate split on newline only, so a mount point containing a space
+	# stays one argument. set -f above keeps globbing out of it.
+	set -- "$_flag"
+	# shellcheck disable=SC2086
+	for _m in $_rm; do set -- "$@" "$_m"; done
+	_tag=disk; [ "$_flag" = -i ] && _tag=inode
+	_rout=`df_sentinel "$_tag" "$@"`
+	if [ $? -eq 124 ]; then
+		# Unavailable: surface each remote mount as a failed (100%) row rather
+		# than dropping it, since the server reads an absent filesystem as
+		# green. This turns one filesystem red instead of purpling the host.
+		# The inode report is read column-wise (iused, ifree and %iused are
+		# fields 6-8), so its marker row carries them too.
+		for _m in $_rm; do
+			if [ "$_flag" = -i ]; then
+				echo "unavailable:$_m 1 1 0 100% 1 0 100% $_m"
+			else
+				echo "unavailable:$_m 1 1 0 100% $_m"
+			fi
+		done
+	else
+		printf '%s\n' "$_rout"
+	fi
+	IFS=$_oifs
+	[ "$_rg" = yes ] && set +f
+	return 0
 }
 # emit_df KIND LABEL FLAG [extra-excludes...]: run_df + failure guard. On a
 # non-zero df with no output, print a one-line marker (no df header) so the

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -23,9 +23,10 @@ LOGFETCHOPTS=""
 # mechanisms, matching rules, examples - lives in xymonclient.cfg(5); the
 # blocks below list only each OS's defaults. Unlisted OSes ignore the
 # variables. WARNING: XYMONCLIENT_FS_DF_LOCAL_ONLY=no can hang df on a stale
-# remote mount and turn the whole host purple - see the manual first. On Linux
-# that hang is bounded by the remote-df sentinel (XYMONCLIENT_FS_REMOTE_DF_BUDGET,
-# XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES); other clients carry it in full.
+# remote mount and turn the whole host purple - see the manual first. On Linux,
+# FreeBSD, NetBSD, OpenBSD and macOS that hang is bounded by the remote-df
+# sentinel (XYMONCLIENT_FS_REMOTE_DF_BUDGET, XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES);
+# the remaining clients carry it in full.
 #
 # Linux (xymonclient-linux.sh) - excludes nodev pseudo-filesystems and the
 # always-full iso9660/squashfs images:

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -153,8 +153,8 @@ probe is not silently reported green. This does not cover the hang
 above: a wedged df never exits.
 
 .IP "\fBXYMONCLIENT_FS_REMOTE_DF_BUDGET\fR"
-Linux only. Seconds to wait for the remote df probe before giving up for
-this cycle. Defaults to \fB30\fR, capped at 3600; empty, zero or
+Linux, FreeBSD, NetBSD, OpenBSD and macOS. Seconds to wait for the remote
+df probe before giving up for this cycle. Defaults to \fB30\fR, capped at 3600; empty, zero or
 non-numeric values fall back to the default.
 .IP
 This is a poll \fIbudget\fR, not a kill timeout. A df blocked on a dead
@@ -183,14 +183,18 @@ such a path blocks. Keep $XYMONTMP on local storage. Symbolic links are
 not resolved, for the same reason.
 
 .IP "\fBXYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES\fR"
-Linux only. The df filesystem types whose stat() hard-blocks when the
-server is unreachable, and which are therefore collected behind the
-sentinel. Defaults to
-\fBnfs nfs4 cifs smb3 ceph glusterfs fuse.glusterfs lustre afs\fR.
-Types are matched as exact df type tokens, so \fBfuse.glusterfs\fR is
+Linux, FreeBSD, NetBSD, OpenBSD and macOS. The filesystem types whose
+stat() hard-blocks when the server is unreachable, and which are
+therefore collected behind the sentinel. The default names each OS's own
+spellings, e.g.
+\fBnfs nfs4 cifs smb3 ceph glusterfs fuse.glusterfs lustre afs\fR on
+Linux and \fBnfs nfs4 smbfs cifs afpfs webdav ceph glusterfs lustre
+afs\fR on macOS.
+Types are matched as exact type tokens, so \fBfuse.glusterfs\fR is
 compared literally rather than as a pattern. Only consulted with
 \fBXYMONCLIENT_FS_DF_LOCAL_ONLY=no\fR, since \fBdf \-l\fR keeps these
-mounts out entirely otherwise.
+mounts out entirely otherwise -- except on macOS, whose df has no such
+flag and where the mount list is filtered instead.
 
 .IP "\fBXYMON\fR"
 Full path to the

--- a/docs/manpages/man5/xymonclient.cfg.5.html
+++ b/docs/manpages/man5/xymonclient.cfg.5.html
@@ -180,9 +180,9 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <p class="Pp"></p>
   </dd>
   <dt id="XYMONCLIENT_FS_REMOTE_DF_BUDGET"><a class="permalink" href="#XYMONCLIENT_FS_REMOTE_DF_BUDGET"><b>XYMONCLIENT_FS_REMOTE_DF_BUDGET</b></a></dt>
-  <dd>Linux only. Seconds to wait for the remote df probe before giving up for
-      this cycle. Defaults to <b>30</b>, capped at 3600; empty, zero or
-      non-numeric values fall back to the default.</dd>
+  <dd>Linux, FreeBSD, NetBSD, OpenBSD and macOS. Seconds to wait for the remote
+      df probe before giving up for this cycle. Defaults to <b>30</b>, capped at
+      3600; empty, zero or non-numeric values fall back to the default.</dd>
   <dt></dt>
   <dd>This is a poll <i>budget</i>, not a kill timeout. A df blocked on a dead
       server sits in uninterruptible D-state, where even SIGKILL is ignored, so
@@ -211,13 +211,16 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <p class="Pp"></p>
   </dd>
   <dt id="XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES"><a class="permalink" href="#XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES"><b>XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES</b></a></dt>
-  <dd>Linux only. The df filesystem types whose stat() hard-blocks when the
-      server is unreachable, and which are therefore collected behind the
-      sentinel. Defaults to <b>nfs nfs4 cifs smb3 ceph glusterfs fuse.glusterfs
-      lustre afs</b>. Types are matched as exact df type tokens, so
+  <dd>Linux, FreeBSD, NetBSD, OpenBSD and macOS. The filesystem types whose
+      stat() hard-blocks when the server is unreachable, and which are therefore
+      collected behind the sentinel. The default names each OS's own spellings,
+      e.g. <b>nfs nfs4 cifs smb3 ceph glusterfs fuse.glusterfs lustre afs</b> on
+      Linux and <b>nfs nfs4 smbfs cifs afpfs webdav ceph glusterfs lustre</b>
+      <b>afs</b> on macOS. Types are matched as exact type tokens, so
       <b>fuse.glusterfs</b> is compared literally rather than as a pattern. Only
       consulted with <b>XYMONCLIENT_FS_DF_LOCAL_ONLY=no</b>, since <b>df -l</b>
-      keeps these mounts out entirely otherwise.
+      keeps these mounts out entirely otherwise -- except on macOS, whose df has
+      no such flag and where the mount list is filtered instead.
     <p class="Pp"></p>
   </dd>
   <dt id="XYMON"><a class="permalink" href="#XYMON"><b>XYMON</b></a></dt>

--- a/tests/client/fs-filter-common.sh
+++ b/tests/client/fs-filter-common.sh
@@ -84,6 +84,56 @@ fsf_extract() {
 	fi
 }
 
+# fsf_wedge_binary PATH -- build the fixture the sentinel tests wedge on: a
+# binary at PATH that sleeps for as many seconds as its first argument. The
+# caller names it "df", because ps -o comm= answers with the interpreter for a
+# script and the PID-reuse guard would then take the live fixture for a
+# recycled pid (@SoundGoof).
+#
+# Copying the system sleep is the obvious way to get a binary of that name, and
+# it works on Linux and the BSDs. It does not work everywhere: on an
+# Apple-silicon Mac the kernel SIGKILLs a copy of a platform binary (rc=137,
+# measured on macOS 26.5), so the wedge dies at once, the sentinel correctly
+# reports a finished probe, and every wedged case fails on a fixture that never
+# wedged. Compile one where there is a compiler, fall back to the copy, and --
+# as asan_usable() does for the sanitizer -- prove the result runs before
+# handing it back.
+fsf_wedge_binary() {
+	_wb=$1
+	mkdir -p "$(dirname "$_wb")"
+	_wbcc=${CC:-cc}
+	if command -v "$_wbcc" > /dev/null 2>&1; then
+		cat > "$_wb.c" <<'WEDGE'
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+	sleep(argc > 1 ? (unsigned int)atoi(argv[1]) : 20);
+	return 0;
+}
+WEDGE
+		"$_wbcc" -o "$_wb" "$_wb.c" > /dev/null 2>&1 || rm -f "$_wb"
+		rm -f "$_wb.c"
+	fi
+	if [ ! -x "$_wb" ]; then
+		_wbsleep=$(command -v sleep) \
+			|| skip "no C compiler and no sleep binary to build the wedge fixture from"
+		cp "$_wbsleep" "$_wb" && chmod +x "$_wb" || fail "cannot create the wedge fixture"
+	fi
+	# A duration, not a condition: what is being waited for here is a failure
+	# that shows up as the process dying immediately, and there is nothing to
+	# poll for that but the passage of time.
+	"$_wb" 5 &
+	_wbpid=$!
+	sleep 1
+	if ! kill -0 "$_wbpid" 2>/dev/null; then
+		skip "the wedge fixture does not stay alive on this host, so a wedged df cannot be simulated (a copied system binary is killed here)"
+	fi
+	kill -9 "$_wbpid" 2>/dev/null || true
+	wait "$_wbpid" 2>/dev/null || true
+}
+
 # fsf_run SNIPPET LOGFILE [ENV...]
 #   Truncate the arg logs, run SNIPPET in a fresh subshell with $TMP as cwd
 #   (so decoy glob files are in scope), and echo the recorded argv from LOGFILE
@@ -99,10 +149,12 @@ fsf_run() {
 	: > "$DF_LOG"
 	: > "$INODE_LOG"
 	: > "$STDERR_LOG"
+	# "|| true": the block's own exit status is not part of the contract, and
+	# under set -e a non-zero one would kill the caller with no message.
 	(
 		cd "$TMP" || exit 1
 		$FSF_SHELL "$_snippet" >/dev/null 2>"$STDERR_LOG"
-	)
+	) || true
 	printf ' %s ' "$(tr '\n' ' ' < "$_logfile")"
 }
 
@@ -219,10 +271,37 @@ fsf_write_fixture() {
 	export FSF_FIXTURE
 }
 
+# fsf_write_mount_stub -- a mount(8) stub rendered from the fixture, in the BSD
+# spelling ("src on MP (TYPE, opts)"). A client that guards hard-blocking mounts
+# reads the mount list on every DF_LOCAL_ONLY=no cycle, so without this stub the
+# test would read the *tester's* mount table -- and probe whatever remote
+# filesystem happens to be mounted there.
+fsf_write_mount_stub() {
+	# FSF_MOUNT_FMT: how this OS's mount(8) spells one line, as a printf format
+	# taking MOUNTPOINT, TYPE, OPTIONS. FreeBSD and macOS put the type first
+	# inside the parentheses; NetBSD and OpenBSD write "... type <fstype> (...)".
+	# Getting this wrong is invisible in a stubbed test and fatal on the host.
+	_fmt=${FSF_MOUNT_FMT:-'src on %s (%s, %s)\n'}
+	{
+		printf '#!/bin/sh\n'
+		printf 'cat <<\'"'"'MOUNT'"'"'\n'
+		while read -r _t _mp _isremote _rest; do
+			[ -n "$_t" ] || continue
+			if [ "$_isremote" = remote ]; then
+				printf "$_fmt" "$_mp" "$_t" nodev
+			else
+				printf "$_fmt" "$_mp" "$_t" local
+			fi
+		done < "$FSF_FIXTURE"
+		printf 'MOUNT\n'
+	} > "$STUB/mount"
+	chmod +x "$STUB/mount"
+}
+
 # fsf_report [ENV=VAL ...] -- run the combined [df]+[inode] block and print it.
 fsf_report() {
 	: > "$STDERR_LOG"; : > "$DF_LOG"; : > "$INODE_LOG"
-	( cd "$TMP" && env "$@" $FSF_SHELL "$FSF_COMBINED" 2>"$STDERR_LOG" )
+	( cd "$TMP" && env "$@" $FSF_SHELL "$FSF_COMBINED" 2>"$STDERR_LOG" ) || true
 }
 
 # fsf_section OUTPUT NAME -- the [df] or [inode] part of a report.
@@ -259,6 +338,18 @@ fsf_selfcheck() {
 	esac
 }
 
+# fsf_assert_loud REPORT MSG -- the section must not read as green. Two
+# spellings are equally loud and a client may use either: the "collection
+# failed" marker (the column goes yellow) or one 100%-full "unavailable:" row
+# per mount (the column goes red). What is forbidden is the third case -- an
+# empty section, which the server reads as "no filesystems, all is well".
+fsf_assert_loud() {
+	case "$1" in
+		*"collection failed"*|*"unavailable:"*) return 0 ;;
+	esac
+	fail "${2:-}: the report is silent, which the server reads as green: '$1'"
+}
+
 # fsf_contract -- the rules every client obeys, asserted on the emitted report.
 fsf_contract() {
 	_out=$(fsf_report)
@@ -266,7 +357,7 @@ fsf_contract() {
 	_in=$(fsf_section "$_out" inode)
 
 	assert_contains "$FSF_LOCAL_MP" "$_df" \
-		"contract: an ordinary local filesystem must be reported"
+		"contract: an ordinary local filesystem must be reported (block stderr: $(tr '\n' ' ' < "$STDERR_LOG" | cut -c1-300))"
 	assert_not_contains "$FSF_PSEUDO_MP" "$_df" \
 		"contract: $FSF_PSEUDO_TYPE is excluded by default"
 	assert_not_contains "$FSF_REMOTE_MP" "$_df" \
@@ -353,8 +444,8 @@ fsf_contract() {
 	# A df that fails, and a filter that leaves nothing, must both be loud: the
 	# server reads an absent filesystem as green, so silence is a false OK.
 	_out=$(fsf_report DF_FAIL=1)
-	assert_contains "collection failed" "$_out" \
-		"contract: a df that exits nonzero with no output emits a failure marker"
+	fsf_assert_loud "$_out" \
+		"contract: a df that exits nonzero with no output must be loud"
 	assert_not_contains "Filesystem" "$_out" \
 		"contract: the failure marker carries no df header (a header reads as a healthy report)"
 	# ... including where the collection is split in two. A client that runs one
@@ -362,9 +453,9 @@ fsf_contract() {
 	# to lose the marker: swallow the plain df's status, and a failure with no
 	# rows becomes an empty section, which the server reads as green.
 	_out=$(fsf_report DF_FAIL=1 XYMONCLIENT_FS_DF_LOCAL_ONLY=no)
-	assert_contains "collection failed" "$_out" \
-		"contract: the failure marker survives DF_LOCAL_ONLY=no"
+	fsf_assert_loud "$_out" \
+		"contract: a df failure stays loud with DF_LOCAL_ONLY=no"
 	_out=$(fsf_report "XYMONCLIENT_FS_EXCLUDE_TYPES=$FSF_ALL_TYPES")
-	assert_contains "collection failed" "$_out" \
+	fsf_assert_loud "$_out" \
 		"contract: excluding every filesystem must be loud, never a silent empty section"
 }

--- a/tests/client/fs-filter-freebsd.sh
+++ b/tests/client/fs-filter-freebsd.sh
@@ -26,7 +26,7 @@ fsf_setup freebsd XYMONCLIENT_FREEBSD
 FSF_LOCAL_TYPE=ufs;      FSF_LOCAL_MP=/
 FSF_PSEUDO_TYPE=procfs;  FSF_PSEUDO_MP=/proc
 FSF_NOINODE_TYPE=msdosfs; FSF_NOINODE_MP=/data
-FSF_REMOTE_TYPE=nfs;     FSF_REMOTE_MP=/net
+FSF_REMOTE_TYPE=fusefs.sshfs; FSF_REMOTE_MP=/ssh
 FSF_EXTRA_TYPE=ext2fs;   FSF_EXTRA_MP=/extra
 FSF_DECOY='procf*'
 
@@ -70,6 +70,10 @@ FSF_COMBINED="$TMP/df-section.sh"
 fsf_extract "$FSF_COMBINED"
 fsf_write_fixture
 fsf_write_stub
+# The client reads the mount list on every DF_LOCAL_ONLY=no cycle now that
+# hard-blocking mounts are guarded (#316); answer it from the fixture rather
+# than from the tester's machine.
+fsf_write_mount_stub
 
 # --- the contract ------------------------------------------------------------
 

--- a/tests/client/fs-filter-linux.sh
+++ b/tests/client/fs-filter-linux.sh
@@ -150,7 +150,7 @@ assert_not_contains " -l " "$args" \
 MISSING="$TMP/df-section-missing.sh"
 sed "s!$TMP/proc.filesystems!$TMP/does-not-exist!g" "$SNIPPET" > "$MISSING"
 : > "$DF_LOG"
-( cd "$TMP" && /bin/sh "$MISSING" >/dev/null 2>"$TMP/stderr" )
+( cd "$TMP" && /bin/sh "$MISSING" >/dev/null 2>"$TMP/stderr" ) || true
 args=$(printf ' %s ' "$(cat "$DF_LOG")")
 assert_contains "not readable, dynamic nodev exclusions disabled" "$(cat "$TMP/stderr")" \
 	"an unreadable filesystem list must warn"

--- a/tests/client/fs-filter-netbsd.sh
+++ b/tests/client/fs-filter-netbsd.sh
@@ -26,7 +26,7 @@ SERVER=$(find_root)/xymond/client/netbsd.c
 FSF_LOCAL_TYPE=ffs;     FSF_LOCAL_MP=/
 FSF_PSEUDO_TYPE=procfs; FSF_PSEUDO_MP=/proc
 FSF_NOINODE_TYPE=msdos; FSF_NOINODE_MP=/data
-FSF_REMOTE_TYPE=nfs;    FSF_REMOTE_MP=/net
+FSF_REMOTE_TYPE=psshfs; FSF_REMOTE_MP=/ssh
 FSF_EXTRA_TYPE=ext2fs;  FSF_EXTRA_MP=/extra
 FSF_DECOY='procf*'
 
@@ -66,6 +66,14 @@ FSF_COMBINED="$TMP/df-section.sh"
 fsf_extract "$FSF_COMBINED"
 fsf_write_fixture
 fsf_write_stub
+# The client reads the mount list on every DF_LOCAL_ONLY=no cycle now that
+# hard-blocking mounts are guarded (#316); answer it from the fixture rather
+# than from the tester's machine.
+# NetBSD and OpenBSD write the type after the mount point, not inside the
+# parentheses -- measured on the lane VMs, where the FreeBSD spelling made
+# fs_mounts() drop every row.
+FSF_MOUNT_FMT='src on %s type %s (%s)\n'
+fsf_write_mount_stub
 
 # --- the contract ------------------------------------------------------------
 

--- a/tests/client/fs-filter-openbsd.sh
+++ b/tests/client/fs-filter-openbsd.sh
@@ -27,7 +27,7 @@ fsf_setup openbsd XYMONCLIENT_OPENBSD
 FSF_LOCAL_TYPE=ffs;     FSF_LOCAL_MP=/
 FSF_PSEUDO_TYPE=procfs; FSF_PSEUDO_MP=/proc
 FSF_NOINODE_TYPE=msdos; FSF_NOINODE_MP=/data
-FSF_REMOTE_TYPE=nfs;    FSF_REMOTE_MP=/net
+FSF_REMOTE_TYPE=fuse; FSF_REMOTE_MP=/ssh
 FSF_EXTRA_TYPE=ext2fs;  FSF_EXTRA_MP=/extra
 FSF_DECOY='procf*'
 
@@ -66,6 +66,14 @@ FSF_COMBINED="$TMP/df-section.sh"
 fsf_extract "$FSF_COMBINED"
 fsf_write_fixture
 fsf_write_stub
+# The client reads the mount list on every DF_LOCAL_ONLY=no cycle now that
+# hard-blocking mounts are guarded (#316); answer it from the fixture rather
+# than from the tester's machine.
+# NetBSD and OpenBSD write the type after the mount point, not inside the
+# parentheses -- measured on the lane VMs, where the FreeBSD spelling made
+# fs_mounts() drop every row.
+FSF_MOUNT_FMT='src on %s type %s (%s)\n'
+fsf_write_mount_stub
 
 # --- the contract ------------------------------------------------------------
 

--- a/tests/client/fs-sentinel-darwin.sh
+++ b/tests/client/fs-sentinel-darwin.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-sentinel-darwin.sh
+#
+# The remote-df sentinel wired into xymonclient-darwin.sh (#316). df_sentinel()
+# itself is byte-identical to the Linux copy -- fs-sentinel-copies.sh enforces
+# that, and fs-sentinel-linux.sh tests its internals (the claim race, PID reuse,
+# a probe that finishes late). What is macOS's own, and what this file tests,
+# is the wiring: splitting the per-path df loop in two, so a hard-blocking
+# mount is probed behind the sentinel instead of by the loop, and emitting
+# marker rows in the column layout each report is parsed with.
+#
+# Everything is driven by a mount fixture and a df stub: no real remote
+# filesystem is involved, and nothing is ever killed except the stub.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"
+
+fsf_setup darwin XYMONCLIENT_DARWIN
+command -v column >/dev/null 2>&1 || skip "column(1) not available"
+grep -q '^df_sentinel()' "$SCRIPT" || fail "remote-df sentinel missing from $SCRIPT (regressed)"
+
+DF_CALLS="$TMP/df.calls"; : > "$DF_CALLS"; export DF_CALLS
+DF_REMOTE="$TMP/df.remote"; : > "$DF_REMOTE"; export DF_REMOTE
+
+# mount(8) as FreeBSD prints it. /net is nfs -- hard-blocking, so it goes behind
+# the sentinel; /ssh is a FUSE remote that stat()s safely and must keep being
+# reported by the plain df.
+cat > "$STUB/mount" <<'EOF'
+#!/bin/sh
+cat <<'MOUNT'
+/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+/dev/disk6s1 on /Volumes/USBHFS (hfs, local, nodev, nosuid, journaled)
+remote:/exp on /net (nfs, nodev, nosuid)
+remote:/exp2 on /net2 (nfs, nodev, nosuid)
+remote:/exp3 on /Volumes/archive type backup (nfs, nodev, nosuid)
+MOUNT
+EOF
+chmod +x "$STUB/mount"
+
+# df stub. It hangs only when asked about the hard-blocking mount by name, which
+# is how a real df wedges: the plain call keeps answering throughout.
+cat > "$STUB/df" <<'EOF'
+#!/bin/sh
+echo "$*" >> "$DF_CALLS"
+_inode=; _named=
+for a in "$@"; do
+	case "$a" in
+		-P|-H) ;;
+		-i) _inode=1 ;;
+		/*) _named="$_named $a" ;;
+		# Real df rejects what it does not know, and the log this stub writes
+		# joins argv with spaces -- so "-P -H" arriving as one word looks
+		# exactly like two. Rejecting it here is the only way the test can see
+		# the difference between the flags being split and not.
+		*) echo "df: illegal option -- $a" >&2; exit 1 ;;
+	esac
+done
+# The loop asks about one path at a time; the sentinel names the whole
+# hard-blocking set at once. Only the latter may hang.
+case " $_named " in *" /net "*) _remote=1 ;; *) _remote= ;; esac
+[ -n "$_remote" ] && echo $$ >> "${DF_REMOTE:-/dev/null}"
+[ -n "$_remote" ] && [ -n "${DF_HANG:-}" ] && exec "$HANGBIN" "${DF_HANGTIME:-20}"
+[ -n "${DF_FAIL:-}" ] && exit 1
+# An exclusion applies to a named operand too: once every operand is excluded,
+# df processes nothing and exits nonzero.
+if [ -n "$_inode" ]; then
+	printf 'Filesystem 1024-blocks Used Available Capacity iused ifree %%iused Mounted on\n'
+	for a in $_named; do printf '/dev/disk 100 50 50 50%% 1000 9000 10%% %s\n' "$a"; done
+	exit 0
+fi
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+for a in $_named; do printf '/dev/disk 100 50 50 50%% %s\n' "$a"; done
+EOF
+chmod +x "$STUB/df"
+
+# The wedge has to look like df to ps, on every OS. A shell script named df
+# reports comm "df" on Linux but "sh" on the BSDs -- the interpreter -- so the
+# PID-reuse guard would decide the recorded pid is not our df and start a
+# second probe. Real df is a binary, so make the stub's wedge one too: a copy
+# of sleep, named df, exec'd in place (same pid, and comm becomes "df").
+HANGBIN="$TMP/hangbin/df"
+fsf_wedge_binary "$HANGBIN"
+export HANGBIN
+
+SNIPPET="$TMP/df-section.sh"
+fsf_extract "$SNIPPET"
+
+mkdir -p "$TMP/probe"
+# The caller's assignments come last so a case can override a default.
+run_cycle() {
+	env DF_CALLS="$DF_CALLS" DF_REMOTE="$DF_REMOTE" \
+		XYMONTMP="$TMP/probe" \
+		XYMONCLIENT_FS_DF_LOCAL_ONLY=no \
+		XYMONCLIENT_FS_REMOTE_DF_BUDGET=2 \
+		PATH="$STUB:$PATH" \
+		"$@" \
+		bash "$SNIPPET" 2>/dev/null || true
+}
+end_stub() { pkill -P "$1" 2>/dev/null || true; kill -9 "$1" 2>/dev/null || true; }
+
+# --- healthy: the guarded mount is reported, the safe remote one still is -----
+out=$(run_cycle)
+assert_contains "/net" "$out" "a healthy hard-blocking mount is reported through the sentinel"
+# With real rows, not the marker: everything the sentinel hands df has to be
+# something df accepts, and a probe that fails on its own arguments looks
+# exactly like a server that stopped answering.
+assert_not_contains "unavailable:/net" "$out" \
+	"a healthy server must produce real rows, never the unavailable marker"
+assert_contains "/Volumes/USBHFS" "$out" "a local filesystem is still reported by the per-path loop"
+assert_contains "/dev/disk" "$out" "and the table still carries real rows"
+assert_equal '0' "$(find "$TMP/probe" -type f | awk 'END { print NR }')" \
+	"a probe that completed leaves no state behind"
+
+# macOS df has no type filter: the guard is that the per-path loop never gets
+# handed a hard-blocking mount. The loop asks about one path per call; the
+# sentinel names the whole set in one. With two nfs mounts in the fixture the
+# two are told apart -- a call naming exactly one of them is the loop reaching
+# it (#316), and a call naming both is the sentinel doing its job.
+assert_equal '0' "$(($(grep -c -E '^-P -[Hi] /net2?$' "$DF_CALLS")))" \
+	"the per-path loop must never probe a hard-blocking mount itself"
+assert_contains "-P -H /net /net2" "$(cat "$DF_CALLS")" \
+	"the guarded set is probed in one call, behind the sentinel"
+# A volume whose name ends in "type <word>" is not the NetBSD spelling. Reading
+# it as one takes the type from the name -- here "backup" -- and the mount then
+# misses the hard-blocking list entirely, so the per-path loop reaches it and
+# hangs on exactly the server the sentinel exists to survive.
+# ... and on the guarded line, not merely somewhere in the log: an unguarded
+# mount shows up there too, probed by the per-path loop, which is the failure.
+assert_contains "/Volumes/archive type backup" "$(grep '^-P -H /net ' "$DF_CALLS")" \
+	"a mount point ending in \"type WORD\" must still be recognised as nfs and guarded"
+
+# --- wedged: both reports surface the mount, each under its own probe ---------
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+out=$(run_cycle DF_HANG=1)
+df_section=$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')
+inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
+assert_contains "unavailable:/net" "$df_section" \
+	"a wedged server must surface the mount in the disk report, not drop it"
+assert_contains "unavailable:/net" "$inode_section" \
+	"and in the inode report, whose columns are read positionally"
+# Shape, not just presence: the inode awk reads iused/ifree/%iused from fields
+# 6-8, so a marker row in the disk layout would be reformatted into nonsense
+# that still contains the mount name.
+assert_contains "100% /net" "$inode_section" \
+	"the inode marker row must carry the inode columns, not the disk ones"
+assert_contains "/Volumes/USBHFS" "$df_section" \
+	"a wedged remote server must not stale or block the local set"
+[ -f "$TMP/probe/df-probe-disk.pid" ] || fail "the wedged disk probe must be left recorded"
+[ -f "$TMP/probe/df-probe-inode.pid" ] || fail "the wedged inode probe must be recorded under its own tag"
+
+# --- still wedged: no second probe -------------------------------------------
+before=$(wc -l < "$DF_CALLS")
+out=$(run_cycle DF_HANG=1)
+after=$(wc -l < "$DF_CALLS")
+assert_equal "$((before + 2))" "$((after))" \
+	"while both probes are wedged, a cycle must run only the two plain dfs"
+assert_contains "unavailable:/net" "$out" "the mount stays unavailable while wedged"
+for _tag in disk inode; do end_stub "$(cat "$TMP/probe/df-probe-$_tag.pid")"; done
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+
+# --- the probe directory is itself on a hard-blocking mount ------------------
+# Nothing may touch it: even `test -w` blocks in D-state there, inside the
+# fail-safe meant to prevent exactly that.
+mkdir -p "$TMP/remoteprobe"
+cat > "$STUB/mount" <<EOF
+#!/bin/sh
+cat <<'MOUNT'
+/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+/dev/disk6s1 on /Volumes/USBHFS (hfs, local, nodev, nosuid, journaled)
+remote:/exp on /net (nfs, nodev, nosuid)
+remote:/p on $TMP/remoteprobe (nfs, nodev, nosuid)
+MOUNT
+EOF
+chmod +x "$STUB/mount"
+out=$(run_cycle DF_HANG=1 XYMONTMP="$TMP/remoteprobe")
+assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
+	"a probe dir on a hard-blocking filesystem must never be touched"
+assert_contains "unavailable:/net" "$out" "the remote set reports unavailable instead"
+
+
+# Same guard, mount list unavailable rather than hostile. Asked directly: with
+# no mount list there is no remote set either, so df_sentinel is never reached
+# through the block. What is reachable is a list that answers once -- long
+# enough to name the remote set -- and fails on the second read in the same
+# cycle. A pipeline would hand this function awk's status, and awk succeeds on
+# no input, so a directory nobody could place would read as local.
+( sed -n '/^probe_dir_is_local()/,/^}/p' "$SCRIPT"
+  printf 'fs_mounts() { return 1; }\n'
+  printf 'probe_dir_is_local /remote/probe\n' ) > "$TMP/pdl.sh"
+if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; then
+	fail "an unreadable mount list must not read as a local probe directory"
+fi
+
+pass "xymonclient-darwin.sh: the remote-df sentinel takes the hard-blocking mounts out of the per-path loop"

--- a/tests/client/fs-sentinel-freebsd.sh
+++ b/tests/client/fs-sentinel-freebsd.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-sentinel-freebsd.sh
+#
+# The remote-df sentinel wired into xymonclient-freebsd.sh (#316). df_sentinel()
+# itself is byte-identical to the Linux copy -- fs-sentinel-copies.sh enforces
+# that, and fs-sentinel-linux.sh tests its internals (the claim race, PID reuse,
+# a probe that finishes late). What is FreeBSD's own, and what this file tests,
+# is the wiring: finding the hard-blocking mounts through mount(8) instead of
+# /proc/mounts, keeping them out of the unguarded df, and emitting marker rows
+# in the column layout each report is parsed with.
+#
+# Everything is driven by a mount fixture and a df stub: no real remote
+# filesystem is involved, and nothing is ever killed except the stub.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"
+
+fsf_setup freebsd XYMONCLIENT_FREEBSD
+grep -q '^df_sentinel()' "$SCRIPT" || fail "remote-df sentinel missing from $SCRIPT (regressed)"
+
+DF_CALLS="$TMP/df.calls"; : > "$DF_CALLS"; export DF_CALLS
+DF_REMOTE="$TMP/df.remote"; : > "$DF_REMOTE"; export DF_REMOTE
+
+# mount(8) as FreeBSD prints it. /net is nfs -- hard-blocking, so it goes behind
+# the sentinel; /ssh is a FUSE remote that stat()s safely and must keep being
+# reported by the plain df.
+cat > "$STUB/mount" <<'EOF'
+#!/bin/sh
+cat <<'MOUNT'
+/dev/ada0p2 on / (ufs, local, soft-updates, journaled)
+srv:/exp on /net (nfs)
+usr@h:/d on /ssh (fusefs.sshfs, local)
+MOUNT
+EOF
+chmod +x "$STUB/mount"
+
+# df stub. It hangs only when asked about the hard-blocking mount by name, which
+# is how a real df wedges: the plain call keeps answering throughout.
+cat > "$STUB/df" <<'EOF'
+#!/bin/sh
+echo "$*" >> "$DF_CALLS"
+_inode=; _named=; _ex=" "
+for a in "$@"; do
+	case "$a" in
+		-i) _inode=1 ;;
+		-t*) _l=${a#-t}; _l=${_l#no}; _ex=" $(echo "$_l" | tr ',' ' ') " ;;
+		/*) _named="$_named $a" ;;
+		-P|-k|-h|-H) ;;
+		# Real df rejects what it does not know, and the log above joins argv
+		# with spaces -- so two flags arriving as one word look exactly like
+		# two flags. Rejecting the unknown word is what tells them apart.
+		*) echo "df: illegal option -- $a" >&2; exit 1 ;;
+	esac
+done
+[ -n "$_named" ] && echo $$ >> "${DF_REMOTE:-/dev/null}"
+[ -n "$_named" ] && [ -n "${DF_HANG:-}" ] && exec "$HANGBIN" "${DF_HANGTIME:-20}"
+[ -n "${DF_FAIL:-}" ] && exit 1
+# An exclusion applies to a named operand too: once every operand is excluded,
+# df processes nothing and exits nonzero.
+if [ -n "$_named" ]; then
+	_keep=
+	for a in $_named; do
+		case "$a" in /net) _t=nfs ;; /ssh) _t=fusefs.sshfs ;; *) _t=ufs ;; esac
+		case "$_ex" in *" $_t "*) ;; *) _keep="$_keep $a" ;; esac
+	done
+	[ -z "$_keep" ] && { echo "df: no file systems processed" >&2; exit 1; }
+	if [ -n "$_inode" ]; then
+		printf 'Filesystem Size Used Avail Capacity iused ifree %%iused Mounted on\n'
+		for a in $_keep; do printf 'srv:/exp 100 50 50 50%% 1000 9000 10%% %s\n' "$a"; done
+	else
+		printf 'Filesystem Size Used Avail Capacity Mounted on\n'
+		for a in $_keep; do printf 'srv:/exp 100G 50G 50G 50%% %s\n' "$a"; done
+	fi
+	exit 0
+fi
+if [ -n "$_inode" ]; then
+	printf 'Filesystem Size Used Avail Capacity iused ifree %%iused Mounted on\n'
+	printf '/dev/ada0p2 100 50 50 50%% 1000 9000 10%% /\n'
+	case "$_ex" in *" fusefs.sshfs "*) ;; *) printf 'usr@h:/d 200 20 180 10%% 5 95 5%% /ssh\n' ;; esac
+	exit 0
+fi
+printf 'Filesystem Size Used Avail Capacity Mounted on\n'
+printf '/dev/ada0p2 100G 50G 50G 50%% /\n'
+case "$_ex" in *" fusefs.sshfs "*) ;; *) printf 'usr@h:/d 200G 20G 180G 10%% /ssh\n' ;; esac
+EOF
+chmod +x "$STUB/df"
+
+# The wedge has to look like df to ps, on every OS. A shell script named df
+# reports comm "df" on Linux but "sh" on the BSDs -- the interpreter -- so the
+# PID-reuse guard would decide the recorded pid is not our df and start a
+# second probe. Real df is a binary, so make the stub's wedge one too: a copy
+# of sleep, named df, exec'd in place (same pid, and comm becomes "df").
+HANGBIN="$TMP/hangbin/df"
+fsf_wedge_binary "$HANGBIN"
+export HANGBIN
+
+SNIPPET="$TMP/df-section.sh"
+fsf_extract "$SNIPPET"
+
+mkdir -p "$TMP/probe"
+# The caller's assignments come last so a case can override a default.
+run_cycle() {
+	env DF_CALLS="$DF_CALLS" DF_REMOTE="$DF_REMOTE" \
+		XYMONTMP="$TMP/probe" \
+		XYMONCLIENT_FS_DF_LOCAL_ONLY=no \
+		XYMONCLIENT_FS_REMOTE_DF_BUDGET=2 \
+		PATH="$STUB:$PATH" \
+		"$@" \
+		/bin/sh "$SNIPPET" 2>/dev/null || true
+}
+end_stub() { pkill -P "$1" 2>/dev/null || true; kill -9 "$1" 2>/dev/null || true; }
+
+# --- healthy: the guarded mount is reported, the safe remote one still is -----
+out=$(run_cycle)
+assert_contains "/net" "$out" "a healthy hard-blocking mount is reported through the sentinel"
+# With real rows, not the marker: everything the sentinel hands df has to be
+# something df accepts, and a probe that fails on its own arguments looks
+# exactly like a server that stopped answering.
+assert_not_contains "unavailable:/net" "$out" \
+	"a healthy server must produce real rows, never the unavailable marker"
+assert_contains "/ssh" "$out" "a remote type that cannot hard-block stays in the plain df"
+assert_contains "/dev/ada0p2" "$out" "and the local set is reported as before"
+assert_equal '0' "$(find "$TMP/probe" -type f | awk 'END { print NR }')" \
+	"a probe that completed leaves no state behind"
+
+# The unguarded df must never be asked to stat a hard-blocking type: the calls
+# that name no mount point are the plain ones, and their -t list has to carry
+# every hard-blocking type (#316).
+plain_args=$(grep -v ' /net' "$DF_CALLS" | tr '\n' ' ')
+assert_contains ",nfs," "$plain_args" "the plain df excludes nfs"
+assert_contains ",smbfs," "$plain_args" "and smbfs"
+assert_contains ",lustre" "$plain_args" "and the rest of the hard-blocking list"
+
+# --- wedged: both reports surface the mount, each under its own probe ---------
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+out=$(run_cycle DF_HANG=1)
+df_section=$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')
+inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
+assert_contains "unavailable:/net" "$df_section" \
+	"a wedged server must surface the mount in the disk report, not drop it"
+assert_contains "unavailable:/net" "$inode_section" \
+	"and in the inode report, whose columns are read positionally"
+# Shape, not just presence: the inode awk reads iused/ifree/%iused from fields
+# 6-8, so a marker row in the disk layout would be reformatted into nonsense
+# that still contains the mount name.
+assert_contains "100% /net" "$inode_section" \
+	"the inode marker row must carry the inode columns, not the disk ones"
+assert_contains "/dev/ada0p2" "$df_section" \
+	"a wedged remote server must not stale or block the local set"
+[ -f "$TMP/probe/df-probe-disk.pid" ] || fail "the wedged disk probe must be left recorded"
+[ -f "$TMP/probe/df-probe-inode.pid" ] || fail "the wedged inode probe must be recorded under its own tag"
+
+# --- still wedged: no second probe -------------------------------------------
+before=$(wc -l < "$DF_CALLS")
+out=$(run_cycle DF_HANG=1)
+after=$(wc -l < "$DF_CALLS")
+assert_equal "$((before + 2))" "$((after))" \
+	"while both probes are wedged, a cycle must run only the two plain dfs"
+assert_contains "unavailable:/net" "$out" "the mount stays unavailable while wedged"
+for _tag in disk inode; do end_stub "$(cat "$TMP/probe/df-probe-$_tag.pid")"; done
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+
+# --- the probe directory is itself on a hard-blocking mount ------------------
+# Nothing may touch it: even `test -w` blocks in D-state there, inside the
+# fail-safe meant to prevent exactly that.
+mkdir -p "$TMP/remoteprobe"
+cat > "$STUB/mount" <<EOF
+#!/bin/sh
+cat <<'MOUNT'
+/dev/ada0p2 on / (ufs, local, soft-updates, journaled)
+srv:/exp on /net (nfs)
+srv:/p on $TMP/remoteprobe (nfs)
+MOUNT
+EOF
+chmod +x "$STUB/mount"
+out=$(run_cycle DF_HANG=1 XYMONTMP="$TMP/remoteprobe")
+assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
+	"a probe dir on a hard-blocking filesystem must never be touched"
+assert_contains "unavailable:/net" "$out" "the remote set reports unavailable instead"
+
+
+# Same guard, mount list unavailable rather than hostile. Asked directly: with
+# no mount list there is no remote set either, so df_sentinel is never reached
+# through the block. What is reachable is a list that answers once -- long
+# enough to name the remote set -- and fails on the second read in the same
+# cycle. A pipeline would hand this function awk's status, and awk succeeds on
+# no input, so a directory nobody could place would read as local.
+( sed -n '/^probe_dir_is_local()/,/^}/p' "$SCRIPT"
+  printf 'fs_mounts() { return 1; }\n'
+  printf 'probe_dir_is_local /remote/probe\n' ) > "$TMP/pdl.sh"
+if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; then
+	fail "an unreadable mount list must not read as a local probe directory"
+fi
+
+pass "xymonclient-freebsd.sh: the remote-df sentinel is wired to mount(8) and both reports"

--- a/tests/client/fs-sentinel-linux.sh
+++ b/tests/client/fs-sentinel-linux.sh
@@ -101,9 +101,7 @@ chmod +x "$STUB/df"
 # (@SoundGoof). exec keeps the pid the client recorded, and leaves the wedge a
 # single process to clean up.
 DF_HANGBIN="$STUB/hang/df"; export DF_HANGBIN
-mkdir -p "$STUB/hang"
-_sleepbin=$(command -v sleep) || fail "no sleep binary to build the wedge fixture from"
-cp "$_sleepbin" "$DF_HANGBIN" && chmod +x "$DF_HANGBIN" || fail "cannot create the wedge fixture"
+fsf_wedge_binary "$DF_HANGBIN"
 
 # Nothing here may outlive the test, including on a failed assertion: fail()
 # exits, and every wedge started by then would keep its delay running.
@@ -148,7 +146,7 @@ run_block() {
 		XYMONCLIENT_FS_REMOTE_DF_BUDGET=2 \
 		PATH="${PS_STUB:+$PS_STUB:}$STUB:$PATH" \
 		"$@" \
-		/bin/sh "$_snip" 2>/dev/null
+		/bin/sh "$_snip" 2>"$TMP/cycle.err" || true
 }
 
 # run_cycle [ENV=VAL ...] -- one client cycle; prints the [df] block.
@@ -164,7 +162,7 @@ local_mounts
 # --- healthy -----------------------------------------------------------------
 out=$(run_cycle)
 assert_contains "/remote/sshfs" "$out" \
-	"a remote filesystem whose type is not hard-blocking must still be reported"
+	"a remote filesystem whose type is not hard-blocking must still be reported (block stderr: $(tr '\n' ' ' < "$TMP/cycle.err" 2>/dev/null | cut -c1-300))"
 assert_contains '/dev/sda1 1000 400 600 40% /' "$out" "the local set must be reported"
 assert_contains 'srv:/exp 100 50 50 50% /remote/nfs' "$out" "the remote set must be reported"
 # The remote df prints its own header; a second one inside the same [df] block
@@ -237,6 +235,45 @@ wait
 assert_equal '1' "$(($(wc -l < "$DF_REMOTE")))" \
 	"concurrent cycles each started a remote df; exactly one may own the probe"
 while read -r _p; do end_stub "$_p"; done < "$DF_REMOTE"
+
+# --- the same window, forced open ---------------------------------------------
+# The 20-cycle race above only lands in the window by luck. This one holds it
+# open: a mv stub sleeps before renaming the pid into place, and a second cycle
+# runs while the first is stuck there. Publishing the pid used to truncate the
+# file first, so the second cycle read an empty value, took it for a stale
+# entry, removed the files and started a probe of its own -- leaving the first
+# cycle's df running with nothing recording it (@SoundGoof). With the rename,
+# the second cycle reads the whole claim and stands down.
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+cat > "$STUB/mv" <<'EOF'
+#!/bin/sh
+# Only the sentinel's publication is delayed; everything else moves at once.
+case "$*" in *df-probe-*.pid) sleep 2 ;; esac
+exec /bin/mv "$@"
+EOF
+chmod +x "$STUB/mv"
+run_cycle DF_HANG=1 DF_HANGTIME=6 >/dev/null 2>&1 &
+_first=$!
+# Wait for the window rather than a duration: the stub's sleep is running once
+# the remote df has been started and the pid file still holds the claim.
+_n=0
+while [ "$_n" -lt 100 ]; do
+	[ -s "$DF_REMOTE" ] && case "$(cat "$TMP/probe/df-probe-disk.pid" 2>/dev/null)" in
+		claim:*) break ;;
+	esac
+	_n=$((_n + 1)); sleep 0.1
+done
+out=$(run_cycle DF_HANG=1 DF_HANGTIME=6)
+wait "$_first" 2>/dev/null || true
+rm -f "$STUB/mv"
+assert_equal '1' "$(($(wc -l < "$DF_REMOTE")))" \
+	"a cycle reading the pid file mid-publication must not start a second probe"
+assert_contains 'unavailable:/remote/nfs' "$out" \
+	"and it must report the mount unavailable, not drop it"
+_recorded=$(cat "$TMP/probe/df-probe-disk.pid" 2>/dev/null)
+assert_equal "$(head -1 "$DF_REMOTE")" "$_recorded" \
+	"the pid file must end up naming the df that is actually running"
+while read -r _p; do end_stub "$_p"; done < "$DF_REMOTE"
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 
 # --- a claim held by another live cycle is respected -------------------------
@@ -276,7 +313,7 @@ local_mounts
 
 # --- the default is unchanged ------------------------------------------------
 rm -f "$TMP"/probe/*
-out=$(env XYMONTMP="$TMP/probe" DF_CALLS="$DF_CALLS" PATH="$STUB:$PATH" /bin/sh "$TMP/df-section.sh" 2>/dev/null)
+out=$(env XYMONTMP="$TMP/probe" DF_CALLS="$DF_CALLS" PATH="$STUB:$PATH" /bin/sh "$TMP/df-section.sh" 2>/dev/null || true)
 assert_contains '/dev/sda1 1000 400 600 40% /' "$out" "the default (local-only) report is unchanged"
 assert_not_contains '/remote/nfs' "$out" "df -l must still keep remote mounts out by default"
 assert_equal '0' "$(find "$TMP/probe" -type f | awk 'END { print NR }')" \
@@ -343,7 +380,7 @@ rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 # comes back empty-and-nonzero and reports the mount 100% full.
 out=$(env DF_CALLS="$DF_CALLS" DF_REMOTE="$DF_REMOTE" XYMONTMP="$TMP/probe" \
 	XYMONCLIENT_FS_DF_LOCAL_ONLY=no XYMONCLIENT_FS_REMOTE_DF_BUDGET=2 \
-	DF_HANG=1 PATH="$STUB:$PATH" /bin/sh "$TMP/df-section.sh" 2>/dev/null)
+	DF_HANG=1 PATH="$STUB:$PATH" /bin/sh "$TMP/df-section.sh" 2>/dev/null || true)
 assert_not_contains '/remote/nfs' "$out" \
 	"a nodev remote type is excluded before the sentinel sees it, so it is not reported"
 assert_equal '0' "$(($(wc -l < "$DF_REMOTE")))" \

--- a/tests/client/fs-sentinel-netbsd.sh
+++ b/tests/client/fs-sentinel-netbsd.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-sentinel-netbsd.sh
+#
+# The remote-df sentinel wired into xymonclient-netbsd.sh (#316). df_sentinel()
+# itself is byte-identical to the Linux copy -- fs-sentinel-copies.sh enforces
+# that, and fs-sentinel-linux.sh tests its internals (the claim race, PID reuse,
+# a probe that finishes late). What is NetBSD's own, and what this file tests,
+# is the wiring: finding the hard-blocking mounts through mount(8) instead of
+# /proc/mounts, keeping them out of the unguarded df, and emitting marker rows
+# in the column layout each report is parsed with.
+#
+# Everything is driven by a mount fixture and a df stub: no real remote
+# filesystem is involved, and nothing is ever killed except the stub.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"
+
+fsf_setup netbsd XYMONCLIENT_NETBSD
+grep -q '^df_sentinel()' "$SCRIPT" || fail "remote-df sentinel missing from $SCRIPT (regressed)"
+
+DF_CALLS="$TMP/df.calls"; : > "$DF_CALLS"; export DF_CALLS
+DF_REMOTE="$TMP/df.remote"; : > "$DF_REMOTE"; export DF_REMOTE
+
+# mount(8) as FreeBSD prints it. /net is nfs -- hard-blocking, so it goes behind
+# the sentinel; /ssh is a remote that stat()s safely and must keep being
+# reported by the plain df.
+cat > "$STUB/mount" <<'EOF'
+#!/bin/sh
+cat <<'MOUNT'
+/dev/ld0a on / type ffs (local)
+srv:/exp on /net type nfs (nodev)
+usr@h:/d on /ssh type psshfs (local)
+MOUNT
+EOF
+chmod +x "$STUB/mount"
+
+# df stub. It hangs only when asked about the hard-blocking mount by name, which
+# is how a real df wedges: the plain call keeps answering throughout.
+cat > "$STUB/df" <<'EOF'
+#!/bin/sh
+echo "$*" >> "$DF_CALLS"
+_inode=; _named=; _ex=" "
+for a in "$@"; do
+	case "$a" in
+		-i) _inode=1 ;;
+		-t*) _l=${a#-t}; _l=${_l#no}; _ex=" $(echo "$_l" | tr ',' ' ') " ;;
+		/*) _named="$_named $a" ;;
+		-P|-k|-h|-H) ;;
+		# Real df rejects what it does not know, and the log above joins argv
+		# with spaces -- so two flags arriving as one word look exactly like
+		# two flags. Rejecting the unknown word is what tells them apart.
+		*) echo "df: illegal option -- $a" >&2; exit 1 ;;
+	esac
+done
+[ -n "$_named" ] && echo $$ >> "${DF_REMOTE:-/dev/null}"
+[ -n "$_named" ] && [ -n "${DF_HANG:-}" ] && exec "$HANGBIN" "${DF_HANGTIME:-20}"
+[ -n "${DF_FAIL:-}" ] && exit 1
+# An exclusion applies to a named operand too: once every operand is excluded,
+# df processes nothing and exits nonzero.
+if [ -n "$_named" ]; then
+	_keep=
+	for a in $_named; do
+		case "$a" in /net) _t=nfs ;; /ssh) _t=psshfs ;; *) _t=ffs ;; esac
+		case "$_ex" in *" $_t "*) ;; *) _keep="$_keep $a" ;; esac
+	done
+	[ -z "$_keep" ] && { echo "df: no file systems processed" >&2; exit 1; }
+	if [ -n "$_inode" ]; then
+		printf 'Filesystem 512-blocks Used Available Capacity iUsed iAvail %%iCap Mounted on\n'
+		for a in $_keep; do printf 'srv:/exp 3837980 2953852 692232 81%% 41013 218057 15%% %s\n' "$a"; done
+	else
+		printf 'Filesystem 512-blocks Used Available Capacity Mounted on\n'
+		for a in $_keep; do printf 'srv:/exp 3837980 2953852 692232 81%% %s\n' "$a"; done
+	fi
+	exit 0
+fi
+if [ -n "$_inode" ]; then
+	printf 'Filesystem 512-blocks Used Available Capacity iUsed iAvail %%iCap Mounted on\n'
+	printf '/dev/ld0a 3837980 2953852 692232 81%% 41013 218057 15%% /\n'
+	case "$_ex" in *" psshfs "*) ;; *) printf 'usr@h:/d 3837980 2953852 692232 81%% 41013 218057 15%% /ssh\n' ;; esac
+	exit 0
+fi
+printf 'Filesystem 512-blocks Used Available Capacity Mounted on\n'
+printf '/dev/ld0a 3837980 2953852 692232 81%% /\n'
+case "$_ex" in *" psshfs "*) ;; *) printf 'usr@h:/d 3837980 2953852 692232 81%% /ssh\n' ;; esac
+EOF
+chmod +x "$STUB/df"
+
+# The wedge has to look like df to ps, on every OS. A shell script named df
+# reports comm "df" on Linux but "sh" on the BSDs -- the interpreter -- so the
+# PID-reuse guard would decide the recorded pid is not our df and start a
+# second probe. Real df is a binary, so make the stub's wedge one too: a copy
+# of sleep, named df, exec'd in place (same pid, and comm becomes "df").
+HANGBIN="$TMP/hangbin/df"
+fsf_wedge_binary "$HANGBIN"
+export HANGBIN
+
+SNIPPET="$TMP/df-section.sh"
+fsf_extract "$SNIPPET"
+
+mkdir -p "$TMP/probe"
+# The caller's assignments come last so a case can override a default.
+run_cycle() {
+	env DF_CALLS="$DF_CALLS" DF_REMOTE="$DF_REMOTE" \
+		XYMONTMP="$TMP/probe" \
+		XYMONCLIENT_FS_DF_LOCAL_ONLY=no \
+		XYMONCLIENT_FS_REMOTE_DF_BUDGET=2 \
+		PATH="$STUB:$PATH" \
+		"$@" \
+		/bin/sh "$SNIPPET" 2>/dev/null || true
+}
+end_stub() { pkill -P "$1" 2>/dev/null || true; kill -9 "$1" 2>/dev/null || true; }
+
+# --- healthy: the guarded mount is reported, the safe remote one still is -----
+out=$(run_cycle)
+assert_contains "/net" "$out" "a healthy hard-blocking mount is reported through the sentinel"
+# With real rows, not the marker: everything the sentinel hands df has to be
+# something df accepts, and a probe that fails on its own arguments looks
+# exactly like a server that stopped answering.
+assert_not_contains "unavailable:/net" "$out" \
+	"a healthy server must produce real rows, never the unavailable marker"
+assert_contains "/ssh" "$out" "a remote type that cannot hard-block stays in the plain df"
+assert_contains "/dev/ld0a" "$out" "and the local set is reported as before"
+assert_equal '0' "$(find "$TMP/probe" -type f | awk 'END { print NR }')" \
+	"a probe that completed leaves no state behind"
+
+# The unguarded df must never be asked to stat a hard-blocking type: the calls
+# that name no mount point are the plain ones, and their -t list has to carry
+# every hard-blocking type (#316).
+plain_args=$(grep -v ' /net' "$DF_CALLS" | tr '\n' ' ')
+assert_contains ",nfs," "$plain_args" "the plain df excludes nfs"
+assert_contains ",smbfs," "$plain_args" "and smbfs"
+assert_contains ",lustre" "$plain_args" "and the rest of the hard-blocking list"
+
+# --- wedged: both reports surface the mount, each under its own probe ---------
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+out=$(run_cycle DF_HANG=1)
+df_section=$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')
+inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
+assert_contains "unavailable:/net" "$df_section" \
+	"a wedged server must surface the mount in the disk report, not drop it"
+assert_contains "unavailable:/net" "$inode_section" \
+	"and in the inode report, whose columns are read positionally"
+# Shape, not just presence: the inode awk reads iused/ifree/%iused from fields
+# 6-8, so a marker row in the disk layout would be reformatted into nonsense
+# that still contains the mount name.
+assert_contains "100% /net" "$inode_section" \
+	"the inode marker row must carry the inode columns, not the disk ones"
+assert_contains "/dev/ld0a" "$df_section" \
+	"a wedged remote server must not stale or block the local set"
+[ -f "$TMP/probe/df-probe-disk.pid" ] || fail "the wedged disk probe must be left recorded"
+[ -f "$TMP/probe/df-probe-inode.pid" ] || fail "the wedged inode probe must be recorded under its own tag"
+
+# --- still wedged: no second probe -------------------------------------------
+before=$(wc -l < "$DF_CALLS")
+out=$(run_cycle DF_HANG=1)
+after=$(wc -l < "$DF_CALLS")
+assert_equal "$((before + 2))" "$((after))" \
+	"while both probes are wedged, a cycle must run only the two plain dfs"
+assert_contains "unavailable:/net" "$out" "the mount stays unavailable while wedged"
+for _tag in disk inode; do end_stub "$(cat "$TMP/probe/df-probe-$_tag.pid")"; done
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+
+# --- the probe directory is itself on a hard-blocking mount ------------------
+# Nothing may touch it: even `test -w` blocks in D-state there, inside the
+# fail-safe meant to prevent exactly that.
+mkdir -p "$TMP/remoteprobe"
+cat > "$STUB/mount" <<EOF
+#!/bin/sh
+cat <<'MOUNT'
+/dev/ld0a on / type ffs (local)
+srv:/exp on /net type nfs (nodev)
+srv:/p on $TMP/remoteprobe type nfs (nodev)
+MOUNT
+EOF
+chmod +x "$STUB/mount"
+out=$(run_cycle DF_HANG=1 XYMONTMP="$TMP/remoteprobe")
+assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
+	"a probe dir on a hard-blocking filesystem must never be touched"
+assert_contains "unavailable:/net" "$out" "the remote set reports unavailable instead"
+
+
+# Same guard, mount list unavailable rather than hostile. Asked directly: with
+# no mount list there is no remote set either, so df_sentinel is never reached
+# through the block. What is reachable is a list that answers once -- long
+# enough to name the remote set -- and fails on the second read in the same
+# cycle. A pipeline would hand this function awk's status, and awk succeeds on
+# no input, so a directory nobody could place would read as local.
+( sed -n '/^probe_dir_is_local()/,/^}/p' "$SCRIPT"
+  printf 'fs_mounts() { return 1; }\n'
+  printf 'probe_dir_is_local /remote/probe\n' ) > "$TMP/pdl.sh"
+if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; then
+	fail "an unreadable mount list must not read as a local probe directory"
+fi
+
+pass "xymonclient-netbsd.sh: the remote-df sentinel is wired to mount(8) and both reports"

--- a/tests/client/fs-sentinel-openbsd.sh
+++ b/tests/client/fs-sentinel-openbsd.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-sentinel-openbsd.sh
+#
+# The remote-df sentinel wired into xymonclient-openbsd.sh (#316). df_sentinel()
+# itself is byte-identical to the Linux copy -- fs-sentinel-copies.sh enforces
+# that, and fs-sentinel-linux.sh tests its internals (the claim race, PID reuse,
+# a probe that finishes late). What is OpenBSD's own, and what this file tests,
+# is the wiring: finding the hard-blocking mounts through mount(8) instead of
+# /proc/mounts, keeping them out of the unguarded df, and emitting marker rows
+# in the column layout each report is parsed with.
+#
+# Everything is driven by a mount fixture and a df stub: no real remote
+# filesystem is involved, and nothing is ever killed except the stub.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"
+
+fsf_setup openbsd XYMONCLIENT_OPENBSD
+grep -q '^df_sentinel()' "$SCRIPT" || fail "remote-df sentinel missing from $SCRIPT (regressed)"
+
+DF_CALLS="$TMP/df.calls"; : > "$DF_CALLS"; export DF_CALLS
+DF_REMOTE="$TMP/df.remote"; : > "$DF_REMOTE"; export DF_REMOTE
+
+# mount(8) as FreeBSD prints it. /net is nfs -- hard-blocking, so it goes behind
+# the sentinel; /ssh is a remote that stat()s safely and must keep being
+# reported by the plain df.
+cat > "$STUB/mount" <<'EOF'
+#!/bin/sh
+cat <<'MOUNT'
+/dev/sd0a on / type ffs (local)
+srv:/exp on /net type nfs (nodev)
+usr@h:/d on /ssh type fuse (local)
+MOUNT
+EOF
+chmod +x "$STUB/mount"
+
+# df stub. It hangs only when asked about the hard-blocking mount by name, which
+# is how a real df wedges: the plain call keeps answering throughout.
+cat > "$STUB/df" <<'EOF'
+#!/bin/sh
+echo "$*" >> "$DF_CALLS"
+_inode=; _named=; _ex=" "
+for a in "$@"; do
+	case "$a" in
+		-i) _inode=1 ;;
+		-t*) _l=${a#-t}; _l=${_l#no}; _ex=" $(echo "$_l" | tr ',' ' ') " ;;
+		/*) _named="$_named $a" ;;
+		-P|-k|-h|-H) ;;
+		# Real df rejects what it does not know, and the log above joins argv
+		# with spaces -- so two flags arriving as one word look exactly like
+		# two flags. Rejecting the unknown word is what tells them apart.
+		*) echo "df: illegal option -- $a" >&2; exit 1 ;;
+	esac
+done
+[ -n "$_named" ] && echo $$ >> "${DF_REMOTE:-/dev/null}"
+[ -n "$_named" ] && [ -n "${DF_HANG:-}" ] && exec "$HANGBIN" "${DF_HANGTIME:-20}"
+[ -n "${DF_FAIL:-}" ] && exit 1
+# An exclusion applies to a named operand too: once every operand is excluded,
+# df processes nothing and exits nonzero.
+if [ -n "$_named" ]; then
+	_keep=
+	for a in $_named; do
+		case "$a" in /net) _t=nfs ;; /ssh) _t=fuse ;; *) _t=ffs ;; esac
+		case "$_ex" in *" $_t "*) ;; *) _keep="$_keep $a" ;; esac
+	done
+	[ -z "$_keep" ] && { echo "df: no file systems processed" >&2; exit 1; }
+	if [ -n "$_inode" ]; then
+		printf 'Filesystem 1K-blocks Used Avail Capacity iused ifree %%iused Mounted on\n'
+		for a in $_keep; do printf 'srv:/exp 100 50 50 50%% 1000 9000 10%% %s\n' "$a"; done
+	else
+		printf 'Filesystem 1K-blocks Used Avail Capacity Mounted on\n'
+		for a in $_keep; do printf 'srv:/exp 100 50 50 50%% %s\n' "$a"; done
+	fi
+	exit 0
+fi
+if [ -n "$_inode" ]; then
+	printf 'Filesystem 1K-blocks Used Avail Capacity iused ifree %%iused Mounted on\n'
+	printf '/dev/sd0a 100 50 50 50%% 1000 9000 10%% /\n'
+	case "$_ex" in *" fuse "*) ;; *) printf 'usr@h:/d 100 50 50 50%% 1000 9000 10%% /ssh\n' ;; esac
+	exit 0
+fi
+printf 'Filesystem 1K-blocks Used Avail Capacity Mounted on\n'
+printf '/dev/sd0a 100 50 50 50%% /\n'
+case "$_ex" in *" fuse "*) ;; *) printf 'usr@h:/d 100 50 50 50%% /ssh\n' ;; esac
+EOF
+chmod +x "$STUB/df"
+
+# The wedge has to look like df to ps, on every OS. A shell script named df
+# reports comm "df" on Linux but "sh" on the BSDs -- the interpreter -- so the
+# PID-reuse guard would decide the recorded pid is not our df and start a
+# second probe. Real df is a binary, so make the stub's wedge one too: a copy
+# of sleep, named df, exec'd in place (same pid, and comm becomes "df").
+HANGBIN="$TMP/hangbin/df"
+fsf_wedge_binary "$HANGBIN"
+export HANGBIN
+
+SNIPPET="$TMP/df-section.sh"
+fsf_extract "$SNIPPET"
+
+mkdir -p "$TMP/probe"
+# The caller's assignments come last so a case can override a default.
+run_cycle() {
+	env DF_CALLS="$DF_CALLS" DF_REMOTE="$DF_REMOTE" \
+		XYMONTMP="$TMP/probe" \
+		XYMONCLIENT_FS_DF_LOCAL_ONLY=no \
+		XYMONCLIENT_FS_REMOTE_DF_BUDGET=2 \
+		PATH="$STUB:$PATH" \
+		"$@" \
+		/bin/sh "$SNIPPET" 2>/dev/null || true
+}
+end_stub() { pkill -P "$1" 2>/dev/null || true; kill -9 "$1" 2>/dev/null || true; }
+
+# --- healthy: the guarded mount is reported, the safe remote one still is -----
+out=$(run_cycle)
+assert_contains "/net" "$out" "a healthy hard-blocking mount is reported through the sentinel"
+# With real rows, not the marker: everything the sentinel hands df has to be
+# something df accepts, and a probe that fails on its own arguments looks
+# exactly like a server that stopped answering.
+assert_not_contains "unavailable:/net" "$out" \
+	"a healthy server must produce real rows, never the unavailable marker"
+assert_contains "/ssh" "$out" "a remote type that cannot hard-block stays in the plain df"
+assert_contains "/dev/sd0a" "$out" "and the local set is reported as before"
+assert_equal '0' "$(find "$TMP/probe" -type f | awk 'END { print NR }')" \
+	"a probe that completed leaves no state behind"
+
+# The unguarded df must never be asked to stat a hard-blocking type: the calls
+# that name no mount point are the plain ones, and their -t list has to carry
+# every hard-blocking type (#316).
+plain_args=$(grep -v ' /net' "$DF_CALLS" | tr '\n' ' ')
+assert_contains ",nfs," "$plain_args" "the plain df excludes nfs"
+assert_contains ",smbfs," "$plain_args" "and smbfs"
+assert_contains ",lustre" "$plain_args" "and the rest of the hard-blocking list"
+
+# --- wedged: both reports surface the mount, each under its own probe ---------
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+out=$(run_cycle DF_HANG=1)
+df_section=$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')
+inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
+assert_contains "unavailable:/net" "$df_section" \
+	"a wedged server must surface the mount in the disk report, not drop it"
+assert_contains "unavailable:/net" "$inode_section" \
+	"and in the inode report, whose columns are read positionally"
+# Shape, not just presence: the inode awk reads iused/ifree/%iused from fields
+# 6-8, so a marker row in the disk layout would be reformatted into nonsense
+# that still contains the mount name.
+assert_contains "100% /net" "$inode_section" \
+	"the inode marker row must carry the inode columns, not the disk ones"
+assert_contains "/dev/sd0a" "$df_section" \
+	"a wedged remote server must not stale or block the local set"
+[ -f "$TMP/probe/df-probe-disk.pid" ] || fail "the wedged disk probe must be left recorded"
+[ -f "$TMP/probe/df-probe-inode.pid" ] || fail "the wedged inode probe must be recorded under its own tag"
+
+# --- still wedged: no second probe -------------------------------------------
+before=$(wc -l < "$DF_CALLS")
+out=$(run_cycle DF_HANG=1)
+after=$(wc -l < "$DF_CALLS")
+assert_equal "$((before + 2))" "$((after))" \
+	"while both probes are wedged, a cycle must run only the two plain dfs"
+assert_contains "unavailable:/net" "$out" "the mount stays unavailable while wedged"
+for _tag in disk inode; do end_stub "$(cat "$TMP/probe/df-probe-$_tag.pid")"; done
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+
+# --- the probe directory is itself on a hard-blocking mount ------------------
+# Nothing may touch it: even `test -w` blocks in D-state there, inside the
+# fail-safe meant to prevent exactly that.
+mkdir -p "$TMP/remoteprobe"
+cat > "$STUB/mount" <<EOF
+#!/bin/sh
+cat <<'MOUNT'
+/dev/sd0a on / type ffs (local)
+srv:/exp on /net type nfs (nodev)
+srv:/p on $TMP/remoteprobe type nfs (nodev)
+MOUNT
+EOF
+chmod +x "$STUB/mount"
+out=$(run_cycle DF_HANG=1 XYMONTMP="$TMP/remoteprobe")
+assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
+	"a probe dir on a hard-blocking filesystem must never be touched"
+assert_contains "unavailable:/net" "$out" "the remote set reports unavailable instead"
+
+
+# Same guard, mount list unavailable rather than hostile. Asked directly: with
+# no mount list there is no remote set either, so df_sentinel is never reached
+# through the block. What is reachable is a list that answers once -- long
+# enough to name the remote set -- and fails on the second read in the same
+# cycle. A pipeline would hand this function awk's status, and awk succeeds on
+# no input, so a directory nobody could place would read as local.
+( sed -n '/^probe_dir_is_local()/,/^}/p' "$SCRIPT"
+  printf 'fs_mounts() { return 1; }\n'
+  printf 'probe_dir_is_local /remote/probe\n' ) > "$TMP/pdl.sh"
+if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; then
+	fail "an unreadable mount list must not read as a local probe directory"
+fi
+
+pass "xymonclient-openbsd.sh: the remote-df sentinel is wired to mount(8) and both reports"


### PR DESCRIPTION
**1 commit.** Closes the fleet gap left by #343: all five filtered clients now bound a wedged remote df instead of losing the host.

The wedge was never Linux's — with `DF_LOCAL_ONLY=no`, df stats remote mounts, and a dead NFS/CIFS server leaves it in an uninterruptible wait where SIGKILL is ignored, so the cycle never finishes and every column goes purple, not just disk. Only the guard was.

`df_sentinel()` is copied verbatim; `fs-sentinel-copies.sh` fails if the copies differ, and `fs-sentinel-linux.sh` keeps testing its internals, so the ports do not re-test them. What is per-OS is the wiring: the mount list (`mount(8)`, `MNT_NOWAIT`, never `-v` on FreeBSD), how the unguarded df is shielded (`-t no<csv>` on the BSDs; macOS has no type filter, so its per-path loop is only handed what it can stat), and where the header comes from when every surviving filesystem is guarded.

Three defects found while building it, each fixed here and pinned by a test:

| defect | how it showed |
|---|---|
| macOS passed `"-P -H"` as one argv word | `df: invalid option --`, rc=64 on a real Mac; every *healthy* guarded mount reported `unavailable:` |
| the pid file was written non-atomically | a cycle reading mid-write took the empty value for a stale entry and started a second probe, leaving the first df unrecorded (@SoundGoof) |
| NetBSD and OpenBSD spell mount(8) as `MP type <fstype> (opts)` | enumeration dropped every row there, so remote filesystems vanished from the report |

The claim is now published by hard-linking a private file into place and the pid by renaming one over it: link fails if the target exists, and a rename replaces in one step, so a reader sees either the whole claim or the whole pid. `probe_dir_is_local()` keeps the mount helper's own status rather than the pipeline's — awk succeeds on no input, and "I cannot read the mount list" is not "this directory is local".

The wedge fixture is compiled rather than copied: `cp $(command -v sleep) df` gives BusyBox's `df` on Alpine, and macOS SIGKILLs a copy of a signed system binary. It falls back to copying, and checks the result survives before handing it back.

| mutation | caught by |
|---|---|
| flags reach the probe as one word | `a healthy server must produce real rows, never the unavailable marker` |
| pid published with a truncating write | `a cycle reading the pid file mid-publication must not start a second probe` (deterministic: a `mv` stub holds the window open) |
| the FreeBSD/macOS parse used on NetBSD | `does not contain '/net'` — the remote mount disappears |
| `probe_dir_is_local` back on the pipeline | `an unreadable mount list must not read as a local probe directory` |
| a mount point ending in `type WORD` read as the NetBSD spelling | `must still be recognised as nfs and guarded` |
| inode report skips the sentinel, or gets a disk-shaped marker row | `and in the inode report, whose columns are read positionally` |

Docs: both tunables were "Linux only"; the default hard-blocking list is per-OS. HTML regenerated with `build/makehtml.sh`.

Suite: 79 passed, 0 skipped, 0 failed on a built tree. Verified on the `cmake/bootstrap` lanes (FreeBSD 13.5/14.3/15.0, NetBSD 9.2–10.1, OpenBSD 7.6/7.7/7.8, macOS 14/15/26) and on a real Apple-silicon Mac.
