### PR TITLE
xymond: publish the color a test itself reported, as prevgapcolor

### DIFF
--- a/common/xymon.1
+++ b/common/xymon.1
@@ -211,12 +211,19 @@ a test repeating its color reports that same color here. Also accepted as
 in-downtime test is recorded blue whatever it reports. \fBnone\fR until a
 status has been reported twice.
 .IP "\fBprevchangecolor\fR"
-The color this test held before its most recent change. Also accepted as
-\fBpreviouscolor\fR. It moves only when the
+The color this test held before its most recent change. It moves only when the
 color changes, so a test that went green, red, red reports color=red,
 prevreportcolor=red, prevchangecolor=green \- it answers "what was this before
 it went bad". \fBnone\fR until the first change, and it survives a xymond
-restart.
+restart. Also accepted as \fBpreviouscolor\fR.
+.IP "\fBprevgapcolor\fR"
+The test's own color while xymond is recording something other than what it
+reports; \fBnone\fR at every other time. It follows the reports arriving
+under the substitution, and a test gone silent keeps its last word. That
+covers a silence, a disable, a modifier, a delayed color change and a
+DOWNTIME window hiding an alert color -- a green report shows through
+DOWNTIME, and the field answers \fBnone\fR: wherever they differ,
+\fBcolor\fR is xymond's and \fBprevgapcolor\fR is the test's own.
 .IP "\fBtestflags\fR"
 For network tests, the flags indicating details about the test (used by xymongen).
 .IP "\fBlastchange\fR"
@@ -342,12 +349,19 @@ a test repeating its color reports that same color here. Also accepted as
 in-downtime test is recorded blue whatever it reports. \fBnone\fR until a
 status has been reported twice.
 .IP "\fBprevchangecolor\fR"
-The color this test held before its most recent change. Also accepted as
-\fBpreviouscolor\fR. It moves only when the
+The color this test held before its most recent change. It moves only when the
 color changes, so a test that went green, red, red reports color=red,
 prevreportcolor=red, prevchangecolor=green \- it answers "what was this before
 it went bad". \fBnone\fR until the first change, and it survives a xymond
-restart.
+restart. Also accepted as \fBpreviouscolor\fR.
+.IP "\fBprevgapcolor\fR"
+The test's own color while xymond is recording something other than what it
+reports; \fBnone\fR at every other time. It follows the reports arriving
+under the substitution, and a test gone silent keeps its last word. That
+covers a silence, a disable, a modifier, a delayed color change and a
+DOWNTIME window hiding an alert color -- a green report shows through
+DOWNTIME, and the field answers \fBnone\fR: wherever they differ,
+\fBcolor\fR is xymond's and \fBprevgapcolor\fR is the test's own.
 .IP "\fBflags\fR"
 For network tests, the flags indicating details about the test (used by xymongen).
 .IP "\fBlastchange\fR"

--- a/docs/manpages/man1/xymon.1.html
+++ b/docs/manpages/man1/xymon.1.html
@@ -256,12 +256,19 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
       a disabled or in-downtime test is recorded blue whatever it reports.
       <b>none</b> until a status has been reported twice.</dd>
   <dt id="prevchangecolor"><a class="permalink" href="#prevchangecolor"><b>prevchangecolor</b></a></dt>
-  <dd>The color this test held before its most recent change. Also accepted as
-      <b>previouscolor</b>. It moves only when the color changes, so a test that
-      went green, red, red reports color=red, prevreportcolor=red,
-      prevchangecolor=green - it answers &quot;what was this before it went
-      bad&quot;. <b>none</b> until the first change, and it survives a xymond
-      restart.</dd>
+  <dd>The color this test held before its most recent change. It moves only when
+      the color changes, so a test that went green, red, red reports color=red,
+      prevreportcolor=red, prevchangecolor=green - it answers &quot;what was
+      this before it went bad&quot;. <b>none</b> until the first change, and it
+      survives a xymond restart. Also accepted as <b>previouscolor</b>.</dd>
+  <dt id="prevgapcolor"><a class="permalink" href="#prevgapcolor"><b>prevgapcolor</b></a></dt>
+  <dd>The test's own color while xymond is recording something other than what
+      it reports; <b>none</b> at every other time. It follows the reports
+      arriving under the substitution, and a test gone silent keeps its last
+      word. That covers a silence, a disable, a modifier, a delayed color change
+      and a DOWNTIME window hiding an alert color -- a green report shows
+      through DOWNTIME, and the field answers <b>none</b>: wherever they differ,
+      <b>color</b> is xymond's and <b>prevgapcolor</b> is the test's own.</dd>
   <dt id="testflags"><a class="permalink" href="#testflags"><b>testflags</b></a></dt>
   <dd>For network tests, the flags indicating details about the test (used by
       xymongen).</dd>
