### PR TITLE
tests: link the lib-only harnesses against the archives every variant builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
       # there. Run it here too, where the binaries this variant produced are on
       # disk, so those tests actually execute against the build.
       #
-      # First such test: tests/server/xymongrep-filter.sh, which drives the
+      # First such test: tests/common/xymongrep-filter.sh, which drives the
       # common/xymongrep this leg just built. This step is the only place in
       # CI where it executes instead of skipping.
       #

--- a/tests/README.md
+++ b/tests/README.md
@@ -99,7 +99,8 @@ it drives is one every variant builds -- `common/xymongrep` in a server tree,
 `client/xymongrep` in a client one -- so it goes under `common/`, and a client
 build gets the coverage it exists for. `analysis-file-ifexist.sh` drives
 `xymond_client`, which only a localclient or server build produces, so it goes
-under `localclient/`.
+under `analysis/`: the area names the subject, and the variant table above says
+which build supplies the binary.
 
 Add a new area by PR when an existing one doesn't fit. Don't bend a
 test to fit the wrong area just to avoid creating a new directory.

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,6 +28,31 @@ Conventions). The runner itself is POSIX sh, and on a host without bash it
 skips the whole suite with exit `77` rather than reporting interpreter
 failures as test failures.
 
+### `XYMON_VARIANT` — telling the suite which build this is
+
+Most tests only execute against a build, so run one first. The suite then needs
+to know *which* build, because the same program lives at different paths
+depending on the variant:
+
+    ./configure --server && make -j$(nproc)
+    XYMON_VARIANT=server ./tests/testsuite
+
+| variant | configured with | `xymongrep` | `xymond_client` |
+| ------- | --------------- | ----------- | --------------- |
+| `server` | `./configure --server` | `common/xymongrep` | `xymond/xymond_client` |
+| `localclient` | `CONFTYPE=client ./configure --client` | `client/xymongrep` | `client/xymond_client` |
+| `client` | `./configure --client` | `client/xymongrep` | not built |
+
+The full table is `variant_products()` in `lib/assert.sh`; it also covers
+`xymond_rrd` and `svcstatus.cgi`, both server-only.
+
+Leaving it unset is the default and stays supported: each test falls back to its
+own in-tree path, which is what a developer run, a release tarball and the
+build-free `tests.yml` lane all do. Setting it is what lets one test run against
+whichever variant a build produced — without it,
+`tests/analysis/analysis-file-ifexist.sh` skips in a localclient build while
+the program it wants sits in `client/`.
+
 ## What lives here, what doesn't
 
 - **Here:** shell-level integration scenarios that exercise binaries,
@@ -38,15 +63,29 @@ failures as test failures.
 
 ## Directory layout
 
-Tests are organised by **domain area**, not by source path. Source
-paths shift over time (CMake migration is in flight); domains don't.
-Cross-cutting scenarios that don't map to a single source dir (e.g.
-shipped-file invariants) get their own area.
+**A test's folder is decided by which builds contain the thing it drives.**
+The folder name labels a set of variants, not a subject.
+
+1. What does the test execute or compile — a binary, a source file, a shipped
+   config, or nothing (a pure scan)?
+2. Which variants produce that thing?
+3. File it in the area below whose row lists exactly those variants.
+
+A test needing several things takes the most restrictive — it needs all of
+them. Among areas covering the same variants the choice is readability, not
+correctness, so settle the variant set first and the name second.
+
+Not by topic: a test *about* server behaviour that only compiles `lib/` code
+runs in every build, and filing it under `server` would skip it in the client
+legs. Not by source path either — those shift (the CMake migration is in
+flight) and one test often spans several.
 
 | Area              | What lives here                                        |
 | ----------------- | ------------------------------------------------------ |
+| `tests/common/`   | tools every variant ships (xymon, xymoncmd, xymongrep, xymoncfg, xymondigest) |
 | `tests/client/`   | xymon client tools and behaviours                      |
