### PR TITLE
tests: stop excluding hosts that are able to run the test

### DIFF
--- a/tests/buildsystem/configure-no-rrd.sh
+++ b/tests/buildsystem/configure-no-rrd.sh
@@ -63,6 +63,20 @@ cd "$SRC"
 # the RRD probe regardless of host fping state.
 export USEXYMONPING=y
 
+# configure.server bails when its make-utility is not GNU make, which on the
+# BSDs it never is: make(1) is BSD make there and GNU make is gmake. The run
+# then aborts before the RRD probe and this test skips for a dependency the
+# host has. Hand it the MAKE= configure.server prints when it bails, detected
+# the way configure.server detects it so the two cannot drift.
+make_is_gnu() {
+	[ "$("$1" -version 2>&1 | head -n 1 | awk '{print $1 " " $2}')" = "GNU Make" ]
+}
+if [ -z "${MAKE:-}" ] && ! make_is_gnu make; then
+	if command -v gmake >/dev/null 2>&1 && make_is_gnu gmake; then
+		export MAKE=gmake
+	fi
+fi
+
 LOG="$TMP/configure.log"
 set +e
 ./configure --server </dev/null >"$LOG" 2>&1

--- a/tests/web/showgraph-single-service.sh
+++ b/tests/web/showgraph-single-service.sh
@@ -28,6 +28,11 @@ require_gnu_make
 # RRD and SSL build flags as configure detected them (SSLLIBS is empty
 # on a tree built without SSL - don't force -lssl on such a link)
 rrddef=$(sed -n 's/^RRDDEF *= *//p' "$ROOT/Makefile")
+# Where <rrd.h> lives, as configure found it: nothing on Linux, but
+# -I/usr/local/include or -I/opt/homebrew/include on the BSDs and macOS. The
+# product Makefiles pass it for every RRD-using object; without it this test
+# fails to compile on a host that builds Xymon perfectly well.
+rrdinc=$(sed -n 's/^RRDINCDIR *= *//p' "$ROOT/Makefile")
 rrdlibs=$(sed -n 's/^RRDLIBS *= *//p' "$ROOT/Makefile")
 [ -n "$rrdlibs" ] || rrdlibs="-lrrd"
 
@@ -45,7 +50,7 @@ trap 'rm -rf "$work"' EXIT HUP INT TERM
 
 harness_cflags=$(xymon_cflags "$ROOT")
 harness_ldflags=$(xymon_ldflags "$ROOT")
-"$CC" $harness_cflags $rrddef -o "$work/showgraph" \
+"$CC" $harness_cflags $rrddef $rrdinc -o "$work/showgraph" \
 	"$ROOT/web/showgraph.c" "$ROOT/lib/libxymoncomm.a" \
 	$pcre_libs $rrdlibs $harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "showgraph does not compile"; }

--- a/tests/web/wmlgen-path-bounds-harness.c
+++ b/tests/web/wmlgen-path-bounds-harness.c
@@ -97,6 +97,13 @@ int main(int argc, char **argv)
 	entry_t *e;
 	int rc, fail = 0;
 
+	/* The test builds the deep directory from this. Reporting it from here
+	   rather than from getconf(1) keeps it the same constant the function
+	   under test is compiled against -- the buffers it fills are char[PATH_MAX]
+	   -- and getconf reports a per-filesystem pathconf(), which need not
+	   agree with the header. */
+	if ((argc == 2) && (strcmp(argv[1], "--pathmax") == 0)) { printf("%d\n", PATH_MAX); return 0; }
+
 	if (argc < 3) { fprintf(stderr, "usage: %s <wmldir> <deep-wmldir>\n", argv[0]); return 2; }
 	wmldir = argv[1];
 

--- a/tests/web/wmlgen-path-bounds.sh
+++ b/tests/web/wmlgen-path-bounds.sh
@@ -52,8 +52,25 @@ harness_cflags=$(xymon_cflags "$ROOT")
 # harness because it has to exist: a single 4000-character component would
 # make the harness's boundary case pass through ENAMETOOLONG at fopen(),
 # whatever the length guard under test does -- measured, it did.