@@ -392,12 +399,19 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
       a disabled or in-downtime test is recorded blue whatever it reports.
       <b>none</b> until a status has been reported twice.</dd>
   <dt id="prevchangecolor~2"><a class="permalink" href="#prevchangecolor~2"><b>prevchangecolor</b></a></dt>
-  <dd>The color this test held before its most recent change. Also accepted as
-      <b>previouscolor</b>. It moves only when the color changes, so a test that
-      went green, red, red reports color=red, prevreportcolor=red,
-      prevchangecolor=green - it answers &quot;what was this before it went
-      bad&quot;. <b>none</b> until the first change, and it survives a xymond
-      restart.</dd>
+  <dd>The color this test held before its most recent change. It moves only when
+      the color changes, so a test that went green, red, red reports color=red,
+      prevreportcolor=red, prevchangecolor=green - it answers &quot;what was
+      this before it went bad&quot;. <b>none</b> until the first change, and it
+      survives a xymond restart. Also accepted as <b>previouscolor</b>.</dd>
+  <dt id="prevgapcolor~2"><a class="permalink" href="#prevgapcolor~2"><b>prevgapcolor</b></a></dt>
+  <dd>The test's own color while xymond is recording something other than what
+      it reports; <b>none</b> at every other time. It follows the reports
+      arriving under the substitution, and a test gone silent keeps its last
+      word. That covers a silence, a disable, a modifier, a delayed color change
+      and a DOWNTIME window hiding an alert color -- a green report shows
+      through DOWNTIME, and the field answers <b>none</b>: wherever they differ,
+      <b>color</b> is xymond's and <b>prevgapcolor</b> is the test's own.</dd>
   <dt id="flags"><a class="permalink" href="#flags"><b>flags</b></a></dt>
   <dd>For network tests, the flags indicating details about the test (used by
       xymongen).</dd>

--- a/tests/server/xymond-checkpoint-roundtrip.sh
+++ b/tests/server/xymond-checkpoint-roundtrip.sh
@@ -208,14 +208,12 @@ esac
 
 stop_xymond
 
-# ---- a gap is carried while it can still bridge, and not once it cannot -----
+# ---- a gap is carried for as long as the daemon holds one -------------------
 #
-# The gap fields exist to let a resumed test carry its hold-time across the
-# silence, which holdtime_bridges() refuses past GAPBRIDGE_VALIDITIES report
-# validities. Past that the gap decides nothing, so it must not be written --
-# otherwise a test whose color xymond permanently overrides (an RRDDS modifier,
-# refreshed by xymond_client every client cycle) carries a record in every
-# checkpoint from the first override until the modifier stops.
+# A gap past its bridge window used to be left out: it could no longer decide
+# anything. prevgapcolor publishes it now, so it decides something again, and a
+# consumer must get the same answer before and after an unrelated restart. The
+# window still governs the hold-time, at the close.
 #
 # Both halves restore and save without sending a status, so the gap is written
 # back exactly as the daemon holds it. The restored validity is defaultvalidity,
@@ -244,10 +242,14 @@ stop_xymond
 [ "$(saved_gapcolor)" = "red" ] \
 	|| fail "a gap 60s old was not carried through a restart (got $(saved_gapcolor)); the hold-time it would bridge is lost"
 
+# The output file goes first: the case above leaves the same color in it, so a
+# run that wrote nothing would be read as this one's answer.
 write_gap_checkpoint "$(( $(date +%s) - 86400 ))"
+rm -f "$work/chk"
 start_xymond --restart="$work/chk.gap"
 stop_xymond
-[ "$(saved_gapcolor)" = "none" ] \
-	|| fail "a day-old gap was written back as $(saved_gapcolor); nothing can bridge it any more, so it is state that never goes away"
+[ -s "$work/chk" ] || fail "xymond wrote no checkpoint on the way out, so the day-old gap is untested"
+[ "$(saved_gapcolor)" = "red" ] \
+	|| fail "a day-old gap was dropped from the checkpoint (got $(saved_gapcolor)); the override has not ended, so prevgapcolor must not answer differently after a restart than before it"
 
-pass "checkpoint round-trip keeps the released status record, carries the flap state, re-derives flapping, and drops a gap past its bridge window"
+pass "checkpoint round-trip keeps the released status record, carries the flap state, re-derives flapping, and carries a gap for as long as it holds one"

