### PR TITLE
do_disk: an unreachable mount reports red without a fabricated sample (#344)

### DIFF
--- a/client/xymonclient-darwin.sh
+++ b/client/xymonclient-darwin.sh
@@ -91,7 +91,7 @@ esac
 : "${XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES=nfs nfs4 smbfs cifs afpfs webdav ceph glusterfs lustre afs}"
 DFPROBEDIR="${XYMONTMP:-/tmp}"
 
-# fs_mounts : one "TYPE<tab>MOUNTPOINT" line per mount, from mount(8). macOS
+# fs_mounts : one "TYPE<tab>MOUNTPOINT<tab>DEVICE" line per mount, from mount(8). macOS
 # mount(8) lists from getmntinfo(MNT_NOWAIT) -- verified in the shipped binary,
 # three call sites, all MNT_NOWAIT -- so it never refreshes statfs and cannot
 # block on a dead server, which df would.
@@ -104,7 +104,8 @@ fs_mounts() {
 			if (match(rest, / \(/) == 0) next
 			mp = substr(rest, 1, RSTART - 1)
 			split(substr(rest, RSTART + 2), a, /[,)]/)
-			printf "%s\t%s\n", a[1], mp
+			dev = substr($0, 1, i - 1)
+			printf "%s\t%s\t%s\n", a[1], mp, dev
 		}'
 }
 
@@ -321,13 +322,26 @@ fs_guarded() {
 	set -- "$@" $_mounts
 	_rout=`df_sentinel "$_tag" "$@"`
 	if [ $? -eq 124 ]; then
-		for _m in $_mounts; do
-			if [ "$_tag" = inode ]; then
-				echo "unavailable:$_m 1 1 0 100% 1 0 100% $_m"
-			else
-				echo "unavailable:$_m 1 1 0 100% $_m"
-			fi
-		done
+		# The row names the server. df could not answer, but the mount table
+		# still knows which device is behind the mount point, and that is the
+		# first thing an operator needs. The sizes are reported as "-": they
+		# were not measured, and a number here would be trended as a reading.
+		# The capacity stays 100% because that is what turns the column red.
+		# The mount list rides the mount-table stream behind an @@ separator:
+		# a -v assignment cannot carry newlines on BSD awk (fs_setop makes
+		# the same move). A spaced device is re-encoded (\040) to keep the
+		# column count.
+		{ fs_mounts; echo '@@'; printf '%s\n' "$_mounts"; } | awk -F'\t' -v inode="$_tag" '
+			$0 == "@@" { rm = 1; next }
+			!rm { dev[$2] = ($3 == "" ? "-" : $3); next }
+			$0 == "" { next }
+			{
+				d = ($0 in dev) ? dev[$0] : "-"
+				n = split(d, dp, / /)
+				if (n > 1) { d = dp[1]; for (j = 2; j <= n; j++) d = d "\\040" dp[j] }
+				if (inode == "inode") printf "%s - - - 100%% - - 100%% %s\n", d, $0
+				else printf "%s - - - 100%% %s\n", d, $0
+			}'
 	else
 		printf '%s\n' "$_rout"
 	fi
@@ -424,7 +438,8 @@ if [ -n "$FILESYSTEMS_INODE" ] || [ -n "$FILESYSTEMS_INODE_REMOTE" ]; then
 	 fi
 	 fs_guarded inode "-P -i" "$FILESYSTEMS_INODE_REMOTE") | awk '
 NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9}
-(NR>=2 && $6>0) {printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}' )
+(NR>=2 && $6 == "-") {printf "%-20s %10s %10s %10s %10s %s\n", $1, "-", "-", "-", $8, $9}
+(NR>=2 && $6 != "-" && $6>0) {printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}' )
 	emit_df inode Inode
 fi
 

--- a/client/xymonclient-freebsd.sh
+++ b/client/xymonclient-freebsd.sh
@@ -77,7 +77,7 @@ esac
 : "${XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES=nfs nfs4 smbfs cifs ceph glusterfs fusefs.glusterfs lustre afs}"
 DFPROBEDIR="${XYMONTMP:-/tmp}"
 
-# fs_mounts : one "TYPE<tab>MOUNTPOINT" line per mount, from mount(8).
+# fs_mounts : one "TYPE<tab>MOUNTPOINT<tab>DEVICE" line per mount, from mount(8).
 # FreeBSD mount(8) lists from getmntinfo(MNT_NOWAIT) unless -v is given,
 # so it never refreshes statfs and cannot block on a dead server. Never -v.
 # df -P would, which is the whole reason this list is read here instead.
@@ -90,7 +90,8 @@ fs_mounts() {
 			if (match(rest, / \(/) == 0) next
 			mp = substr(rest, 1, RSTART - 1)
 			split(substr(rest, RSTART + 2), a, /[,)]/)
-			printf "%s\t%s\n", a[1], mp
+			dev = substr($0, 1, i - 1)
+			printf "%s\t%s\t%s\n", a[1], mp, dev
 		}'
 }
 
@@ -308,15 +309,28 @@ run_df() {
 		# Unavailable: surface each remote mount as a failed (100%) row rather
 		# than dropping it, since the server reads an absent filesystem as
 		# green. This turns one filesystem red instead of purpling the host.
+		# The row names the server. df could not answer, but the mount table
+		# still knows which device is behind the mount point, and that is the
+		# first thing an operator needs. The sizes are reported as "-": they
+		# were not measured, and a number here would be trended as a reading.
+		# The capacity stays 100% because that is what turns the column red.
 		# The inode report is read column-wise (iused, ifree and %iused are
-		# fields 6-8), so its marker row carries them too.
-		for _m in $_rm; do
-			if [ "$_flag" = -i ]; then
-				echo "unavailable:$_m 1 1 0 100% 1 0 100% $_m"
-			else
-				echo "unavailable:$_m 1 1 0 100% $_m"
-			fi
-		done
+		# fields 6-8), so its marker row carries those columns too.
+		# The mount list rides the mount-table stream behind an @@ separator:
+		# a -v assignment cannot carry newlines on BSD awk (fs_setop makes
+		# the same move). A spaced device is re-encoded (\040) to keep the
+		# column count.
+		{ fs_mounts; echo '@@'; printf '%s\n' "$_rm"; } | awk -F'\t' -v inode="$_flag" '
+			$0 == "@@" { rm = 1; next }
+			!rm { dev[$2] = ($3 == "" ? "-" : $3); next }
+			$0 == "" { next }
+			{
+				d = ($0 in dev) ? dev[$0] : "-"
+				n = split(d, dp, / /)
+				if (n > 1) { d = dp[1]; for (j = 2; j <= n; j++) d = d "\\040" dp[j] }
+				if (inode == "-i") printf "%s - - - 100%% - - 100%% %s\n", d, $0
+				else printf "%s - - - 100%% %s\n", d, $0
+			}'
 	else
 		printf '%s\n' "$_rout"
 	fi
@@ -357,7 +371,8 @@ N
 s/[ 	]*\n[ 	]*/ /
 }' | awk '
 NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9}
