### PR TITLE
client: name the OS primitives, so one lane tests every client

### DIFF
--- a/client/xymonclient-darwin.sh
+++ b/client/xymonclient-darwin.sh
@@ -156,6 +156,15 @@ probe_dir_is_local()
 	'
 }
 
+# fs_procname PID : the command name of a running process. ps is POSIX and
+# reads process state only, so it cannot touch a wedged mount. Named so that
+# df_sentinel() stays identical across the five clients, and so a test
+# replaces the primitive rather than the code that uses it.
+fs_procname()
+{
+	ps -o comm= -p "$1" 2>/dev/null | tr -d '[:space:]'
+}
+
 df_sentinel()
 {
 	_tag="$1"; shift
@@ -202,16 +211,29 @@ df_sentinel()
 				;;
 			?*)
 				# A df we recorded. Still wedged? The command name is
-				# checked so a recycled PID does not look like one. ps, not
-				# /proc: POSIX, same answer, already a dependency of this
-				# client, and it reads process state only -- it cannot touch
-				# the wedged mount. Basename, because comm is the short name
-				# on Linux and the BSDs and the full path on macOS.
-				_c=$(ps -o comm= -p "$_old" 2>/dev/null | tr -d '[:space:]')
+				# checked so a recycled PID does not look like one.
+				# fs_procname() is where each OS reads it -- /proc on Linux,
+				# ps elsewhere -- and neither touches the filesystem, so a
+				# wedged mount cannot block the check. Basename, because the
+				# name is short on Linux and the BSDs, the full path on macOS.
+				_c=$(fs_procname "$_old")
 				_c=${_c##*/}
-				if kill -0 "$_old" 2>/dev/null && [ "$_c" = df ]; then
-					rm -f "$_tmpf"
-					return 124
+				if kill -0 "$_old" 2>/dev/null; then
+					case "$_c" in
+					  df) rm -f "$_tmpf"; return 124 ;;
+					  "")
+						# The two mistakes are not equally cheap. Restarting
+						# a probe that is in fact still running leaves another
+						# df on a dead server, and those cannot be killed;
+						# keeping a mount unavailable for a cycle is visible
+						# and bounded. So when the name cannot be read at all
+						# -- no ps in a minimal container, no /proc, a pid
+						# that just went away -- assume the probe is ours.
+						echo "xymonclient: cannot read the command name of pid $_old; assuming the remote df is still running" >&2
+						rm -f "$_tmpf"
+						return 124
+						;;
+					esac
 				fi
 				;;
 		esac

--- a/client/xymonclient-freebsd.sh
+++ b/client/xymonclient-freebsd.sh
@@ -120,6 +120,15 @@ probe_dir_is_local()
 	'
 }
 
+# fs_procname PID : the command name of a running process. ps is POSIX and
+# reads process state only, so it cannot touch a wedged mount. Named so that
+# df_sentinel() stays identical across the five clients, and so a test
+# replaces the primitive rather than the code that uses it.
+fs_procname()
+{
+	ps -o comm= -p "$1" 2>/dev/null | tr -d '[:space:]'
+}
+
 df_sentinel()
 {
 	_tag="$1"; shift
@@ -166,16 +175,29 @@ df_sentinel()
 				;;
 			?*)
 				# A df we recorded. Still wedged? The command name is
-				# checked so a recycled PID does not look like one. ps, not
-				# /proc: POSIX, same answer, already a dependency of this
-				# client, and it reads process state only -- it cannot touch
-				# the wedged mount. Basename, because comm is the short name
-				# on Linux and the BSDs and the full path on macOS.
-				_c=$(ps -o comm= -p "$_old" 2>/dev/null | tr -d '[:space:]')
+				# checked so a recycled PID does not look like one.
+				# fs_procname() is where each OS reads it -- /proc on Linux,
+				# ps elsewhere -- and neither touches the filesystem, so a
+				# wedged mount cannot block the check. Basename, because the
+				# name is short on Linux and the BSDs, the full path on macOS.
+				_c=$(fs_procname "$_old")
 				_c=${_c##*/}
-				if kill -0 "$_old" 2>/dev/null && [ "$_c" = df ]; then
-					rm -f "$_tmpf"
-					return 124
+				if kill -0 "$_old" 2>/dev/null; then
+					case "$_c" in
+					  df) rm -f "$_tmpf"; return 124 ;;
+					  "")
+						# The two mistakes are not equally cheap. Restarting
+						# a probe that is in fact still running leaves another
+						# df on a dead server, and those cannot be killed;
+						# keeping a mount unavailable for a cycle is visible
+						# and bounded. So when the name cannot be read at all
+						# -- no ps in a minimal container, no /proc, a pid
+						# that just went away -- assume the probe is ours.
+						echo "xymonclient: cannot read the command name of pid $_old; assuming the remote df is still running" >&2
+						rm -f "$_tmpf"
+						return 124
+						;;
+					esac
 				fi
 				;;
 		esac

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -45,11 +45,34 @@ uptime
 echo "[who]"
 who
 echo "[df]"
+# fs_mounts : one "TYPE<tab>MOUNTPOINT" line per mount. Linux reads
+# /proc/mounts, which cannot block on a dead server and needs no fork; the BSD
+# and macOS clients read mount(8). Same output either way, so probe_dir_is_local()
+# and the remote-set awk below are the same code in all five clients, and a test
+# replaces this one function instead of rewriting a path only Linux has.
+fs_mounts()
+{
+	[ -r /proc/mounts ] || return 1
+	awk '{ mp = $2; gsub(/\\040/, " ", mp); printf "%s\t%s\n", $3, mp }' /proc/mounts
+}
+
+# fs_filesystems : the filesystem types the kernel knows, "nodev" first where
+# the type has no backing device. Linux only -- the other clients exclude by
+# name, not by this list.
+fs_filesystems()
+{
+	[ -r /proc/filesystems ] || return 1
+	while read -r _dev _type; do printf '%s %s\n' "$_dev" "$_type"; done < /proc/filesystems
+}
+
 # Default: exclude every nodev (pseudo) filesystem in df/inode output, except
 # rootfs. The always-100%-full read-only images (iso9660, squashfs) are not
 # nodev types and are excluded via XYMONCLIENT_FS_EXCLUDE_TYPES below.
-if [ -r /proc/filesystems ]; then
-	EXCLUDES=$(awk '$1 == "nodev" && $2 != "rootfs" { printf "%s%s", sep, $2; sep=" " }' /proc/filesystems)
+# The status is the helper's, not awk's: a pipeline reports its last command,
+# and awk succeeds happily on no input at all - which is what an unreadable
+# list looks like from there.
+if _fslist=$(fs_filesystems); then
+	EXCLUDES=$(printf '%s\n' "$_fslist" | awk '$1 == "nodev" && $2 != "rootfs" { printf "%s%s", sep, $2; sep=" " }')
 else
 	# Only the dynamic nodev exclusions are disabled here; the EXCLUDE_TYPES
 	# defaults (iso9660/squashfs) and the local-only df -l behavior still apply.
