### PR TITLE
rrdcached: bring devel's rrdcached group onto main, built and corrected (TBT 138/222/226/227, devel 01f79009/a1718cd7/0e7d1962)

### DIFF
--- a/lib/rrd_api_compat.h
+++ b/lib/rrd_api_compat.h
@@ -47,6 +47,11 @@ static int xymon_rrd_fetch(int argc, xymon_rrd_argv_item_t *argv,
 	return rrd_fetch(argc, xymon_rrd_api_argv(argv), start, end, step, dscount, dsnames, data);
 }
 
+static int xymon_rrd_flushcached(int argc, xymon_rrd_argv_item_t *argv)
+{
+	return rrd_flushcached(argc, xymon_rrd_api_argv(argv));
+}
+
 static int xymon_rrd_graph(int argc, xymon_rrd_argv_item_t *argv,
 				  char ***calcpr, int *xsize, int *ysize,
 				  void *prdata, double *ymin, double *ymax)

--- a/tests/buildsystem/rrd-api-compat.sh
+++ b/tests/buildsystem/rrd-api-compat.sh
@@ -42,6 +42,7 @@ int rrd_create(int, $argv);
 int rrd_fetch(int, $argv, time_t *, time_t *, unsigned long *,
               unsigned long *, char ***, rrd_value_t **);
 int rrd_graph(int, $argv, char ***, int *, int *, void *, double *, double *);
+int rrd_flushcached(int, $argv);
 #endif
 EOF
 }
@@ -65,6 +66,7 @@ int main(void)
 			      &dsnames, &data);
 	(void)xymon_rrd_graph(1, argv, &calcpr, &xsize, &ysize, 0,
 			      &ymin, &ymax);
+	(void)xymon_rrd_flushcached(1, argv);
 	return 0;
 }
 EOF

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -135,6 +135,48 @@ void errormsg(char *msg)
 	exit(1);
 }
 
+#if defined(RRDTOOL14)
+void rrd_cached_flush(char *hostname)
+{
+	/* Build a cache-flush request, and send it rrdtool or rrdcached */
+	DIR *dirHandle;
+	struct dirent * dirEntry;
+	char dirName[PATH_MAX];
+	char fileName[PATH_MAX];
+	char *flush_args[2];
+	int i, len;
+
+	flush_args[0] = "rrd_flushcached";
+	// flush_args[1] = "--daemon";
+	// flush_args[2] = getenv("RRDCACHED_ADDRESS"); // prerequisite
+	flush_args[1] = fileName;
+	
+	/* get this host's RRD directory */
+	snprintf(dirName, sizeof(dirName), "%s/%s", xgetenv("XYMONRRDS"), hostname);
+
+	/* now iterate all the rrd files in this directory */
+	dirHandle = opendir(dirName);
+	if (!dirHandle) {
+		if (errno != ENOENT) errprintf("showgraph: could not open %s: %s\n", dirName, strerror(errno));
+		return;
+	}
+
+	for (i = 1; (dirEntry = readdir(dirHandle)) && (i < 24); i++)
+	{
+		len = strlen(dirEntry->d_name);
+		if ((len < 4) || strcmp(dirEntry->d_name + len - 4, ".rrd") != 0) continue;
+
+		/* create final filename */
+		snprintf(fileName, sizeof(fileName), "%s/%s", hostname, dirEntry->d_name);
+		dbgprintf(" - found an RRD file to ask to be flushed: %s\n", fileName);
+
+		/* and flush */
+		rrd_flushcached(2, flush_args);
+	}
+	closedir(dirHandle);
+}
+#endif
+
 void request_cacheflush(char *hostname)
 {
 	/* Build a cache-flush request, and send it to all of the $XYMONTMP/rrdctl.* sockets */
@@ -206,6 +248,17 @@ void request_cacheflush(char *hostname)
 	}
 	closedir(dir);
 	xfree(req);
