### PR TITLE
tests: verify fs_mounts drops nothing without assuming / is visible

### DIFF
--- a/tests/client/fs-mounts.sh
+++ b/tests/client/fs-mounts.sh
@@ -86,6 +86,10 @@ fi
 }
 [ -s "$TMP/out" ] || fail "$os: fs_mounts() listed no mounts on a running system"
 
+# One snapshot for the Linux checks below, taken now: the stat loop can grow
+# the live table (stat of an automount point mounts it).
+[ "$kernel" != Linux ] || cat /proc/mounts > "$TMP/mounts"
+
 # What the helper actually produced, on failure only: a count ("listed 2 mounts
 # but not /") says something is wrong without saying what, and re-running a BSD
 # lane to find out costs half an hour.
@@ -125,20 +129,28 @@ while IFS= read -r line; do
 	[ "$mp" != / ] || root_type=$type
 done < "$TMP/out"
 
-# / is mounted on every system that can run this, so its absence means the
-# enumerator dropped rows rather than merely mangling them.
-[ -n "$root_type" ] || { dump_rows; fail "$os: fs_mounts() listed $lineno mount(s) but not /, so it is dropping rows"; }
+# A chroot entered without pivot_root (cowbuilder, schroot: issue #395) has
+# no / row in /proc/mounts. So on Linux the no-drop check is exact -- row
+# counts must match -- and / is required only when the input shows it. The
+# BSDs and macOS stay unconditional: getmntinfo() sees / even in a chroot.
+if [ "$kernel" = Linux ]; then
+	want=$(awk 'END { print NR }' "$TMP/mounts")
+	[ "$lineno" -eq "$want" ] \
+		|| { dump_rows; fail "$os: fs_mounts() listed $lineno mount(s) but /proc/mounts has $want, so it is dropping rows"; }
+	if awk '$2 == "/" { found = 1 } END { exit !found }' "$TMP/mounts"; then
+		[ -n "$root_type" ] || { dump_rows; fail "$os: /proc/mounts lists / but fs_mounts() did not, so it is mangling rows"; }
+	fi
+else
+	[ -n "$root_type" ] || { dump_rows; fail "$os: fs_mounts() listed $lineno mount(s) but not /, so it is dropping rows"; }
+fi
 
 # Paths that all look absolute but none of which resolve would be a parse
 # producing well-formed nonsense; one that resolves is enough to rule that out.
 [ "$present" -gt 0 ] || { dump_rows; fail "$os: none of the $lineno mountpoints fs_mounts() reported exists"; }
 
-# One thing no host can be relied on to have: a mount point with a space in it.
-# Linux escapes it as \040 in /proc/mounts, and a client that stopped decoding
-# that would hand df a path that does not exist -- reporting the filesystem
-# unavailable while its disk is fine. So the parser is fed the line directly.
-# The BSDs need no equivalent: mount(8) prints the space, and the " on " / " ("
-# split keeps it.
+# No host can be relied on to have a mount point with a space in it (Linux
+# escapes it as \040), so the parser is fed such a line directly. The BSDs
+# print the space raw; the " on " / " (" split keeps it.
 if [ "$kernel" = Linux ]; then
 	# The awk program out of the helper, run over one fixture line instead of
 	# the file. Extracted rather than copied, so it is this client's parser
@@ -147,9 +159,9 @@ if [ "$kernel" = Linux ]; then
 	awkprog=$(sed -n '/^fs_mounts()/,/^}/p' "$script" | sed -n "s/^[[:space:]]*awk '\(.*\)' .*/\1/p")
 	[ -n "$awkprog" ] \
 		|| fail "$os: fs_mounts() no longer parses with a single awk program -- update this check with it"
-	decoded=$(printf 'server:/export /remote/team\\040share nfs4 rw 0 0\n' | awk "$awkprog")
-	assert_equal "nfs4	/remote/team share" "$decoded" \
-		"$os: an escaped space in a mount point is decoded, not passed through"
+	decoded=$(printf 'server:/export /remote/team\\040share\\040x nfs4 rw 0 0\n' | awk "$awkprog")
+	assert_equal "nfs4	/remote/team share x" "$decoded" \
+		"$os: every escaped space in a mount point is decoded, not just the first"
 fi
 
-pass "no client refreshes mount(8), and $os's fs_mounts() parses this host ($lineno mounts, / is $root_type)"
+pass "no client refreshes mount(8), and $os's fs_mounts() parses this host ($lineno mounts, / is ${root_type:-not visible from this chroot})"


### PR DESCRIPTION
Fixes #395.

A cowbuilder/schroot build root is a plain directory entered with `chroot(2)`, so `/proc/mounts`
lists only the mounts reachable from it -- no `/` row. The test required a `/` row as a proxy for
"no rows dropped" and failed on correct output.

On Linux the check is now exact: `fs_mounts()` is a one-row-per-line transform of `/proc/mounts`,
so the row counts must match (one snapshot, taken before the stat loop can trigger an automount),
and `/` is required only when the input shows it. BSD/macOS lanes unchanged: `getmntinfo()` reports
the full table even inside a chroot.

| case | old test | new test |
|---|---|---|
| normal host | PASS | PASS |
| plain-dir chroot, no `/` row (`unshare -rmpf` repro) | FAIL | PASS |
| client sabotaged to drop its last row | PASS (miss) | FAIL |

Backslash hardening found during review: #397, stacked on this.