@@ -134,24 +157,40 @@ esac
 DFPROBEDIR="${XYMONTMP:-/tmp}"
 
 # probe_dir_is_local DIR : true when DIR is not itself on a hard-blocking
-# filesystem. Decided purely from /proc/mounts (reading it never blocks) by
-# longest mount-point prefix, and deliberately WITHOUT stat()ing DIR: if DIR
-# were on the wedged mount, even `test -w DIR` would block in D-state inside
-# the very fail-safe meant to prevent that. Symlinks are not resolved for the
-# same reason (readlink would stat), so keep XYMONTMP on a real local path.
+# filesystem. Decided purely from the mount list by longest mount-point prefix,
+# and deliberately WITHOUT stat()ing DIR: if DIR were on the wedged mount, even
+# `test -w DIR` would block in D-state inside the very fail-safe meant to
+# prevent that. Symlinks are not resolved for the same reason (readlink would
+# stat), so keep XYMONTMP on a real local path.
 probe_dir_is_local()
 {
-	[ -r /proc/mounts ] || return 1
-	awk -v dir="$1" -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+	# The helper's status, not the pipeline's: a pipeline reports its last
+	# command, and awk succeeds on no input at all -- which is what an
+	# unreadable mount list looks like from there. Answering "local" then
+	# sends the probe at a directory that may sit on the wedged mount this
+	# exists to keep away from.
+	_pdlm=$(fs_mounts) || return 1
+	printf '%s\n' "$_pdlm" | awk -F'\t' -v dir="$1" -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
 		BEGIN { n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1 }
 		{
-			mp = $2; gsub(/\\040/, " ", mp)
+			mp = $2
 			if (dir == mp || mp == "/" || substr(dir, 1, length(mp) + 1) == mp "/") {
-				if (length(mp) >= length(best)) { best = mp; besttype = $3 }
+				if (length(mp) >= length(best)) { best = mp; besttype = $1 }
 			}
 		}
 		END { exit (besttype in t) ? 1 : 0 }
-	' /proc/mounts
+	'
+}
+
+# fs_procname PID : the command name of a running process. Linux answers from
+# /proc, with no external command at all; the BSD and macOS clients answer with
+# ps. Named so that df_sentinel() stays identical across the five clients, and
+# so a test replaces the primitive rather than rewriting a path only Linux has.
+fs_procname()
+{
+	[ -r "/proc/$1/comm" ] || return 0
+	read -r _name < "/proc/$1/comm" || return 0
+	printf '%s\n' "$_name"
 }
 
 # df_sentinel TAG ARGS... : df for the remote set with at most ONE outstanding
@@ -205,16 +244,29 @@ df_sentinel()
 				;;
 			?*)
 				# A df we recorded. Still wedged? The command name is
-				# checked so a recycled PID does not look like one. ps, not
-				# /proc: POSIX, same answer, already a dependency of this
-				# client, and it reads process state only -- it cannot touch
-				# the wedged mount. Basename, because comm is the short name
-				# on Linux and the BSDs and the full path on macOS.
-				_c=$(ps -o comm= -p "$_old" 2>/dev/null | tr -d '[:space:]')
+				# checked so a recycled PID does not look like one.
+				# fs_procname() is where each OS reads it -- /proc on Linux,
+				# ps elsewhere -- and neither touches the filesystem, so a
+				# wedged mount cannot block the check. Basename, because the
+				# name is short on Linux and the BSDs, the full path on macOS.
+				_c=$(fs_procname "$_old")
 				_c=${_c##*/}
-				if kill -0 "$_old" 2>/dev/null && [ "$_c" = df ]; then
-					rm -f "$_tmpf"
-					return 124
+				if kill -0 "$_old" 2>/dev/null; then
+					case "$_c" in
+					  df) rm -f "$_tmpf"; return 124 ;;
+					  "")
+						# The two mistakes are not equally cheap. Restarting
+						# a probe that is in fact still running leaves another
+						# df on a dead server, and those cannot be killed;
+						# keeping a mount unavailable for a cycle is visible
+						# and bounded. So when the name cannot be read at all
+						# -- no ps in a minimal container, no /proc, a pid
+						# that just went away -- assume the probe is ours.
+						echo "xymonclient: cannot read the command name of pid $_old; assuming the remote df is still running" >&2
+						rm -f "$_tmpf"
+						return 124
+						;;
+					esac
 				fi
 				;;
 		esac
@@ -341,13 +393,12 @@ run_df()
 	# left out.
 	# From here on the plain df's status is what a caller sees when nothing at
 	# all was collected: no local rows, and no remote set to fall back on.
-	[ -r /proc/mounts ] || return $_prc
-	_rm=$(awk -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" -v excl="$EXCLUDES" '
+	_rm=$(fs_mounts | awk -F'\t' -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" -v excl="$EXCLUDES" '
 		BEGIN {
 			n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1
 			m = split(excl,  b, /[ \t]+/); for (i = 1; i <= m; i++) x[b[i]] = 1
 		}
-		($3 in t) && !($3 in x) { mp = $2; gsub(/\\040/, " ", mp); print mp }' /proc/mounts)
+		($1 in t) && !($1 in x) { print $2 }')
 	[ -n "$_rm" ] || return $_prc
 
 	case $- in *f*) _rg=no ;; *) _rg=yes; set -f ;; esac

--- a/client/xymonclient-netbsd.sh
+++ b/client/xymonclient-netbsd.sh
@@ -109,6 +109,15 @@ probe_dir_is_local()
 	'
 }
 
+# fs_procname PID : the command name of a running process. ps is POSIX and
+# reads process state only, so it cannot touch a wedged mount. Named so that
+# df_sentinel() stays identical across the five clients, and so a test
+# replaces the primitive rather than the code that uses it.
+fs_procname()
+{
+	ps -o comm= -p "$1" 2>/dev/null | tr -d '[:space:]'
+}
+
 df_sentinel()
 {
 	_tag="$1"; shift
@@ -155,16 +164,29 @@ df_sentinel()
 				;;
 			?*)
 				# A df we recorded. Still wedged? The command name is
