### PR TITLE
tests: a basic regex has no \?, and the suite now says so

### DIFF
--- a/tests/buildsystem/test-suite-portability.sh
+++ b/tests/buildsystem/test-suite-portability.sh
@@ -157,6 +157,31 @@ check_uname_guard() {
 
 for f in $files; do check_uname_guard "$f" "$work/violations"; done
 
+# "\?", "\+" and "\|" are GNU (and Spencer) extensions to a *basic* regex, not
+# POSIX. OpenBSD's grep reads them as the literal characters, so a pattern
+# using one silently stops matching there -- and a test that greps for
+# something it produced itself then reports the thing it was checking as
+# changed, which is the wrong place to look. In an ERE all three are standard,
+# so the fix is -E (and escaping the pipes that were literal before).
+# check_posix_bre FILE OUT -- append this file's BRE violations to OUT.
+check_posix_bre() {
+	local f=$1 out=$2 line n
+	{ grep -nE '(^|[^[:alnum:]_])(grep|sed)([^[:alnum:]_]|$)' "$f" 2>/dev/null || true; } | \
+	{ grep -vE '^[0-9]+:[[:space:]]*#' || true; } | \
+	while IFS= read -r line; do
+		if printf '%s' "$line" | grep -qE '(grep|sed)[[:space:]]+-[[:alnum:]]*[EP]'; then
+			continue	# -E (or -P): the operators below are the standard ones
+		fi
+		if printf '%s' "$line" | grep -qE '\\[?+|]'; then
+			n=${line%%:*}
+			printf 'posix-bre\t%s\t%s\n' "${f#"$ROOT"/}:$n" \
+				'\? \+ and \| are not POSIX in a basic regex; OpenBSD reads them literally. Use -E' >>"$out"
+		fi
+	done
+}
+
+for f in $files; do check_posix_bre "$f" "$work/violations"; done
+
 if [ -s "$work/violations" ]; then
 	printf 'portability rules broken by the test suite:\n\n' >&2
 	sort "$work/violations" | awk -F'\t' '{ printf "  [%s] %s\n      %s\n", $1, $2, $3 }' >&2
@@ -192,6 +217,20 @@ bypass="$work/bypass.sh"
 check_link_flags "$bypass" "$work/probe-violations"
 assert_equal "2" "$(wc -l <"$work/probe-violations" | tr -d " ")" \
 	"the link-flags rule no longer reports both missing helpers for an archive built without them"
+
+# The BRE rule the same way, and with the ERE beside it: a rule that fired on
+# both would be met by turning every -E off again.
+brefile="$work/bre.sh"
+{
+	printf '#!/usr/bin/env bash\n'
+	printf "grep -q 'a\\\\|b' f\n"
+	printf "grep -Eq 'a\\|b' f\n"
+	printf "sed -n 's/x\\\\+/y/p' f\n"
+} >"$brefile"
+: >"$work/bre-violations"
+check_posix_bre "$brefile" "$work/bre-violations"
+assert_equal "2" "$(wc -l <"$work/bre-violations" | tr -d " ")" \
+	"the POSIX-BRE rule no longer separates a GNU-only basic regex from an extended one"
 
 # The uname rule the same way, on both sides: a guard without the declaration
 # is reported, the same guard with it is not.

--- a/tests/server/xymond-checkpoint-roundtrip.sh
+++ b/tests/server/xymond-checkpoint-roundtrip.sh
@@ -191,7 +191,10 @@ stop_xymond
 awk -F'|' -v OFS='|' '$2 == ".flapstate." { if (NF < 11) exit 3; $11 = "1000000,1000000" } { print }' \
 	"$work/chk" > "$work/chk.stale" \
 	|| fail "the .flapstate. record has fewer fields than the flap ring's position; the format changed"
-grep -q '^@@XYMONDCHK-V1|\.flapstate\.|\([^|]*|\)\{8\}1000000,1000000\(|.*\)\?$' "$work/chk.stale" \
+# ERE, not BRE: "\?" is a GNU extension that OpenBSD's grep takes for a literal
+# "?", so the pattern could not match there and the failure read as a changed
+# record format. In an ERE the pipes are the ones that need escaping.
+grep -Eq '^@@XYMONDCHK-V1\|\.flapstate\.\|([^|]*\|){8}1000000,1000000(\|.*)?$' "$work/chk.stale" \
 	|| fail "could not backdate the flap ring; the .flapstate. record format changed"
 
 start_xymond --restart="$work/chk.stale"


### PR DESCRIPTION
The OpenBSD 7.8 server lane fails `tests/server/xymond-checkpoint-roundtrip.sh` with

```
FAIL: could not backdate the flap ring; the .flapstate. record format changed
```

The record format had not changed. The test backdates the flap ring, then greps the file it just wrote to confirm the edit landed, with a **basic** regex ending in `\(|.*\)\?$`.

`\?` is a GNU extension — POSIX has no optional operator in a BRE. OpenBSD's grep reads it as a literal `?`, so the pattern demanded a `?` before end-of-line, the checkpoint line has none, and the grep returned 1. Measured:

| engine | `\?` |
|---|---|
| GNU grep (Linux lane) | optional — matches |
| busybox grep | optional — matches |
| literal `?` (strict POSIX BRE) | **no match** |

Which is why it is OpenBSD-only, and why it was invisible on every platform it was written and reviewed on. The message made it worse: it points at the record layout, which is the one thing that was fine.

The pattern is an ERE now, where `?` and `{8}` are both standard; the pipes that were literal in a BRE are escaped instead. Same matches — it still accepts the backdated line and still rejects an untouched one.

**Second half: the rule that would have caught it.** `tests/buildsystem/test-suite-portability.sh` already encodes "every rule here is a failure the suite actually had". This is one more: `\?`, `\+` and `\|` on a `grep` or `sed` line that does not pass `-E`.

Checked against the real thing — with the pre-fix line restored:

```
[posix-bre] tests/server/xymond-checkpoint-roundtrip.sh:194
    \? \+ and \| are not POSIX in a basic regex; OpenBSD reads them literally. Use -E
```

The probe beside it carries one of each spelling plus the `-E` form, so a rule that fired on both — which could be satisfied by turning every `-E` off — fails the probe instead of passing it.

That probe earned its place immediately. The rule's first pattern was `\\(\?|\\\+|\\\|)`, which reads as *"a backslash, then one of `?` `\+` `\|`"* — so it required **two** backslashes for the `\+` and `\|` spellings and matched only the `\?` one. It would have caught the line above and quietly missed the other two thirds of what it claims to cover. The probe reported 0 where it required 2, which is what a half-working rule looks like from outside. The pattern is `\\[?+|]` now.

Sweep: this was the only GNU-only BRE in the suite. Suite 86 passed / 0 skipped / 0 failed here.