-(NR>=2 && $8 != "-"){printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
+(NR>=2 && $8 != "-" && $6 == "-"){printf "%-20s %10s %10s %10s %10s %s\n", $1, "-", "-", "-", $8, $9}
+(NR>=2 && $8 != "-" && $6 != "-"){printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
 fi
 echo "[mount]"
 mount

--- a/client/xymonclient-freebsd.sh
+++ b/client/xymonclient-freebsd.sh
@@ -346,9 +346,16 @@ run_df() {
 emit_df() {
 	_kind="$1"; _label="$2"; shift 2
 	_out=`run_df "$@"`; _rc=$?
-	if [ -z "$_out" ] && [ "$_rc" -ne 0 ]; then
-		echo "xymonclient-freebsd: df $_kind collection failed (status $_rc) with no output; reporting data as unavailable" >&2
-		echo "$_label report collection failed: df exited $_rc with no output"
+	if [ -z "$_out" ]; then
+		# No rows at all. A non-zero exit is a collection failure - surface a
+		# marker so the server goes yellow. A clean exit means nothing matched
+		# (e.g. an inode report whose filesystems are all zfs, which are
+		# excluded): emit nothing, so the server's empty-report path stays green
+		# rather than rejecting a stray header-only row as "columns not found".
+		if [ "$_rc" -ne 0 ]; then
+			echo "xymonclient-freebsd: df $_kind collection failed (status $_rc) with no output; reporting data as unavailable" >&2
+			echo "$_label report collection failed: df exited $_rc with no output"
+		fi
 		return 1
 	fi
 	return 0

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -45,7 +45,7 @@ uptime
 echo "[who]"
 who
 echo "[df]"
-# fs_mounts : one "TYPE<tab>MOUNTPOINT" line per mount. Linux reads
+# fs_mounts : one "TYPE<tab>MOUNTPOINT<tab>DEVICE" line per mount. Linux reads
 # /proc/mounts, which cannot block on a dead server and needs no fork; the BSD
 # and macOS clients read mount(8). Same output either way, so probe_dir_is_local()
 # and the remote-set awk below are the same code in all five clients, and a test
@@ -56,7 +56,8 @@ fs_mounts()
 	# Decode \040, then \134 by split/concat (a gsub replacement backslash
 	# differs between mawk and gawk). \011/\012 stay escaped: the rows are
 	# tab- and newline-delimited, so decoding them would truncate the path.
-	awk '{ mp = $2; gsub(/\\040/, " ", mp); n = split(mp, s, /\\134/); mp = s[1]; for (i = 2; i <= n; i++) mp = mp "\\" s[i]; printf "%s\t%s\n", $3, mp }' /proc/mounts
+	# The device follows as a third column; it is decoded the same way.
+	awk '{ mp = $2; gsub(/\\040/, " ", mp); n = split(mp, s, /\\134/); mp = s[1]; for (i = 2; i <= n; i++) mp = mp "\\" s[i]; dev = $1; gsub(/\\040/, " ", dev); m = split(dev, d, /\\134/); dev = d[1]; for (i = 2; i <= m; i++) dev = dev "\\" d[i]; printf "%s\t%s\t%s\n", $3, mp, dev }' /proc/mounts
 }
 
 # fs_filesystems : the filesystem types the kernel knows, "nodev" first where
@@ -419,10 +420,27 @@ run_df()
 		# Unavailable: surface each remote mount as a failed (100%) row rather
 		# than dropping it, since the server reads an absent filesystem as
 		# green. This turns one filesystem red instead of purpling the host.
-		for _m in $_rm; do
-			# printf, not echo: sh's echo escape-processes a decoded backslash.
-			printf '%s\n' "unavailable:$_m 1 1 0 100% $_m"
-		done
+		#
+		# The row names the server. df could not answer, but the mount table
+		# still knows which device is behind the mount point, and that is the
+		# first thing an operator needs. The sizes are reported as "-": they
+		# were not measured, and a number here would be trended as a reading.
+		# The capacity stays 100% because that is what turns the column red.
+		# The mount list rides the mount-table stream behind an @@ separator:
+		# a -v assignment cannot carry newlines on BSD awk (fs_setop makes
+		# the same move). A spaced device is re-encoded (\040) to keep the
+		# column count. printf, not echo: sh's echo escape-processes a
+		# decoded backslash.
+		{ fs_mounts; echo '@@'; printf '%s\n' "$_rm"; } | awk -F'\t' '
+			$0 == "@@" { rm = 1; next }
+			!rm { dev[$2] = ($3 == "" ? "-" : $3); next }
+			$0 == "" { next }
+			{
+				d = ($0 in dev) ? dev[$0] : "-"
+				n = split(d, dp, / /)
+				if (n > 1) { d = dp[1]; for (j = 2; j <= n; j++) d = d "\\040" dp[j] }
+				printf "%s - - - 100%% %s\n", d, $0
+			}'
 	else
 		printf '%s\n' "$_rout"
 	fi

--- a/client/xymonclient-netbsd.sh
+++ b/client/xymonclient-netbsd.sh
@@ -65,7 +65,7 @@ esac
 : "${XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES=nfs nfs4 smbfs cifs ceph glusterfs puffs|nfs lustre afs}"
 DFPROBEDIR="${XYMONTMP:-/tmp}"
 
-# fs_mounts : one "TYPE<tab>MOUNTPOINT" line per mount, from mount(8).
+# fs_mounts : one "TYPE<tab>MOUNTPOINT<tab>DEVICE" line per mount, from mount(8).
 # NetBSD mount(8) lists from getmntinfo(MNT_NOWAIT), so it never refreshes
 # statfs and cannot block on a dead server.
 # df -P would, which is the whole reason this list is read here instead.
@@ -79,7 +79,8 @@ fs_mounts() {
 			mp = substr(rest, 1, RSTART - 1)
 			type = substr(rest, RSTART + 6)
 			sub(/ \(.*/, "", type)
-			printf "%s\t%s\n", type, mp
+			dev = substr($0, 1, i - 1)
+			printf "%s\t%s\t%s\n", type, mp, dev
 		}'
 }
 
@@ -297,15 +298,28 @@ run_df() {
 		# Unavailable: surface each remote mount as a failed (100%) row rather
 		# than dropping it, since the server reads an absent filesystem as
 		# green. This turns one filesystem red instead of purpling the host.
+		# The row names the server. df could not answer, but the mount table
+		# still knows which device is behind the mount point, and that is the
+		# first thing an operator needs. The sizes are reported as "-": they
+		# were not measured, and a number here would be trended as a reading.
+		# The capacity stays 100% because that is what turns the column red.
 		# The inode report is read column-wise (iused, ifree and %iused are
-		# fields 6-8), so its marker row carries them too.
-		for _m in $_rm; do
-			if [ "$_flag" = -i ]; then
-				echo "unavailable:$_m 1 1 0 100% 1 0 100% $_m"
-			else
-				echo "unavailable:$_m 1 1 0 100% $_m"
-			fi
-		done
+		# fields 6-8), so its marker row carries those columns too.
+		# The mount list rides the mount-table stream behind an @@ separator:
+		# a -v assignment cannot carry newlines on BSD awk (fs_setop makes
+		# the same move). A spaced device is re-encoded (\040) to keep the
+		# column count.
+		{ fs_mounts; echo '@@'; printf '%s\n' "$_rm"; } | awk -F'\t' -v inode="$_flag" '
+			$0 == "@@" { rm = 1; next }
+			!rm { dev[$2] = ($3 == "" ? "-" : $3); next }
+			$0 == "" { next }
+			{
+				d = ($0 in dev) ? dev[$0] : "-"
+				n = split(d, dp, / /)
+				if (n > 1) { d = dp[1]; for (j = 2; j <= n; j++) d = d "\\040" dp[j] }
+				if (inode == "-i") printf "%s - - - 100%% - - 100%% %s\n", d, $0
+				else printf "%s - - - 100%% %s\n", d, $0
+			}'
 	else
 		printf '%s\n' "$_rout"
 	fi
@@ -336,6 +350,7 @@ N
 s/[ 	]*\n[ 	]*/ /
 }' | awk '
 NR == 1 { print "Filesystem itotal iused ifree %iused Mounted on"; next }
+$6 == "-" { printf "%s %s %s %s %s %s\n", $1, "-", "-", "-", $8, $9; next }
 ($6 + $7) <= 0 { next }
 { printf "%s %d %d %d %s %s\n", $1, $6+$7, $6, $7, $8, $9 }
 '

--- a/client/xymonclient-openbsd.sh
+++ b/client/xymonclient-openbsd.sh
@@ -73,7 +73,7 @@ esac
 : "${XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES=nfs nfs4 smbfs cifs ceph glusterfs lustre afs}"
 DFPROBEDIR="${XYMONTMP:-/tmp}"
 
-# fs_mounts : one "TYPE<tab>MOUNTPOINT" line per mount, from mount(8).
+# fs_mounts : one "TYPE<tab>MOUNTPOINT<tab>DEVICE" line per mount, from mount(8).
 # OpenBSD mount(8) lists from getmntinfo(MNT_NOWAIT), so it never refreshes
 # statfs and cannot block on a dead server.
 # df -P would, which is the whole reason this list is read here instead.
@@ -87,7 +87,8 @@ fs_mounts() {
 			mp = substr(rest, 1, RSTART - 1)
 			type = substr(rest, RSTART + 6)
 			sub(/ \(.*/, "", type)
-			printf "%s\t%s\n", type, mp
+			dev = substr($0, 1, i - 1)
+			printf "%s\t%s\t%s\n", type, mp, dev
 		}'
 }
 
@@ -305,15 +306,28 @@ run_df() {
 		# Unavailable: surface each remote mount as a failed (100%) row rather
 		# than dropping it, since the server reads an absent filesystem as
 		# green. This turns one filesystem red instead of purpling the host.
+		# The row names the server. df could not answer, but the mount table
+		# still knows which device is behind the mount point, and that is the
+		# first thing an operator needs. The sizes are reported as "-": they
+		# were not measured, and a number here would be trended as a reading.
+		# The capacity stays 100% because that is what turns the column red.
 		# The inode report is read column-wise (iused, ifree and %iused are
-		# fields 6-8), so its marker row carries them too.
-		for _m in $_rm; do
-			if [ "$_flag" = -i ]; then
-				echo "unavailable:$_m 1 1 0 100% 1 0 100% $_m"
-			else
-				echo "unavailable:$_m 1 1 0 100% $_m"
-			fi
-		done
+		# fields 6-8), so its marker row carries those columns too.
+		# The mount list rides the mount-table stream behind an @@ separator:
+		# a -v assignment cannot carry newlines on BSD awk (fs_setop makes
+		# the same move). A spaced device is re-encoded (\040) to keep the
+		# column count.
+		{ fs_mounts; echo '@@'; printf '%s\n' "$_rm"; } | awk -F'\t' -v inode="$_flag" '
+			$0 == "@@" { rm = 1; next }
+			!rm { dev[$2] = ($3 == "" ? "-" : $3); next }
+			$0 == "" { next }
+			{
+				d = ($0 in dev) ? dev[$0] : "-"
+				n = split(d, dp, / /)
+				if (n > 1) { d = dp[1]; for (j = 2; j <= n; j++) d = d "\\040" dp[j] }
+				if (inode == "-i") printf "%s - - - 100%% - - 100%% %s\n", d, $0
+				else printf "%s - - - 100%% %s\n", d, $0
+			}'
 	else
 		printf '%s\n' "$_rout"
 	fi
@@ -354,7 +368,8 @@ N
 s/[ 	]*\n[ 	]*/ /
 }' | awk '
 NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9}
-(NR>=2 && ($6 + $7) > 0){printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
+(NR>=2 && $6 == "-"){printf "%-20s %10s %10s %10s %10s %s\n", $1, "-", "-", "-", $8, $9}
+(NR>=2 && $6 != "-" && ($6 + $7) > 0){printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
 fi
 echo "[mount]"
 mount

--- a/tests/client/fs-filter-common.sh
+++ b/tests/client/fs-filter-common.sh
@@ -222,6 +222,11 @@ _ex=" "; _local=; _named=; _inode=
 $FSF_STUB_PARSE
 if [ -n "\$_inode" ]; then echo "\$*" >> "$INODE_LOG"; else echo "\$*" >> "$DF_LOG"; fi
 [ -n "\${DF_FAIL:-}" ] && exit 1
+# A ZFS-only host: -t no<zfs> excludes every filesystem, and FreeBSD df then
+# exits 0 with no output at all (not the nonzero-empty above). Model that for
+# the inode call, so a test can prove the client emits an empty [inode] rather
+# than a header-only row the server rejects as "columns not found" (#398).
+[ -n "\${DF_INODE_EMPTY_OK:-}" ] && [ -n "\$_inode" ] && exit 0
 # Every fixture entry the argv did not filter out. An operand that is itself
 # excluded leaves df with nothing to process: it exits nonzero having printed
 # nothing, which is the shape that hid the guarded probe being handed the

--- a/tests/client/fs-filter-common.sh
+++ b/tests/client/fs-filter-common.sh
@@ -356,13 +356,18 @@ fsf_selfcheck() {
 
 # fsf_assert_loud REPORT MSG -- the section must not read as green. Two
 # spellings are equally loud and a client may use either: the "collection
-# failed" marker (the column goes yellow) or one 100%-full "unavailable:" row
+# failed" marker (the column goes yellow) or one 100%-full unmeasured row
 # per mount (the column goes red). What is forbidden is the third case -- an
 # empty section, which the server reads as "no filesystems, all is well".
+#
+# The unmeasured row is matched on its columns, one line at a time: spacing
+# differs per client (column-aligned vs single-spaced), and a whole-report
+# glob took dashes in device names plus any 100% row for the marker.
 fsf_assert_loud() {
 	case "$1" in
-		*"collection failed"*|*"unavailable:"*) return 0 ;;
+		*"collection failed"*) return 0 ;;
 	esac
+	printf '%s\n' "$1" | grep -Eq '^[^ ]+ +- +- +- +100% ' && return 0
 	fail "${2:-}: the report is silent, which the server reads as green: '$1'"
 }
 

--- a/tests/client/fs-filter-freebsd.sh
+++ b/tests/client/fs-filter-freebsd.sh
@@ -101,6 +101,15 @@ assert_contains "tmpfs" "$inode_args" \
 assert_not_contains "tmpfs" "$disk_args" \
 	"the disk report keeps tmpfs: RAM-backed capacity is real"
 
+# A ZFS-only host: df -i excludes every filesystem and FreeBSD df then exits 0
+# with no output. The client must emit an EMPTY [inode] section - not a stray
+# header-only row that the server rejects with "Expected strings (%iused and
+# Mounted) not found in df output" (issue #398). The server's own empty-report
+# path then keeps the column green.
+inode_sec=$(fsf_section "$(fsf_report DF_INODE_EMPTY_OK=1)" inode)
+assert_equal "" "$inode_sec" \
+	"an all-zfs host (empty df -i, exit 0) yields an empty [inode] section, no stray header"
+
 # ... and an admin who wants those inode rows back has the documented escape.
 fsf_report XYMONCLIENT_FS_INCLUDE_TYPES=tmpfs >/dev/null
 inode_args=$(printf ' %s ' "$(tr '\n' ' ' < "$INODE_LOG")")

--- a/tests/client/fs-mounts.sh
+++ b/tests/client/fs-mounts.sh
@@ -96,18 +96,20 @@ fi
 dump_rows() { printf 'fs_mounts() returned:\n' >&2; sed -e 's/^/  /' "$TMP/out" >&2; }
 
 # The rows are what the rest of the block indexes into, so check the shape
-# rather than the contents: type, tab, mountpoint, and nothing else.
+# rather than the contents: type, tab, mountpoint, tab, device. The device is
+# what the sentinel names when a server stops answering, so it is part of the
+# contract even though nothing else reads it.
 lineno=0
 present=0
 root_type=
 while IFS= read -r line; do
 	lineno=$((lineno + 1))
 	fields=$(printf '%s' "$line" | awk -F'\t' '{ print NF }')
-	[ "$fields" = 2 ] \
-		|| { dump_rows; fail "$os: fs_mounts() line $lineno is not 'type<TAB>mountpoint' ($fields tab-separated fields): $line"; }
+	[ "$fields" = 3 ] \
+		|| { dump_rows; fail "$os: fs_mounts() line $lineno is not 'type<TAB>mountpoint<TAB>device' ($fields tab-separated fields): $line"; }
 
 	type=${line%%	*}
-	mp=${line#*	}
+	mp=${line#*	}; mp=${mp%%	*}
 
 	# A parse that drifted by a field yields plausible-looking garbage, so
 	# check what a mountpoint always is: an absolute path. Not that it exists
@@ -161,13 +163,13 @@ if [ "$kernel" = Linux ]; then
 	[ -n "$awkprog" ] \
 		|| fail "$os: fs_mounts() no longer parses with a single awk program -- update this check with it"
 	decoded=$(printf 'server:/export /remote/team\\040share\\040x nfs4 rw 0 0\n' | awk "$awkprog")
-	assert_equal "nfs4	/remote/team share x" "$decoded" \
-		"$os: every escaped space in a mount point is decoded, not just the first"
+	assert_equal "nfs4	/remote/team share x	server:/export" "$decoded" \
+		"$os: every escaped space in a mount point is decoded, not just the first, and the device is named"
 	decoded=$(printf 'server:/export /remote/\\134\\134a\\134 nfs4 rw 0 0\n' | awk "$awkprog")
-	assert_equal 'nfs4	/remote/\\a\' "$decoded" \
-		"$os: escaped backslashes -- leading, doubled, trailing -- are all decoded"
+	assert_equal 'nfs4	/remote/\\a\	server:/export' "$decoded" \
+		"$os: escaped backslashes -- leading, doubled, trailing -- are all decoded, and the device is named"
 	decoded=$(printf 'server:/export /remote/a\\134040b nfs4 rw 0 0\n' | awk "$awkprog")
-	assert_equal 'nfs4	/remote/a\040b' "$decoded" \
+	assert_equal 'nfs4	/remote/a\040b	server:/export' "$decoded" \
 		"$os: a literal backslash-040 in a mount point survives; decoding \\134 first would turn it into a space"
 fi
 

--- a/tests/client/fs-sentinel-darwin.sh
+++ b/tests/client/fs-sentinel-darwin.sh
@@ -109,7 +109,7 @@ assert_contains "/net" "$out" "a healthy hard-blocking mount is reported through
 # With real rows, not the marker: everything the sentinel hands df has to be
 # something df accepts, and a probe that fails on its own arguments looks
 # exactly like a server that stopped answering.
-assert_not_contains "unavailable:/net" "$out" \
+assert_not_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" \
 	"a healthy server must produce real rows, never the unavailable marker"
 assert_contains "/Volumes/USBHFS" "$out" "a local filesystem is still reported by the per-path loop"
 assert_contains "/dev/disk" "$out" "and the table still carries real rows"
@@ -139,9 +139,9 @@ rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 out=$(run_cycle DF_HANG=1)
 df_section=$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')
 inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
-assert_contains "unavailable:/net" "$df_section" \
+assert_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$df_section" \
 	"a wedged server must surface the mount in the disk report, not drop it"
-assert_contains "unavailable:/net" "$inode_section" \
+assert_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$inode_section" \
 	"and in the inode report, whose columns are read positionally"
 # Shape, not just presence: the inode awk reads iused/ifree/%iused from fields
 # 6-8, so a marker row in the disk layout would be reformatted into nonsense
@@ -159,7 +159,7 @@ out=$(run_cycle DF_HANG=1)
 after=$(wc -l < "$DF_CALLS")
 assert_equal "$((before + 2))" "$((after))" \
 	"while both probes are wedged, a cycle must run only the two plain dfs"
-assert_contains "unavailable:/net" "$out" "the mount stays unavailable while wedged"
+assert_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the mount stays unavailable while wedged"
 for _tag in disk inode; do end_stub "$(cat "$TMP/probe/df-probe-$_tag.pid")"; done
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 
@@ -180,7 +180,7 @@ chmod +x "$STUB/mount"
 out=$(run_cycle DF_HANG=1 XYMONTMP="$TMP/remoteprobe")
 assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
 	"a probe dir on a hard-blocking filesystem must never be touched"
-assert_contains "unavailable:/net" "$out" "the remote set reports unavailable instead"
+assert_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the remote set reports unavailable instead"
 
 
 # Same guard, mount list unavailable rather than hostile. Asked directly: with

--- a/tests/client/fs-sentinel-freebsd.sh
+++ b/tests/client/fs-sentinel-freebsd.sh
@@ -121,7 +121,7 @@ assert_contains "/net" "$out" "a healthy hard-blocking mount is reported through
 # With real rows, not the marker: everything the sentinel hands df has to be
 # something df accepts, and a probe that fails on its own arguments looks
 # exactly like a server that stopped answering.
-assert_not_contains "unavailable:/net" "$out" \
+assert_not_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" \
 	"a healthy server must produce real rows, never the unavailable marker"
 assert_contains "/ssh" "$out" "a remote type that cannot hard-block stays in the plain df"
 assert_contains "/dev/ada0p2" "$out" "and the local set is reported as before"
@@ -141,9 +141,9 @@ rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 out=$(run_cycle DF_HANG=1)
 df_section=$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')
 inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
-assert_contains "unavailable:/net" "$df_section" \
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$df_section" \
 	"a wedged server must surface the mount in the disk report, not drop it"
-assert_contains "unavailable:/net" "$inode_section" \
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$inode_section" \
 	"and in the inode report, whose columns are read positionally"
 # Shape, not just presence: the inode awk reads iused/ifree/%iused from fields
 # 6-8, so a marker row in the disk layout would be reformatted into nonsense
@@ -161,7 +161,7 @@ out=$(run_cycle DF_HANG=1)
 after=$(wc -l < "$DF_CALLS")
 assert_equal "$((before + 2))" "$((after))" \
 	"while both probes are wedged, a cycle must run only the two plain dfs"
-assert_contains "unavailable:/net" "$out" "the mount stays unavailable while wedged"
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the mount stays unavailable while wedged"
 for _tag in disk inode; do end_stub "$(cat "$TMP/probe/df-probe-$_tag.pid")"; done
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 
@@ -181,7 +181,7 @@ chmod +x "$STUB/mount"
 out=$(run_cycle DF_HANG=1 XYMONTMP="$TMP/remoteprobe")
 assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
 	"a probe dir on a hard-blocking filesystem must never be touched"
-assert_contains "unavailable:/net" "$out" "the remote set reports unavailable instead"
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the remote set reports unavailable instead"
 
 
 # Same guard, mount list unavailable rather than hostile. Asked directly: with

--- a/tests/client/fs-sentinel-linux.sh
+++ b/tests/client/fs-sentinel-linux.sh
@@ -170,7 +170,7 @@ mkdir -p "$TMP/probe"
 # -- not in /proc/mounts' column order. That is the point of the helper: the
 # test states what the client needs to know, and each OS's client is what knows
 # where to read it.
-local_mounts() { printf 'ext4\t/\nnfs4\t/remote/nfs\nsshfs\t/remote/sshfs\n' > "$MOUNTS"; }
+local_mounts() { printf 'ext4\t/\t/dev/sda1\nnfs4\t/remote/nfs\tsrv:/exp\nsshfs\t/remote/sshfs\tusr@h:/d\n' > "$MOUNTS"; }
 local_mounts
 
 # --- healthy -----------------------------------------------------------------
@@ -190,7 +190,7 @@ rm -f "$TMP"/probe/*
 out=$(DF_HANG=1 run_cycle DF_HANG=1)
 assert_contains '/dev/sda1 1000 400 600 40% /' "$out" \
 	"a wedged remote server must not stale or block the local set"
-assert_contains 'unavailable:/remote/nfs' "$out" \
+assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
 	"an unreachable mount must be surfaced, not dropped (the server reads absent as green)"
 assert_contains ' 100% /remote/nfs' "$out" "the unavailable row must read as full so the column goes red"
 [ -f "$TMP/probe/df-probe-disk.pid" ] || fail "the wedged df must be left recorded as the sentinel"
@@ -204,7 +204,7 @@ out=$(DF_HANG=1 run_cycle DF_HANG=1)
 after=$(wc -l < "$DF_CALLS")
 assert_equal "$((before + 1))" "$((after))" \
 	"while one df is wedged, a cycle must run only the local df -- not a second remote one"
-assert_contains 'unavailable:/remote/nfs' "$out" "the mount stays unavailable while wedged"
+assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" "the mount stays unavailable while wedged"
 
 # --- recovery ----------------------------------------------------------------
 # End the wedge and wait for it to actually be gone: while the recorded df is
@@ -229,7 +229,7 @@ assert_equal '0' "$(find "$TMP/probe" -type f | awk 'END { print NR }')" \
 # and then reported unavailable.
 rm -f "$TMP"/probe/*
 out=$(run_cycle XYMONCLIENT_FS_EXCLUDE_TYPES=nfs4)
-assert_not_contains 'unavailable:/remote/nfs' "$out" \
+assert_not_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
 	"an excluded type was probed anyway and its healthy mount reported unavailable"
 assert_not_contains '/remote/nfs' "$out" "an excluded type must not be reported at all"
 assert_contains '/dev/sda1 1000 400 600 40% /' "$out" "the local set must still be reported"
@@ -282,7 +282,7 @@ wait "$_first" 2>/dev/null || true
 rm -f "$STUB/mv"
 assert_equal '1' "$(($(wc -l < "$DF_REMOTE")))" \
 	"a cycle reading the pid file mid-publication must not start a second probe"
-assert_contains 'unavailable:/remote/nfs' "$out" \
+assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
 	"and it must report the mount unavailable, not drop it"
 _recorded=$(cat "$TMP/probe/df-probe-disk.pid" 2>/dev/null)
 assert_equal "$(head -1 "$DF_REMOTE")" "$_recorded" \
@@ -329,7 +329,7 @@ wait "$_first" 2>/dev/null || true
 rm -f "$STUB/ln" "$LN_HELD"
 assert_equal '1' "$(($(wc -l < "$DF_REMOTE")))" \
 	"a cycle reading the pid file between the link and the claim started a second probe"
-assert_contains 'unavailable:/remote/nfs' "$out" \
+assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
 	"the cycle that read the fresh claim must report unavailable, not drop the mount"
 _recorded=$(cat "$TMP/probe/df-probe-disk.pid" 2>/dev/null)
 assert_equal "$(head -1 "$DF_REMOTE")" "$_recorded" \
@@ -350,25 +350,55 @@ printf 'claim:%s\n' "$holder" > "$TMP/probe/df-probe-disk.pid"
 out=$(run_cycle)
 assert_equal '0' "$(($(wc -l < "$DF_REMOTE")))" \
 	"a probe already claimed by a live cycle was started a second time"
-assert_contains 'unavailable:/remote/nfs' "$out" \
+assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
 	"a probe claimed by another cycle must report unavailable, not start a second df"
 kill "$holder" 2>/dev/null || true; wait "$holder" 2>/dev/null || true
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 
 # --- df fails ----------------------------------------------------------------
 out=$(DF_FAIL=1 run_cycle DF_FAIL=1)
-assert_contains 'unavailable:/remote/nfs' "$out" \
+assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
 	"a remote df that exits nonzero must report unavailable, not a partial set"
+
+# --- every hard-blocked mount is surfaced, not just one -----------------------
+# The list used to be handed to awk as a -v value, which BSD awk rejects when
+# it holds two or more mounts (embedded newline): no rows at all, and the
+# whole set went absent -- green (@SoundGoof). It rides awk's input now.
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+printf 'ext4\t/\t/dev/sda1\nnfs4\t/remote/nfs\tsrv:/exp\nnfs4\t/remote/nfs2\tsrv2:/exp\n' > "$MOUNTS"
+out=$(DF_HANG=1 run_cycle DF_HANG=1)
+assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
+	"the first hard-blocked mount must be surfaced"
+assert_contains 'srv2:/exp - - - 100% /remote/nfs2' "$out" \
+	"and the second: a multi-mount list must survive the handover to awk"
+while read -r _p; do end_stub "$_p"; done < "$DF_REMOTE"
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+
+# --- a device containing spaces keeps the row's column count ------------------
+# The marker row is read positionally, so a decoded device shifts every column
+# after it: the server sees neither the marker nor the mount -- green during
+# the outage, plus an RRD for a filesystem that does not exist (@SoundGoof).
+# Re-encoding (\040) keeps the six fields.
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+printf 'ext4\t/\t/dev/sda1\nnfs4\t/remote/nfs\tsrv:/team share\n' > "$MOUNTS"
+out=$(DF_HANG=1 run_cycle DF_HANG=1)
+assert_contains 'srv:/team\040share - - - 100% /remote/nfs' "$out" \
+	"a spaced device must be \\040-encoded so the columns hold"
+assert_not_contains 'srv:/team share' "$out" \
+	"the decoded device must not reach the report: it splits the row"
+while read -r _p; do end_stub "$_p"; done < "$DF_REMOTE"
+rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
+local_mounts
 
 # --- the probe dir is itself on a hard-blocking mount ------------------------
 # Nothing may touch it: `test -w` on a wedged mount blocks in D-state, inside
 # the fail-safe meant to prevent exactly that.
 mkdir -p "$TMP/remoteprobe"
-printf 'ext4\t/\nnfs4\t/remote/nfs\nnfs4\t%s\n' "$TMP/remoteprobe" > "$MOUNTS"
+printf 'ext4\t/\t/dev/sda1\nnfs4\t/remote/nfs\tsrv:/exp\nnfs4\t%s\tsrv:/probe\n' "$TMP/remoteprobe" > "$MOUNTS"
 out=$(run_cycle XYMONTMP="$TMP/remoteprobe" DF_HANG=1)
 assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
 	"a probe dir on a hard-blocking filesystem must never be touched"
-assert_contains 'unavailable:/remote/nfs' "$out" "the remote set must report unavailable instead"
+assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" "the remote set must report unavailable instead"
 
 # Same guard, asked directly. Driving it through the block cannot reach it: with
 # no mount list there is no remote set either, so df_sentinel is never called.
@@ -418,7 +448,7 @@ _after=$(wc -l < "$DF_CALLS")
 rmdir "$TMP/probe/df-probe-disk.pid"
 assert_equal 1 "$((_after - _before))" \
 	"an unrecordable pid must stop the remote df from starting (only the plain df may run)"
-assert_contains "unavailable:/remote/nfs" "$pidout" \
+assert_contains "srv:/exp - - - 100% /remote/nfs" "$pidout" \
 	"an unrecordable pid must report the remote set unavailable, not drop it"
 
 # --- the inode report is guarded too, under its own tag ----------------------
@@ -427,13 +457,14 @@ assert_contains "unavailable:/remote/nfs" "$pidout" \
 # no-inode-limit drop, which throws away rows whose IUse% column is "-".
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 out=$(DF_HANG=1 run_full DF_HANG=1)
-assert_contains 'unavailable:/remote/nfs' "$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')" \
+assert_contains 'srv:/exp - - - 100% /remote/nfs' "$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')" \
 	"a wedged server must surface the mount in the disk report"
-assert_contains 'unavailable:/remote/nfs' "$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')" \
+assert_contains 'srv:/exp - - - 100% /remote/nfs' "$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')" \
 	"and in the inode report: an absent filesystem reads as green there too"
 # The columns, not just the mount name: this row is read positionally, and a
-# marker that says 0% used is a green row carrying the word "unavailable".
-assert_contains 'unavailable:/remote/nfs 1 1 0 100% /remote/nfs' \
+# marker that says 0% used is a green row however it names the device. The
+# sizes are "-" because nothing measured them; only the capacity is asserted.
+assert_contains 'srv:/exp - - - 100% /remote/nfs' \
 	"$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')" \
 	"the inode marker must read as full, or the column stays green"
 [ -f "$TMP/probe/df-probe-disk.pid" ] || fail "the disk probe must be recorded"
@@ -485,13 +516,13 @@ assert_contains '/remote/sshfs' "$out" \
 # a cycle is visible and bounded. So an unreadable name must NOT restart.
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"; : > "$DF_CALLS"
 out=$(DF_HANG=1 run_cycle DF_HANG=1)
-assert_contains 'unavailable:/remote/nfs' "$out" "the wedge is recorded to begin with"
+assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" "the wedge is recorded to begin with"
 before=$(wc -l < "$DF_CALLS")
 out=$(DF_HANG=1 run_cycle DF_HANG=1 FS_PROCNAME=)
 after=$(wc -l < "$DF_CALLS")
 assert_equal "$((before + 1))" "$((after))" \
 	"with the name unreadable the wedged df must be assumed ours -- not restarted"
-assert_contains 'unavailable:/remote/nfs' "$out" "and the mount stays unavailable while it is"
+assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" "and the mount stays unavailable while it is"
 
 # A name that is neither ours nor empty is a recycled pid, and must restart.
 : > "$DF_CALLS"

--- a/tests/client/fs-sentinel-netbsd.sh
+++ b/tests/client/fs-sentinel-netbsd.sh
@@ -121,7 +121,7 @@ assert_contains "/net" "$out" "a healthy hard-blocking mount is reported through
 # With real rows, not the marker: everything the sentinel hands df has to be
 # something df accepts, and a probe that fails on its own arguments looks
 # exactly like a server that stopped answering.
-assert_not_contains "unavailable:/net" "$out" \
+assert_not_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" \
 	"a healthy server must produce real rows, never the unavailable marker"
 assert_contains "/ssh" "$out" "a remote type that cannot hard-block stays in the plain df"
 assert_contains "/dev/ld0a" "$out" "and the local set is reported as before"
@@ -141,9 +141,9 @@ rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 out=$(run_cycle DF_HANG=1)
 df_section=$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')
 inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
-assert_contains "unavailable:/net" "$df_section" \
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$df_section" \
 	"a wedged server must surface the mount in the disk report, not drop it"
-assert_contains "unavailable:/net" "$inode_section" \
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$inode_section" \
 	"and in the inode report, whose columns are read positionally"
 # Shape, not just presence: the inode awk reads iused/ifree/%iused from fields
 # 6-8, so a marker row in the disk layout would be reformatted into nonsense
@@ -161,7 +161,7 @@ out=$(run_cycle DF_HANG=1)
 after=$(wc -l < "$DF_CALLS")
 assert_equal "$((before + 2))" "$((after))" \
 	"while both probes are wedged, a cycle must run only the two plain dfs"
-assert_contains "unavailable:/net" "$out" "the mount stays unavailable while wedged"
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the mount stays unavailable while wedged"
 for _tag in disk inode; do end_stub "$(cat "$TMP/probe/df-probe-$_tag.pid")"; done
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 
@@ -181,7 +181,7 @@ chmod +x "$STUB/mount"
 out=$(run_cycle DF_HANG=1 XYMONTMP="$TMP/remoteprobe")
 assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
 	"a probe dir on a hard-blocking filesystem must never be touched"
-assert_contains "unavailable:/net" "$out" "the remote set reports unavailable instead"
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the remote set reports unavailable instead"
 
 
 # Same guard, mount list unavailable rather than hostile. Asked directly: with

--- a/tests/client/fs-sentinel-openbsd.sh
+++ b/tests/client/fs-sentinel-openbsd.sh
@@ -121,7 +121,7 @@ assert_contains "/net" "$out" "a healthy hard-blocking mount is reported through
 # With real rows, not the marker: everything the sentinel hands df has to be
 # something df accepts, and a probe that fails on its own arguments looks
 # exactly like a server that stopped answering.
-assert_not_contains "unavailable:/net" "$out" \
+assert_not_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" \
 	"a healthy server must produce real rows, never the unavailable marker"
 assert_contains "/ssh" "$out" "a remote type that cannot hard-block stays in the plain df"
 assert_contains "/dev/sd0a" "$out" "and the local set is reported as before"
@@ -141,9 +141,9 @@ rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 out=$(run_cycle DF_HANG=1)
 df_section=$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')
 inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
-assert_contains "unavailable:/net" "$df_section" \
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$df_section" \
 	"a wedged server must surface the mount in the disk report, not drop it"
-assert_contains "unavailable:/net" "$inode_section" \
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$inode_section" \
 	"and in the inode report, whose columns are read positionally"
 # Shape, not just presence: the inode awk reads iused/ifree/%iused from fields
 # 6-8, so a marker row in the disk layout would be reformatted into nonsense
@@ -161,7 +161,7 @@ out=$(run_cycle DF_HANG=1)
 after=$(wc -l < "$DF_CALLS")
 assert_equal "$((before + 2))" "$((after))" \
 	"while both probes are wedged, a cycle must run only the two plain dfs"
-assert_contains "unavailable:/net" "$out" "the mount stays unavailable while wedged"
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the mount stays unavailable while wedged"
 for _tag in disk inode; do end_stub "$(cat "$TMP/probe/df-probe-$_tag.pid")"; done
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 
@@ -181,7 +181,7 @@ chmod +x "$STUB/mount"
 out=$(run_cycle DF_HANG=1 XYMONTMP="$TMP/remoteprobe")
 assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
 	"a probe dir on a hard-blocking filesystem must never be touched"
-assert_contains "unavailable:/net" "$out" "the remote set reports unavailable instead"
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the remote set reports unavailable instead"
 
 
 # Same guard, mount list unavailable rather than hostile. Asked directly: with

--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -72,6 +72,14 @@ assert_match() {
 	fi
 }
 
+# assert_not_match REGEX STRING [MSG] -- the negation of assert_match
+assert_not_match() {
+	local re=$1 s=$2 msg=${3:-}
+	if [[ $s =~ $re ]]; then
+		fail "${msg:+$msg: }'$s' matches /$re/"
+	fi
+}
+
 # assert_file_exists PATH [MSG]
 assert_file_exists() {
 	local p=$1 msg=${2:-}

--- a/tests/rrd/disk-unavailable-no-sample.sh
+++ b/tests/rrd/disk-unavailable-no-sample.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/rrd/disk-unavailable-no-sample.sh
+#
+# When a remote mount is unreachable the client reports it as a df-shaped row,
+# "unavailable:/mnt 1 1 0 100% /mnt", so the disk column goes red instead of the
+# whole host going purple. The row carries no reading: the numbers in it exist
+# to breach the panic threshold, nothing measured them.
+#
+# Trending it therefore writes 100% used and 1 KB for as long as the server is
+# unreachable -- a full filesystem that was never measured, with the pre-outage
+# values buried behind it. The RRD must keep its last real sample instead (#344).
+#
+# Drives the real xymond_rrd, as tests/rrd/inode-unix-columns.sh does, over two
+# messages: one with a genuine reading, then one where the same mount has gone
+# unavailable. The second must not move the RRD.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMOND_RRD xymond/xymond_rrd
+
+ROOT=$(find_root)
+require_c_buildenv "$ROOT"
+[ -f "$ROOT/Makefile" ] || skip "tree not configured (no Makefile)"
+
+work=$(mktempdir)
+mkdir -p "$work/home/etc" "$work/tmp" "$work/rrd"
+: > "$work/home/etc/analysis.cfg"
+: > "$work/hosts.cfg"
+
+buildflags_output=$("$XYMON_MAKE" -s -C "$ROOT" -f Makefile -f - disk-test-flags <<'EOF'
+.PHONY: disk-test-flags
+disk-test-flags:
+	@printf '%s\n' 'ldflags=$(LDFLAGS)' 'rpathopt=$(RPATHOPT)' \
+		'rrddef=$(RRDDEF)' 'rrdincdir=$(RRDINCDIR)' 'rrdlibs=$(RRDLIBS)'
+EOF
+) || fail "cannot read configured RRD build flags"
+# Read the lines into an array without mapfile: that is a bash 4 builtin
+# and macOS ships bash 3.2, where the suite runs under /usr/bin/env bash.
+buildflags=()
+while IFS= read -r line; do buildflags+=("$line"); done <<< "$buildflags_output"
+[ "${#buildflags[@]}" -eq 5 ] || fail "configured RRD build flags are incomplete"
+ldflags=${buildflags[0]#ldflags=}
+rpathopt=${buildflags[1]#rpathopt=}
+rrddef=${buildflags[2]#rrddef=}
+rrdincdir=${buildflags[3]#rrdincdir=}
+rrdlibs=${buildflags[4]#rrdlibs=}
+[ -n "$rrdlibs" ] || rrdlibs="-lrrd"
+
+# The last-update reader is the one tests/rrd/inode-unix-columns.sh builds; it
+# takes any RRD, so there is no second harness to keep in step.
+# Configured flags are deliberate word-split lists.
+# shellcheck disable=SC2086
+"$CC" $ldflags -iquote "$ROOT/include" $rrddef $rrdincdir \
+	-o "$work/rrd-lastupdate" $rpathopt \
+	"$ROOT/tests/rrd/inode-unix-columns-harness.c" $rrdlibs \
+	2>"$work/cc.log" || {
+	cat "$work/cc.log" >&2
+	fail "librrd last-update harness does not compile"
+}
+
+# send_disk TIMESTAMP REMOTE-ROW -- one disk status message through xymond_rrd.
+# The local filesystem is identical in both, so anything that moves belongs to
+# the remote one.
+send_disk() {
+	printf '%s' "@@status|$1|127.0.0.1||unix.test|disk|$(($1 + 1800))|green||||||||||unix|
+status unix.test.disk green $1 - Filesystems ok
+Filesystem 1024-blocks Used Available Capacity Mounted on
+/dev/sda1 1000000 400000 600000 40% /
+$2
+@@
+" | env \
+		XYMONHOME="$work/home" \
+		XYMONVAR="$work" \
+		XYMONTMP="$work/tmp" \
+		XYMONRRDS="$work/rrd" \
+		HOSTSCFG="$work/hosts.cfg" \
+		TEST2RRD="disk" \
+		GRAPHS="disk" \
+		"$XYMOND_RRD" --no-cache --rrddir="$work/rrd" \
+		>>"$work/xymond_rrd.log" 2>&1
+}
+
+# The mount is measured first, so the RRD holds a real sample to protect. A
+# reading well away from the sentinel's 100%/1 makes a fabricated sample
+# unmistakable.
+first=$(date +%s)
+send_disk "$first" "srv:/exp 200000 50000 150000 25% /remote/nfs"
+
+rrd="$work/rrd/unix.test/disk,remote,nfs.rrd"
+assert_file_exists "$rrd" "the measured remote mount is trended"
+before=$("$work/rrd-lastupdate" "$rrd")
+assert_match "${first}:[[:space:]]+25([.]0+)?[[:space:]]+50000([.]0+)?" "$before" \
+	"the measured reading reaches the RRD"
+
+# The server has gone away: same mount, sentinel row. Five minutes on, so a
+# sample taken here would land in its own step rather than being folded into
+# the one above.
+second=$((first + 300))
+send_disk "$second" "unavailable:/remote/nfs 1 1 0 100% /remote/nfs"
+
+after=$("$work/rrd-lastupdate" "$rrd")
+assert_equal "$before" "$after" \
+	"an unmeasured mount was trended: the RRD moved to the sentinel's placeholder 100%/1 instead of keeping the last reading it actually had"
+
+# The local filesystem must be unaffected -- the skip is for the sentinel row,
+# not for the message that carries it.
+localrrd="$work/rrd/unix.test/disk,root.rrd"
+assert_file_exists "$localrrd" "the local filesystem is still trended"
+assert_match "${second}:" "$("$work/rrd-lastupdate" "$localrrd")" \
+	"the local filesystem took the second cycle's sample"
+
+# The inode column is trended by the same do_disk_rrd() (xymond/do_rrd.c), and
+# the BSD and darwin clients carry the inode fields in the sentinel row too, so
+# the same row has to be skipped on that path as well.
+send_inode() {
+	printf '%s' "@@status|$1|127.0.0.1||unix.test|inode|$(($1 + 1800))|green||||||||||unix|
+status unix.test.inode green $1 - Filesystems ok
+Filesystem itotal iused ifree %iused Mounted on
+$2
+@@
+" | env \
+		XYMONHOME="$work/home" \
+		XYMONVAR="$work" \
+		XYMONTMP="$work/tmp" \
+		XYMONRRDS="$work/rrd" \
+		HOSTSCFG="$work/hosts.cfg" \
+		TEST2RRD="inode" \
+		GRAPHS="inode" \
+		"$XYMOND_RRD" --no-cache --rrddir="$work/rrd" \
+		>>"$work/xymond_rrd.log" 2>&1
+}
+
+send_inode "$first" "srv:/exp 259070 41020 218050 15% /remote/nfs"
+irrd="$work/rrd/unix.test/inode,remote,nfs.rrd"
+assert_file_exists "$irrd" "the measured remote mount is trended for inodes"
+ibefore=$("$work/rrd-lastupdate" "$irrd")
+assert_match "${first}:[[:space:]]+15([.]0+)?[[:space:]]+41020([.]0+)?" "$ibefore" \
+	"the measured inode reading reaches the RRD"
+
+# The row a BSD or darwin client sends: the df columns plus the inode ones.
+send_inode "$second" "unavailable:/remote/nfs 1 1 0 100% 1 0 100% /remote/nfs"
+assert_equal "$ibefore" "$("$work/rrd-lastupdate" "$irrd")" \
+	"an unmeasured mount was trended for inodes: the RRD took the sentinel row's placeholder instead of keeping its last reading"
+
+# A host may be named "unavailable", and an NFS device is spelled
+# "<server>:<export>", so a real reading can begin with the same twelve
+# characters. The sentinel names the same mount on both ends of the row and a
+# real device cannot, which is what separates them -- dropping this reading
+# would lose the graph for a filesystem that is up and answering.
+third=$((second + 300))
+send_disk "$third" "unavailable:/export 200000 50000 150000 25% /real/nfs"
+realrrd="$work/rrd/unix.test/disk,real,nfs.rrd"
+assert_file_exists "$realrrd" \
+	"a genuine reading from a server named 'unavailable' was taken for the sentinel row and dropped"
+assert_match "${third}:[[:space:]]+25([.]0+)?[[:space:]]+50000([.]0+)?" \
+	"$("$work/rrd-lastupdate" "$realrrd")" \
+	"the genuine reading must be trended, not skipped by the prefix alone"
+
+pass "an unreachable mount reports red without writing a fabricated sample to its disk or inode RRD"

--- a/tests/rrd/disk-unavailable-no-sample.sh
+++ b/tests/rrd/disk-unavailable-no-sample.sh
@@ -4,9 +4,9 @@
 # tests/rrd/disk-unavailable-no-sample.sh
 #
 # When a remote mount is unreachable the client reports it as a df-shaped row,
-# "unavailable:/mnt 1 1 0 100% /mnt", so the disk column goes red instead of the
-# whole host going purple. The row carries no reading: the numbers in it exist
-# to breach the panic threshold, nothing measured them.
+# "srv:/exp - - - 100% /mnt": it names the device, so the operator can see which
+# server went away, and reports 100% so the disk column goes red instead of the
+# whole host going purple. The sizes are "-" because nothing measured them.
 #
 # Trending it therefore writes 100% used and 1 KB for as long as the server is
 # unreachable -- a full filesystem that was never measured, with the pre-outage
@@ -100,7 +100,7 @@ assert_match "${first}:[[:space:]]+25([.]0+)?[[:space:]]+50000([.]0+)?" "$before
 # sample taken here would land in its own step rather than being folded into
 # the one above.
 second=$((first + 300))
-send_disk "$second" "unavailable:/remote/nfs 1 1 0 100% /remote/nfs"
+send_disk "$second" "srv:/exp - - - 100% /remote/nfs"
 
 after=$("$work/rrd-lastupdate" "$rrd")
 assert_equal "$before" "$after" \
@@ -141,23 +141,34 @@ ibefore=$("$work/rrd-lastupdate" "$irrd")
 assert_match "${first}:[[:space:]]+15([.]0+)?[[:space:]]+41020([.]0+)?" "$ibefore" \
 	"the measured inode reading reaches the RRD"
 
-# The row a BSD or darwin client sends: the df columns plus the inode ones.
-send_inode "$second" "unavailable:/remote/nfs 1 1 0 100% 1 0 100% /remote/nfs"
+# The BSD and darwin sentinels emit the marker with the inode columns too,
+# but every client's [inode] pipeline collapses it before it is sent: what
+# reaches the server is the same six-field shape as the disk report.
+send_inode "$second" "srv:/exp - - - 100% /remote/nfs"
 assert_equal "$ibefore" "$("$work/rrd-lastupdate" "$irrd")" \
 	"an unmeasured mount was trended for inodes: the RRD took the sentinel row's placeholder instead of keeping its last reading"
 
-# A host may be named "unavailable", and an NFS device is spelled
-# "<server>:<export>", so a real reading can begin with the same twelve
-# characters. The sentinel names the same mount on both ends of the row and a
-# real device cannot, which is what separates them -- dropping this reading
+# The skip is on the values, not on the device name, so a server that happens
+# to be called "unavailable" is trended like any other: dropping this reading
 # would lose the graph for a filesystem that is up and answering.
 third=$((second + 300))
 send_disk "$third" "unavailable:/export 200000 50000 150000 25% /real/nfs"
 realrrd="$work/rrd/unix.test/disk,real,nfs.rrd"
 assert_file_exists "$realrrd" \
-	"a genuine reading from a server named 'unavailable' was taken for the sentinel row and dropped"
+	"a genuine reading from a server named 'unavailable' was mistaken for an unmeasured row and dropped"
 assert_match "${third}:[[:space:]]+25([.]0+)?[[:space:]]+50000([.]0+)?" \
 	"$("$work/rrd-lastupdate" "$realrrd")" \
-	"the genuine reading must be trended, not skipped by the prefix alone"
+	"the genuine reading must be trended: only the values say a row was not measured"
+
+# A spaced device arrives \040-encoded (the client re-encodes it to keep the
+# column count). The marker must be recognised the same: the RRD stays, and
+# no filesystem is invented.
+fourth=$((third + 300))
+rrdcount=$(find "$work/rrd" -name '*.rrd' | wc -l)
+send_disk "$fourth" 'srv:/team\040share - - - 100% /remote/nfs'
+assert_equal "$before" "$("$work/rrd-lastupdate" "$rrd")" \
+	"an unmeasured row naming a spaced device moved the RRD"
+assert_equal "$((rrdcount))" "$(($(find "$work/rrd" -name '*.rrd' | wc -l)))" \
+	"an unmeasured row naming a spaced device created an RRD of its own"
 
 pass "an unreachable mount reports red without writing a fabricated sample to its disk or inode RRD"

--- a/tests/server/disk-unavailable-honest-message.sh
+++ b/tests/server/disk-unavailable-honest-message.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/disk-unavailable-honest-message.sh
+#
+# An unreachable mount arrives as the client's marker row,
+# "srv:/exp - - - 100% /remote/nfs": "-" sizes because nothing measured them,
+# 100% so the disk column goes red on any server. Routing that 100% through
+# the ordinary percent threshold made the alert text lie about the failure:
+# "&red /remote/nfs (100% used) has reached the PANIC level (95%)" reads as a
+# full disk, when the truth is a mount that did not answer.
+#
+# unix_disk_report()/unix_inode_report() must recognise the marker by its
+# values ("-" in the free column plus the marker's 100%) and name the failure
+# instead. Pinned here, by driving the real xymond_client in --local
+# --no-update mode (statuses print to stdout instead of being sent):
+#
+#   - the marker row alerts "&red /remote/nfs is unreachable (not measured)"
+#     in both the disk and the inode status, and no longer emits the
+#     disk-full PANIC text for that mount
+#   - a genuinely full filesystem (real sizes, 100%) still takes the normal
+#     threshold path and reports the PANIC text -- the honest message must
+#     not swallow real alerts
+#   - an AIX-style all-dash row ("-" in the percent column too, as df -Ik
+#     writes for /proc) is NOT mistaken for the marker: its status stays
+#     green with no "unreachable" line
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin XYMOND_CLIENT xymond/xymond_client
+
+work=$(mktempdir)
+mkdir -p "$work/home"
+: > "$work/analysis.cfg"
+
+# Two client reports through one worker run: a Linux host carrying the marker
+# next to a healthy and a genuinely full filesystem, then an AIX host whose
+# /proc row is all dashes. XYMONHOME points at a directory of its own so the
+# backfeed-queue probe fails and every generated status lands on stdout.
+out=$(printf '%s' '@@client|1755640000|127.0.0.1|unix.test|linux|linux|
+[df]
+Filesystem 1024-blocks Used Available Capacity Mounted on
+/dev/sda1 1000000 400000 600000 40% /
+srv:/exp - - - 100% /remote/nfs
+/dev/sdb1 1000000 1000000 0 100% /full
+[inode]
+Filesystem Inodes IUsed IFree IUse% Mounted on
+/dev/sda1 65536 1024 64512 2% /
+srv:/exp - - - 100% /remote/nfs
+@@
+@@client|1755640000|127.0.0.1|aix.test|aix|aix|
+[df]
+Filesystem 1024-blocks Used Free %Used Mounted on
+/dev/hd4 1000000 400000 600000 40% /
+/proc - - - - /proc
+@@
+' | env \
+	XYMONHOME="$work/home" \
+	XYMONTMP="$work" \
+	"$XYMOND_CLIENT" --local --no-update --config="$work/analysis.cfg" \
+	2>"$work/stderr.log") || fail "xymond_client exited non-zero: $(cat "$work/stderr.log")"
+
+# The marker names the failure, in the disk and the inode status alike.
+assert_contains "&red /remote/nfs is unreachable (not measured)" "$out" \
+	"the unreachable mount is still reported as a full disk instead of being named unreachable"
+assert_match "unix,test\.disk red" "$out" \
+	"the disk column did not go red on the unreachable mount"
+assert_match "unix,test\.inode red" "$out" \
+	"the inode column did not go red on the unreachable mount"
+assert_contains "ID=/remote/nfs" "$out" \
+	"the inode alert for the unreachable mount lost its ID comment"
+
+# The disk-full text is gone for the marker...
+assert_not_contains "/remote/nfs (100% used)" "$out" \
+	"the unreachable mount still claims '100% used' as if it were a full disk"
+
+# ...but a genuinely full filesystem still raises it: real sizes, so the
+# values say it was measured.
+assert_contains "&red /full (100% used) has reached the PANIC level" "$out" \
+	"a genuinely full filesystem no longer alerts through the threshold path"
+
+# The AIX all-dash /proc row has no 100% -- it is not the marker, and must
+# not start alerting.
+assert_match "aix,test\.disk green" "$out" \
+	"the AIX all-dash /proc row turned the disk column non-green"
+assert_not_contains "/proc is unreachable" "$out" \
+	"the AIX all-dash /proc row was mistaken for the unavailable-mount marker"
+
+pass "an unreachable mount is named in the alert instead of being reported as a full disk"

--- a/xymond/rrd/do_disk.c
+++ b/xymond/rrd/do_disk.c
@@ -97,35 +97,6 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 		/* All clients except AS/400 report the mount-point with slashes - ALSO Win32 clients. */
 		if ((dsystype != DT_AS400) && (strchr(curline, '/') == NULL)) goto nextline;
 
-		/*
-		 * A mount the client could not measure. The remote-df sentinel
-		 * reports it as a df-shaped row so the column goes red instead of
-		 * the whole host going purple, but the row carries no reading: the
-		 * "1 1 0 100%" in it is a placeholder that exists to breach the
-		 * panic threshold. Trending it writes 100% used and 1 KB for as
-		 * long as the server is unreachable, so the graph shows a full
-		 * filesystem that was never measured, and the pre-outage values are
-		 * lost behind it. Skip the row here and the RRD keeps its last real
-		 * sample; the status page still shows the row, and the disk column
-		 * is red either way.
-		 */
-		if (strncmp(curline, "unavailable:", 12) == 0) {
-			/*
-			 * The prefix alone is not the marker: an NFS export from a
-			 * server named "unavailable" spells its device the same way.
-			 * The sentinel names the mount twice -- "unavailable:/mnt ...
-			 * /mnt" -- so require the two to agree, which a real device
-			 * cannot do unless it is already mounted on itself.
-			 */
-			char *sname = curline + 12;
-			size_t snamelen = strcspn(sname, " \t");
-			char *mount = strrchr(curline, ' ');
-
-			if (mount && (snamelen > 0) &&
-			    (strncmp(mount+1, sname, snamelen) == 0) && (*(mount+1+snamelen) == '\0'))
-				goto nextline;
-		}
-
 		/* red/yellow filesystems show up twice */
 		if ((dsystype != DT_NETAPP) && (dsystype != DT_NETWARE) && (dsystype != DT_AS400)) {
 			if (*curline == '&') goto nextline; 
@@ -135,6 +106,19 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 		for (columncount=0; (columncount<20); columncount++) columns[columncount] = "";
 		fsline = xstrdup(curline); columncount = 0; p = strtok(fsline, " ");
 		while (p && (columncount < 20)) { columns[columncount++] = p; p = strtok(NULL, " "); }
+
+		/*
+		 * A row without a reading: an unreachable mount is reported with "-"
+		 * sizes (nothing measured them) and 100% so the column goes red.
+		 * Trending it would write a full filesystem over the pre-outage
+		 * readings, so it is skipped. The test is on the values, not the
+		 * device name; the one df writing this shape itself, AIX "df -Ik" on
+		 * /proc, carried no reading either and trended as zeros.
+		 */
+		if ((strcmp(columns[1], "-") == 0) && (strcmp(columns[2], "-") == 0)) {
+			xfree(fsline);
+			goto nextline;
+		}
 
 		/* 
 		 * Some Unix filesystem reports contain the word "Filesystem".

--- a/xymond/rrd/do_disk.c
+++ b/xymond/rrd/do_disk.c
@@ -97,6 +97,35 @@ int do_disk_rrd(char *hostname, char *testname, char *classname, char *pagepaths
 		/* All clients except AS/400 report the mount-point with slashes - ALSO Win32 clients. */
 		if ((dsystype != DT_AS400) && (strchr(curline, '/') == NULL)) goto nextline;
 
+		/*
+		 * A mount the client could not measure. The remote-df sentinel
+		 * reports it as a df-shaped row so the column goes red instead of
+		 * the whole host going purple, but the row carries no reading: the
+		 * "1 1 0 100%" in it is a placeholder that exists to breach the
+		 * panic threshold. Trending it writes 100% used and 1 KB for as
+		 * long as the server is unreachable, so the graph shows a full
+		 * filesystem that was never measured, and the pre-outage values are
+		 * lost behind it. Skip the row here and the RRD keeps its last real
+		 * sample; the status page still shows the row, and the disk column
+		 * is red either way.
+		 */
+		if (strncmp(curline, "unavailable:", 12) == 0) {
+			/*
+			 * The prefix alone is not the marker: an NFS export from a
+			 * server named "unavailable" spells its device the same way.
+			 * The sentinel names the mount twice -- "unavailable:/mnt ...
+			 * /mnt" -- so require the two to agree, which a real device
+			 * cannot do unless it is already mounted on itself.
+			 */
+			char *sname = curline + 12;
+			size_t snamelen = strcspn(sname, " \t");
+			char *mount = strrchr(curline, ' ');
+
+			if (mount && (snamelen > 0) &&
+			    (strncmp(mount+1, sname, snamelen) == 0) && (*(mount+1+snamelen) == '\0'))
+				goto nextline;
+		}
+
 		/* red/yellow filesystems show up twice */
 		if ((dsystype != DT_NETAPP) && (dsystype != DT_NETWARE) && (dsystype != DT_AS400)) {
 			if (*curline == '&') goto nextline; 

--- a/xymond/xymond_client.c
+++ b/xymond/xymond_client.c
@@ -585,7 +585,7 @@ void unix_disk_report(char *hostname, char *clientclass, enum ostype_t os,
 		}
 		else {
 			char *fsname = NULL, *levelstr = NULL;
-			int abswarn, abspanic;
+			int abswarn, abspanic, unmeasured = 0;
 			long levelpct = -1, levelabs = -1, warnlevel, paniclevel;
 
 			p = strdup(bol);
@@ -600,7 +600,11 @@ void unix_disk_report(char *hostname, char *clientclass, enum ostype_t os,
 						    &ignored, &group);
 
 				strcpy(p, bol);
-				levelstr = getcolumn(p, freecol); if (levelstr) levelabs = atol(levelstr);
+				levelstr = getcolumn(p, freecol);
+				if (levelstr) {
+					unmeasured = (strcmp(levelstr, "-") == 0);
+					levelabs = atol(levelstr);
+				}
 				strcpy(p, bol);
 				levelstr = getcolumn(p, capacol); if (levelstr) levelpct = atol(levelstr);
 
@@ -610,6 +614,17 @@ void unix_disk_report(char *hostname, char *clientclass, enum ostype_t os,
 
 				if (ignored) {
 					/* Forget about this one */
+				}
+				else if (unmeasured && (levelpct == 100)) {
+					/* The client's unavailable-mount marker: "-" sizes because
+					 * nothing measured them, 100% so the column still goes red
+					 * on a server without this check. An all-dash row (AIX
+					 * /proc) has no 100% and stays out. */
+					if (diskcolor < COL_RED) diskcolor = COL_RED;
+
+					sprintf(msgline, "&red %s is unreachable (not measured)\n", fsname);
+					addtobuffer(monmsg, msgline);
+					addalertgroup(group);
 				}
 				else if ( (abspanic && (levelabs <= paniclevel)) || 
 				     (!abspanic && (levelpct >= paniclevel)) ) {
@@ -765,7 +780,7 @@ void unix_inode_report(char *hostname, char *clientclass, enum ostype_t os,
 		}
 		else {
 			char *fsname = NULL, *levelstr = NULL;
-			int abswarn, abspanic;
+			int abswarn, abspanic, unmeasured = 0;
 			long levelpct = -1, levelabs = -1, warnlevel, paniclevel;
 
 			p = strdup(bol);
@@ -780,7 +795,11 @@ void unix_inode_report(char *hostname, char *clientclass, enum ostype_t os,
 						    &ignored, &group);
 
 				strcpy(p, bol);
-				levelstr = getcolumn(p, freecol); if (levelstr) levelabs = atol(levelstr);
+				levelstr = getcolumn(p, freecol);
+				if (levelstr) {
+					unmeasured = (strcmp(levelstr, "-") == 0);
+					levelabs = atol(levelstr);
+				}
 				strcpy(p, bol);
 				levelstr = getcolumn(p, capacol); if (levelstr) levelpct = atol(levelstr);
 
@@ -790,6 +809,16 @@ void unix_inode_report(char *hostname, char *clientclass, enum ostype_t os,
 
 				if (ignored) {
 					/* Forget about this one */
+				}
+				else if (unmeasured && (levelpct == 100)) {
+					/* The unavailable-mount marker, passed through by the
+					 * clients' inode reformatters -- same shape as in the
+					 * disk report. */
+					if (inodecolor < COL_RED) inodecolor = COL_RED;
+
+					sprintf(msgline, "&red <!-- ID=%s --> %s is unreachable (not measured)\n", fsname, fsname);
+					addtobuffer(monmsg, msgline);
+					addalertgroup(group);
 				}
 				else if ( (abspanic && (levelabs <= paniclevel)) || 
 				     (!abspanic && (levelpct >= paniclevel)) ) {


### PR DESCRIPTION
Closes #344. The server-side guard, the row it keys on, then the alert that names it.

**Commit 1 — do_disk skips a row without a reading.** The client's unavailable marker was trended
as a real sample: 100% / 1 KB every cycle of an outage, burying the pre-outage graph. The skip
triggers on `-` in both size columns; status is untouched (color is decided in `xymond_client.c`).
One side effect outside #344: AIX `df -Ik` writes the same all-dash shape for `/proc`, which was
trended as fabricated zeros — that row is now skipped too, losing nothing measured.

**Commit 2 — the marker names the server and reports no value.**
`unavailable:/mnt 1 1 0 100% /mnt` becomes `srv:/exp - - - 100% /remote/nfs`: `fs_mounts()` carries
the device as a third field, `-` means unmeasured, `100%` keeps the column red. The values-based
skip retires the device-name special case — a server genuinely named `unavailable` is trended like
any other. The BSD/macOS inode reformatters previously turned `-` back into `0` or dropped the row
(green during an outage); they now pass the marker through, collapsed on the wire to the same
six-field shape as the disk report.

**Commit 3 — FreeBSD all-ZFS inode report (#398).** On a ZFS-only host `df -i` excludes every
filesystem and exits 0 with no output; the clean-but-empty case fell through and became a garbage
`itotal` row the server could not parse (red). An empty result now emits an empty report, keeping
the server's all-ZFS green path. Confirmed working by @feld on the affected host.

**Commit 4 — the alert names the failure.** Routing the marker's `100%` through the percent
threshold made the alert read "(100% used) has reached the PANIC level" — a full disk, when the
truth is a mount that did not answer. `unix_disk_report()`/`unix_inode_report()` now recognise the
marker by its values (`-` free plus the marker's `100%`) and report
"&red /remote/nfs is unreachable (not measured)" instead; IGNORE rules still apply, the wire is
untouched (an old server still goes red via its thresholds). AIX's all-dash `/proc` row has no
`100%` and stays green; a genuinely full filesystem has real sizes and keeps the PANIC path.

Both review findings are fixed:
- The mount list reaches the fallback awk on its input stream behind an `@@` separator
  (`fs_setop()`'s move): a `-v` assignment cannot carry newlines on BSD awk, so two or more guarded
  mounts emitted no rows at all.
- A device containing spaces is re-encoded (`\040`) so the marker row keeps its column count.

| check | result |
|---|---|
| full suite on a built tree | 88 passed / 0 skipped / 0 failed |
| commit-1 skip removed | FAIL — RRD moves to `100 1` |
| skip as a bare prefix test | FAIL — a real `unavailable:`-named server loses its RRD |
| client tests under one-true-awk (= BSD awk) | pass; pre-fix scripts FAIL (`newline in string`) |
| spaced-device fixture vs pre-fix client | FAIL — the decoded row splits the columns |
| commit-3 all-zfs fixture vs pre-fix client | FAIL — the exact garbage row from #398 |
| commit-4 test vs pre-fix server | FAIL — the marker alerts "(100% used) has reached the PANIC level" |

---
**Merge sequencing.** Not git-stacked, but overlaps **#397** on the client scripts (`fs_mounts`, the `run_df` unavailable row) and `tests/client/fs-mounts.sh`. Suggested order: **#397 → this** (#396, which #397 built on, is already merged). The second merge combines this PR's third `fs_mounts` field (device) with #397's `\134`/escape decoding on mp+dev, and keeps this PR's awk-based unavailable row (it supersedes #397's `echo`→`printf`, whose loop this removes). The inode fix here (issue #398, commit 3) no longer collides with the test-infra stack #391→#167→#319→#179→#394 — its case was moved off the shared `pass` line. Commit 4 touches only `xymond/xymond_client.c` plus a new `tests/server/` file, so it adds nothing to the overlap.