-				# checked so a recycled PID does not look like one. ps, not
-				# /proc: POSIX, same answer, already a dependency of this
-				# client, and it reads process state only -- it cannot touch
-				# the wedged mount. Basename, because comm is the short name
-				# on Linux and the BSDs and the full path on macOS.
-				_c=$(ps -o comm= -p "$_old" 2>/dev/null | tr -d '[:space:]')
+				# checked so a recycled PID does not look like one.
+				# fs_procname() is where each OS reads it -- /proc on Linux,
+				# ps elsewhere -- and neither touches the filesystem, so a
+				# wedged mount cannot block the check. Basename, because the
+				# name is short on Linux and the BSDs, the full path on macOS.
+				_c=$(fs_procname "$_old")
 				_c=${_c##*/}
-				if kill -0 "$_old" 2>/dev/null && [ "$_c" = df ]; then
-					rm -f "$_tmpf"
-					return 124
+				if kill -0 "$_old" 2>/dev/null; then
+					case "$_c" in
+					  df) rm -f "$_tmpf"; return 124 ;;
+					  "")
+						# The two mistakes are not equally cheap. Restarting
+						# a probe that is in fact still running leaves another
+						# df on a dead server, and those cannot be killed;
+						# keeping a mount unavailable for a cycle is visible
+						# and bounded. So when the name cannot be read at all
+						# -- no ps in a minimal container, no /proc, a pid
+						# that just went away -- assume the probe is ours.
+						echo "xymonclient: cannot read the command name of pid $_old; assuming the remote df is still running" >&2
+						rm -f "$_tmpf"
+						return 124
+						;;
+					esac
 				fi
 				;;
 		esac

--- a/client/xymonclient-openbsd.sh
+++ b/client/xymonclient-openbsd.sh
@@ -117,6 +117,15 @@ probe_dir_is_local()
 	'
 }
 
+# fs_procname PID : the command name of a running process. ps is POSIX and
+# reads process state only, so it cannot touch a wedged mount. Named so that
+# df_sentinel() stays identical across the five clients, and so a test
+# replaces the primitive rather than the code that uses it.
+fs_procname()
+{
+	ps -o comm= -p "$1" 2>/dev/null | tr -d '[:space:]'
+}
+
 df_sentinel()
 {
 	_tag="$1"; shift
@@ -163,16 +172,29 @@ df_sentinel()
 				;;
 			?*)
 				# A df we recorded. Still wedged? The command name is
-				# checked so a recycled PID does not look like one. ps, not
-				# /proc: POSIX, same answer, already a dependency of this
-				# client, and it reads process state only -- it cannot touch
-				# the wedged mount. Basename, because comm is the short name
-				# on Linux and the BSDs and the full path on macOS.
-				_c=$(ps -o comm= -p "$_old" 2>/dev/null | tr -d '[:space:]')
+				# checked so a recycled PID does not look like one.
+				# fs_procname() is where each OS reads it -- /proc on Linux,
+				# ps elsewhere -- and neither touches the filesystem, so a
+				# wedged mount cannot block the check. Basename, because the
+				# name is short on Linux and the BSDs, the full path on macOS.
+				_c=$(fs_procname "$_old")
 				_c=${_c##*/}
-				if kill -0 "$_old" 2>/dev/null && [ "$_c" = df ]; then
-					rm -f "$_tmpf"
-					return 124
+				if kill -0 "$_old" 2>/dev/null; then
+					case "$_c" in
+					  df) rm -f "$_tmpf"; return 124 ;;
+					  "")
+						# The two mistakes are not equally cheap. Restarting
+						# a probe that is in fact still running leaves another
+						# df on a dead server, and those cannot be killed;
+						# keeping a mount unavailable for a cycle is visible
+						# and bounded. So when the name cannot be read at all
+						# -- no ps in a minimal container, no /proc, a pid
+						# that just went away -- assume the probe is ours.
+						echo "xymonclient: cannot read the command name of pid $_old; assuming the remote df is still running" >&2
+						rm -f "$_tmpf"
+						return 124
+						;;
+					esac
 				fi
 				;;
 		esac

--- a/tests/README.md
+++ b/tests/README.md
@@ -96,6 +96,31 @@ maintenance.
   "The wiring this test guards is gone" must `fail`. The one exception is
   a test deliberately staged ahead of an unmerged feature — call that out
   in the test and remove the staging skip the moment the feature lands.
+- **Test another OS's code here; keep its primitives behind a named
+  helper.** A test may extract a block from any client and run it under
+  stubs, whatever OS the lane happens to be -- that is how one lane
+  covers all five clients, and why `tests/client/fs-filter-*.sh` are not
+  `uname`-guarded. The price is paid on both sides. The extracted region
+  must be POSIX shell with portable tool flags (no bashism, no GNU-only
+  flag, no `/proc`), and whatever is genuinely per-OS lives in a named
+  helper -- `fs_mounts`, `fs_filesystems`, `fs_procname` -- which the
+  test replaces *by name* with `fsf_stub_helper`, never by rewriting the
+  path the helper reads. `tests/buildsystem/test-suite-portability.sh`
+  enforces both halves.
+  That leaves the helpers' own bodies covered by nothing, since every
+  stubbed test throws them away. Close that with a **native test**: one
+  that exercises the real primitive, guarded by `uname` and skipping
+  where it doesn't apply (`tests/client/fs-procname.sh`,
+  `tests/client/fs-mounts.sh`). These are the only tests allowed to
+  guard on `uname`, and they should stay few -- one per primitive, not
+  one per behaviour that happens to use it.
+- **A fixture that has to be a real binary is built, not copied.** Use
+  `fsf_wedge_binary` (tests/client/fs-filter-common.sh): it compiles one, falls
+  back to copying, and checks the result still runs before handing it back.
+  Copying a system binary looks portable and is not -- BusyBox picks its applet
+  from `argv[0]`, so `cp $(command -v sleep) df` gives you `df`; macOS kills a
+  copy of a signed system binary outright. Both were found the expensive way,
+  on lanes, and neither shows on a developer's Linux box.
 - **Deterministic.** Tests must produce the same result every run, on
   any contributor's box and in CI. Flaky tests are removed, not
   retried. If a test needs to wait for something, wait for the

--- a/tests/buildsystem/test-suite-portability.sh
+++ b/tests/buildsystem/test-suite-portability.sh
@@ -100,6 +100,18 @@ report "root-lane" 'chmod +[-+=rwx]*[0-7]?[0-5][0-7][0-7]([^0-9]|$)|chmod +[ugoa
 report "include-shadow" '\-I *"?\$\{?ROOT' \
 	"an -I source directory also answers <angle> includes; use -iquote (macOS: lib/availability.h captures the SDK's Availability.h)"
 
+# A test replaces an OS primitive by naming the helper that holds it, not by
+# rewriting the path it reads. A rewritten path only works for the one OS that
+# has that path, so the same test cannot cover the other four clients -- and
+# the client is then free to reach for the primitive anywhere, which is how
+# /proc ended up in three places in the Linux [df] block.
+# Any sed reaching for /proc, not one delimiter's worth: s;...;...; and s|...|
+# rewrite a path just as well as s#...#, and a rule that knows four spellings
+# is a rule the next test writer works around by accident. A test that has to
+# name the path anyway -- the native ones -- reads it, it does not sed it.
+report "path-rewrite" 'sed.*/proc/' \
+	"replace the helper by name (fsf_stub_helper), not the path it reads"
+
 # Interpreters the BSD runners do not have.
 report "interpreter" '(^|[^-[:alnum:]_])(python3?|perl)[[:space:]]' \
 	"not installed on the BSD lanes; awk and sh are"