-| `tests/server/`   | xymond-side tools (xymongrep, xymoncgimsg, alert routing) |
+| `tests/analysis/`  | the local data analyser (`xymond_client`, wherever the variant builds it) |
+| `tests/server/`   | xymond-side tools (xymoncgimsg, alert routing, config parsing) |
 | `tests/network/`  | xymonnet probes (xymonping, network checks)            |
 | `tests/web/`      | CGIs, HTML rendering paths                             |
 | `tests/packaging/`| cross-cutting: shipped files, paths, generated configs |
@@ -54,6 +93,13 @@ shipped-file invariants) get their own area.
 | `tests/integration/` | end-to-end scenarios spanning multiple components   |
 | `tests/lib/`      | sourced helpers (`assert.sh`, future `net.sh` etc.)    |
 | `tests/fixtures/` | shared data files (config snippets, expected outputs)  |
+
+Worked through: `xymongrep-filter.sh` reads as server-side work, but the binary
+it drives is one every variant builds -- `common/xymongrep` in a server tree,
+`client/xymongrep` in a client one -- so it goes under `common/`, and a client
+build gets the coverage it exists for. `analysis-file-ifexist.sh` drives
+`xymond_client`, which only a localclient or server build produces, so it goes
+under `localclient/`.
 
 Add a new area by PR when an existing one doesn't fit. Don't bend a
 test to fit the wrong area just to avoid creating a new directory.