+
+	/* If using rrdcached, send that a flush request as well 
+	 * Note: It's possible you might be using two layers of caching here (xymond_rrd's
+	 * as well as the rrdtool caching daemon. Send ours first to give it a chance to
+	 * perhaps send it off to the daemon first.
+	 *
+	 * This variable can be controlled independently in ~/etc/cgioptions.cfg.
+	 */
+#if defined(RRDTOOL14)
+	if ((getenv("RRDCACHED_ADDRESS") != NULL) && (strlen(getenv("RRDCACHED_ADDRESS")) > 0)) rrd_cached_flush(hostname);
+#endif
 
 	/*
 	 * Sleep 0.3 secs to allow the cache flush to happen.

--- a/web/showgraph.c
+++ b/web/showgraph.c
@@ -135,22 +135,31 @@ void errormsg(char *msg)
 	exit(1);
 }
 
-#if defined(RRDTOOL14)
+/*
+ * Ask rrdcached to write this host's RRDs out before we read them.
+ *
+ * Every RRD is named, not just the first two dozen: a host past the cap
+ * would be graphed from whatever the daemon had last written, which is the
+ * stale-graph problem this function exists to prevent - and it would appear
+ * only on the hosts with the most tests.
+ *
+ * rrd_flushcached() parses an argv of its own, so reset getopt around it the
+ * way generate_graph() does before rrd_graph(); and clear the error it leaves
+ * when there is no daemon to talk to, which is not this CGI's to report.
+ */
 void rrd_cached_flush(char *hostname)
 {
-	/* Build a cache-flush request, and send it rrdtool or rrdcached */
 	DIR *dirHandle;
 	struct dirent * dirEntry;
 	char dirName[PATH_MAX];
 	char fileName[PATH_MAX];
-	char *flush_args[2];
-	int i, len;
+	xymon_rrd_argv_item_t flush_args[3];
+	int len;
 
-	flush_args[0] = "rrd_flushcached";
-	// flush_args[1] = "--daemon";
-	// flush_args[2] = getenv("RRDCACHED_ADDRESS"); // prerequisite
+	flush_args[0] = "rrdflushcached";
 	flush_args[1] = fileName;
-	
+	flush_args[2] = NULL;
+
 	/* get this host's RRD directory */
 	snprintf(dirName, sizeof(dirName), "%s/%s", xgetenv("XYMONRRDS"), hostname);
 
@@ -161,8 +170,7 @@ void rrd_cached_flush(char *hostname)
 		return;
 	}
 
-	for (i = 1; (dirEntry = readdir(dirHandle)) && (i < 24); i++)
-	{
+	while ((dirEntry = readdir(dirHandle)) != NULL) {
 		len = strlen(dirEntry->d_name);
 		if ((len < 4) || strcmp(dirEntry->d_name + len - 4, ".rrd") != 0) continue;
 
@@ -171,11 +179,12 @@ void rrd_cached_flush(char *hostname)
 		dbgprintf(" - found an RRD file to ask to be flushed: %s\n", fileName);
 
 		/* and flush */
-		rrd_flushcached(2, flush_args);
+		optind = opterr = 0; rrd_clear_error();
+		xymon_rrd_flushcached(2, flush_args);
+		rrd_clear_error();
 	}
 	closedir(dirHandle);
 }
-#endif
 
 void request_cacheflush(char *hostname)
 {
@@ -256,9 +265,7 @@ void request_cacheflush(char *hostname)
 	 *
 	 * This variable can be controlled independently in ~/etc/cgioptions.cfg.
 	 */
-#if defined(RRDTOOL14)
 	if ((getenv("RRDCACHED_ADDRESS") != NULL) && (strlen(getenv("RRDCACHED_ADDRESS")) > 0)) rrd_cached_flush(hostname);
-#endif
 
 	/*
 	 * Sleep 0.3 secs to allow the cache flush to happen.

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -40,6 +40,7 @@ static char rcsid[] = "$Id$";
 extern int seq;	/* from xymond_rrd.c */
 
 char *rrddir = NULL;
+int ext_rrd_cache = 0;		/* Has external rrdcached running */
 int use_rrd_cache = 1;         /* Use the cache by default */
 int no_rrd = 0;                /* Write to rrd by default */
 
@@ -233,7 +234,7 @@ static void setupinterval(int intvl)
 	rrdinterval = (intvl ? intvl : DEFAULT_RRD_INTERVAL);
 }
 
