### PR TITLE
xymond: let xymondboard select oldcolor, and add previouscolor (#355)

### DIFF
--- a/common/xymon.1
+++ b/common/xymon.1
@@ -203,6 +203,19 @@ The name of the host
 The name of the test
 .IP "\fBcolor\fR"
 Status color (green, yellow, red, blue, clear, purple)
+.IP "\fBoldcolor\fR"
+The color xymond recorded for this test at the previous report. xymond assigns
+it on every message, not only on a change, so a test repeating its color
+reports that same color here. It is the color xymond \fIrecorded\fR, which is
+not always the one the test sent: a disabled or in-downtime test is recorded
+blue whatever it reports. Until a status has been reported twice this is
+\fBnone\fR, the "no previous color" marker.
+.IP "\fBpreviouscolor\fR"
+The color this test held before its most recent change. Unlike \fBoldcolor\fR
+it does not follow a repeated color, so a test that went green, red, red
+reports color=red, oldcolor=red, previouscolor=green \- it answers "what was
+this before it went bad". \fBnone\fR until the first change, and it survives a
+xymond restart.
 .IP "\fBtestflags\fR"
 For network tests, the flags indicating details about the test (used by xymongen).
 .IP "\fBlastchange\fR"
@@ -320,6 +333,19 @@ The name of the host
 The name of the test
 .IP "\fBcolor\fR"
 Status color (green, yellow, red, blue, clear, purple)
+.IP "\fBoldcolor\fR"
+The color xymond recorded for this test at the previous report. xymond assigns
+it on every message, not only on a change, so a test repeating its color
+reports that same color here. It is the color xymond \fIrecorded\fR, which is
+not always the one the test sent: a disabled or in-downtime test is recorded
+blue whatever it reports. Until a status has been reported twice this is
+\fBnone\fR, the "no previous color" marker.
+.IP "\fBpreviouscolor\fR"
+The color this test held before its most recent change. Unlike \fBoldcolor\fR
+it does not follow a repeated color, so a test that went green, red, red
+reports color=red, oldcolor=red, previouscolor=green \- it answers "what was
+this before it went bad". \fBnone\fR until the first change, and it survives a
+xymond restart.
 .IP "\fBflags\fR"
 For network tests, the flags indicating details about the test (used by xymongen).
 .IP "\fBlastchange\fR"

--- a/docs/manpages/man1/xymon.1.html
+++ b/docs/manpages/man1/xymon.1.html
@@ -248,6 +248,20 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
   <dd>The name of the test</dd>
   <dt id="color"><a class="permalink" href="#color"><b>color</b></a></dt>
   <dd>Status color (green, yellow, red, blue, clear, purple)</dd>
+  <dt id="oldcolor"><a class="permalink" href="#oldcolor"><b>oldcolor</b></a></dt>
+  <dd>The color xymond recorded for this test at the previous report. xymond
+      assigns it on every message, not only on a change, so a test repeating its
+      color reports that same color here. It is the color xymond
+      <i>recorded</i>, which is not always the one the test sent: a disabled or
+      in-downtime test is recorded blue whatever it reports. Until a status has
+      been reported twice this is <b>none</b>, the &quot;no previous color&quot;
+      marker.</dd>
+  <dt id="previouscolor"><a class="permalink" href="#previouscolor"><b>previouscolor</b></a></dt>
+  <dd>The color this test held before its most recent change. Unlike
+      <b>oldcolor</b> it does not follow a repeated color, so a test that went
+      green, red, red reports color=red, oldcolor=red, previouscolor=green - it
+      answers &quot;what was this before it went bad&quot;. <b>none</b> until
+      the first change, and it survives a xymond restart.</dd>
   <dt id="testflags"><a class="permalink" href="#testflags"><b>testflags</b></a></dt>
   <dd>For network tests, the flags indicating details about the test (used by
       xymongen).</dd>
@@ -370,6 +384,20 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
   <dd>The name of the test</dd>
   <dt id="color~3"><a class="permalink" href="#color~3"><b>color</b></a></dt>
   <dd>Status color (green, yellow, red, blue, clear, purple)</dd>
+  <dt id="oldcolor~2"><a class="permalink" href="#oldcolor~2"><b>oldcolor</b></a></dt>
+  <dd>The color xymond recorded for this test at the previous report. xymond
+      assigns it on every message, not only on a change, so a test repeating its
+      color reports that same color here. It is the color xymond
+      <i>recorded</i>, which is not always the one the test sent: a disabled or
+      in-downtime test is recorded blue whatever it reports. Until a status has
+      been reported twice this is <b>none</b>, the &quot;no previous color&quot;
+      marker.</dd>
+  <dt id="previouscolor~2"><a class="permalink" href="#previouscolor~2"><b>previouscolor</b></a></dt>
+  <dd>The color this test held before its most recent change. Unlike
+      <b>oldcolor</b> it does not follow a repeated color, so a test that went
+      green, red, red reports color=red, oldcolor=red, previouscolor=green - it
+      answers &quot;what was this before it went bad&quot;. <b>none</b> until
+      the first change, and it survives a xymond restart.</dd>
   <dt id="flags"><a class="permalink" href="#flags"><b>flags</b></a></dt>
   <dd>For network tests, the flags indicating details about the test (used by
       xymongen).</dd>

--- a/tests/server/xymond-checkpoint-roundtrip.sh
+++ b/tests/server/xymond-checkpoint-roundtrip.sh
@@ -184,9 +184,14 @@ stop_xymond
 # flag still says "flapping"; the ring says the test has been quiet for a day,
 # and the ring is what counts.
 
-awk -F'|' -v OFS='|' '$2 == ".flapstate." { $NF = "1000000,1000000" } { print }' \
-	"$work/chk" > "$work/chk.stale"
-grep -q '^@@XYMONDCHK-V1|\.flapstate\.|.*|1000000,1000000$' "$work/chk.stale" \
+# The ring is field 11, named rather than taken as the last one: fields have
+# been appended after it (previouscolor), and $NF then rewrites the wrong one
+# while still producing a line that ends in the value written -- the edit reads
+# as applied and changes nothing.
+awk -F'|' -v OFS='|' '$2 == ".flapstate." { if (NF < 11) exit 3; $11 = "1000000,1000000" } { print }' \
+	"$work/chk" > "$work/chk.stale" \
+	|| fail "the .flapstate. record has fewer fields than the flap ring's position; the format changed"
+grep -q '^@@XYMONDCHK-V1|\.flapstate\.|\([^|]*|\)\{8\}1000000,1000000\(|.*\)\?$' "$work/chk.stale" \
 	|| fail "could not backdate the flap ring; the .flapstate. record format changed"
 
 start_xymond --restart="$work/chk.stale"

--- a/tests/server/xymondboard-color-history.sh
+++ b/tests/server/xymondboard-color-history.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymondboard-color-history.sh
+#
+# The two colors a board consumer can ask for, and the difference between them:
+#
+#   oldcolor        the color of the previous report, assigned on every message
+#   previouscolor   the color held before the most recent change
+#
+# They are the same only until a test repeats itself. A test that goes green,
+# red, red reports color=red oldcolor=red previouscolor=green -- and it is
+# previouscolor that answers "what was it before this went bad", which is what
+# a display or an alert rule wants (@SoundGoof, #355).
+#
+# Both are selectable fields now. They were carried on xymond's internal
+# channels before this, so a module could see them and a `fields=` consumer
+# could not.
+#
+# Needs a built tree: xymond itself and the xymon client.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+require_bin XYMOND xymond/xymond
+require_bin XYMONCLIENT common/xymon
+
+work=$(mktempdir)
+
+XYMOND_PID=""
+stop_xymond() {
+	[ -n "$XYMOND_PID" ] || return 0
+	kill "$XYMOND_PID" 2>/dev/null || true
+	local i=0
+	while kill -0 "$XYMOND_PID" 2>/dev/null && [ "$i" -lt 100 ]; do
+		sleep 0.1
+		i=$((i+1))
+	done
+	XYMOND_PID=""
+}
+register_cleanup stop_xymond
+
+printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.cfg"
+
+mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
+    -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
+	"$ROOT/xymond/etcfiles/xymonserver.cfg" > "$work/xymonserver.cfg" \
+	|| skip "no xymonserver.cfg to run against"
+
+free_port() {
+	local p tries=0
+	while [ "$tries" -lt 50 ]; do
+		p=$(( 20000 + (RANDOM % 20000) ))
+		"$XYMONCLIENT" "127.0.0.1:$p" "ping" >/dev/null 2>&1 || { printf '%s' "$p"; return 0; }
+		tries=$((tries+1))
+	done
+	return 1
+}
+
+start_xymond() {
+	local i=0
+	PORT=$(free_port) || fail "no free port for xymond"
+	"$XYMOND" --no-daemon --listen="127.0.0.1:$PORT" \
+		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
+		--pidfile="$work/xymond.pid" --checkpoint-file="$work/chk.out" \
+		"$@" \
+		> "$work/xymond.log" 2>&1 &
+	XYMOND_PID=$!
+
+	while [ "$i" -lt 100 ]; do
+		"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 && return 0
+		kill -0 "$XYMOND_PID" 2>/dev/null || { cat "$work/xymond.log" >&2; fail "xymond exited during startup"; }
+		sleep 0.1
+		i=$((i+1))
+	done
+	cat "$work/xymond.log" >&2
+	fail "xymond did not answer on 127.0.0.1:$PORT"
+}
+
+send() { "$XYMONCLIENT" "127.0.0.1:$PORT" "$1" || fail "xymond rejected: $1"; }
+status() { send "status testhost,example,com.conn $1 msg"; sleep 0.4; }
+
+# board FIELD -- one field of the conn status, through the fields= selector a
+# consumer uses. An unknown field name yields an empty column, which is exactly
+# what this test is here to catch.
+board() {
+	"$XYMONCLIENT" "127.0.0.1:$PORT" "xymondboard fields=testname,$1" 2>/dev/null \
+		| awk -F'|' '$1 == "conn" { print $2 }'
+}
+
+assert_colors() {
+	local wantcolor=$1 wantold=$2 wantprev=$3 label=$4
+	local gotcolor gotold gotprev
+	gotcolor=$(board color); gotold=$(board oldcolor); gotprev=$(board previouscolor)
+	[ "$gotcolor" = "$wantcolor" ] && [ "$gotold" = "$wantold" ] && [ "$gotprev" = "$wantprev" ] \
+		|| fail "$label: expected color=$wantcolor oldcolor=$wantold previouscolor=$wantprev, got color=$gotcolor oldcolor=$gotold previouscolor=$gotprev"
+}
+
+start_xymond
+
+# --- a status nobody has seen change ------------------------------------------
+# "none" is the no-previous-color sentinel, and it is not a transition. It
+# stands for oldcolor only until the second report: oldcolor is assigned on
+# every message, so a repeated green makes it green while previouscolor is
+# still none -- nothing has changed yet.
+status green
+assert_colors green none none "first report"
+
+status green
+assert_colors green green none "a repeated color moves oldcolor, not previouscolor"
+
+# --- the case the field exists for --------------------------------------------
+status red
+assert_colors red green green "the change itself"
+
+status red
+assert_colors red red green "a repeat after the change keeps what came before it"
+
+# --- and it follows the next change, not the reports in between ---------------
+status yellow
+assert_colors yellow red red "the next change moves previouscolor to the color that was held"
+
+# --- across a restart ----------------------------------------------------------
+# A monitoring server restarts, often during the incident the operator is
+# looking at. A field whose whole job is to say what came before is worth
+# nothing if it forgets exactly then, so it rides the checkpoint.
+stop_xymond   # xymond writes its checkpoint while shutting down
+[ -s "$work/chk.out" ] || fail "xymond wrote no checkpoint file"
+
+start_xymond --restart="$work/chk.out"
+assert_colors yellow red red "a restored status keeps the color it held before the change"
+
+pass "xymondboard exposes oldcolor and previouscolor, and previouscolor survives a restart"

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -132,6 +132,7 @@ typedef struct xymond_log_t {
 	time_t *flapchange;	/* Table of the most recent status-change times, used for flap detection */
 	time_t pregaplastchange;	/* The "lastchange" saved when a no-data gap began */
 	time_t gapstart;	/* When that gap began; bounds how far a resume may bridge */
+	int previouscolor;	/* The color held before the most recent change, or NO_COLOR before the first one */
 	int pregapcolor;	/* The color recorded before the gap, or NO_COLOR when not in one */
 	int pregapvalidity;	/* The report validity in force when the gap began, in minutes */
 	int validity;		/* Minutes this test's reports stay valid; sizes the bridge bound */
@@ -309,7 +310,8 @@ xymond_statistics_t xymond_stats[] = {
 	{ NULL, 0 }
 };
 
-enum boardfield_t { F_NONE, F_IP, F_HOSTNAME, F_TESTNAME, F_MATCHEDTAG, F_COLOR, F_FLAGS, 
+enum boardfield_t { F_NONE, F_IP, F_HOSTNAME, F_TESTNAME, F_MATCHEDTAG, F_COLOR,
+		    F_OLDCOLOR, F_PREVIOUSCOLOR, F_FLAGS, 
 		    F_LASTCHANGE, F_LOGTIME, F_VALIDTIME, F_ACKTIME, F_DISABLETIME,
 		    F_SENDER, F_COOKIE, F_LINE1,
 		    F_ACKMSG, F_DISMSG, F_MSG, F_CLIENT, F_CLIENTTSTAMP,
@@ -332,6 +334,8 @@ boardfieldnames_t boardfieldnames[] = {
 	{ "matchedtags", F_MATCHEDTAG },
 	{ "testname", F_TESTNAME },
 	{ "color", F_COLOR },
+	{ "oldcolor", F_OLDCOLOR },
+	{ "previouscolor", F_PREVIOUSCOLOR },
 	{ "flags", F_FLAGS },
 	{ "lastchange", F_LASTCHANGE },
 	{ "logtime", F_LOGTIME },
@@ -1349,7 +1353,7 @@ void get_hts(char *msg, char *sender, char *origin,
 			lwalk->pregapcolor = NO_COLOR;
 			lwalk->pregapvalidity = defaultvalidity;
 			lwalk->validity = defaultvalidity;
-			lwalk->color = lwalk->oldcolor = NO_COLOR;
+			lwalk->color = lwalk->oldcolor = lwalk->previouscolor = NO_COLOR;
 			lwalk->host = hwalk;
 			lwalk->test = twalk;
 			lwalk->origin = owalk;
@@ -1913,6 +1917,11 @@ void handle_status(unsigned char *msg, char *sender, char *hostname, char *testn
 	 * are about to stop seeing began, not when we stopped seeing it. */
 	prevlastchange = log->lastchange;
 
+	/* oldcolor is the previous *report*; previouscolor is the color held
+	 * before the most recent change. They differ for as long as a test keeps
+	 * repeating a color: oldcolor follows it, previouscolor stays on what came
+	 * before the transition, which is what "how did we get here" asks for. */
+	if (newcolor != log->color) log->previouscolor = log->color;
 	log->oldcolor = log->color;
 	log->color = newcolor;
 	oldalertstatus = decide_alertstate(log->oldcolor);
@@ -3602,6 +3611,8 @@ strbuffer_t *generate_outbuf(strbuffer_t **prebuf, boardfield_t *boardfields, xy
 		  case F_HOSTNAME: addtobuffer(buf, hwalk->hostname); break;
 		  case F_TESTNAME: addtobuffer(buf, lwalk->test->name); break;
 		  case F_COLOR: addtobuffer(buf, colnames[lwalk->color]); break;
+		  case F_OLDCOLOR: addtobuffer(buf, colnames[lwalk->oldcolor]); break;
+		  case F_PREVIOUSCOLOR: addtobuffer(buf, colnames[lwalk->previouscolor]); break;
 		  case F_FLAGS: if (lwalk->testflags) addtobuffer(buf, lwalk->testflags); break;
 		  case F_LASTCHANGE: snprintf(l, sizeof(l), "%d", (int)lwalk->lastchange); addtobuffer(buf, l); break;
 		  case F_LOGTIME: snprintf(l, sizeof(l), "%d", (int)lwalk->logtime); addtobuffer(buf, l); break;
@@ -5140,6 +5151,7 @@ void save_checkpoint(void)
 				   gap_within_window(now - lwalk->gapstart, lwalk->pregapvalidity));
 
 			if ((iores >= 0) && (lwalk->flapping || gapopen ||
+					     (lwalk->previouscolor != NO_COLOR) ||
 					     ((flapcount > 1) && lwalk->flapchange[1]))) {
 				int fi;
 
@@ -5166,6 +5178,12 @@ void save_checkpoint(void)
 						(gapopen ? lwalk->pregapvalidity : 0));
 				for (fi = 0; ((fi < flapcount) && (iores >= 0)); fi++)
 					iores = fprintf(fd, "%s%ld", ((fi == 0) ? "" : ","), (long)lwalk->flapchange[fi]);
+				/* After the flap-change list, not before it: the record is
+				 * read by position, so anything inserted earlier would shift
+				 * the list and misread every checkpoint written until now. A
+				 * reader that predates this field stops at its own last case
+				 * and ignores the extra one. */
+				if (iores >= 0) iores = fprintf(fd, "|%s", colnames[lwalk->previouscolor]);
 				if (iores >= 0) iores = fprintf(fd, "\n");
 			}
 
@@ -5333,6 +5351,7 @@ void load_checkpoint(char *fn)
 			xymond_log_t *log = NULL;
 			int flapping = 0, oldflapcolor = NO_COLOR, currflapcolor = NO_COLOR;
 			int pregapcolor = NO_COLOR, pregapvalidity = defaultvalidity;
+			int previouscolor = NO_COLOR;
 			time_t pregaplastchange = 0, gapstart = 0;
 			char *flapchangestr = NULL;
 
@@ -5366,6 +5385,10 @@ void load_checkpoint(char *fn)
 					}
 					break;
 				  case 10: flapchangestr = item; break;
+				  /* Absent from checkpoints written before this field
+				   * existed; such a status comes back with no previous
+				   * color, which is what it had. */
+				  case 11: previouscolor = restore_color(item); break;
 				  default: break;
 				}
 				item = gettok(NULL, "|\n"); i++;
@@ -5383,6 +5406,7 @@ void load_checkpoint(char *fn)
 				 */
 				log->oldflapcolor = oldflapcolor;
 				log->currflapcolor = currflapcolor;
+				log->previouscolor = previouscolor;
 				log->pregapcolor = pregapcolor;
 				log->pregaplastchange = pregaplastchange;
 				log->pregapvalidity = pregapvalidity;


### PR DESCRIPTION
**1 commit**, on `main` — not stacked on #355, and it makes #355 unnecessary: the manual text lands here, corrected.

`oldcolor` is not a `xymondboard` field. It has been on xymond's internal channels forever, but `boardfieldnames[]` has no entry for it, so `xymondboard fields=hostname,testname,color,oldcolor` returns an empty column, and `xymondlog`'s default list does not carry it either. #355 was about to document it as one.

Both are selectable now, and a second color comes with them, because the one that exists does not answer the question people ask of it:

| | assigned | after green, red, red |
|---|---|---|
| `oldcolor` | every message | `red` |
| `previouscolor` | only on a real change | `green` |

`previouscolor` is what a display or an alert rule wants — what was this before it went bad (@SoundGoof).

**Persistence.** `previouscolor` rides the `.flapstate.` checkpoint record, appended *after* the flap ring so nothing shifts: a reader that predates it stops at its own last case, and a checkpoint written before it restores as "no previous color", which is what those statuses had. A monitoring server restarts during the incident an operator is looking at; a field whose job is to say what came before is worth nothing if it forgets exactly then.

That append is why `xymond-checkpoint-roundtrip.sh` changes. It backdated the flap ring through `$NF`, which now rewrites `previouscolor` instead — and still produces a line ending in the value it wrote, so its own guard passed while the edit changed nothing. It names field 11 now, and fails loudly if the record ever gets shorter.

**The manual page also drops two claims the code contradicts**, both from #355's text:

- "a status whose color has never changed reports `none`" — only its *first* report does. Send green twice and `oldcolor` is green, though nothing ever changed.
- "the color this test reported" — it is the color xymond *recorded*. A disabled or in-downtime test reports green and is recorded blue, and blue is what comes back.

| mutation | caught by |
|---|---|
| `previouscolor` assigned on every message | `a repeated color moves oldcolor, not previouscolor: expected previouscolor=none, got green` |
| the checkpoint field dropped on restore | `a restored status keeps the color it held before the change: expected previouscolor=red, got none` |

Suite: 76 passed, 0 skipped, 0 failed on a built tree. Manual page HTML regenerated with `build/makehtml.sh`.
