### PR TITLE
tests: -iquote in the three harnesses that still used -I, and a rule so it stays that way

### DIFF
--- a/tests/buildsystem/test-suite-portability.sh
+++ b/tests/buildsystem/test-suite-portability.sh
@@ -88,6 +88,18 @@ report "gnu-regex" '(grep|sed|awk|expr)[^|]*\\(b|<|>|w|W|s|S|d|D)([^[:alnum:]]|$
 report "root-lane" 'chmod +[-+=rwx]*[0-7]?[0-5][0-7][0-7]([^0-9]|$)|chmod +[ugoa]*-w' \
 	"the lanes run as root; a permission bit will not force this failure"
 
+# An -I directory is searched for <angle> includes too, so a source directory
+# put there can capture a system header. macOS makes that concrete: the SDK's
+# stdio.h includes <Availability.h>, the filesystem is case-insensitive, and
+# lib/availability.h answers instead -- every system type after it is unknown,
+# and the three tests that reached lib/ this way did not build on the macOS
+# lanes. -iquote is searched for "quoted" includes only, which is all an
+# in-tree header needs. Generated directories are deliberately NOT flagged:
+# rrd-api-compat.sh puts its mock <rrd.h> on -I precisely so that an angle
+# include finds it.
+report "include-shadow" '\-I *"?\$\{?ROOT' \
+	"an -I source directory also answers <angle> includes; use -iquote (macOS: lib/availability.h captures the SDK's Availability.h)"
+
 # Interpreters the BSD runners do not have.
 report "interpreter" '(^|[^-[:alnum:]_])(python3?|perl)[[:space:]]' \
 	"not installed on the BSD lanes; awk and sh are"
@@ -129,10 +141,11 @@ probe="$work/probe.sh"
 	printf 'grep -E %s x\n' "'\\bword\\b'"
 	printf 'chmod 500 d\n'
 	printf 'chmod 555 d\n'
+	printf 'cc -I"$ROOT/lib" x.c\n'
 } >"$probe"
 probe_pattern=$(IFS='|'; printf '%s' "${__rule_patterns[*]}")
 hits=$(grep -cE "$probe_pattern" "$probe")
-assert_equal "6" "$hits" "the rule patterns no longer match the constructs they are meant to catch"
+assert_equal "7" "$hits" "the rule patterns no longer match the constructs they are meant to catch"
 
 # The link-flags rule the same way, including the bypass it used to allow: the
 # helpers named in a comment and nowhere else.

--- a/tests/server/xymond-flap-purple-pin.sh
+++ b/tests/server/xymond-flap-purple-pin.sh
@@ -58,7 +58,7 @@ harness_ldflags=$(xymon_ldflags "$ROOT")
 # those paths.
 harness_cflags=$(xymon_cflags "$ROOT")
 # shellcheck disable=SC2086
-"$CC" $harness_cflags -I"$ROOT/lib" -o "$work/harness" \
+"$CC" $harness_cflags -iquote "$ROOT/lib" -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
 	$harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }

--- a/tests/server/xymond-gap-validity.sh
+++ b/tests/server/xymond-gap-validity.sh
@@ -72,7 +72,7 @@ harness_ldflags=$(xymon_ldflags "$ROOT")
 # pcre2.h, which lives under /usr/local/include or /usr/pkg/include on the BSDs.
 harness_cflags=$(xymon_cflags "$ROOT")
 # shellcheck disable=SC2086
-"$CC" $harness_cflags -I"$ROOT/lib" -o "$work/harness" \
+"$CC" $harness_cflags -iquote "$ROOT/lib" -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" $harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 

--- a/tests/server/xymond-holdtime-bridge.sh
+++ b/tests/server/xymond-holdtime-bridge.sh
@@ -69,7 +69,7 @@ harness_ldflags=$(xymon_ldflags "$ROOT")
 # those paths.
 harness_cflags=$(xymon_cflags "$ROOT")
 # shellcheck disable=SC2086
-"$CC" $harness_cflags -I"$ROOT/lib" -o "$work/harness" \
+"$CC" $harness_cflags -iquote "$ROOT/lib" -o "$work/harness" \
 	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
 	$harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }


### PR DESCRIPTION
Three tests fail on **every macOS Server lane** and have since they were added. One cause:

```
In file included from .../SDKs/MacOSX.sdk/usr/include/_stdio.h:71:
lib/Availability.h:18:2: error: unknown type name 'time_t'
lib/Availability.h:47:30: error: unknown type name 'FILE'
```

An `-I` directory answers `<angle>` includes too. The SDK's `stdio.h` includes
`<Availability.h>`, the filesystem is case-insensitive, and **our own `lib/availability.h`**
answers instead -- so every system type after it is unknown and the harness does not build.

| | |
|---|---|
| `tests/server/xymond-flap-purple-pin.sh:61` | `-I"$ROOT/lib"` |
| `tests/server/xymond-gap-validity.sh:75` | `-I"$ROOT/lib"` |
| `tests/server/xymond-holdtime-bridge.sh:72` | `-I"$ROOT/lib"` |

`89499737d` ("tests: reach in-tree headers with -iquote, not -I") converted ten tests on
2026-08-11. These three arrived two days later in `0ee9b6f39`, written with the old
spelling, so the sweep could not have covered them -- which is the argument for a rule
rather than another sweep.

**The rule**: `include-shadow` flags an `-I` whose directory is under `$ROOT`, with the
non-vacuity probe entry that keeps it honest (4 -> 5 constructs). Generated directories are
deliberately not flagged: `rrd-api-compat.sh` puts its mock `<rrd.h>` on `-I` precisely so
an angle include finds it, and says so in a comment -- I broke that in a first pass and the
suite caught it.

Evidence: with one `-I` put back, the lint reports
`[include-shadow] tests/server/xymond-gap-validity.sh:75`; with the three fixed it passes.
Suite: 0 failed.

Found by reading an old lane run (`bonomani/xymon` run 31796174740, 2026-08-14): 48 jobs,
the only failures were macOS 14/15/26 Server, all three from this.

Note for whoever merges second: #360 also adds a rule to this file, so one of the two will
need its probe count bumped by one.