-static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
+static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata, int dosync)
 {
 	/* Flush any updates we've cached */
 	xymon_rrd_argv_item_t updparams[5+CACHESZ+1] = { "rrdupdate", filedir, "-t", NULL, NULL, NULL, };
@@ -265,9 +266,11 @@ static int flush_cached_updates(updcacheitem_t *cacheitem, char *newdata)
 	/*
 	 * RRDtool 1.2+ uses mmap'ed I/O, but the Linux kernel does not update timestamps when
 	 * doing file I/O on mmap'ed files. This breaks our check for stale/nostale RRD's.
-	 * So do an explicit timestamp update on the file here.
+	 * So do an explicit timestamp update on the file here if we're doing this on request
+	 * for a user and ultimately responsible for the file, instead of just basic periodic 
+	 * flushing or sending it over to a later cache like rrdcached.
 	 */
-	utimes(filedir, NULL);
+	if (dosync && !ext_rrd_cache) utimes(filedir, NULL);
 #endif
 
 	/* Clear the cached data */
@@ -526,7 +529,7 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	else callcounter = 0;
 
 	/* At this point, we will commit the update to disk */
-	result = flush_cached_updates(cacheitem, rrdvalues);
+	result = flush_cached_updates(cacheitem, rrdvalues, 0);
 	if (result != 0) {
 		char *msg = rrd_get_error();
 
@@ -650,7 +653,7 @@ void rrdcacheflushall(void)
 		cacheitem = (updcacheitem_t *) xtreeData(updcache, handle);
 		if (cacheitem->valcount > 0) {
 			sprintf(filedir, "%s%s", rrddir, cacheitem->key);
-			flush_cached_updates(cacheitem, NULL);
+			flush_cached_updates(cacheitem, NULL, 0);
 		}
 	}
 }
@@ -702,7 +705,7 @@ void rrdcacheflushhost(char *hostname)
 			if (cacheitem->valcount > 0) {
 				dbgprintf("Flushing cache '%s'\n", cacheitem->key);
 				sprintf(filedir, "%s%s", rrddir, cacheitem->key);
-				flush_cached_updates(cacheitem, NULL);
+				flush_cached_updates(cacheitem, NULL, 1);
 			}
 			/* Fall through */
 

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -609,7 +609,10 @@ static void updcache_host_op(char *hostname, int flushfirst, char *flushas)
 			else {
 				snprintf(filedir, sizeof(filedir), "%s%s", rrddir, cacheitem->key);
 			}
