### PR TITLE
lib, xymond, xymonnet: copy strings with room for the terminator

### DIFF
--- a/lib/loadhosts_net.c
+++ b/lib/loadhosts_net.c
@@ -92,7 +92,7 @@ int load_hostinfo(char *targethost)
 
 	hival_hostinfo.hostname = hivals[XMH_HOSTNAME];
 	if (hivals[XMH_IP]) 
-		strncpy(hival_hostinfo.ip, hivals[XMH_IP], sizeof(hival_hostinfo.ip));
+		snprintf(hival_hostinfo.ip, sizeof(hival_hostinfo.ip), "%s", hivals[XMH_IP]);
 	else
 		*(hival_hostinfo.ip) = '\0';
 

--- a/lib/sendmsg.c
+++ b/lib/sendmsg.c
@@ -274,7 +274,7 @@ static int sendtoxymond(char *recipient, char *message, FILE *respfd, char **res
 		hent = gethostbyname(rcptip);
 		if (hent) {
 			memcpy(&addr, *(hent->h_addr_list), sizeof(struct in_addr));
-			strncpy(hostip, inet_ntoa(addr), sizeof(hostip));
+			snprintf(hostip, sizeof(hostip), "%s", inet_ntoa(addr));
 
 			if (inet_aton(hostip, &addr) == 0) {
 				result = XYMONSEND_EBADIP;

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -3742,7 +3742,7 @@ void do_message(conn_t *msg, char *origin)
 
 	/* Most likely, we will not send a response */
 	msg->doingwhat = NOTALK;
-	strncpy(sender, inet_ntoa(msg->addr.sin_addr), sizeof(sender));
+	snprintf(sender, sizeof(sender), "%s", inet_ntoa(msg->addr.sin_addr));
 	now = getcurrenttime(NULL);
 	timeroffset = (getcurrenttime(NULL) - gettimer());
 

--- a/xymonnet/xymonnet.c
+++ b/xymonnet/xymonnet.c
@@ -237,7 +237,7 @@ char *deptest_failed(testedhost_t *host, char *testname)
 		t = find_test(dephostname, deptestname);
 		if (t && !t->open) {
 			if (strlen(result) == 0) {
-				strncpy(result, "\nThis test depends on the following test(s) that failed:\n\n", sizeof(result));
+				snprintf(result, sizeof(result), "%s", "\nThis test depends on the following test(s) that failed:\n\n");
 			}
 
 			if ((strlen(result) + strlen(dephostname) + strlen(deptestname) + 2) < sizeof(result)) {
@@ -842,7 +842,7 @@ void load_tests(void)
 				errprintf("Host %s appears twice in hosts.cfg! This may cause strange results\n", h->hostname);
 			}
 	
-			strncpy(h->ip, xmh_item(hwalk, XMH_IP), sizeof(h->ip));
+			snprintf(h->ip, sizeof(h->ip), "%s", xmh_item(hwalk, XMH_IP));
 			if (!h->testip && (dnsmethod != IP_ONLY)) add_host_to_dns_queue(h->hostname);
 		}
 		else {
@@ -873,7 +873,7 @@ char *ip_to_test(testedhost_t *h)
 		dnsresult = dnsresolve(h->hostname);
 
 		if (dnsresult) {
-			strncpy(h->ip, dnsresult, sizeof(h->ip));
+			snprintf(h->ip, sizeof(h->ip), "%s", dnsresult);
 		}
 		else if ((dnsmethod == DNS_THEN_IP) && !nullip) {
 			/* Already have the IP setup */
@@ -1149,7 +1149,7 @@ int start_ping_service(service_t *service)
 
 		if (t->host->dnserror || t->host->noping) continue;
 
-		strncpy(ip, ip_to_test(t->host), sizeof(ip));
+		snprintf(ip, sizeof(ip), "%s", ip_to_test(t->host));
 		handle = xtreeFind(iptree, ip);
 		if (handle == xtreeEnd(iptree)) {
 			rec = strdup(ip);


### PR DESCRIPTION
Seven calls of the form

```c
strncpy(dst, src, sizeof(dst));
```

which is the one shape of `strncpy` that cannot be right: it copies at most as many bytes as
the buffer holds, so a source of exactly that length leaves the destination **with no
terminating NUL**. Everything downstream then reads past the end -- and each of these
buffers is handed straight to `strcmp`, `inet_aton`, `xtreeFind` or a `%s`.

gcc flags them as `-Wstringop-truncation` ("specified bound N equals destination size"),
which is how they were found:

| site | source |
|---|---|
| `xymond/xymond.c:3745` | `inet_ntoa()` |
| `lib/loadhosts_net.c:95` | `hivals[XMH_IP]` |
| `lib/sendmsg.c:277` | `inet_ntoa()` |
| `xymonnet/xymonnet.c:240` | a fixed string |
| `xymonnet/xymonnet.c:845` | `xmh_item(XMH_IP)` |
| `xymonnet/xymonnet.c:876` | `dnsresolve()` |
| `xymonnet/xymonnet.c:1152` | `ip_to_test()` |

All seven now use `snprintf(dst, sizeof(dst), "%s", src)` -- bounded, and always terminated.
That is the form this tree already prefers: `lib/sig.c`, `lib/links.c` and
`lib/loadalerts.c` were converted the same way, and `xymond.c:1861` already wrote
`sizeof(...)-1` for the same reason.

**No behaviour change today**: none of these sources reaches the limit (IPv4 addresses and a
hostname). What it removes is a class of latent unterminated-string bug, and the warnings
that were pointing at it.

Verified per file, `gcc -O2 -Wall -Wextra`:

```
lib/loadhosts.c (which #includes loadhosts_net.c)   1 -> 0
lib/sendmsg.c                                       1 -> 0
xymond/xymond.c                                     1 -> 0
xymonnet/xymonnet.c                                 3 -> 0
```

Two of these were not in the original inventory in #372: `sendmsg.c:277` and
`xymonnet.c:1152` turned up only once the files compiled with the right include paths
(`loadhosts_net.c` has no includes of its own -- it is pulled into `loadhosts.c`; `xymonnet.c`
needs tirpc).

**Left alone**: the `strncpy(dst, "literal", sizeof(dst))` calls elsewhere in `lib/`. The
compiler can see those fit and does not warn; rewriting them would be churn with no defect
behind it.

Part of the inventory in #372.