@@ -125,6 +137,26 @@ check_link_flags() {
 
 for f in $files; do check_link_flags "$f" "$work/violations"; done
 
+# A uname guard is how a test stops covering four of the five clients. It is
+# allowed in exactly one place -- the test of an OS primitive itself, which
+# cannot run anywhere else -- and such a test says so in its header:
+#
+#     # native-primitive: fs_procname
+#
+# The declaration is the exemption, not the filename, so a test that grows a
+# uname guard has to state which primitive it is there to exercise.
+# check_uname_guard FILE OUT -- append this file's uname violations to OUT.
+check_uname_guard() {
+	local f=$1 out=$2 code
+	code=$(grep -vE '^[[:space:]]*#' "$f" || true)
+	printf '%s\n' "$code" | grep -q 'uname' || return 0
+	grep -qE '^#[[:space:]]*native-primitive:[[:space:]]*[A-Za-z_]' "$f" && return 0
+	printf 'uname-guard\t%s\t%s\n' "${f#"$ROOT"/}" \
+		"guards on uname without a '# native-primitive: NAME' header; stub the helper instead so the test covers every client" >>"$out"
+}
+
+for f in $files; do check_uname_guard "$f" "$work/violations"; done
+
 if [ -s "$work/violations" ]; then
 	printf 'portability rules broken by the test suite:\n\n' >&2
 	sort "$work/violations" | awk -F'\t' '{ printf "  [%s] %s\n      %s\n", $1, $2, $3 }' >&2
@@ -142,10 +174,11 @@ probe="$work/probe.sh"
 	printf 'chmod 500 d\n'
 	printf 'chmod 555 d\n'
 	printf 'cc -I"$ROOT/lib" x.c\n'
+	printf 'sed s#/proc/mounts#f# x\n'
 } >"$probe"
 probe_pattern=$(IFS='|'; printf '%s' "${__rule_patterns[*]}")
 hits=$(grep -cE "$probe_pattern" "$probe")
-assert_equal "7" "$hits" "the rule patterns no longer match the constructs they are meant to catch"
+assert_equal "8" "$hits" "the rule patterns no longer match the constructs they are meant to catch"
 
 # The link-flags rule the same way, including the bypass it used to allow: the
 # helpers named in a comment and nowhere else.
@@ -160,4 +193,27 @@ check_link_flags "$bypass" "$work/probe-violations"
 assert_equal "2" "$(wc -l <"$work/probe-violations" | tr -d " ")" \
 	"the link-flags rule no longer reports both missing helpers for an archive built without them"
 
-pass "the test suite keeps to bash 3.2, portable tool flags, and the configured build flags"
+# The uname rule the same way, on both sides: a guard without the declaration
+# is reported, the same guard with it is not.
+: >"$work/uname-violations"
+undeclared="$work/undeclared.sh"
+{
+	printf '#!/usr/bin/env bash\n'
+	printf '[ "$(uname -s)" = Linux ] || exit 77\n'
+} >"$undeclared"
+check_uname_guard "$undeclared" "$work/uname-violations"
+assert_equal "1" "$(wc -l <"$work/uname-violations" | tr -d " ")" \
+	"the uname rule no longer reports a test that guards on uname without declaring its primitive"
+
+declared="$work/declared.sh"
+{
+	printf '#!/usr/bin/env bash\n'
+	printf '# native-primitive: fs_procname\n'
+	printf '[ "$(uname -s)" = Linux ] || exit 77\n'
+} >"$declared"
+: >"$work/uname-violations"
+check_uname_guard "$declared" "$work/uname-violations"
+assert_equal "0" "$(wc -l <"$work/uname-violations" | tr -d " ")" \
+	"the uname rule now reports a declared native-primitive test, which is the one place a guard belongs"
+
+pass "the test suite keeps to bash 3.2, portable tool flags, the configured build flags, and one lane per client"

--- a/tests/client/fs-filter-common.sh
+++ b/tests/client/fs-filter-common.sh
@@ -134,6 +134,22 @@ WEDGE
 	wait "$_wbpid" 2>/dev/null || true
 }
 
+# fsf_stub_helper FILE NAME BODY
+#   Replace a named helper in an extracted block. The clients keep every OS
+#   primitive behind such a helper -- fs_mounts, fs_filesystems, fs_procname --
+#   so a test replaces the primitive the same way it replaces a command, by
+#   name, instead of rewriting a path that only one OS has. The block runs as a
+#   script, so the definition is edited in place rather than overridden.
+fsf_stub_helper() {
+	awk -v n="$2" -v b="$3" '
+		$0 == n "()" || $0 == n "() {" { print n "() {"; print b; print "}"; skip = 1; next }
+		skip && $0 == "{" { next }
+		skip && $0 == "}" { skip = 0; next }
+		skip { next }
+		{ print }
+	' "$1" > "$1.stubbed" && mv "$1.stubbed" "$1"
+}
+
 # fsf_run SNIPPET LOGFILE [ENV...]
 #   Truncate the arg logs, run SNIPPET in a fresh subshell with $TMP as cwd
 #   (so decoy glob files are in scope), and echo the recorded argv from LOGFILE

--- a/tests/client/fs-filter-linux.sh
+++ b/tests/client/fs-filter-linux.sh
@@ -89,7 +89,7 @@ EOF
 # /proc/mounts: local only, so the remote-df sentinel stays dormant here -- it
 # has its own test. Without this rewrite the LOCAL_ONLY=no case would walk the
 # *tester's* mount table and probe a real cifs/ceph/glusterfs mount.
-printf '/dev/sda1 / ext4 rw 0 0\n' > "$TMP/proc.mounts"
+printf 'ext4\t/\n' > "$TMP/proc.mounts"
 export XYMONTMP="$TMP"
 
 # Files whose names match the type globs used below: if a configured token were
@@ -97,11 +97,18 @@ export XYMONTMP="$TMP"
 : > "$TMP/sysfs"
 : > "$TMP/fuse.sshfs"
 
-PROC_REWRITE="s!/proc/filesystems!$TMP/proc.filesystems!g; s!/proc/mounts!$TMP/proc.mounts!g"
+# The OS primitives are replaced by name: the client keeps each behind a
+# helper, and the fixtures below are written in the helper's contract --
+# "TYPE<tab>MOUNTPOINT" for fs_mounts -- rather than in the column order of a
+# file only Linux has.
 SNIPPET="$TMP/df-section.sh"