--- a/tests/server/xymond-gap-validity-harness.c
+++ b/tests/server/xymond-gap-validity-harness.c
@@ -41,13 +41,13 @@ static int silence_and_return(int opencolor, int openvalidity, time_t gaplen,
 
 	/* xymond invents a colour because nothing arrived: the gap opens, and it
 	 * is the validity in force at that moment that sizes the window. */
-	update_gapstate(&log, COL_PURPLE, 1, t0, heldsince, openvalidity);
+	update_gapstate(&log, COL_PURPLE, 1, 1, t0, heldsince, openvalidity);
 
 	/* The test comes back with its own colour, and its own promise. */
 	log.validity = backvalidity;
 	log.oldcolor = COL_PURPLE;
 	log.lastchange = t0 + gaplen;
-	update_gapstate(&log, backcolor, 0, t0 + gaplen, t0 + gaplen, backvalidity);
+	update_gapstate(&log, backcolor, 0, 0, t0 + gaplen, t0 + gaplen, backvalidity);
 
 	return (log.lastchange == heldsince);
 }

--- a/tests/server/xymond-gap-validity.sh
+++ b/tests/server/xymond-gap-validity.sh
@@ -59,7 +59,7 @@ harness_ldflags=$(xymon_ldflags "$ROOT")
 	printf '#define GAPBRIDGE_VALIDITIES %s\n' "$limit"
 	printf 'typedef struct xymond_log_t {\n'
 	printf '\tint oldcolor;\n\tint validity;\n\ttime_t lastchange;\n'
-	printf '\tint pregapcolor;\n\tint pregapvalidity;\n'
+	printf '\tint pregapcolor;\n\tint gapreportedcolor;\n\tint lastreportedcolor;\n\tint pregapvalidity;\n'
 	printf '\ttime_t pregaplastchange;\n\ttime_t gapstart;\n'
 	printf '} xymond_log_t;\n'
 	printf '%s\n' "$window"

--- a/tests/server/xymond-holdtime-gap.sh
+++ b/tests/server/xymond-holdtime-gap.sh
@@ -52,6 +52,12 @@ stop_xymond() {
 		sleep 0.1
 		i=$((i+1))
 	done
+	# Reap before returning: several cases read the checkpoint the exit
+	# wrote, and a poll that gives up can hand them a file mid-write. A
+	# shutdown still running after the window is ended hard -- its
+	# checkpoint is lost, and the read fails loudly rather than flaking.
+	kill -9 "$XYMOND_PID" 2>/dev/null || true
+	wait "$XYMOND_PID" 2>/dev/null || true
 	XYMOND_PID=""
 }
 register_cleanup stop_xymond
@@ -120,6 +126,13 @@ lastchange() {
 		| awk -F'|' '$1 == "conn" { print $2 }'
 }
 