+#
+# From the host's own PATH_MAX -- 4096 on Linux, 1024 on the BSDs and macOS --
+# not a literal cut for the widest, which cannot be created anywhere else. The
+# distance carries the boundary case: the harness fills what is left with the
+# host card's name, so 36 bytes short leaves that card exactly fitting and the
+# status card, one ".<column>" longer, exactly not.
+pathmax=$("$work/harness" --pathmax) || fail "the harness cannot report PATH_MAX"
+case $pathmax in ''|*[!0-9]*) fail "the harness reported PATH_MAX as '$pathmax'" ;; esac
+
 deep="$work/wml"
-while [ ${#deep} -lt 3900 ]; do deep="$deep/$(printf 'd%.0s' $(seq 1 200))"; done
+target=$((pathmax - 36))
+[ ${#deep} -lt "$target" ] || skip "the temporary directory is already within 36 bytes of PATH_MAX ($pathmax)"
+while [ ${#deep} -lt "$target" ]; do
+	# The last component is cut to land on the target exactly, so the margin
+	# above is the measured one and not whatever a fixed step overshoots to.
+	room=$((target - ${#deep} - 1))
+	if [ "$room" -gt 200 ]; then room=200; fi
+	deep="$deep/$(printf 'd%.0s' $(seq 1 $room))"
+done
 mkdir -p "$deep" 2>/dev/null || skip "cannot create a directory path near PATH_MAX here"
 
 out=$("$work/harness" "$work/wml" "$deep" 2>&1) \


### PR DESCRIPTION
**1 commit, tests only.** Three tests answered for the host instead of asking it, and each shaped its answer like Linux.

`wmlgen-path-bounds.sh` built its deep directory to a 3900-byte literal, cut for Linux's PATH_MAX. The BSDs and macOS stop at 1024, so the `mkdir` failed and the test skipped — on the platforms whose limit is tightest, for a guard measured against PATH_MAX itself (`wmlgen.c` fills `char[PATH_MAX]`). It takes the constant from the harness now, compiled against the same header as the function under test, rather than from `getconf`, whose per-filesystem `pathconf()` need not agree. 36 bytes short leaves the host card exactly fitting and the status card exactly not:

| PATH_MAX | directory | name | host card | status card |
|---|---|---|---|---|
| 4096 | 4060 | 30 | 4095 — fits | 4100 — refused |
| 1024 | 988 | 30 | 1023 — fits | 1028 — refused |

The Linux row is what the literal already produced, so nothing changes there.

`configure-no-rrd.sh` ran `./configure --server` with whatever `make(1)` is. On the BSDs that is BSD make, so `configure.server` aborted on its first check and never reached the RRD probe: skipped for a dependency the host has, GNU make being installed there as `gmake`. It hands over the `MAKE=` that `configure.server` prints when it bails.

`showgraph-single-service.sh` compiled `showgraph.c` without `RRDINCDIR` — empty on Linux, `-I/usr/local/include` or `-I/opt/homebrew/include` elsewhere, and passed by the product Makefiles for every RRD-using object. Without it the test cannot find `<rrd.h>` on a host that builds Xymon fine, and calls that "showgraph does not compile". Latent, and only because those hosts happen to search the directory their compiler was built with. Found by codex on the sibling test in #349.

| mutation | caught by |
|---|---|
| the `snprintf` guard removed from `wmlgen.c` | `a status-card path that does not fit was reported as written` |
| BSD make on PATH, gmake beside it | before: `SKIP: GNU make unavailable`; after: passes |
| `RRDINCDIR` pointed at a header that `#error`s | the flag reaches the compiler; before, it was dropped |

Un-skips 14 lanes for the first (macOS 14/15/26, FreeBSD 13.5/14.3/15.0, NetBSD 9.2–10.1, OpenBSD 7.6/7.7/7.8) and 11 for the second. The BSD behaviour is arithmetic and a simulated `make`, verified locally; the lanes confirm it.

Left as skips: `-fsanitize=address` is genuinely absent from NetBSD, OpenBSD and most Alpine lanes, and `column(1)` from Alpine — that one costs only redundancy, since `fs-filter-darwin.sh` still runs on macOS and the three BSDs.

Suite: 86 passed, 0 skipped, 0 failed on a built tree. Rebased on current `main`.
