### PR TITLE
tests: hold the df sentinel's claim window open, do not race for it (#379)

### DIFF
--- a/tests/client/fs-sentinel-linux.sh
+++ b/tests/client/fs-sentinel-linux.sh
@@ -290,6 +290,53 @@ assert_equal "$(head -1 "$DF_REMOTE")" "$_recorded" \
 while read -r _p; do end_stub "$_p"; done < "$DF_REMOTE"
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 
+# --- the claim window, forced open --------------------------------------------
+# The publication above is one of two steps that must not be seen half-done.
+# The other is the claim: it is written to a private file and hard-linked into
+# place, so the pidfile carries its content from the instant the name exists.
+# Writing to the pidfile directly cannot do that -- the name appears first and
+# the claim lands after -- and an entry read in between is empty, which reads as
+# stale: the second cycle removes it and starts a df on top of the first.
+# An ln stub holds the first claim *after* linking, so a second cycle reads the
+# pidfile inside exactly that window. It must find a whole claim and stand down.
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+LN_HELD="$TMP/ln-held"; rm -f "$LN_HELD"
+cat > "$STUB/ln" <<'EOF'
+#!/bin/sh
+# The link itself is real and immediate; only the return from the first claim
+# is held, which is the window a reader has to survive.
+case "$*" in
+	*df-probe-*.pid)
+		/bin/ln "$@" || exit $?
+		[ -e "$LN_HELD" ] || { : > "$LN_HELD"; sleep 3; }
+		exit 0
+		;;
+esac
+exec /bin/ln "$@"
+EOF
+chmod +x "$STUB/ln"
+( run_cycle DF_HANG=1 DF_HANGTIME=8 LN_HELD="$LN_HELD" > "$TMP/claim-first.out" 2>/dev/null ) &
+_first=$!
+# Wait for the window rather than a duration: it is open once the pidfile exists
+# and the cycle that linked it has not returned from ln yet.
+_n=0
+while [ "$_n" -lt 100 ]; do
+	[ -e "$TMP/probe/df-probe-disk.pid" ] && [ -e "$LN_HELD" ] && break
+	_n=$((_n + 1)); sleep 0.1
+done
+out=$(run_cycle DF_HANG=1 DF_HANGTIME=8 LN_HELD="$LN_HELD")
+wait "$_first" 2>/dev/null || true
+rm -f "$STUB/ln" "$LN_HELD"
+assert_equal '1' "$(($(wc -l < "$DF_REMOTE")))" \
+	"a cycle reading the pid file between the link and the claim started a second probe"
+assert_contains 'unavailable:/remote/nfs' "$out" \
+	"the cycle that read the fresh claim must report unavailable, not drop the mount"
+_recorded=$(cat "$TMP/probe/df-probe-disk.pid" 2>/dev/null)
+assert_equal "$(head -1 "$DF_REMOTE")" "$_recorded" \
+	"the pid file must name the df that is actually running"
+while read -r _p; do end_stub "$_p"; done < "$DF_REMOTE"
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+
 # --- a claim held by another live cycle is respected -------------------------
 # Racing for the window above is probabilistic -- it takes many cycles to land
 # in it -- so the state it produces is set up directly instead: a pidfile


### PR DESCRIPTION
The sentinel takes the probe in two steps a second cycle must never catch half-done: the claim, and the publication of the df's pid. The publication has a case that forces its window open with an `mv` stub. The claim had only the 20-concurrent-cycles case — which reaches the window by luck. That is the case reported failing intermittently in #379 (a NetBSD 2-CPU lane, and roughly one run in 22 locally), and a race that reproduces once in twenty runs cannot say *which* of the two steps regressed when it fails.

The claim is written to a private file and hard-linked into place, so the pidfile carries its content from the instant the name exists. Writing the pidfile directly cannot do that — the name appears first, the claim lands after — and an entry read in between is empty, which reads as stale: the reader removes it and starts a df on top of the one already running.

An `ln` stub links for real and then holds the first claim before returning, which is the window a reader has to survive. A second cycle runs inside it and must find a whole claim and stand down.

| client code | result |
|---|---|
| as on `main` (content written, then linked) | pass |
| name linked first, `claim:$$` written after | **FAIL — expected '1', got '2'** |

Two dfs on one wedged mount is what the sentinel exists to prevent, so the case fails for the right reason.

Waits for the window rather than for a duration; deterministic over repeat runs. `tests/buildsystem/test-suite-portability.sh` passes — no `uname` guard, no `/proc` rewriting, pure `sh` — so it runs on every lane.

Does not change client code. Whether #379 is still live is a separate question: `4fd7f685f` landed ~10 h before it was filed, and the issue quotes the pre-`ln` claim. Either way this pins the half that had no deterministic guard.
