### PR TITLE
xymongen: bound the WML paths, and report a path that does not fit

### DIFF
--- a/tests/web/wmlgen-path-bounds-harness.c
+++ b/tests/web/wmlgen-path-bounds-harness.c
@@ -1,0 +1,205 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Driver for the real generate_wml_statuscard(), extracted from
+ * xymongen/wmlgen.c by the test beside this file.
+ *
+ * The function is static and sits on top of xymongen's whole object graph, so
+ * what it needs is stubbed rather than linked: the daemon exchange returns a
+ * canned log, and the types carry only the fields the function reads. What is
+ * NOT stubbed is the function itself -- it is the production text, so a fix
+ * that stops holding has nowhere to hide.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <limits.h>
+#include <errno.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/resource.h>
+
+#define MAX_LINE_LEN 16384
+#define XYMON_TIMEOUT 30
+#define XYMONSEND_OK 0
+
+typedef struct column_t { char *name; } column_t;
+typedef struct entry_t { column_t *column; int color; int acked; struct entry_t *next; } entry_t;
+typedef struct host_t { char *hostname; } host_t;
+typedef struct sendreturn_t { int dummy; } sendreturn_t;
+
+static char *wmldir;
+static char *timestamp = "Mon Jan  1 00:00:00 2026";
+
+/* The canned log: a header line, then one body line the parser copies out. */
+static const char *CANNED = "green Mon Jan  1 00:00:00 2026\nplain body line\n";
+
+static sendreturn_t *newsendreturnbuf(int a, void *b) { (void)a; (void)b; return (sendreturn_t *)calloc(1, sizeof(sendreturn_t)); }
+static char *expected_req;	/* what this call must have been handed */
+static int req_mismatch;
+
+static int sendmessage(char *req, void *a, int b, sendreturn_t *c)
+{
+	(void)a; (void)b; (void)c;
+	/*
+	 * The whole request, not its prefix: a "fix" that bounded this by
+	 * truncating the names would stop overflowing and still ask the daemon
+	 * about the wrong test, which a prefix check cannot tell apart.
+	 */
+	if (expected_req && (strcmp(req, expected_req) != 0)) {
+		fprintf(stderr, "FAIL: request was %zu bytes, expected %zu\n",
+			strlen(req), strlen(expected_req));
+		req_mismatch = 1;
+	}
+	return XYMONSEND_OK;
+}
+
+static void expect_req(const char *host, const char *col)
+{
+	free(expected_req);
+	expected_req = (char *)malloc(strlen(host) + strlen(col) + sizeof("xymondlog ."));
+	sprintf(expected_req, "xymondlog %s.%s", host, col);
+}
+static int empty_answer;	/* xymond has no log for this test */
+static char *getsendreturnstr(sendreturn_t *s, int a)
+{
+	(void)s; (void)a;
+	/* Still an allocation: "no status" is an empty string, not a NULL, which
+	   is exactly the case whose early return used to drop it. */
+	return strdup(empty_answer ? "" : CANNED);
+}
+static void freesendreturnbuf(sendreturn_t *s) { free(s); }
+static void wml_header(FILE *fd, const char *name, int n) { (void)name; (void)n; fprintf(fd, "<wml>\n"); }
+static void errprintf(const char *fmt, ...) { (void)fmt; }
+static void *xmalloc(size_t n) { void *p = malloc(n); if (!p) abort(); return p; }
+static void xfree(void *p) { free(p); }
+
+#include "wmlgen-statuscard.inc"
+
+static entry_t *mkentry(const char *col)
+{
+	entry_t *e = (entry_t *)calloc(1, sizeof(entry_t));
+	e->column = (column_t *)calloc(1, sizeof(column_t));
+	e->column->name = strdup(col);
+	return e;
+}
+
+static char *repeat(char c, size_t n)
+{
+	char *s = (char *)malloc(n + 1);
+	memset(s, c, n); s[n] = '\0';
+	return s;
+}
+
+int main(int argc, char **argv)
+{
+	host_t host;
+	entry_t *e;
+	int rc, fail = 0;
+
+	if (argc < 3) { fprintf(stderr, "usage: %s <wmldir> <deep-wmldir>\n", argv[0]); return 2; }
+	wmldir = argv[1];
+
+	/* 1. An ordinary card is written, and says so. */
+	char *hn;
+
+	hn = strdup("short.host");
+	host.hostname = hn;
+	e = mkentry("conn");
+	expect_req(hn, "conn");
+	rc = generate_wml_statuscard(&host, e);
+	if (rc != 1) { fprintf(stderr, "FAIL: an ordinary status card reported failure (%d)\n", rc); fail = 1; }
+	free(hn);
+
+	/* 2. A hostname far past the old 1 KiB request buffer. Nothing here
+	   asserts a value: the assertion is that ASan sees no write past the
+	   buffer the request is built in, which happens before any path check. */
+	hn = repeat('h', 1200);
+	host.hostname = hn;
+	expect_req(hn, "conn");
+	rc = generate_wml_statuscard(&host, e);
+	if (rc != 0) { fprintf(stderr, "NOTE: the 1200-byte name produced a card (%d)\n", rc); }
+	free(hn);
+
+	/* 3. The boundary that matters to the caller: the host card's own path
+	   fits, and the status card's -- one component longer -- does not. The
+	   function must report that, so the caller can stop advertising it. */
+	{
+		/* The deep directory, so every component stays inside NAME_MAX and it
+		   is the *path* length that decides. With one huge component instead,
+		   fopen() fails with ENAMETOOLONG and the case proves nothing about
+		   the guard. */
+		size_t room;
+		char *name;
+		char hostfn[PATH_MAX];
+		int n;
+
+		wmldir = argv[2];
+		room = PATH_MAX - strlen(wmldir) - strlen("/") - strlen(".wml") - 1;
+		if (room > 60) room = 60;              /* a plain name, well inside NAME_MAX */
+		name = repeat('n', room);
+		n = snprintf(hostfn, sizeof(hostfn), "%s/%s.wml", wmldir, name);
+
+		if ((n < 0) || (n >= (int)sizeof(hostfn))) {
+			fprintf(stderr, "FAIL: the host-card path was meant to fit, and does not (%d)\n", n);
+			fail = 1;
+		}
+		host.hostname = name;
+		expect_req(name, "conn");
+		rc = generate_wml_statuscard(&host, e);   /* adds ".<column>" -- cannot fit */
+		if (rc != 0) {
+			fprintf(stderr, "FAIL: a status-card path that does not fit was reported as written (%d)\n", rc);
+			fail = 1;
+		}
+		free(name);
+	}
+
+	/* 4. A status xymond has no log for. The answer is an empty string rather
+	   than NULL -- an allocation the caller owns -- and the early return has
+	   to release it. Nothing here asserts a value; LeakSanitizer does. */
+	hn = strdup("nolog.host");
+	host.hostname = hn;
+	expect_req(hn, "conn");
+	empty_answer = 1;
+	rc = generate_wml_statuscard(&host, e);
+	empty_answer = 0;
+	if (rc != 0) { fprintf(stderr, "FAIL: a card with no status was reported as written (%d)\n", rc); fail = 1; }
+	free(hn);
+
+	/* 5. A write that cannot finish. RLIMIT_FSIZE makes every write past the
+	   limit fail (SIGXFSZ ignored so the failure comes back as an error, not
+	   a signal), which is where a full filesystem surfaces: at fprintf and
+	   fclose, not at fopen. A card written short must not be reported as
+	   written, or the caller links to a truncated one. */
+	{
+		struct rlimit rl;
+
+		signal(SIGXFSZ, SIG_IGN);
+		/* The soft limit only. Lowering the hard one is a one-way door for
+		   an unprivileged process, and it would cap what the sanitizer can
+		   write for the rest of the run -- its report came out truncated. */
+		if (getrlimit(RLIMIT_FSIZE, &rl) != 0) rl.rlim_max = RLIM_INFINITY;
+		rl.rlim_cur = 64;
+		if (setrlimit(RLIMIT_FSIZE, &rl) == 0) {
+			hn = strdup("shortwrite.host");
+			host.hostname = hn;
+			expect_req(hn, "conn");
+			rc = generate_wml_statuscard(&host, e);
+			if (rc != 0) {
+				fprintf(stderr, "FAIL: a card whose write could not finish was reported as written (%d)\n", rc);
+				fail = 1;
+			}
+			free(hn);
+			rl.rlim_cur = rl.rlim_max;
+			setrlimit(RLIMIT_FSIZE, &rl);
+		}
+		else fprintf(stderr, "note: RLIMIT_FSIZE unavailable, the short-write case is unverified\n");
+	}
+
+	free(e->column->name); free(e->column); free(e);
+	free(expected_req);
+	if (req_mismatch) { fprintf(stderr, "FAIL: the daemon request did not carry the names whole\n"); fail = 1; }
+
+	if (!fail) printf("OK\n");
+	return fail;
+}