-fsf_extract "$SNIPPET" "$PROC_REWRITE" '\[inode\]'
+fsf_extract "$SNIPPET" "" '\[inode\]'
 FSF_COMBINED="$TMP/df-inode-section.sh"
-fsf_extract "$FSF_COMBINED" "$PROC_REWRITE"
+fsf_extract "$FSF_COMBINED"
+for _snip in "$SNIPPET" "$FSF_COMBINED"; do
+	fsf_stub_helper "$_snip" fs_mounts "\tcat \"$TMP/proc.mounts\""
+	fsf_stub_helper "$_snip" fs_filesystems "\tcat \"$TMP/proc.filesystems\""
+done
 
 # readlink stub: the block resolves /dev/root early on.
 cat > "$STUB/readlink" <<'EOF'
@@ -147,8 +154,12 @@ assert_not_contains " -l " "$args" \
 	"DF_LOCAL_ONLY=no must not fall back to -l: that would drop healthy remote filesystems"
 
 # An unreadable /proc/filesystems disables only the derived exclusions.
+# The helper is what fails when the list cannot be read, so that is what the
+# case replaces -- a stub that returns non-zero, like the real one does on an
+# unreadable /proc/filesystems.
 MISSING="$TMP/df-section-missing.sh"
-sed "s!$TMP/proc.filesystems!$TMP/does-not-exist!g" "$SNIPPET" > "$MISSING"
+cp "$SNIPPET" "$MISSING"
+fsf_stub_helper "$MISSING" fs_filesystems "\treturn 1"
 : > "$DF_LOG"
 ( cd "$TMP" && /bin/sh "$MISSING" >/dev/null 2>"$TMP/stderr" ) || true
 args=$(printf ' %s ' "$(cat "$DF_LOG")")
@@ -160,5 +171,18 @@ assert_contains " -x iso9660 " "$args" \
 	"the EXCLUDE_TYPES defaults still apply without /proc/filesystems"
 assert_not_contains " -x proc " "$args" \
 	"only the derived nodev exclusions are lost"
+
+# An unreadable mount list, with DF_LOCAL_ONLY=no and a df that fails. This is
+# the one path where the failure marker has two ways to be lost: the plain df's
+# status is kept for the remote fallback, and the fallback itself now depends on
+# a helper that can fail. A silent empty section here is a green disk column on
+# a host where df collected nothing at all.
+NOMOUNTS="$TMP/df-inode-section-nomounts.sh"
+cp "$FSF_COMBINED" "$NOMOUNTS"
+fsf_stub_helper "$NOMOUNTS" fs_mounts "\treturn 1"
+_out=$(cd "$TMP" && env DF_FAIL=1 XYMONCLIENT_FS_DF_LOCAL_ONLY=no \
+	/bin/sh "$NOMOUNTS" 2>/dev/null || true)
+fsf_assert_loud "$_out" \
+	"a df failure with no readable mount list must still be loud"
 
 pass "xymonclient-linux.sh: the FS filter contract, nodev exclusions, and the hard-block guard"