+# board_field FIELD -- one field of the conn status, through the selector a
+# consumer uses.
+board_field() {
+	"$XYMONCLIENT" "127.0.0.1:$PORT" "xymondboard fields=testname,$1" 2>/dev/null \
+		| awk -F'|' '$1 == "conn" { print $2 }'
+}
+
 xymondboard_color() {
 	"$XYMONCLIENT" "127.0.0.1:$PORT" "xymondboard fields=testname,color" 2>/dev/null \
 		| awk -F'|' '$1 == "conn" { print $2 }'
@@ -154,8 +167,22 @@ assert_fresh() {
 HELDSINCE=$(( $(date +%s) - 86400 ))
 write_checkpoint clear "$(( $(date +%s) - 60 ))" red "$(( $(date +%s) - 60 ))"
 start_xymond --restart="$work/chk"
+
+# While the gap is open, the board says what the test was before it went
+# quiet. Without it, a consumer reading a snapshot sees the color xymond
+# invented and cannot tell a real transition from a blind period: this one
+# reads clear, and clear is not something the test ever reported.
+gapcolor=$(board_field prevgapcolor)
+[ "$gapcolor" = "red" ] \
+	|| fail "an open gap must publish the color held before it, got prevgapcolor=$gapcolor"
+
 status red
 assert_held "$HELDSINCE" "same-color resume"
+
+# The gap is closed by that report, so there is no pre-gap color to publish.
+gapcolor=$(board_field prevgapcolor)
+[ "$gapcolor" = "none" ] \
+	|| fail "a closed gap must publish no pre-gap color, got prevgapcolor=$gapcolor"
 stop_xymond
 
 # ---- 2. resume with a different color: a fresh hold-time -------------------
@@ -222,6 +249,13 @@ printf '@@XYMONDCHK-V1||testhost.example.com|conn|127.0.0.1|red||red|%s|%s|%s|0|
 start_xymond --restart="$work/chk"
 status red
 [ "$(xymondboard_color)" = "blue" ] || fail "DOWNTIME did not force the status blue; the tag was not applied"
+
+# The board says which of the two colors is the test's own. This is why
+# prevgapcolor is not documented as "went silent": here the test is reporting,
+# and xymond is recording something else anyway.
+gapcolor=$(board_field prevgapcolor)
+[ "$gapcolor" = "red" ] \
+	|| fail "under DOWNTIME the board must still publish the reporter's own color, got prevgapcolor=$gapcolor"
 stop_xymond
 
 flapstate=$(grep '^@@XYMONDCHK-V1|\.flapstate\.|' "$work/chk.out" || true)
@@ -233,6 +267,55 @@ gapheld=$(printf '%s' "$flapstate" | awk -F'|' '{ print $9 }')
 	|| fail "gap opened by DOWNTIME recorded the color as $gapcolor, expected the pre-window red"
 [ "$gapheld" = "$HELDSINCE" ] \
 	|| fail "gap opened by DOWNTIME recorded hold-time $gapheld, expected $HELDSINCE"
+
+# ---- 5b. prevgapcolor is the reporter's word, not the pre-override color ----
+#
+# The discriminating case (@SoundGoof): the recorded color and the reported one
+# differ. A green host enters DOWNTIME and the test starts reporting red --
+# xymond records blue, and prevgapcolor must answer red, the color the test
+# itself is saying right now, not the green that stood before the window.
+# Publishing the bridge state answered green here; the two are separate
+# questions and separate fields. A later report refreshes the answer, and the
+# checkpoint carries it across a restart.
+
+printf '@@XYMONDCHK-V1||testhost.example.com|conn|127.0.0.1|green||green|%s|%s|%s|0|0|0|0|status testhost,example,com.conn green fine|||0|0\n' \
+	"$(( $(date +%s) - 3600 ))" "$(( $(date +%s) - 3600 ))" "$(( $(date +%s) + 86400 ))" > "$work/chk"
+rm -f "$work/chk.out"
+start_xymond --restart="$work/chk"
+status red
+[ "$(xymondboard_color)" = "blue" ] || fail "DOWNTIME did not force the status blue; the tag was not applied"
+gapcolor=$(board_field prevgapcolor)
+[ "$gapcolor" = "red" ] \
+	|| fail "the test reports red under the window and xymond heard it: got prevgapcolor=$gapcolor"
+status yellow
+gapcolor=$(board_field prevgapcolor)
+[ "$gapcolor" = "yellow" ] \
+	|| fail "a later report must refresh the reporter's word, got prevgapcolor=$gapcolor"
+stop_xymond	# xymond writes $work/chk.out on the way out
+
+gapfield=$(grep '^@@XYMONDCHK-V1|\.flapstate\.|' "$work/chk.out" | awk -F'|' '{ print $10 }')
+case "$gapfield" in
+	*:yellow) ;;
+	*) fail "the checkpoint must carry the reporter's word on the gap record, got '$gapfield'" ;;
+esac
+
+start_xymond --restart="$work/chk.out"
+gapcolor=$(board_field prevgapcolor)
+[ "$gapcolor" = "yellow" ] \
+	|| fail "the reporter's word came back as '$gapcolor' after a restart, on a window that had not ended"
+stop_xymond
+
+# A hostile line: the word's suffix present on a record whose gap field says
+# none. Restored on its own it would publish, and stick -- no gap, no close to
+# clear it. It must restore to none, like the gap it does not have.
+printf '@@XYMONDCHK-V1||testhost.example.com|conn|127.0.0.1|green||green|%s|%s|%s|0|0|0|0|status testhost,example,com.conn green fine|||0|0\n' \
+	"$(( $(date +%s) - 3600 ))" "$(( $(date +%s) - 3600 ))" "$(( $(date +%s) + 86400 ))" > "$work/chk"
+printf '@@XYMONDCHK-V1|.flapstate.|testhost.example.com|conn|0|none|none|none|0|0:0:red|0,0,0,0,0\n' >> "$work/chk"
+start_xymond --restart="$work/chk"
+gapcolor=$(board_field prevgapcolor)
+[ "$gapcolor" = "none" ] \
+	|| fail "a checkpoint word without a gap must not publish, got prevgapcolor=$gapcolor"
+stop_xymond
 
 # ---- 6. the same, on a running daemon --------------------------------------
 #
@@ -280,4 +363,37 @@ status red
 assert_held "$HELDSINCE" "reports arriving during a disable must not end the gap"
 stop_xymond
 