@@ -142,6 +188,13 @@ maintenance.
   require_cfg XYMONSERVER_CFG xymond/etcfiles/xymonserver.cfg  # config files
   SCRIPT="${XYMONCLIENT_LINUX:-$ROOT/client/xymonclient-linux.sh}"  # scripts
   ```
+  `require_bin` resolves in three steps, first match wins: an explicitly
+  exported `$VAR`; then, if `XYMON_VARIANT` is set and the table knows this
+  role, the path that variant builds it at; then the caller's default. A role
+  the table names but this variant's row omits is a `skip` -- that build
+  genuinely does not produce it. A role the table does not mention at all
+  falls through to the default, so an undeclared product degrades to a probe
+  rather than a false claim.
   This keeps tests usable in CMake out-of-source builds (the build
   system passes the real path), in the in-tree Makefile build (default
   matches), and in autopkgtest (the control file exports installed

--- a/tests/analysis/analysis-file-ifexist.sh
+++ b/tests/analysis/analysis-file-ifexist.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# tests/server/analysis-file-ifexist.sh
+# tests/analysis/analysis-file-ifexist.sh
 #
 # Regression guard for IFEXIST being accepted as an alias for OPTIONAL in a
 # FILE rule (analysis.cfg / client-local.cfg), added for compatibility with

--- a/tests/common/loadhosts-canonical-charset.sh
+++ b/tests/common/loadhosts-canonical-charset.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# tests/server/loadhosts-canonical-charset.sh
+# tests/common/loadhosts-canonical-charset.sh
 #
 # Behavioural test of the BUILT xymongrep binary, exercising the real
 # load_hostnames() path in libxymon. A canonical hostname (field 2 of

--- a/tests/common/xymongrep-filter.sh
+++ b/tests/common/xymongrep-filter.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# tests/server/xymongrep-filter.sh
+# tests/common/xymongrep-filter.sh
 #
 # Behavioural test of the BUILT xymongrep binary: hosts.cfg tag selection.
 #

--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -381,6 +381,75 @@ find_root() {
 
 # ---- binary discovery --------------------------------------------------------
 
+# ---- build products, by variant ---------------------------------------------
+
+# variant_products -- one row per build variant: the products a test may ask
+# for, keyed by role, and the path this variant puts each at.
+#
+# The same program lives at different paths depending on what was built:
+# a server build puts the local data analyser at xymond/xymond_client, a
+# localclient build at client/xymond_client. A test that hardcodes one path
+# skips in the other build even though the program is right there. Stating the
+# paths once, here, is what lets one test run against whichever variant a leg
+# happens to have built.
+#
+# A server build carries both common/xymongrep and client/xymongrep; the server
+# row names common/, which is what the server package ships.
+variant_products() {
+	cat <<-'EOF'
+		server       XYMONGREP=common/xymongrep XYMOND_CLIENT=xymond/xymond_client XYMOND_RRD=xymond/xymond_rrd SVCSTATUS_CGI=web/svcstatus.cgi
+		localclient  XYMONGREP=client/xymongrep XYMOND_CLIENT=client/xymond_client
+		client       XYMONGREP=client/xymongrep
+	EOF
+}
+
+# known_variants -- the variant names the table above declares, one per line.
+# Read from the table rather than written again, so the two cannot disagree.
+known_variants() {
+	local line
+	while read -r line; do
+		# shellcheck disable=SC2086  # deliberate: split the row into fields
+		set -- $line
+		[ -n "${1:-}" ] && printf '%s\n' "$1"
+	done <<<"$(variant_products)"
+}
+
+# product_declared ROLE -- true when any row mentions ROLE.
+#
+# Absent from every row is not the same as absent from this variant's row. The
+# first means the table says nothing about this product -- so the caller's
+# DEFAULT still decides, exactly as it does with no variant declared. The
+# second means this variant genuinely does not build it. Collapsing the two
+# makes every role the table has not learned yet report as "this build does not
+# produce it", which is a confident answer to a question nothing asked.
+product_declared() {
+	local want_r=$1 line kv
+	while read -r line; do
+		# shellcheck disable=SC2086
+		set -- $line
+		shift
+		for kv; do [ "${kv%%=*}" = "$want_r" ] && return 0; done
+	done <<<"$(variant_products)"
+	return 1
+}
+
+# product_path VARIANT ROLE -- where VARIANT builds ROLE. Empty when that
+# variant does not build it at all, which is a different thing from "the build
+# should have produced it and did not" and is reported differently.
+product_path() {
+	local want_v=$1 want_r=$2 line kv
+	while read -r line; do
+		# shellcheck disable=SC2086
+		set -- $line
+		[ "${1:-}" = "$want_v" ] || continue
+		shift
+		for kv; do
+			[ "${kv%%=*}" = "$want_r" ] && { printf '%s\n' "${kv#*=}"; return 0; }
+		done
+		return 0
+	done <<<"$(variant_products)"
+}
+
 # require_bin VAR DEFAULT -- ensure $VAR (or DEFAULT if unset) points to an
 # executable; export VAR with the resolved path. Skip if the in-tree DEFAULT
 # is absent (the binary just wasn't built in this configuration), but FAIL if
@@ -394,7 +463,7 @@ find_root() {
 #     require_bin XYMONGREP common/xymongrep
 #     "$XYMONGREP" --hosts=...
 #
-# First consumer: tests/server/xymongrep-filter.sh. This helper is what lets
+# First consumer: tests/common/xymongrep-filter.sh. This helper is what lets
 # the same test run against an in-tree build (the DEFAULT path, resolved from
 # the repo root), a CMake out-of-source build, or an installed package under
 # Debian autopkgtest (both export an absolute $VAR). It is also what makes the
@@ -411,9 +480,19 @@ require_bin() {
 	# wrong path and skip with 77 even when the binary exists. An explicit env
 	# override (absolute path from CMake/autopkgtest) is used verbatim.
 	if [ -z "$cur" ]; then
-		case $default in
-			/*) cur=$default ;;
-			*)  cur=$(find_root)/$default ;;
+		local rel=$default
+		# A declared variant knows better than the caller's default: it says
+		# which build this is, and the table says where that build puts the
+		# product. Without one -- a developer run, a release tarball, the
+		# build-free tests.yml lane -- the default stands.
+		if [ -n "${XYMON_VARIANT:-}" ] && product_declared "$var"; then
+			rel=$(product_path "$XYMON_VARIANT" "$var")
+			[ -n "$rel" ] \
+				|| skip "the ${XYMON_VARIANT} build does not produce $var"
+		fi
+		case $rel in
+			/*) cur=$rel ;;
+			*)  cur=$(find_root)/$rel ;;
 		esac
 	fi
 	if [ ! -x "$cur" ]; then

--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -403,6 +403,21 @@ variant_products() {
 	EOF
 }
 
+# An unknown XYMON_VARIANT is indistinguishable from a variant that declares no
+# products: product_path returns nothing, the caller skips, and
+# `XYMON_VARIANT=sever ./tests/testsuite` finishes green having quietly dropped
+# the binary coverage the variant exists to select. Checked where the variant is
+# read, so a typo fails the tests it would have silently removed.
+validate_variant() {
+	[ -n "${XYMON_VARIANT:-}" ] || return 0
+	# Checked once per test: require_bin is called for each product a test
+	# needs, and the answer cannot change within a run.
+	[ -n "${XYMON_VARIANT_CHECKED:-}" ] && return 0
+	known_variants | grep -qxF "$XYMON_VARIANT" \
+		|| fail "XYMON_VARIANT='$XYMON_VARIANT' is not a known variant -- expected one of: $(known_variants | tr '\n' ' ' | sed 's/ $//')"
+	XYMON_VARIANT_CHECKED=1
+}
+
 # known_variants -- the variant names the table above declares, one per line.
 # Read from the table rather than written again, so the two cannot disagree.
 known_variants() {
@@ -486,6 +501,7 @@ require_bin() {
 		# product. Without one -- a developer run, a release tarball, the
 		# build-free tests.yml lane -- the default stands.
 		if [ -n "${XYMON_VARIANT:-}" ] && product_declared "$var"; then
+			validate_variant
 			rel=$(product_path "$XYMON_VARIANT" "$var")
 			[ -n "$rel" ] \
 				|| skip "the ${XYMON_VARIANT} build does not produce $var"

--- a/tests/network/netrc-password.sh
+++ b/tests/network/netrc-password.sh
@@ -50,7 +50,7 @@ assert_not_contains "snprintf(item->auth, login_len," "$src" \
 # the source guard above already stands, so pass with a note.
 command -v "$CC" >/dev/null 2>&1 \
 	|| pass "url.c keeps the #226 snprintf size (source check; no C compiler for the behavioural run)"
-[ -f "$ROOT/lib/libxymoncomm.a" ] \
+[ -f "$ROOT/lib/libxymonclient.a" ] && [ -f "$ROOT/lib/libxymonclientcomm.a" ] \
 	|| pass "url.c keeps the #226 snprintf size (source check; library not built for the behavioural run)"
 
 work=$(mktempdir)
@@ -87,7 +87,8 @@ EOF
 harness_cflags=$(xymon_cflags "$ROOT")
 harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags -o "$work/harness" \
-	"$work/harness.c" "$SRC" "$ROOT/lib/libxymoncomm.a" $harness_ldflags $pcre_libs 2>"$work/cc.log" \
+	"$work/harness.c" "$SRC" "$ROOT/lib/libxymonclientcomm.a" "$ROOT/lib/libxymonclient.a" \
+	$harness_ldflags $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "netrc harness does not compile"; }
 
 # A password whose last byte matters: the off-by-one drops the trailing 't'.

--- a/tests/server/config-include-dir.sh
+++ b/tests/server/config-include-dir.sh
@@ -75,7 +75,7 @@ check_declares "$ROOT/client/xymonclient.cfg.DIST"              "xymonclient.d"
 
 CC=${CC:-cc}
 if ! command -v "$CC" >/dev/null 2>&1 \
-	|| [ ! -f "$ROOT/include/config.h" ] || [ ! -f "$ROOT/lib/libxymoncomm.a" ]; then
+	|| [ ! -f "$ROOT/include/config.h" ] || [ ! -f "$ROOT/lib/libxymonclient.a" ] || [ ! -f "$ROOT/lib/libxymonclientcomm.a" ]; then
 	pass "shipped configs declare their drop-in directories (#222); stackio mechanism check skipped (tree not built)"
 fi
 
@@ -90,7 +90,8 @@ fi
 harness_cflags=$(xymon_cflags "$ROOT")
 harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" -DSTANDALONE $harness_cflags -o "$work/stackio" \
-	"$ROOT/lib/stackio.c" "$ROOT/lib/libxymoncomm.a" $harness_ldflags $pcre_libs 2>"$work/cc.log" \
+	"$ROOT/lib/stackio.c" "$ROOT/lib/libxymonclientcomm.a" "$ROOT/lib/libxymonclient.a" \
+	$harness_ldflags $pcre_libs 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "standalone stackio does not compile"; }
 
 # The STANDALONE reader reads argv[1] via stackfgets() (which expands include

--- a/tests/server/notbefore-notafter.sh
+++ b/tests/server/notbefore-notafter.sh
@@ -40,15 +40,15 @@ ROOT=$(find_root)
 CC=${CC:-cc}
 command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
 
-[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymonclient.a" ] \
 	|| skip "tree not built (run make first; the post-build CI suite covers this)"
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-notbefore.XXXXXX")
 trap 'rm -rf "$work"' EXIT HUP INT TERM
 
 require_gnu_make
-"$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
-	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+"$XYMON_MAKE" -C "$ROOT/lib" libxymonclientcomm.a libxymonclient.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh the xymon client libraries"; }
 
 cat > "$work/hosts.cfg" <<'EOF'
 127.0.0.1 inwindow.example.com # conn NOTBEFORE:199001010000 NOTAFTER:209001010000
@@ -164,7 +164,7 @@ EOF
 harness_cflags=$(xymon_cflags "$ROOT")
 harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags -o "$work/harness" \
-	"$work/harness.c" "$ROOT/lib/libxymoncomm.a" \
+	"$work/harness.c" "$ROOT/lib/libxymonclientcomm.a" "$ROOT/lib/libxymonclient.a" \
 	$harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 

--- a/tests/server/xmh-item-names.sh
+++ b/tests/server/xmh-item-names.sh
@@ -47,14 +47,14 @@ templates) and also what xmh_item_isflag[] is derived from:
 $mismatched"
 
 require_c_buildenv "$ROOT"
-[ -f "$ROOT/lib/libxymoncomm.a" ] \
+[ -f "$ROOT/lib/libxymonclient.a" ] \
 	|| skip "tree not built (run make first; the post-build CI suite covers this)"
 
 
 work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-xmh-item-names.XXXXXX")
 trap 'rm -rf "$work"' EXIT HUP INT TERM
 
-build_xymon_libs "$ROOT" "$work/libbuild.log" libxymoncomm.a
+build_xymon_libs "$ROOT" "$work/libbuild.log" libxymonclientcomm.a libxymonclient.a
 
 cat > "$work/hosts.cfg" <<'EOF'
 127.0.0.1 taghost.example.com # conn dialup MULTIHOMED
@@ -64,7 +64,8 @@ EOF
 harness_cflags=$(xymon_cflags "$ROOT")
 harness_ldflags=$(xymon_ldflags "$ROOT")
 "$CC" $harness_cflags -o "$work/harness" \
-	"$here/xmh-item-names-harness.c" "$ROOT/lib/libxymoncomm.a" \
+	"$here/xmh-item-names-harness.c" \
+	"$ROOT/lib/libxymonclientcomm.a" "$ROOT/lib/libxymonclient.a" \
 	$harness_ldflags 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
 


### PR DESCRIPTION
**Bottom of a 5-PR stack** (#391 → #167 → #319 → #179 → #394); own commits: the 2 shown. Merge first.

Two changes that make tests find what a build actually produced. Refs #166.

- `variant_products()` in `tests/lib/assert.sh`: one table of per-variant product paths. `require_bin` resolves an exported `$VAR`, then the variant's row, then the caller's default; an undeclared product degrades to a probe rather than a false claim.
- Four harnesses linked `libxymoncomm.a`, which only a server build produces, and skipped on client builds that compile the same objects into `libxymonclientcomm.a` + `libxymonclient.a` — built by every variant (comm first; the reverse fails to link).

All CI checks green at this head.