--- a/tests/client/fs-mounts.sh
+++ b/tests/client/fs-mounts.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-mounts.sh
+#
+# Mount enumeration is the documented per-OS seam: /proc/mounts on Linux,
+# mount(8) on the BSDs and macOS. Every other filesystem test replaces it with
+# a fixture, so nothing else looks at what the real thing prints or at what the
+# clients ask it for. Two things are checked here that a fixture cannot check:
+#
+#   1. no client asks mount(8) to refresh (static, runs on every lane)
+#   2. this host's own fs_mounts() parses this host's real output (native)
+#
+# (1) matters because the sentinel exists for mounts whose server is gone.
+# Listing them is safe -- FreeBSD's mount(8) calls getmntinfo(MNT_NOWAIT), as
+# do NetBSD, OpenBSD and macOS -- but `mount -v` on FreeBSD passes MNT_WAIT,
+# which stats every filesystem and blocks on exactly the dead mount the
+# sentinel is trying to report. The verbose flag would look like an
+# improvement in review; this is the note that says it is not.
+#
+# native-primitive: fs_mounts
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+TMP=$(mktempdir)
+
+# ---------------------------------------------------------------- static ---
+
+clients=0
+for script in "$ROOT"/client/xymonclient-*.sh; do
+	grep -q '^fs_mounts()' "$script" || continue
+	clients=$((clients + 1))
+	os=$(basename "$script" .sh)
+
+	# Only the enumerator's own body, so an unrelated `mount -v` elsewhere in a
+	# client (there is none today) would not be blamed on this rule.
+	sed -n '/^fs_mounts()/,/^}/p' "$script" > "$TMP/$os"
+	[ -s "$TMP/$os" ] || fail "$os: fs_mounts() is declared but its body could not be extracted -- the '}' terminator moved?"
+
+	if grep -Eq 'mount[[:space:]]+(-[[:alnum:]]*v|--verbose)' "$TMP/$os"; then
+		fail "$os: fs_mounts() runs mount verbosely, which asks the kernel to stat every filesystem (MNT_WAIT) and hangs on the dead mounts the sentinel reports"
+	fi
+done
+
+[ "$clients" -gt 0 ] || fail "no client declares fs_mounts(): mount enumeration regressed out of the tree"
+
+# ---------------------------------------------------------------- native ---
+
+kernel=$(uname -s)
+case "$kernel" in
+  Linux)   os=linux ;;
+  FreeBSD) os=freebsd ;;
+  NetBSD)  os=netbsd ;;
+  OpenBSD) os=openbsd ;;
+  Darwin)  os=darwin ;;
+  *) skip "no client for $kernel, so its mount output is nobody's contract" ;;
+esac
+
+script="$ROOT/client/xymonclient-$os.sh"
+[ -f "$script" ] || skip "$script missing"
+grep -q '^fs_mounts()' "$script" || fail "$os: fs_mounts() missing from the client this host runs"
+
+# mount(8) lives in /sbin on the BSDs and macOS, and the client calls it by
+# name: it inherits its PATH from xymonlaunch, where /sbin is present, while a
+# CI shell's PATH need not be. Name the directories rather than skip -- a skip
+# here left NetBSD's mount parsing unverified for a whole campaign.
+case $kernel in
+  Linux) ;;
+  *) PATH="$PATH:/sbin:/usr/sbin" ;;
+esac
+command -v mount > /dev/null 2>&1 || [ "$kernel" = Linux ] \
+	|| skip "no mount(8) on this host, which is what its client reads"
+
+# Run the helper alone, against the real system, exactly as the client would.
+( sed -n '/^fs_mounts()/,/^}/p' "$script"; echo 'fs_mounts' ) > "$TMP/run.sh"
+if ! sh "$TMP/run.sh" > "$TMP/out" 2> "$TMP/err"; then
+	printf '%s\n' "$(cat "$TMP/err")" >&2
+	fail "$os: fs_mounts() failed on the host it is written for"
+fi
+[ ! -s "$TMP/err" ] || {
+	printf '%s\n' "$(cat "$TMP/err")" >&2
+	fail "$os: fs_mounts() wrote to stderr; the client's caller would leak that into the status message"
+}
+[ -s "$TMP/out" ] || fail "$os: fs_mounts() listed no mounts on a running system"
+
+# What the helper actually produced, on failure only: a count ("listed 2 mounts
+# but not /") says something is wrong without saying what, and re-running a BSD
+# lane to find out costs half an hour.
+dump_rows() { printf 'fs_mounts() returned:\n' >&2; sed -e 's/^/  /' "$TMP/out" >&2; }
+
+# The rows are what the rest of the block indexes into, so check the shape
+# rather than the contents: type, tab, mountpoint, and nothing else.
+lineno=0
+present=0
+root_type=
+while IFS= read -r line; do
+	lineno=$((lineno + 1))
+	fields=$(printf '%s' "$line" | awk -F'\t' '{ print NF }')
+	[ "$fields" = 2 ] \
+		|| { dump_rows; fail "$os: fs_mounts() line $lineno is not 'type<TAB>mountpoint' ($fields tab-separated fields): $line"; }
+
+	type=${line%%	*}
+	mp=${line#*	}
+
+	# A parse that drifted by a field yields plausible-looking garbage, so
+	# check what a mountpoint always is: an absolute path. Not that it exists
+	# -- an unprivileged reader cannot stat every one of them (docker's
+	# overlay dirs are root-only) -- and not that it is a directory, since a
+	# bind mount over a file is legal and WSL ships one at /init.
+	case "$mp" in
+	  /*) [ ! -e "$mp" ] || present=$((present + 1)) ;;
+	  *) dump_rows; fail "$os: fs_mounts() reported '$mp' as a mountpoint, which is not an absolute path: $line" ;;
+	esac
+
+	case "$type" in
+	  ''|*[[:space:]]*|*'('*|*')'*|*,*)
+		dump_rows
+		fail "$os: fs_mounts() reported '$type' as a filesystem type, so the parse picked up the wrong part of the line: $line"
+		;;
+	esac
+
+	[ "$mp" != / ] || root_type=$type
+done < "$TMP/out"
+
+# / is mounted on every system that can run this, so its absence means the
+# enumerator dropped rows rather than merely mangling them.
+[ -n "$root_type" ] || { dump_rows; fail "$os: fs_mounts() listed $lineno mount(s) but not /, so it is dropping rows"; }
+
+# Paths that all look absolute but none of which resolve would be a parse
+# producing well-formed nonsense; one that resolves is enough to rule that out.
+[ "$present" -gt 0 ] || { dump_rows; fail "$os: none of the $lineno mountpoints fs_mounts() reported exists"; }
+
+# One thing no host can be relied on to have: a mount point with a space in it.
+# Linux escapes it as \040 in /proc/mounts, and a client that stopped decoding
+# that would hand df a path that does not exist -- reporting the filesystem
+# unavailable while its disk is fine. So the parser is fed the line directly.
+# The BSDs need no equivalent: mount(8) prints the space, and the " on " / " ("
+# split keeps it.
+if [ "$kernel" = Linux ]; then
+	# The awk program out of the helper, run over one fixture line instead of
+	# the file. Extracted rather than copied, so it is this client's parser
+	# that is tested; the pattern names awk, never the path, which is what the
+	# suite's own portability rules ask for.
+	awkprog=$(sed -n '/^fs_mounts()/,/^}/p' "$script" | sed -n "s/^[[:space:]]*awk '\(.*\)' .*/\1/p")
+	[ -n "$awkprog" ] \
+		|| fail "$os: fs_mounts() no longer parses with a single awk program -- update this check with it"
+	decoded=$(printf 'server:/export /remote/team\\040share nfs4 rw 0 0\n' | awk "$awkprog")
+	assert_equal "nfs4	/remote/team share" "$decoded" \
+		"$os: an escaped space in a mount point is decoded, not passed through"
+fi
+
+pass "no client refreshes mount(8), and $os's fs_mounts() parses this host ($lineno mounts, / is $root_type)"

--- a/tests/client/fs-procname.sh
+++ b/tests/client/fs-procname.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-procname.sh
+#
+# The suite runs every client's [df] block with its OS primitives replaced,
+# which is what lets one lane verify all five. A stub is only as good as the
+# assumption behind it, and fs_procname() rests on one per platform:
+#
+#   Linux        /proc/PID/comm holds the name of the running executable
+#   BSD, macOS   ps -o comm= prints it, with a leading path on macOS
+#
+# Nothing else checks those, so if either changed, every stubbed test would
+# stay green while the PID-reuse guard broke in production. This one runs the
+# client's own helper -- extracted, not reimplemented, or a client that started
+# asking ps for the wrong thing would still pass here -- against a process
+# whose name it knows, and skips on any OS whose rule is not recorded.
+#
+# native-primitive: fs_procname
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"	# fsf_wedge_binary
+
+ROOT=$(find_root)
+
+os=$(uname -s)
+case "$os" in
+  Linux)   client=linux ;;
+  FreeBSD) client=freebsd ;;
+  NetBSD)  client=netbsd ;;
+  OpenBSD) client=openbsd ;;
+  Darwin)  client=darwin ;;
+  *) skip "no recorded process-name rule for $os" ;;
+esac
+
+script="$ROOT/client/xymonclient-$client.sh"
+[ -f "$script" ] || skip "$script missing"
+grep -q '^fs_procname()' "$script" \
+	|| fail "$client: fs_procname() missing from the client this host runs"
+
+case "$os" in
+  Linux)
+	[ -r /proc/self/comm ] || skip "no /proc on this Linux, so its client cannot use it either"
+	;;
+  *)
+	command -v ps > /dev/null 2>&1 || skip "no ps, which is what this OS's client reads"
+	;;
+esac
+
+work=$(mktempdir)
+
+# The client's helper, run alone. Extracting it is the point: a reimplementation
+# here would test this file's idea of the primitive, not the client's.
+{ sed -n '/^fs_procname()/,/^}/p' "$script"; printf 'fs_procname "$1"\n'; } > "$work/procname.sh"
+procname() { sh "$work/procname.sh" "$1"; }
+
+# A process named "df" that does nothing but wait -- the shape of the wedged df
+# the guard exists for, and the shape its fixtures imitate. Built rather than
+# copied: this test asks what ps says about a binary called df, and a copied
+# /bin/sleep is not reliably one. On Alpine it is BusyBox, which reads its
+# applet from argv[0] and so runs df and exits.
+fsf_wedge_binary "$work/df"
+"$work/df" 30 &
+pid=$!
+# Off the shell's job table, or reaping it prints "Killed" into the suite's
+# output, which reads like a failure and is not one.
+disown "$pid" 2>/dev/null || true
+register_cleanup "kill -9 $pid 2>/dev/null || true"
+
+# Wait for the exec, not for a duration: until then the pid is still the forking
+# shell and would answer with the shell's name.
+i=0
+while :; do
+	kill -0 "$pid" 2>/dev/null || fail "the fixture exited before it could be inspected"
+	case "$(procname "$pid")" in
+	  *df) break ;;
+	esac
+	i=$((i + 1))
+	[ "$i" -lt 100 ] || fail "$client: fs_procname() never named the fixture after 10s -- the primitive it reads has changed"
+	sleep 0.1
+done
+
+name=$(procname "$pid")
+[ -n "$name" ] || fail "$client: fs_procname() returned nothing for a running process"
+
+# The caller strips the path and compares to "df" (see df_sentinel), so that is
+# what is checked here.
+assert_equal "df" "${name##*/}" \
+	"$client: fs_procname() names a running process after its executable"
+
+case "$os" in
+  Linux)
+	# No path, no arguments -- and no external command: minimal images ship
+	# without ps, which is why the Linux client reads /proc itself.
+	assert_equal "df" "$name" \
+		"Linux: the name comes back bare, with no path and no arguments"
+	;;
+  Darwin)
+	# macOS prints the full path where the BSDs print the bare name. Both are
+	# handled, but pin which is which: if macOS ever switched, the caller's
+	# ${_c##*/} would go from load-bearing to dead and nothing would say so.
+	case "$name" in
+	  /*) ;;
+	  *) fail "macOS used to print the full path in comm; it printed '$name'" ;;
+	esac
+	;;
+esac
+
+# A pid that is gone must answer empty rather than something the caller would
+# mistake for a name: that is what makes an unreadable name distinguishable
+# from a finished probe.
+kill -9 "$pid" 2>/dev/null || true
+wait "$pid" 2>/dev/null || true
+dead=$(procname "$pid")
+assert_equal "" "$dead" \
+	"$client: fs_procname() returns nothing for a pid that no longer exists"
+
+pass "$client: fs_procname() answers as this OS's client assumes"

--- a/tests/client/fs-sentinel-linux.sh
+++ b/tests/client/fs-sentinel-linux.sh
@@ -117,12 +117,22 @@ PS_STUB=
 # Extract the [df] block with /proc repointed at the fixtures. The PID-reuse
 # guard is exercised for real -- it reads process state through ps, which every
 # host this suite runs on has, so nothing here is rewritten for it.
-PROC_REWRITE="s#/proc/mounts#$MOUNTS#g; s#/proc/filesystems#$TMP/filesystems#g"
-fsf_extract "$TMP/df-section.sh" "$PROC_REWRITE" '\[inode\]'
+fsf_extract "$TMP/df-section.sh" "" '\[inode\]'
 # The [inode] block runs the sentinel a second time, under its own tag: a wedged
 # server therefore leaves TWO probes outstanding per cycle, not one, and the
 # unavailable rows have to survive the no-inode-limit drop as well.
-fsf_extract "$TMP/df-inode-section.sh" "$PROC_REWRITE"
+fsf_extract "$TMP/df-inode-section.sh"
+
+# The OS primitives are replaced by name, not by path: the client keeps each
+# one behind a helper, so this is the same move for /proc as putting a stub df
+# on PATH is for a command. FS_PROCNAME lets a case below answer for the guard.
+stub_helpers() {
+	fsf_stub_helper "$1" fs_mounts "\tcat \"$MOUNTS\""
+	fsf_stub_helper "$1" fs_filesystems "\tcat \"$TMP/filesystems\""
+	fsf_stub_helper "$1" fs_procname "\techo \"\${FS_PROCNAME-df}\""
+}
+stub_helpers "$TMP/df-section.sh"
+stub_helpers "$TMP/df-inode-section.sh"
 
 # end_stub PID : end a wedged df stub. The stub exec'd the wedge into its own
 # process, so there is no child to orphan -- the pid is the whole of it.
@@ -156,7 +166,11 @@ run_cycle() { run_block "$TMP/df-section.sh" "$@"; }
 run_full() { run_block "$TMP/df-inode-section.sh" "$@"; }
 
 mkdir -p "$TMP/probe"
-local_mounts() { printf '/dev/sda1 / ext4 rw 0 0\nsrv:/exp /remote/nfs nfs4 rw 0 0\nusr@h:/d /remote/sshfs sshfs rw 0 0\n' > "$MOUNTS"; }
+# The mount fixture is written in fs_mounts()' contract -- "TYPE<tab>MOUNTPOINT"
+# -- not in /proc/mounts' column order. That is the point of the helper: the
+# test states what the client needs to know, and each OS's client is what knows
+# where to read it.
+local_mounts() { printf 'ext4\t/\nnfs4\t/remote/nfs\nsshfs\t/remote/sshfs\n' > "$MOUNTS"; }
 local_mounts
 
 # --- healthy -----------------------------------------------------------------
@@ -303,12 +317,24 @@ assert_contains 'unavailable:/remote/nfs' "$out" \
 # Nothing may touch it: `test -w` on a wedged mount blocks in D-state, inside
 # the fail-safe meant to prevent exactly that.
 mkdir -p "$TMP/remoteprobe"
-printf '/dev/sda1 / ext4 rw 0 0\nsrv:/exp /remote/nfs nfs4 rw 0 0\nsrv:/p %s nfs4 rw 0 0\n' \
-	"$TMP/remoteprobe" > "$MOUNTS"
+printf 'ext4\t/\nnfs4\t/remote/nfs\nnfs4\t%s\n' "$TMP/remoteprobe" > "$MOUNTS"
 out=$(run_cycle XYMONTMP="$TMP/remoteprobe" DF_HANG=1)
 assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
 	"a probe dir on a hard-blocking filesystem must never be touched"
 assert_contains 'unavailable:/remote/nfs' "$out" "the remote set must report unavailable instead"
+
+# Same guard, asked directly. Driving it through the block cannot reach it: with
+# no mount list there is no remote set either, so df_sentinel is never called.
+# What is reachable is a mount list that works once -- long enough to name the
+# remote set -- and fails on the second read inside the same cycle. Then this
+# function decides, and a pipeline would hand it awk's status: awk succeeds on
+# no input, so the answer would be "local" for a directory nobody could place.
+( sed -n '/^probe_dir_is_local()/,/^}/p' "$SCRIPT"
+  printf 'fs_mounts() { return 1; }\n'
+  printf 'probe_dir_is_local /remote/probe\n' ) > "$TMP/pdl.sh"
+if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; then
+	fail "an unreadable mount list must not read as a local probe directory"
+fi
 local_mounts
 
 # --- the default is unchanged ------------------------------------------------
@@ -390,45 +416,32 @@ assert_equal '0' "$(find "$TMP/probe" -type f | awk 'END { print NR }')" \
 assert_contains '/remote/sshfs' "$out" \
 	"while a remote type that is not nodev is still reported, as DF_LOCAL_ONLY=no asks"
 
-# --- the same wedge, under the BSDs' rule for a process name -----------------
-#
-# Everything above ran against the host's own ps, so on Linux it says nothing
-# about the platforms where this first broke. The two differ in one rule: BSD
-# reports the basename of the process's executable, Linux the name it was
-# handed, which for a script is the script. Reading /proc/PID/exe applies the
-# BSD rule on a Linux host, so the case that failed on four BSDs is exercised
-# here rather than only in the VM lanes. Not needed where the host's ps already
-# answers that way, and /proc is absent there anyway.
-if [ -r /proc/self/exe ]; then
-	mkdir -p "$STUB/bsdps"
-	cat > "$STUB/bsdps/ps" <<'EOF'
-#!/bin/sh
-# ps -o comm= -p PID, with the BSDs' answer: the executable's basename.
-_pid=; _prev=
-for _a in "$@"; do
-	case "$_prev" in -p) _pid=$_a ;; esac
-	_prev=$_a
-done
-[ -n "$_pid" ] || exit 1
-_exe=$(readlink "/proc/$_pid/exe" 2>/dev/null) || exit 1
-[ -n "$_exe" ] || exit 1
-echo "${_exe##*/}"
-EOF
-	chmod +x "$STUB/bsdps/ps"
+# --- the guard cannot read the name ------------------------------------------
+# fs_procname() answers from /proc here and from ps elsewhere, and either can
+# come back empty: no ps in a minimal container (measured on the Debian
+# container lanes, where every sentinel test failed for this), no /proc, or a
+# pid that has just gone. The two mistakes then available are not equally
+# cheap. Restarting a probe that is in fact still running leaves another df on
+# a dead server, and those cannot be killed; keeping the mount unavailable for
+# a cycle is visible and bounded. So an unreadable name must NOT restart.
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"; : > "$DF_CALLS"
+out=$(DF_HANG=1 run_cycle DF_HANG=1)
+assert_contains 'unavailable:/remote/nfs' "$out" "the wedge is recorded to begin with"
+before=$(wc -l < "$DF_CALLS")
+out=$(DF_HANG=1 run_cycle DF_HANG=1 FS_PROCNAME=)
+after=$(wc -l < "$DF_CALLS")
+assert_equal "$((before + 1))" "$((after))" \
+	"with the name unreadable the wedged df must be assumed ours -- not restarted"
+assert_contains 'unavailable:/remote/nfs' "$out" "and the mount stays unavailable while it is"
 