-pass "hold-time survives a same-color resume, and only that: a different color, an ended gap on a restored and on a running daemon, a disable with and without reports inside it, and a DOWNTIME window are each handled"
+# ---- 7. a gap outlives its bridge window, and the restart ------------------
+#
+# A disable or a DOWNTIME routinely outlives the two hours a hold-time can be
+# carried across. The checkpoint used to drop the gap at that point, so
+# prevgapcolor answered "none" after an unrelated restart on an override still
+# in force. The window governs the hold-time, and the second half is that check.
+
+HELDSINCE=$(( $(date +%s) - 172800 ))
+write_checkpoint clear "$(( $(date +%s) - 86400 ))" red "$(( $(date +%s) - 86400 ))"
+rm -f "$work/chk.out"
+start_xymond --restart="$work/chk"
+
+gapcolor=$(board_field prevgapcolor)
+[ "$gapcolor" = "red" ] \
+	|| fail "a day-old gap must still publish the color held before it, got prevgapcolor=$gapcolor"
+
+stop_xymond	# xymond writes $work/chk.out on the way out
+
+grep -q '|\.flapstate\.|testhost\.example\.com|conn|0|none|none|red|' "$work/chk.out" \
+	|| { sed -n '1,4p' "$work/chk.out" >&2
+	     fail "the checkpoint dropped a gap past its bridge window, so prevgapcolor cannot survive a restart"; }
+
+start_xymond --restart="$work/chk.out"
+gapcolor=$(board_field prevgapcolor)
+[ "$gapcolor" = "red" ] \
+	|| fail "prevgapcolor came back as '$gapcolor' after a restart, on an override that had not ended"
+
+# The window still decides the hold-time, and decides it the same way: this gap
+# is a day old, so the red that closes it starts now.
+status red
+assert_fresh "a gap past its window must not carry the hold-time, restored or not"
+stop_xymond
+
+pass "hold-time survives a same-color resume, and only that: a different color, an ended gap on a restored and on a running daemon, a disable with and without reports inside it, a DOWNTIME window, a gap that outlives its bridge window, and prevgapcolor answering the reporter's own word under an override, across a restart, are each handled"

--- a/tests/server/xymondboard-color-history.sh
+++ b/tests/server/xymondboard-color-history.sh
@@ -158,4 +158,16 @@ assert_colors yellow red red "a restored status keeps the color it held before t
 [ "$(board previouscolor)" = "$(board prevchangecolor)" ] \
 	|| fail "the previouscolor alias must resolve to the same field as prevchangecolor"
 