-			if (flush_cached_updates(cacheitem, NULL) != 0) {
+			/* dosync=0: this is the drop/rename path, not a request for
+			 * a reader, and the file is about to move out from under
+			 * any timestamp we would set on it. */
+			if (flush_cached_updates(cacheitem, NULL, 0) != 0) {
 				errprintf("Could not flush cached updates for %s before the rename: %s\n",
 					  cacheitem->key, rrd_get_error());
 			}

--- a/xymond/do_rrd.c
+++ b/xymond/do_rrd.c
@@ -43,6 +43,8 @@ char *rrddir = NULL;
 int ext_rrd_cache = 0;		/* Has external rrdcached running */
 int use_rrd_cache = 1;         /* Use the cache by default */
 int no_rrd = 0;                /* Write to rrd by default */
+int cacheflushsz = 1;		/* Cache multipler set to 1x by default */
+int releasecachedelay = -1;	/* Don't start auto-flushing the cache right away */
 
 static int  processorfd = 0;
 static FILE *processorstream = NULL;
@@ -62,7 +64,6 @@ static char *fnparams[4] = { NULL, };  /* Saved parameters passed to setupfn() *
 #define DEFAULT_RRD_INTERVAL 300
 static int  rrdinterval = DEFAULT_RRD_INTERVAL;
 
-#define CACHESZ 12             /* # of updates that can be cached - updates are usually 5 minutes apart */
 static int updcache_keyofs = -1;
 static void * updcache;
 typedef struct updcacheitem_t {
@@ -511,11 +512,14 @@ static int create_and_update_rrd(char *hostname, char *testname, char *classname
 	 * fill at the same speed); this would result in huge load-spikes every 
 	 * rrdinterval*CACHESZ seconds.
 	 *
-	 * So to smooth the load, we force the update through for every CACHESZ 
+	 * So to smooth the load, we force the update through for every CACHESZ*multiplier 
 	 * updates, regardless of how much is in the cache. This gives us a steady 
 	 * (although slightly higher) load.
+	 * This can be modified with the cachemultiplier option to xymond_rrd.
+	 * We wait 10m (roughly 2 PDPs) after startup to give any previous xymond_rrd's
+	 * a chance to flush their caches first (since rrdtool can't handle out-of-order data well).
 	 */
-	if (use_rrd_cache && (++callcounter < CACHESZ)) {
+	if (use_rrd_cache && ((++callcounter < cacheflushsz) || releasecachedelay) ) {
 		if (cacheitem && (cacheitem->valcount < CACHESZ)) {
 			cacheitem->updseq[cacheitem->valcount] = seq;
 			cacheitem->updtime[cacheitem->valcount] = updtime;
@@ -667,6 +671,11 @@ void rrdcacheflushhost(char *hostname)
 	time_t now = gettimer();
 
 	if (updcache_keyofs == -1) return;
+
+	if (releasecachedelay) {
+		dbgprintf("Flush of '%s' skipped, too soon after restart of xymond_rrd\n", hostname);
+		return;
+	}
 
 	/* If we get a full path for the key, skip the leading rrddir */
 	if (strncmp(hostname, rrddir, updcache_keyofs) == 0) hostname += updcache_keyofs;

--- a/xymond/do_rrd.h
+++ b/xymond/do_rrd.h
@@ -15,8 +15,12 @@
 
 #include "libxymon.h"
 
+#define CACHESZ 12             /* # of updates that can be cached - updates are usually 5 minutes apart */
+
 extern char *rrddir;
 extern char *trackmax;
+extern int cacheflushsz;
+extern int releasecachedelay;
 extern int use_rrd_cache;
 extern int ext_rrd_cache;
 extern int no_rrd;

--- a/xymond/do_rrd.h
+++ b/xymond/do_rrd.h
@@ -18,6 +18,7 @@
 extern char *rrddir;
 extern char *trackmax;
 extern int use_rrd_cache;
+extern int ext_rrd_cache;
 extern int no_rrd;
 extern void setup_exthandler(char *handlerpath, char *ids);
 extern void update_rrd(char *hostname, char *testname, char *restofmsg, time_t tstamp, char *sender, xymonrrd_t *ldef, char *classname, char *pagepaths);

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -194,6 +194,10 @@ int main(int argc, char *argv[])
 	struct sockaddr_un ctlsockaddr;
 	int ctlsocket;
 	int usebackfeedqueue = 0;
+	int force_backfeedqueue = 0;
+	int comboflushtime;
+	int checkctltime;
+	struct timespec *timeout = NULL;
 
 	/* Handle program options. */
 	for (argi = 1; (argi < argc); argi++) {
@@ -215,6 +219,17 @@ int main(int argc, char *argv[])
 		else if (argnmatch(argv[argi], "--processor=")) {
 			char *p = strchr(argv[argi], '=');
 			processor = strdup(p+1);
+		}
+		else if (strncmp(argv[argi], "--flushtimeout=", 15) == 0) {
+			timeout = (struct timespec *)(malloc(sizeof(struct timespec)));
+			timeout->tv_sec = (atoi(argv[argi]+15));
+			timeout->tv_nsec = 0;
+		}
+		else if (strcmp(argv[argi], "--bfq") == 0) {
+			force_backfeedqueue = 1;
+		}
+		else if (strcmp(argv[argi], "--no-bfq") == 0) {
+			force_backfeedqueue = -1;
 		}
 		else if (strcmp(argv[argi], "--no-cache") == 0) {
 			use_rrd_cache = 0;
@@ -247,10 +262,20 @@ int main(int argc, char *argv[])
 
 	if (exthandler && extids) setup_exthandler(exthandler, extids);
 
-	usebackfeedqueue = (sendmessage_init_local() > 0);
+	/* Open up our extcombo message for any modifications */
+	usebackfeedqueue = ((force_backfeedqueue >= 0) ? (sendmessage_init_local() > 0) : 0);
+	if (force_backfeedqueue == 1 && usebackfeedqueue <= 0) {
+		errprintf("Unable to set up backfeed queue when --bfq given; aborting\n");
+		exit(0);
+	}
+	if (usebackfeedqueue) combo_start_local(); else combo_start();
 
 	/* Do the network stuff if needed */
 	net_worker_run(ST_RRD, LOC_STICKY, update_locator_hostdata);
+	now = gettimer();
+	comboflushtime = now + 23;
+	checkctltime = now + 4;
+
 
 	setup_signalhandler("xymond_rrd");
 	memset(&sa, 0, sizeof(sa));
@@ -323,7 +348,9 @@ int main(int argc, char *argv[])
 		}
 
 		/* See if we have any cache-control messages pending */
-		do {
+		if ((checkctltime < now) && (ctlsocket != -1)) {
+		    dbgprintf("xymond_rrd: checking for rrdctl flush messages\n");
+		    do {
 			n = recv(ctlsocket, ctlbuf, sizeof(ctlbuf), 0);
 			gotcachectlmessage = (n > 0);
 			if (gotcachectlmessage) {
@@ -338,10 +365,13 @@ int main(int argc, char *argv[])
 					if (eol) { bol = eol+1; } else bol = NULL;
 				} while (bol && *bol);
 			}
-		} while (gotcachectlmessage);
+		    } while (gotcachectlmessage);
+		    checkctltime = now + 7;
+		}
+
 
 		/* Get next message */
-		msg = get_xymond_message(C_LAST, argv[0], &seq, NULL);
+		msg = get_xymond_message(C_LAST, argv[0], &seq, timeout);
 		if (msg == NULL) {
 			running = 0;
 			continue;
@@ -353,6 +383,23 @@ int main(int argc, char *argv[])
 			load_hostnames(xgetenv("HOSTSCFG"), NULL, get_fqdn());
 			load_client_config(NULL);
 			reloadtime = now + 600;
+			comboflushtime = now + 23;
+		}
+		if ((comboflushtime < now)) {
+			/*
+			 * We fork a subprocess when processing drophost requests.
+			 * Pickup any finished child processes to avoid zombies
+			 */
+			while (wait3(&childstat, WNOHANG, NULL) > 0) ;
+
+			/* Make sure any combo of pending modify's goes out */
+			/* if we don't have an idle message timeout set */
+			if (timeout == NULL) {
+				dbgprintf("Flushing any pending extcombo messages\n");
+				combo_end();
+				if (usebackfeedqueue) combo_start_local(); else combo_start();
+			}
+			comboflushtime = now + 23;
 		}
 
 		/* Split the message in the first line (with meta-data), and the rest */
@@ -362,7 +409,6 @@ int main(int argc, char *argv[])
 			restofmsg = eoln+1;
 		}
 
-		if (usebackfeedqueue) combo_start_local(); else combo_start();
 
 		/* Parse the meta-data */
 		metacount = 0; 
@@ -419,7 +465,9 @@ int main(int argc, char *argv[])
 			continue;
 		}
 		else if (strncmp(metadata[0], "@@idle", 6) == 0) {
-			/* Ignored */
+			dbgprintf("Got an 'idle' message\n");
+			combo_end();
+			if (usebackfeedqueue) combo_start_local(); else combo_start();
 			continue;
 		}
 		else if (strncmp(metadata[0], "@@logrotate", 11) == 0) {
@@ -564,20 +612,16 @@ int main(int argc, char *argv[])
 		else if ((metacount > 5) && (strncmp(metadata[0], "@@renametest", 12) == 0)) {
 			/* Not implemented. See "droptest". */
 		}
-
-		combo_end();
-
-		/* 
-		 * We fork a subprocess when processing drophost requests.
-		 * Pickup any finished child processes to avoid zombies
-		 */
-		while (wait3(&childstat, WNOHANG, NULL) > 0) ;
 	}
 
 	/* Flush all cached updates to disk */
 	errprintf("Shutting down, flushing cached updates to disk\n");
 	rrdcacheflushall();
 	errprintf("Cache flush completed\n");
+
+	/* Close out any modify's waiting to be sent */
+	combo_end();
+	if (usebackfeedqueue) sendmessage_finish_local();
 
 	/* Close the external processor */
 	shutdown_extprocessor();

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -219,6 +219,12 @@ int main(int argc, char *argv[])
 		else if (strcmp(argv[argi], "--no-cache") == 0) {
 			use_rrd_cache = 0;
 		}
+		else if (strcmp(argv[argi], "--extcache") == 0) {
+			ext_rrd_cache = 1;
+		}
+		else if (strcmp(argv[argi], "--no-extcache") == 0) {
+			ext_rrd_cache = -1;
+		}
 		else if (strcmp(argv[argi], "--no-rrd") == 0) {
 			no_rrd = 1;
 		}
@@ -234,6 +240,10 @@ int main(int argc, char *argv[])
 	if ((rrddir == NULL) && xgetenv("XYMONRRDS")) {
 		rrddir = strdup(xgetenv("XYMONRRDS"));
 	}
+
+	/* Has external rrdcached running? Use env by default */
+	ext_rrd_cache = ((ext_rrd_cache >= 0) ? (getenv("RRDCACHED_ADDRESS") != NULL) : 0); 
+	dbgprintf("xymond_rrd: External cache: %d\n", ext_rrd_cache);
 
 	if (exthandler && extids) setup_exthandler(exthandler, extids);
 

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -197,6 +197,11 @@ int main(int argc, char *argv[])
 	int force_backfeedqueue = 0;
 	int comboflushtime;
 	int checkctltime;
+	/* Set before the loop and carried across iterations: the cachectl and
+	 * release-delay checks at the top of each pass read it before the pass
+	 * refreshes it, so a per-iteration declaration reads an indeterminate
+	 * value on the way in. */
+	time_t now;
 	struct timespec *timeout = NULL;
 
 	/* Handle program options. */
@@ -243,9 +248,10 @@ int main(int argc, char *argv[])
 		else if (strcmp(argv[argi], "--no-rrd") == 0) {
 			no_rrd = 1;
 		}
-		else if (strcmp(argv[argi], "--cachemultiplier=") == 0) {
-			cacheflushsz = atoi(argv[argi]+18);
-			if (cacheflushsz == 0) cacheflushsz = 1;
+		else if (argnmatch(argv[argi], "--cachemultiplier=")) {
+			char *p = strchr(argv[argi], '=');
+			cacheflushsz = atoi(p+1);
+			if (cacheflushsz <= 0) cacheflushsz = 1;
 		}
 		else if (net_worker_option(argv[argi])) {
 			/* Handled in the subroutine */
@@ -263,8 +269,13 @@ int main(int argc, char *argv[])
 		rrddir = strdup(xgetenv("XYMONRRDS"));
 	}
 
-	/* Has external rrdcached running? Use env by default */
-	ext_rrd_cache = ((ext_rrd_cache >= 0) ? (getenv("RRDCACHED_ADDRESS") != NULL) : 0); 
+	/*
+	 * Has an external rrdcached running? The environment answers when nothing
+	 * on the command line did - but --extcache and --no-extcache are answers,
+	 * and a flag the environment can overrule is not a flag.
+	 */
+	if (ext_rrd_cache == 0) ext_rrd_cache = (getenv("RRDCACHED_ADDRESS") != NULL);
+	else ext_rrd_cache = (ext_rrd_cache > 0);
 	dbgprintf("xymond_rrd: External cache: %d\n", ext_rrd_cache);
 
 	if (exthandler && extids) setup_exthandler(exthandler, extids);
@@ -346,7 +357,6 @@ int main(int argc, char *argv[])
                 ssize_t n;
 		char ctlbuf[PATH_MAX];
 		int gotcachectlmessage;
-		time_t now;
 
 		/* If we need to re-open our external processor, do so */
 		if (reloadextprocessor) {

--- a/xymond/xymond_rrd.c
+++ b/xymond/xymond_rrd.c
@@ -243,12 +243,19 @@ int main(int argc, char *argv[])
 		else if (strcmp(argv[argi], "--no-rrd") == 0) {
 			no_rrd = 1;
 		}
+		else if (strcmp(argv[argi], "--cachemultiplier=") == 0) {
+			cacheflushsz = atoi(argv[argi]+18);
+			if (cacheflushsz == 0) cacheflushsz = 1;
+		}
 		else if (net_worker_option(argv[argi])) {
 			/* Handled in the subroutine */
 		}
 	}
 
 	save_errbuf = 0;
+
+	dbgprintf("rrd cache flush multiplier: %d\n", cacheflushsz);
+	cacheflushsz *= CACHESZ;
 
 	if (no_rrd && !processor) errprintf("RRD writing disabled, but no external processor has been specified.\n");
 
@@ -273,6 +280,7 @@ int main(int argc, char *argv[])
 	/* Do the network stuff if needed */
 	net_worker_run(ST_RRD, LOC_STICKY, update_locator_hostdata);
 	now = gettimer();
+	releasecachedelay = (int)now + 600;
 	comboflushtime = now + 23;
 	checkctltime = now + 4;
 
@@ -350,6 +358,8 @@ int main(int argc, char *argv[])
 		/* See if we have any cache-control messages pending */
 		if ((checkctltime < now) && (ctlsocket != -1)) {
 		    dbgprintf("xymond_rrd: checking for rrdctl flush messages\n");
+		    if (releasecachedelay && (releasecachedelay < (int)now)) releasecachedelay = 0;
+
 		    do {
 			n = recv(ctlsocket, ctlbuf, sizeof(ctlbuf), 0);
 			gotcachectlmessage = (n > 0);


### PR DESCRIPTION
**Draft, parked.** #106 says these three go back together or not at all, and as 4.4 material rather than 4.3.32. This is that group made to build and hold on main, so the decision can be taken against working code instead of three 2015 commits.

Structure follows the TBT convention: J.C. Cleaver's commits first, our corrections in one commit on top.

| commit | author | note |
|---|---|---|
| `01f79009` experimental rrdcached support | J. Cleaver | verbatim (`Changes` and the pre-`RRD_CONST_ARGS` probe hunks dropped) |
| `a1718cd7` cachectl/zombie/combo-flush frequency, bfq flags | J. Cleaver | **resolved**, see below |
| `0e7d1962` 10m restart delay, cache-size multiplier | J. Cleaver | **resolved**, see below |
| corrections | Bonomani | makes the above build and behave |

**The two resolutions**, recorded in the commit bodies rather than left implicit:

- The pre-loop block drops devel's `load_hostnames()` / `load_client_config()` / `reloadtime` lines. Main loads both lazily inside the loop, seeded by `reloadtime = 0`, so applying them as written loads hosts.cfg and the client config a second time at startup. `now` / `comboflushtime` / `checkctltime` / `releasecachedelay` are kept — the ports introduce the last three.
- `rrd_destroy()` stays unconditional. Wrapping it in `DEBUG_FOR_VALGRIND`, as devel does, would revert what landed in #200.

**What the correction commit fixes**

| | |
|---|---|
| `RRDTOOL14` guards | nothing defines that macro on main — the probe is `RRD_CONST_ARGS`. The guarded code compiled to nothing, so the feature was dead on arrival. Guards deleted rather than re-plumbed: `rrd_flushcached` has been in RRDtool since 1.4, under the 1.5.0 floor already set for `rrd_last`, so there is nothing to probe for and no new configure surface. |
| bare `char *argv[]` | goes through the compat wrapper now, like every other RRDtool entry point since the argv API split |
| 24-file cap in `rrd_cached_flush()` | removed. A host with more tests was graphed from whatever rrdcached had last written on its own schedule — the stale graph the flush exists to prevent, showing up first on the hosts watched hardest. |
| `now` | read at the top of each pass before that pass refreshes it, so it belongs to `main()`, not the loop body. As applied, the cachectl and release-delay checks read an uninitialized value on the first pass. |
| `--cachemultiplier=N` | matched with `strcmp` against a string ending in `=`, so it matched only the valueless spelling and then read the multiplier from the terminating NUL. `argnmatch()` now. |
| `--extcache` | overwritten by the environment probe right after being parsed, so it could only ever agree with `RRDCACHED_ADDRESS`. An explicit flag now wins, in both directions. |
| `updcache_host_op()` | main-only, so the ports left its `flush_cached_updates()` call one argument short. `dosync=0` — the file is about to move and no reader asked for it. |

**Before this is taken further**

Rebase onto main after #349, and drop the `dosync` / `ext_rrd_cache` guard around `utimes()` when you do: #349 deletes that call outright, so `rrd_nofsync` has nothing left to apply to. The `rrd_nofsync` → `01f79009` mapping on #106 goes with it.

Worth weighing against the gain. Xymon already coalesces writes 12:1 (`CACHESZ`), so what rrdcached adds is asynchrony and crash durability, not fewer writes — and it turns a slow filesystem into a failed update and a failed graph, since neither `rrd_update` nor `rrd_graph` degrades when the daemon is unreachable (`rrd_last` does).

Build clean, no new warnings in the touched files. Suite: 86 passed, 0 skipped, 0 failed.