-	while read -r _p; do end_stub "$_p"; done < "$DF_REMOTE"
-	rm -f "$TMP"/probe/*; : > "$DF_REMOTE"; : > "$DF_CALLS"
+# A name that is neither ours nor empty is a recycled pid, and must restart.
+: > "$DF_CALLS"
+before=$(wc -l < "$DF_CALLS")
+out=$(DF_HANG=1 run_cycle DF_HANG=1 FS_PROCNAME=someoneelse)
+after=$(wc -l < "$DF_CALLS")
+assert_equal "$((before + 2))" "$((after))" \
+	"a pid whose name is another process must be treated as recycled, and the probe restarted"
+while read -r _p; do end_stub "$_p"; done < "$DF_REMOTE"
 
-	PS_STUB="$STUB/bsdps"
-	out=$(DF_HANG=1 run_cycle DF_HANG=1)
-	assert_contains 'unavailable:/remote/nfs' "$out" \
-		"the wedge must be surfaced under BSD ps semantics too"
-	before=$(wc -l < "$DF_CALLS")
-	out=$(DF_HANG=1 run_cycle DF_HANG=1)
-	after=$(wc -l < "$DF_CALLS")
-	PS_STUB=
-	assert_equal "$((before + 1))" "$((after))" \
-		"under BSD ps semantics the wedged df went unrecognised and a second remote one started"
-fi
 
 pass "the remote-df sentinel bounds a wedged mount, in both reports, without blocking the client"


### PR DESCRIPTION
**1 own commit**; the other is #366, which this is stacked on. Answers the design question on #361 (@SoundGoof): should Linux production code change so its tests can run elsewhere?

Yes, and narrowly. Only the OS primitives move behind a name — `fs_mounts`, `fs_filesystems`, `fs_procname` — and a test replaces one *by name* (`fsf_stub_helper`) instead of rewriting a path only one OS has. That is what lets a single lane exercise all five clients; before this, two tests rewrote `/proc` paths with `sed` and so only ever exercised the client that has `/proc`.

It has already paid for itself twice, both found because the tests could suddenly run where they could not before:

- `ps` is absent from a stock Debian container (`debian:12` has none; `procps` is not Essential). The PID-reuse guard read an empty name, concluded its own `df` had finished, and started another against the dead server every cycle. An unreadable name now means "still running": one cycle of `unavailable:` is bounded and visible, an extra `df` in D-state cannot be killed.
- The native mount test found NetBSD and OpenBSD spelling mount(8) differently from FreeBSD — fixed in #366.

**The cost is that nothing exercises the primitives any more**, since every other test stubs them. Two `uname`-guarded native tests do: `fs-procname.sh` (does this host name a process the way its client assumes?) and `fs-mounts.sh` (this host's own `fs_mounts()` against the real system, plus a check on every lane that no client asks `mount(8)` to refresh — FreeBSD's `-v` means `MNT_WAIT`, which blocks on the dead mount being reported). They are the only two allowed to guard on `uname`, and `tests/buildsystem/test-suite-portability.sh` enforces that: a `uname` guard without a `# native-primitive:` header is reported, as is a `sed` that rewrites a `/proc` path.

`probe_dir_is_local()` keeps the helper's status rather than the pipeline's: awk succeeds on no input, so "I cannot read the mount list" would otherwise read as "this directory is local" — in the guard whose whole job is to not touch a directory that may sit on the wedged mount.

| mutation | caught by |
|---|---|
| the unreadable-name branch removed (a container without `ps`) | `with the name unreadable the wedged df must be assumed ours: expected '3', got '4'` |
| the client reads the command line instead of the name | `fs_procname() never named the fixture after 10s` |
| `\040` no longer decoded in a Linux mount point | `an escaped space in a mount point is decoded, not passed through` |
| `probe_dir_is_local` back on the pipeline | `an unreadable mount list must not read as a local probe directory` |
| a test rewrites a `/proc` path, or guards on `uname` undeclared | `[path-rewrite]`, `[uname-guard]` |

Suite: 81 passed, 0 skipped, 0 failed on a built tree.