--- a/tests/web/wmlgen-path-bounds.sh
+++ b/tests/web/wmlgen-path-bounds.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/web/wmlgen-path-bounds.sh
+#
+# generate_wml_statuscard() builds two things from a hostname and a column
+# name: the request it sends to xymond, and the path it writes the card to.
+# Neither was bounded, and they fail differently.
+#
+#   - The request was a 1 KiB stack buffer filled with sprintf(). hosts.cfg
+#     lets a hostname run to MAX_LINE_LEN (16 KiB, loadlayout.c:423), and
+#     nothing between the two imposes a smaller limit, so a long name in the
+#     config overflowed the stack -- before any path check and before the
+#     daemon was contacted (@SoundGoof, reproduced under ASan).
+#
+#   - The path is bounded by PATH_MAX, which is real, so an overlong one is
+#     refused. The refusal has to reach the caller: do_wml_cards() links to
+#     the card from the host card, and a card it skipped silently left a link
+#     to a file that does not exist. That case needs no oversized name at all
+#     -- the status path is one component longer than the host card's own, so
+#     a wmldir near the limit is enough to put one inside and the other out.
+#
+# The real function is extracted and driven, rather than reimplemented: a copy
+# would keep passing after production stopped doing this.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_cc
+ROOT=$(find_root)
+SRC="$ROOT/xymongen/wmlgen.c"
+[ -f "$SRC" ] || fail "cannot find xymongen/wmlgen.c"
+
+work=$(mktempdir)
+mkdir -p "$work/wml"
+
+sed -n '/^static int generate_wml_statuscard/,/^}/p' "$SRC" > "$work/wmlgen-statuscard.inc"
+grep -q "generate_wml_statuscard" "$work/wmlgen-statuscard.inc" \
+	|| fail "could not extract generate_wml_statuscard() from wmlgen.c -- has its signature changed?"
+grep -q "xymondlog" "$work/wmlgen-statuscard.inc" \
+	|| fail "the extracted function does not build the daemon request; the extraction is wrong"
+
+harness_cflags=$(xymon_cflags "$ROOT")
+# shellcheck disable=SC2086  # deliberate word-splitting, as the neighbouring tests do
+"$CC" $harness_cflags -I"$work" -o "$work/harness" \
+	"$(dirname "$0")/wmlgen-path-bounds-harness.c" 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+# A directory deep enough that a short name still overflows PATH_MAX, with
+# every component well inside NAME_MAX. Sized in the shell rather than the
+# harness because it has to exist: a single 4000-character component would
+# make the harness's boundary case pass through ENAMETOOLONG at fopen(),
+# whatever the length guard under test does -- measured, it did.
+deep="$work/wml"
+while [ ${#deep} -lt 3900 ]; do deep="$deep/$(printf 'd%.0s' $(seq 1 200))"; done
+mkdir -p "$deep" 2>/dev/null || skip "cannot create a directory path near PATH_MAX here"
+
+out=$("$work/harness" "$work/wml" "$deep" 2>&1) \
+	|| fail "the status-card bounds are not held: $out"
+
+# The overflow itself is only visible to a sanitizer: the write is past a stack
+# buffer, which a plain build survives without a word.
+if asan_usable; then
+	# shellcheck disable=SC2086
+	"$CC" $harness_cflags -fsanitize=address -g -I"$work" -o "$work/harness-asan" \
+		"$(dirname "$0")/wmlgen-path-bounds-harness.c" 2>"$work/cc-asan.log" \
+		|| { cat "$work/cc-asan.log" >&2; fail "sanitized harness does not compile"; }
+
+	set +e
+	"$work/harness-asan" "$work/wml" "$deep" >"$work/asan.out" 2>&1
+	set -e
+	# Leaks count too: the harness itself frees everything it takes, so what
+	# LeakSanitizer reports here was allocated by the function under test --
+	# which is how the early return for an unavailable status was dropping
+	# the log buffer it had just been handed.
+	if grep -q "ERROR: AddressSanitizer" "$work/asan.out"; then
+		sed -n '1,12p' "$work/asan.out" >&2
+		fail "a hostname longer than the request buffer overflowed it"
+	fi
+	if grep -q "ERROR: LeakSanitizer" "$work/asan.out"; then
+		sed -n '1,14p' "$work/asan.out" >&2
+		fail "the status-card path leaked memory"
+	fi
+else
+	printf 'note: %s cannot build and run ASan binaries, the overflow itself is unverified\n' \
+		"${CC:-cc}" >&2
+fi
+
+pass "a status card refuses a path that does not fit, and its request is sized to the names"

--- a/xymongen/wmlgen.c
+++ b/xymongen/wmlgen.c
@@ -47,11 +47,15 @@ static void delete_old_cards(char *dirname)
         }
 
 	if (chdir(dirname) == -1) {
+		closedir(xymoncards);
 		return;
 	}
 	while ((d = readdir(xymoncards))) {
 		strcpy(fn, d->d_name);
-		stat(fn, &st);
+		/* An entry that vanished between readdir() and here leaves st
+		   untouched, and deciding to unlink from an uninitialised st_mode
+		   is deciding from whatever was on the stack. */
+		if (stat(fn, &st) != 0) continue;
 		if ((fn[0] != '.') && S_ISREG(st.st_mode) && (st.st_mtime < (now-3600))) {
 			unlink(fn);
 		}
@@ -85,25 +89,44 @@ static void wml_header(FILE *output, char *cardid, int idpart)
 }
 
 
-static void generate_wml_statuscard(host_t *host, entry_t *entry)
+/*
+ * Returns 1 when the card was written. The caller advertises it from the host
+ * card, so a skipped one has to be a refusal it can see: reporting and
+ * returning quietly left a link to a file that was never created.
+ */
+static int generate_wml_statuscard(host_t *host, entry_t *entry)
 {
 	char fn[PATH_MAX];
 	FILE *fd;
 	char *msg = NULL, *logbuf = NULL;
+	int writefailed;
 	char l[MAX_LINE_LEN], lineout[MAX_LINE_LEN];
 	char *p, *outp, *nextline;
-	char xymondreq[1024];
+	char *xymondreq;
 	int xymondresult;
 	sendreturn_t *sres;
 
+	/*
+	 * Sized to the names, not to a guess. This was a 1 KiB stack buffer filled
+	 * with sprintf() from a hostname that hosts.cfg lets run to MAX_LINE_LEN
+	 * (16 KiB, loadlayout.c) -- a stack-buffer overflow reached from the
+	 * config, before any of the path checks below and before the daemon is
+	 * even contacted (@SoundGoof, under ASan). A request has no natural
+	 * length limit, so there is nothing here to refuse: allocate what the
+	 * names need.
+	 */
 	sres = newsendreturnbuf(1, NULL);
+	xymondreq = (char *)xmalloc(strlen(host->hostname) + strlen(entry->column->name) +
+				    sizeof("xymondlog ."));
 	sprintf(xymondreq, "xymondlog %s.%s", host->hostname, entry->column->name);
 	xymondresult = sendmessage(xymondreq, NULL, XYMON_TIMEOUT, sres);
+	xfree(xymondreq);
 	logbuf = getsendreturnstr(sres, 1);
 	freesendreturnbuf(sres);
 	if ((xymondresult != XYMONSEND_OK) || (logbuf == NULL) || (strlen(logbuf) == 0)) {
 		errprintf("WML: Status not available\n");
-		return;
+		if (logbuf) xfree(logbuf);	/* an empty answer is still an allocation */
+		return 0;
 	}
 
 	msg = strchr(logbuf, '\n');
@@ -113,17 +136,22 @@ static void generate_wml_statuscard(host_t *host, entry_t *entry)
 	else {
 		errprintf("WML: Unable to parse log data\n");
 		xfree(logbuf);
-		return;
+		return 0;
 	}
 
 	nextline = msg;
 	l[MAX_LINE_LEN - 1] = '\0';
 
-	snprintf(fn, sizeof(fn), "%s/%s.%s.wml", wmldir, host->hostname, entry->column->name);
+	if (snprintf(fn, sizeof(fn), "%s/%s.%s.wml", wmldir, host->hostname, entry->column->name) >= (int)sizeof(fn)) {
+		errprintf("WML: path too long for %s.%s, card skipped\n", host->hostname, entry->column->name);
+		xfree(logbuf);
+		return 0;
+	}
 	fd = fopen(fn, "w");
 	if (fd == NULL) {
 		errprintf("Cannot create file %s\n", fn);
-		return;
+		xfree(logbuf);
+		return 0;
 	}
 
 	wml_header(fd, "name", 1);
@@ -243,14 +271,29 @@ static void generate_wml_statuscard(host_t *host, entry_t *entry)
 	}
 	fprintf(fd, "<br/> </p> </card> </wml>\n");
 
-	fclose(fd);
+	/*
+	 * A full filesystem surfaces at fclose(), not before, and the caller is
+	 * about to link to this file: reporting success for a card that was not
+	 * written whole would advertise a truncated one. The partial file is
+	 * removed rather than left, since nothing will link to it.
+	 */
+	writefailed = ferror(fd);
+	if (fclose(fd) != 0) writefailed = 1;	/* || would skip the close */
+	if (writefailed) {
+		errprintf("WML: cannot write %s: %s\n", fn, strerror(errno));
+		unlink(fn);
+		if (logbuf) xfree(logbuf);
+		return 0;
+	}
 	if (logbuf) xfree(logbuf);
+	return 1;
 }
 
 
 void do_wml_cards(char *webdir)
 {
 	FILE		*nongreenfd, *hostfd;
+	int		hostfailed, nongreenfailed;
 	char		nongreenfn[PATH_MAX], hostfn[PATH_MAX];
 	hostlist_t	*h;
 	entry_t		*t;
@@ -259,7 +302,10 @@ void do_wml_cards(char *webdir)
 	int		nongreenpart = 1;
 
 	/* Determine where the WML files go */
-	sprintf(wmldir, "%s/wml", webdir);
+	if (snprintf(wmldir, sizeof(wmldir), "%s/wml", webdir) >= (int)sizeof(wmldir)) {
+		errprintf("WML: output directory path too long: %s/wml\n", webdir);
+		return;
+	}
 
 	/* Make sure the WML directory exists */
 	if (chdir(wmldir) != 0) mkdir(wmldir, 0755);
@@ -294,8 +340,16 @@ void do_wml_cards(char *webdir)
 		h->hostentry->wapcolor = COL_GREEN;
 		for (t = h->hostentry->entries; (t); t = t->next) {
 			if (t->onwap && ((t->color == COL_RED) || (t->color == COL_YELLOW))) {
-				generate_wml_statuscard(h->hostentry, t);
-				h->hostentry->anywaps = 1;
+				/*
+				 * onwap is what the host card below links from, so a card
+				 * that was not written has to clear it. Otherwise a status
+				 * path that does not fit - reachable with names that are
+				 * not themselves oversized, since it is one component
+				 * longer than the host card's own path - leaves a link to
+				 * a file that does not exist.
+				 */
+				if (generate_wml_statuscard(h->hostentry, t)) h->hostentry->anywaps = 1;
+				else t->onwap = 0;
 			}
 			else {
 				/* Clear the onwap flag - makes testing later a bit simpler */
@@ -312,7 +366,10 @@ void do_wml_cards(char *webdir)
 	}
 
 	/* Start the non-green WML card */
-	snprintf(nongreenfn, sizeof(nongreenfn), "%s/nongreen.wml.tmp", wmldir);
+	if (snprintf(nongreenfn, sizeof(nongreenfn), "%s/nongreen.wml.tmp", wmldir) >= (int)sizeof(nongreenfn)) {
+		errprintf("WML: path too long for the non-green card in %s\n", wmldir);
+		return;
+	}
 	nongreenfd = fopen(nongreenfn, "w");
 	if (nongreenfd == NULL) {
 		errprintf("Cannot open non-green WML file %s\n", nongreenfn);
@@ -336,10 +393,14 @@ void do_wml_cards(char *webdir)
 		if (h->hostentry->anywaps) {
 
 			/* Create the host WAP card, with links to individual test results */
-			snprintf(hostfn, sizeof(hostfn), "%s/%s.wml", wmldir, h->hostentry->hostname);
+			if (snprintf(hostfn, sizeof(hostfn), "%s/%s.wml", wmldir, h->hostentry->hostname) >= (int)sizeof(hostfn)) {
+				errprintf("WML: path too long for host %s, card skipped\n", h->hostentry->hostname);
+				continue;
+			}
 			hostfd = fopen(hostfn, "w");
 			if (hostfd == NULL) {
 				errprintf("Cannot create file %s\n", hostfn);
+				fclose(nongreenfd);	/* the normal path below closes it */
 				return;
 			}
 
@@ -361,7 +422,17 @@ void do_wml_cards(char *webdir)
 				}
 			}
 			fprintf(hostfd, "\n</p> </card> </wml>\n");
-			fclose(hostfd);
+
+			/* Linked to from the non-green card below, so a page that was
+			   not written whole must not be advertised: a full filesystem
+			   surfaces here, not at the fopen() above. */
+			hostfailed = ferror(hostfd);
+			if (fclose(hostfd) != 0) hostfailed = 1;
+			if (hostfailed) {
+				errprintf("WML: cannot write %s: %s\n", hostfn, strerror(errno));
+				unlink(hostfn);
+				continue;
+			}
 
 			/* Create the link from the nongreen wap card to the host card */
 			fprintf(nongreenfd, "<b><anchor title=\"%s\">%s<go href=\"%s.wml\"/></anchor></b> %s<br/>\n", 
@@ -375,21 +446,35 @@ void do_wml_cards(char *webdir)
 			 */
 			if (ftello(nongreenfd) >= wmlmaxchars) {
 				char oldnongreenfn[PATH_MAX];
+				char nextnongreenfn[PATH_MAX];
 
 				/* WML link is from the nongreenfd except leading wmldir+'/' */
 				strcpy(oldnongreenfn, nongreenfn+strlen(wmldir)+1);
 
 				nongreenpart++;
 
+				/*
+				 * The name of the next card is settled before this one links
+				 * to it. Written the other way round, a path that does not
+				 * fit closed this card with a "Next" pointing at a file the
+				 * refusal below then never created.
+				 */
+				if (snprintf(nextnongreenfn, sizeof(nextnongreenfn), "%s/nongreen-%d.wml", wmldir, nongreenpart) >= (int)sizeof(nextnongreenfn)) {
+					errprintf("WML: path too long for non-green card %d in %s\n", nongreenpart, wmldir);
+					fprintf(nongreenfd, "</p> </card> </wml>\n");
+					fclose(nongreenfd);
+					return;
+				}
+
 				fprintf(nongreenfd, "<br /><b><anchor title=\"Next\">Next<go href=\"nongreen-%d.wml\"/></anchor></b>\n", nongreenpart);
 				fprintf(nongreenfd, "</p> </card> </wml>\n");
 				fclose(nongreenfd);
 
 				/* Start a new Nongreen WML card */
-				snprintf(nongreenfn, sizeof(nongreenfn), "%s/nongreen-%d.wml", wmldir, nongreenpart);
+				strcpy(nongreenfn, nextnongreenfn);
 				nongreenfd = fopen(nongreenfn, "w");
 				if (nongreenfd == NULL) {
-					errprintf("Cannot open Nongreen WML file %s\n", nongreenfd);
+					errprintf("Cannot open Nongreen WML file %s\n", nongreenfn);
 					return;
 				}
 				wml_header(nongreenfd, "card", nongreenpart);
@@ -403,15 +488,27 @@ void do_wml_cards(char *webdir)
 	}
 
 	fprintf(nongreenfd, "</p> </card> </wml>\n");
-	fclose(nongreenfd);
+
+	/* Renamed over the card the phone is reading, so the same rule as the
+	   host cards: publish it only if it was written whole. */
+	nongreenfailed = ferror(nongreenfd);
+	if (fclose(nongreenfd) != 0) nongreenfailed = 1;
+	if (nongreenfailed) {
+		errprintf("WML: cannot write %s: %s\n", nongreenfn, strerror(errno));
+		unlink(nongreenfn);
+		return;
+	}
 
 	if (chdir(wmldir) == 0) {
 		/* Rename the top-level file into place now */
 		rename("nongreen.wml.tmp", "nongreen.wml");
 
 		/* Make sure there is the index.wml file pointing to nongreen.wml */
-		if (!symlink("nongreen.wml", "index.wml")) {
-			errprintf("symlink nongreen.xml->index.wml failed: %s\n", strerror(errno));
+		/* symlink() returns 0 on success: the test was inverted, so this
+		   reported a failure every time it worked and said nothing when it
+		   did not. EEXIST is the normal case - the link outlives the run. */
+		if ((symlink("nongreen.wml", "index.wml") != 0) && (errno != EEXIST)) {
+			errprintf("symlink nongreen.wml->index.wml failed: %s\n", strerror(errno));
 		}
 	}
 


### PR DESCRIPTION
`wmlgen.c` builds five file paths into fixed buffers from `$XYMONWEB`, a hostname and a column name. gcc warned about four of them on every Linux lane; the fifth was silent and worse — `sprintf(wmldir, "%s/wml", webdir)`, unbounded, from a configured value. Each path is now built with a checked `snprintf`, and a path that does not fit skips that output instead of writing a truncated one.

Everything below came out of review, and each is measured:

| | before | after |
|---|---|---|
| the daemon request | `sprintf()` into a 1 KiB stack buffer from a hostname `hosts.cfg` lets run to 16 KiB — a stack overflow reached from the config, before any path check | allocated to the size of the names; a request has no natural limit, so there is nothing here to refuse |
| a skipped status card | still advertised: the host card links from `t->onwap`, which a refused write left set | `generate_wml_statuscard()` reports whether it wrote; the caller clears `onwap` and withholds `anywaps` |
| the split non-green card | wrote `Next -> nongreen-<n>.wml` **before** the check deciding whether that name fits | the name is settled first |
| a card, host card or non-green card that could not be written whole | published anyway — a full filesystem surfaces at `fclose()`, not `fopen()` | removed, not advertised |
| the log buffer on "status not available" | leaked — xymond answering with no log is an empty string, not `NULL` | released |
| `delete_old_cards()` | acted on `st_mode` after an unchecked `stat()`; leaked the directory handle on a failed `chdir()` | both checked |
| `symlink()` for `index.wml` | test inverted: reported a failure every time it worked, silent when it did not | reported when it fails, `EEXIST` excepted |

**Test:** `tests/web/wmlgen-path-bounds.sh` drives the real `generate_wml_statuscard()`, extracted rather than reimplemented, over an ordinary card, a 1200-byte hostname, a path at the limit, a status with no log, and a write that cannot finish (`RLIMIT_FSIZE`). It compares the whole daemon request, not its prefix — a bound that truncated the names would pass a prefix check while asking about the wrong test — and the sanitized run fails on leaks as well as overflows.

The limit case builds a *deep directory* rather than one long name: sized as one component it exceeds `NAME_MAX`, so `fopen()` fails with `ENAMETOOLONG` whatever the guard does, and the case passed with the guard disabled. Measured, then fixed.

**Not taken:** devel's answer to the warnings (`3686fbeef`) is `#pragma GCC diagnostic ignored "-Wformat-overflow"` around the `sprintf` calls. It silences the message and keeps the truncation, it names the wrong warning group for main's bounded calls, and clang — the compiler on the BSD and macOS lanes — rejects that group, so porting it would *add* a warning per site there.

**Not covered, rather than implied:** `do_wml_cards()` itself, so the caller's `onwap`/`anywaps` handling is read, not tested.