-pass "xymondboard exposes prevreportcolor (alias oldcolor) and prevchangecolor, and prevchangecolor survives a restart"
+# The generated rows -- info, trends, clientlog -- are fake log records built
+# per request from a memset() struct, where zero is COL_GREEN. A color-history
+# field left at it reads as "was green before", which for these rows says a
+# change or a gap happened to something that has no history at all.
+for generated in info trends; do
+	row=$("$XYMONCLIENT" "127.0.0.1:$PORT" "xymondboard fields=testname,prevchangecolor,prevgapcolor" 2>/dev/null \
+		| awk -F'|' -v t="$generated" '$1 == t { print $2 "/" $3 }')
+	[ -n "$row" ] || fail "no $generated row on the board, so this case proves nothing"
+	[ "$row" = "none/none" ] \
+		|| fail "the generated $generated row reports prevchangecolor/prevgapcolor=$row; it has no history to report"
+done
+
+pass "xymondboard exposes prevreportcolor (alias oldcolor) and prevchangecolor, prevchangecolor survives a restart, and the generated rows claim no history"

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -134,6 +134,8 @@ typedef struct xymond_log_t {
 	time_t gapstart;	/* When that gap began; bounds how far a resume may bridge */
 	int prevchangecolor;	/* The color held before the most recent change, or NO_COLOR before the first one */
 	int pregapcolor;	/* The color recorded before the gap, or NO_COLOR when not in one */
+	int gapreportedcolor;	/* The reporter's own color while a gap is open, or NO_COLOR */
+	int lastreportedcolor;	/* The last real report's color, before any DOWNTIME rewrite */
 	int pregapvalidity;	/* The report validity in force when the gap began, in minutes */
 	int validity;		/* Minutes this test's reports stay valid; sizes the bridge bound */
 	time_t logtime;		/* time when last update was received */
@@ -311,7 +313,7 @@ xymond_statistics_t xymond_stats[] = {
 };
 
 enum boardfield_t { F_NONE, F_IP, F_HOSTNAME, F_TESTNAME, F_MATCHEDTAG, F_COLOR,
-		    F_PREVREPORTCOLOR, F_PREVCHANGECOLOR, F_FLAGS, 
+		    F_PREVREPORTCOLOR, F_PREVCHANGECOLOR, F_PREVGAPCOLOR, F_FLAGS,
 		    F_LASTCHANGE, F_LOGTIME, F_VALIDTIME, F_ACKTIME, F_DISABLETIME,
 		    F_SENDER, F_COOKIE, F_LINE1,
 		    F_ACKMSG, F_DISMSG, F_MSG, F_CLIENT, F_CLIENTTSTAMP,
@@ -341,6 +343,7 @@ boardfieldnames_t boardfieldnames[] = {
 	{ "oldcolor", F_PREVREPORTCOLOR },
 	{ "prevchangecolor", F_PREVCHANGECOLOR },
 	{ "previouscolor", F_PREVCHANGECOLOR },
+	{ "prevgapcolor", F_PREVGAPCOLOR },
 	{ "flags", F_FLAGS },
 	{ "lastchange", F_LASTCHANGE },
 	{ "logtime", F_LOGTIME },
@@ -1356,6 +1359,8 @@ void get_hts(char *msg, char *sender, char *origin,
 			 */
 			if (flapcount > 0) lwalk->flapchange[0] = getcurrenttime(NULL);
 			lwalk->pregapcolor = NO_COLOR;
+			lwalk->gapreportedcolor = NO_COLOR;
+			lwalk->lastreportedcolor = NO_COLOR;
 			lwalk->pregapvalidity = defaultvalidity;
 			lwalk->validity = defaultvalidity;
 			lwalk->color = lwalk->oldcolor = lwalk->prevchangecolor = NO_COLOR;
@@ -1370,6 +1375,10 @@ void get_hts(char *msg, char *sender, char *origin,
 
 done:
 	if (colstr) {
+		/* The raw color, kept before the DOWNTIME rewrite below: what
+		 * handle_status() receives is already blue, and prevgapcolor
+		 * publishes the reporter's own word. */
+		if (lwalk) lwalk->lastreportedcolor = *color;
 		if ((*color == COL_RED) || (*color == COL_YELLOW) || (*color == COL_PURPLE)) {
 			char *cause;
 
@@ -1584,6 +1593,7 @@ static int holdtime_bridges(int newcolor, int pregapcolor, time_t gaplen, int va
  * cannot do.
  */
 static void update_gapstate(xymond_log_t *log, int newcolor, int xymondchose,
+			    int synthetic,
 			    time_t now, time_t prevlastchange, int prevvalidity)
 {
 	if (xymondchose) {
@@ -1596,10 +1606,23 @@ static void update_gapstate(xymond_log_t *log, int newcolor, int xymondchose,
 			/* The range test keeps COL_CLIENT (99), which parse_color()
 			 * accepts, out of colnames[] at checkpoint time. */
 			log->pregapcolor = log->oldcolor;
+			/* Before a gap, recorded == reported: until a real report
+			 * says otherwise, the reporter's last own color is this. */
+			log->gapreportedcolor = log->oldcolor;
 			log->pregaplastchange = prevlastchange;
 			log->pregapvalidity = prevvalidity;
 			log->gapstart = now;
 		}
+		/*
+		 * Every real report under the substitution refreshes the
+		 * reporter's own color: lastreportedcolor, kept by get_hts()
+		 * before the DOWNTIME rewrite (reportedcolor is already blue
+		 * here). A synthetic status is xymond's own voice and moves
+		 * nothing; a silent test keeps its last real word.
+		 */
+		if ((log->pregapcolor != NO_COLOR) && !synthetic &&
+		    (log->lastreportedcolor >= 0) && (log->lastreportedcolor < COL_COUNT))
+			log->gapreportedcolor = log->lastreportedcolor;
 	}
 	else if (log->pregapcolor != NO_COLOR) {
 		/*
@@ -1620,6 +1643,7 @@ static void update_gapstate(xymond_log_t *log, int newcolor, int xymondchose,
 		if (holdtime_bridges(newcolor, log->pregapcolor, (now - log->gapstart), log->pregapvalidity))
 			log->lastchange = log->pregaplastchange;
 		log->pregapcolor = NO_COLOR;
+		log->gapreportedcolor = NO_COLOR;
 	}
 }
 
@@ -2069,6 +2093,7 @@ void handle_status(unsigned char *msg, char *sender, char *hostname, char *testn
 	if (!issummary)
 		update_gapstate(log, newcolor,
 				(synthetic || log->downtimeactive || (newcolor != reportedcolor)),
+				synthetic,
 				now, prevlastchange, prevvalidity);
 
 	if (!issummary) {
@@ -3617,6 +3642,7 @@ strbuffer_t *generate_outbuf(strbuffer_t **prebuf, boardfield_t *boardfields, xy
 		  case F_COLOR: addtobuffer(buf, colnames[lwalk->color]); break;
 		  case F_PREVREPORTCOLOR: addtobuffer(buf, colnames[lwalk->oldcolor]); break;
 		  case F_PREVCHANGECOLOR: addtobuffer(buf, colnames[lwalk->prevchangecolor]); break;
+		  case F_PREVGAPCOLOR: addtobuffer(buf, colnames[lwalk->gapreportedcolor]); break;
 		  case F_FLAGS: if (lwalk->testflags) addtobuffer(buf, lwalk->testflags); break;
 		  case F_LASTCHANGE: snprintf(l, sizeof(l), "%d", (int)lwalk->lastchange); addtobuffer(buf, l); break;
 		  case F_LOGTIME: snprintf(l, sizeof(l), "%d", (int)lwalk->logtime); addtobuffer(buf, l); break;
@@ -4336,6 +4362,13 @@ void do_message(conn_t *msg, char *origin)
 			trendslogrec.test = &trendstest;
 
 			clientlogrec.color = infologrec.color = trendslogrec.color = COL_GREEN;
+			/* The rest of these records is zeroed, and zero is COL_GREEN, so a
+			 * color field left at it does not read as "no color" -- it reads as
+			 * green, which for a color-history field means something happened.
+			 * These rows have no history: they are generated per request. */
+			clientlogrec.prevchangecolor = infologrec.prevchangecolor = trendslogrec.prevchangecolor = NO_COLOR;
+			clientlogrec.pregapcolor = infologrec.pregapcolor = trendslogrec.pregapcolor = NO_COLOR;
+			clientlogrec.gapreportedcolor = infologrec.gapreportedcolor = trendslogrec.gapreportedcolor = NO_COLOR;
 			clientlogrec.message = infologrec.message = trendslogrec.message = "";
 			faketestinit = 1;
 		}
@@ -5143,16 +5176,16 @@ void save_checkpoint(void)
 			 * seeded with its creation time, on both paths -- and testing it
 			 * would put a record after every status. Real history means two.
 			 *
-			 * A gap past its bridge window is not state either: no color can
-			 * carry a hold-time across it any more, so it is over whatever
-			 * happens next. Saying so here is what keeps it from being saved
-			 * for as long as the override lasts -- xymond_client refreshes an
-			 * RRDDS modifier every client cycle, and while one is in force the
-			 * color being recorded is never the reporter's, so nothing ever
-			 * closes the gap.
+			 * A gap lasts as long as the substitution that opened it:
+			 * update_gapstate() opens it and closes it, with the bridge
+			 * window nowhere in that lifetime. Saved only while the window held, prevgapcolor answered
+			 * "none" after an unrelated restart on an override still in force,
+			 * and a disable or DOWNTIME outlives two hours routinely. The
+			 * window still decides the hold-time, where it always did: in
+			 * holdtime_bridges(), at the close. Costs a record per test under a
+			 * lasting override.
 			 */
-			gapopen = ((lwalk->pregapcolor != NO_COLOR) &&
-				   gap_within_window(now - lwalk->gapstart, lwalk->pregapvalidity));
+			gapopen = (lwalk->pregapcolor != NO_COLOR);
 
 			if ((iores >= 0) && (lwalk->flapping || gapopen ||
 					     ((flapcount > 1) && lwalk->flapchange[1]))) {
@@ -5170,15 +5203,19 @@ void save_checkpoint(void)
 				 * Without it a restored gap came back with defaultvalidity,
 				 * and the next checkpoint dropped a gap whose real window was
 				 * longer - the hold-time was lost on the second restart.
+				 * The reporter's own color rides the same suffix chain, for
+				 * the same reason; a file without it restores the pre-gap
+				 * color, the reporter's last word as of the open.
 				 */
-				iores = fprintf(fd, "@@XYMONDCHK-V1|.flapstate.|%s|%s|%d|%s|%s|%s|%ld|%ld:%d|",
+				iores = fprintf(fd, "@@XYMONDCHK-V1|.flapstate.|%s|%s|%d|%s|%s|%s|%ld|%ld:%d:%s|",
 						hwalk->hostname, lwalk->test->name,
 						lwalk->flapping,
 						colnames[lwalk->oldflapcolor], colnames[lwalk->currflapcolor],
 						colnames[gapopen ? lwalk->pregapcolor : NO_COLOR],
 						(long)(gapopen ? lwalk->pregaplastchange : 0),
 						(long)(gapopen ? lwalk->gapstart : 0),
-						(gapopen ? lwalk->pregapvalidity : 0));
+						(gapopen ? lwalk->pregapvalidity : 0),
+						colnames[gapopen ? lwalk->gapreportedcolor : NO_COLOR]);
 				for (fi = 0; ((fi < flapcount) && (iores >= 0)); fi++)
 					iores = fprintf(fd, "%s%ld", ((fi == 0) ? "" : ","), (long)lwalk->flapchange[fi]);
 				if (iores >= 0) iores = fprintf(fd, "\n");
@@ -5360,6 +5397,7 @@ void load_checkpoint(char *fn)
 			xymond_log_t *log = NULL;
 			int flapping = 0, oldflapcolor = NO_COLOR, currflapcolor = NO_COLOR;
 			int pregapcolor = NO_COLOR, pregapvalidity = defaultvalidity;
+			int gapreportedcolor = NO_COLOR;
 			time_t pregaplastchange = 0, gapstart = 0;
 			char *flapchangestr = NULL;
 
@@ -5389,7 +5427,11 @@ void load_checkpoint(char *fn)
 					 * defaultvalidity, exactly as it did then. */
 					char *vp;
 					gapstart = (time_t)strtol(item, &vp, 10);
-					if (vp && (*vp == ':')) pregapvalidity = atoi(vp+1);
+					if (vp && (*vp == ':')) {
+						pregapvalidity = atoi(vp+1);
+						vp = strchr(vp+1, ':');
+						if (vp) gapreportedcolor = restore_color(vp+1);
+					}
 					}
 					break;
 				  case 10: flapchangestr = item; break;
@@ -5411,6 +5453,13 @@ void load_checkpoint(char *fn)
 				log->oldflapcolor = oldflapcolor;
 				log->currflapcolor = currflapcolor;
 				log->pregapcolor = pregapcolor;
+				/* Only with a gap to belong to -- a suffix on a record whose
+				 * gap field says none would otherwise publish, and stick,
+				 * with no close to clear it. Absent from files written
+				 * before the field existed: the reporter's last word as of
+				 * the open was the pre-gap color. */
+				log->gapreportedcolor = (pregapcolor == NO_COLOR) ? NO_COLOR :
+							(gapreportedcolor != NO_COLOR) ? gapreportedcolor : pregapcolor;
 				log->pregaplastchange = pregaplastchange;
 				log->pregapvalidity = pregapvalidity;
 				log->gapstart = gapstart;
@@ -5590,6 +5639,8 @@ void load_checkpoint(char *fn)
 		 * COL_GREEN, so a file written before the field existed would restore
 		 * every test as "was green before". */
 		ltail->pregapcolor = NO_COLOR;
+		ltail->gapreportedcolor = NO_COLOR;
+		ltail->lastreportedcolor = NO_COLOR;
 		ltail->prevchangecolor = NO_COLOR;
 		/* Not checkpointed: the test's next report sets its real validity,
 		 * which arrives within one validity period by definition. */


### PR DESCRIPTION
**1 commit.** `xymondboard fields=…,prevgapcolor` — the color a test itself reports, while xymond
is recording one of its own.

| | `color` | `prevgapcolor` |
|---|---|---|
| normal | what the test reported | `none` |
| disable, DOWNTIME, modifier, delayed change, silence | xymond's choice | the test's own word |

It follows the reports arriving under the override — a green host whose disk fills during DOWNTIME
answers `blue,red`, not the green that stood before the window — and a test gone silent keeps its
last real word. Two fields, two jobs: `pregapcolor` keeps hold-time bridging (the color to resume
to), `gapreportedcolor` is published. One subtlety the review surfaced ran deeper than the gap
code: the DOWNTIME rewrite happens in `get_hts()`, so `handle_status()` never sees the reported
red — the raw color is now kept (`lastreportedcolor`) just before that rewrite.

The checkpoint carries the word on the gap record, riding the existing suffix chain
(`gapstart:validity:color`) so older files still parse; absent, it restores as the pre-gap color,
and a suffix on a record whose gap field says `none` restores as `none` — no gap, no close to ever
clear it. DOWNTIME substitutes only alert colors: a green report shows through and answers `none`
(manpage says so now).
A gap is saved for as long as the substitution lasts, not only while its bridge window holds, so a
restart during a longer override keeps answering. The generated `info`/`trends`/`clientlog` rows
answer `none`, not the `green` their zeroed records spelled (same fault as `prevchangecolor`, #355).

| case | assertion |
|---|---|
| green host, red reports under DOWNTIME | `prevgapcolor=red` — fails on the previous head with `green` |
| hostile checkpoint: word suffix, no gap | restores `none`, not a sticking `red` |
| a later report under the window | refreshes the answer |
| checkpoint + restart mid-override | the word survives; a day-old gap still refuses the hold-time |
| generated `info`/`trends` rows | `none/none`, not `green/green` |

Suite: 86 passed, 0 skipped, 0 failed on a built tree. Manpage reworded at both field lists, HTML
regenerated with `build/makehtml.sh`. Base is current `main`.
