### PR TITLE
client: survive backslashes in mount points

### DIFF
--- a/client/xymonclient-darwin.sh
+++ b/client/xymonclient-darwin.sh
@@ -144,7 +144,9 @@ probe_dir_is_local()
 	# sends the probe at a directory that may sit on the wedged mount this
 	# exists to keep away from.
 	_pdlm=$(fs_mounts) || return 1
-	printf '%s\n' "$_pdlm" | awk -F'\t' -v dir="$1" -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+	# dir via ENVIRON, not -v: -v escape-processes backslashes (gawk: \c -> c).
+	printf '%s\n' "$_pdlm" | _pdldir="$1" awk -F'\t' -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+		BEGIN { dir = ENVIRON["_pdldir"] }
 		BEGIN { n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1 }
 		{
 			mp = $2

--- a/client/xymonclient-freebsd.sh
+++ b/client/xymonclient-freebsd.sh
@@ -108,7 +108,9 @@ probe_dir_is_local()
 	# sends the probe at a directory that may sit on the wedged mount this
 	# exists to keep away from.
 	_pdlm=$(fs_mounts) || return 1
-	printf '%s\n' "$_pdlm" | awk -F'\t' -v dir="$1" -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+	# dir via ENVIRON, not -v: -v escape-processes backslashes (gawk: \c -> c).
+	printf '%s\n' "$_pdlm" | _pdldir="$1" awk -F'\t' -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+		BEGIN { dir = ENVIRON["_pdldir"] }
 		BEGIN { n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1 }
 		{
 			mp = $2

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -173,7 +173,9 @@ probe_dir_is_local()
 	# sends the probe at a directory that may sit on the wedged mount this
 	# exists to keep away from.
 	_pdlm=$(fs_mounts) || return 1
-	printf '%s\n' "$_pdlm" | awk -F'\t' -v dir="$1" -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+	# dir via ENVIRON, not -v: -v escape-processes backslashes (gawk: \c -> c).
+	printf '%s\n' "$_pdlm" | _pdldir="$1" awk -F'\t' -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+		BEGIN { dir = ENVIRON["_pdldir"] }
 		BEGIN { n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1 }
 		{
 			mp = $2

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -53,7 +53,10 @@ echo "[df]"
 fs_mounts()
 {
 	[ -r /proc/mounts ] || return 1
-	awk '{ mp = $2; gsub(/\\040/, " ", mp); printf "%s\t%s\n", $3, mp }' /proc/mounts
+	# Decode \040, then \134 by split/concat (a gsub replacement backslash
+	# differs between mawk and gawk). \011/\012 stay escaped: the rows are
+	# tab- and newline-delimited, so decoding them would truncate the path.
+	awk '{ mp = $2; gsub(/\\040/, " ", mp); n = split(mp, s, /\\134/); mp = s[1]; for (i = 2; i <= n; i++) mp = mp "\\" s[i]; printf "%s\t%s\n", $3, mp }' /proc/mounts
 }
 
 # fs_filesystems : the filesystem types the kernel knows, "nodev" first where
@@ -415,7 +418,8 @@ run_df()
 		# than dropping it, since the server reads an absent filesystem as
 		# green. This turns one filesystem red instead of purpling the host.
 		for _m in $_rm; do
-			echo "unavailable:$_m 1 1 0 100% $_m"
+			# printf, not echo: sh's echo escape-processes a decoded backslash.
+			printf '%s\n' "unavailable:$_m 1 1 0 100% $_m"
 		done
 	else
 		printf '%s\n' "$_rout"

--- a/client/xymonclient-netbsd.sh
+++ b/client/xymonclient-netbsd.sh
@@ -97,7 +97,9 @@ probe_dir_is_local()
 	# sends the probe at a directory that may sit on the wedged mount this
 	# exists to keep away from.
 	_pdlm=$(fs_mounts) || return 1
-	printf '%s\n' "$_pdlm" | awk -F'\t' -v dir="$1" -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+	# dir via ENVIRON, not -v: -v escape-processes backslashes (gawk: \c -> c).
+	printf '%s\n' "$_pdlm" | _pdldir="$1" awk -F'\t' -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+		BEGIN { dir = ENVIRON["_pdldir"] }
 		BEGIN { n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1 }
 		{
 			mp = $2

--- a/client/xymonclient-openbsd.sh
+++ b/client/xymonclient-openbsd.sh
@@ -105,7 +105,9 @@ probe_dir_is_local()
 	# sends the probe at a directory that may sit on the wedged mount this
 	# exists to keep away from.
 	_pdlm=$(fs_mounts) || return 1
-	printf '%s\n' "$_pdlm" | awk -F'\t' -v dir="$1" -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+	# dir via ENVIRON, not -v: -v escape-processes backslashes (gawk: \c -> c).
+	printf '%s\n' "$_pdlm" | _pdldir="$1" awk -F'\t' -v types="$XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES" '
+		BEGIN { dir = ENVIRON["_pdldir"] }
 		BEGIN { n = split(types, a, /[ \t]+/); for (i = 1; i <= n; i++) t[a[i]] = 1 }
 		{
 			mp = $2

--- a/tests/client/fs-mounts.sh
+++ b/tests/client/fs-mounts.sh
@@ -148,9 +148,10 @@ fi
 # producing well-formed nonsense; one that resolves is enough to rule that out.
 [ "$present" -gt 0 ] || { dump_rows; fail "$os: none of the $lineno mountpoints fs_mounts() reported exists"; }
 
-# No host can be relied on to have a mount point with a space in it (Linux
-# escapes it as \040), so the parser is fed such a line directly. The BSDs
-# print the space raw; the " on " / " (" split keeps it.
+# No host can be relied on to have a mount point with a space or backslash in
+# it (Linux: \040, \134), so the parser is fed such lines directly. \134 must
+# decode last, or a literal "\040" (kernel: \134040) becomes a space. The BSDs
+# print both raw; the " on " / " (" split keeps them.
 if [ "$kernel" = Linux ]; then
 	# The awk program out of the helper, run over one fixture line instead of
 	# the file. Extracted rather than copied, so it is this client's parser
@@ -162,6 +163,12 @@ if [ "$kernel" = Linux ]; then
 	decoded=$(printf 'server:/export /remote/team\\040share\\040x nfs4 rw 0 0\n' | awk "$awkprog")
 	assert_equal "nfs4	/remote/team share x" "$decoded" \
 		"$os: every escaped space in a mount point is decoded, not just the first"
+	decoded=$(printf 'server:/export /remote/\\134\\134a\\134 nfs4 rw 0 0\n' | awk "$awkprog")
+	assert_equal 'nfs4	/remote/\\a\' "$decoded" \
+		"$os: escaped backslashes -- leading, doubled, trailing -- are all decoded"
+	decoded=$(printf 'server:/export /remote/a\\134040b nfs4 rw 0 0\n' | awk "$awkprog")
+	assert_equal 'nfs4	/remote/a\040b' "$decoded" \
+		"$os: a literal backslash-040 in a mount point survives; decoding \\134 first would turn it into a space"
 fi
 
 pass "no client refreshes mount(8), and $os's fs_mounts() parses this host ($lineno mounts, / is ${root_type:-not visible from this chroot})"

--- a/tests/client/fs-sentinel-darwin.sh
+++ b/tests/client/fs-sentinel-darwin.sh
@@ -196,4 +196,16 @@ if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; 
 	fail "an unreadable mount list must not read as a local probe directory"
 fi
 
+# The probe dir must reach awk intact: -v escape-processes it (every awk turns
+# \t into a tab), hence ENVIRON; the quoted heredoc keeps printf off the bytes.
+( sed -n '/^probe_dir_is_local()/,/^}/p' "$SCRIPT"
+  cat <<'PDL'
+fs_mounts() { printf 'nfs4\t%s\n' '/remote/a\tb'; }
+probe_dir_is_local '/remote/a\tb/x'
+PDL
+) > "$TMP/pdl.sh"
+if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; then
+	fail "a probe directory under a backslash-named mount must not read as local"
+fi
+
 pass "xymonclient-darwin.sh: the remote-df sentinel takes the hard-blocking mounts out of the per-path loop"

--- a/tests/client/fs-sentinel-freebsd.sh
+++ b/tests/client/fs-sentinel-freebsd.sh
@@ -197,4 +197,16 @@ if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; 
 	fail "an unreadable mount list must not read as a local probe directory"
 fi
 
+# The probe dir must reach awk intact: -v escape-processes it (every awk turns
+# \t into a tab), hence ENVIRON; the quoted heredoc keeps printf off the bytes.
+( sed -n '/^probe_dir_is_local()/,/^}/p' "$SCRIPT"
+  cat <<'PDL'
+fs_mounts() { printf 'nfs4\t%s\n' '/remote/a\tb'; }
+probe_dir_is_local '/remote/a\tb/x'
+PDL
+) > "$TMP/pdl.sh"
+if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; then
+	fail "a probe directory under a backslash-named mount must not read as local"
+fi
+
 pass "xymonclient-freebsd.sh: the remote-df sentinel is wired to mount(8) and both reports"

--- a/tests/client/fs-sentinel-linux.sh
+++ b/tests/client/fs-sentinel-linux.sh
@@ -382,6 +382,18 @@ assert_contains 'unavailable:/remote/nfs' "$out" "the remote set must report una
 if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; then
 	fail "an unreadable mount list must not read as a local probe directory"
 fi
+
+# The probe dir must reach awk intact: -v escape-processes it (every awk turns
+# \t into a tab), hence ENVIRON; the quoted heredoc keeps printf off the bytes.
+( sed -n '/^probe_dir_is_local()/,/^}/p' "$SCRIPT"
+  cat <<'PDL'
+fs_mounts() { printf 'nfs4\t%s\n' '/remote/a\tb'; }
+probe_dir_is_local '/remote/a\tb/x'
+PDL
+) > "$TMP/pdl.sh"
+if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; then
+	fail "a probe directory under a backslash-named mount must not read as local"
+fi
 local_mounts
 
 # --- the default is unchanged ------------------------------------------------

--- a/tests/client/fs-sentinel-netbsd.sh
+++ b/tests/client/fs-sentinel-netbsd.sh
@@ -197,4 +197,16 @@ if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; 
 	fail "an unreadable mount list must not read as a local probe directory"
 fi
 
+# The probe dir must reach awk intact: -v escape-processes it (every awk turns
+# \t into a tab), hence ENVIRON; the quoted heredoc keeps printf off the bytes.
+( sed -n '/^probe_dir_is_local()/,/^}/p' "$SCRIPT"
+  cat <<'PDL'
+fs_mounts() { printf 'nfs4\t%s\n' '/remote/a\tb'; }
+probe_dir_is_local '/remote/a\tb/x'
+PDL
+) > "$TMP/pdl.sh"
+if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; then
+	fail "a probe directory under a backslash-named mount must not read as local"
+fi
+
 pass "xymonclient-netbsd.sh: the remote-df sentinel is wired to mount(8) and both reports"

--- a/tests/client/fs-sentinel-openbsd.sh
+++ b/tests/client/fs-sentinel-openbsd.sh
@@ -197,4 +197,16 @@ if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; 
 	fail "an unreadable mount list must not read as a local probe directory"
 fi
 
+# The probe dir must reach awk intact: -v escape-processes it (every awk turns
+# \t into a tab), hence ENVIRON; the quoted heredoc keeps printf off the bytes.
+( sed -n '/^probe_dir_is_local()/,/^}/p' "$SCRIPT"
+  cat <<'PDL'
+fs_mounts() { printf 'nfs4\t%s\n' '/remote/a\tb'; }
+probe_dir_is_local '/remote/a\tb/x'
+PDL
+) > "$TMP/pdl.sh"
+if XYMONCLIENT_FS_REMOTE_HARDBLOCK_TYPES="nfs nfs4 cifs" /bin/sh "$TMP/pdl.sh"; then
+	fail "a probe directory under a backslash-named mount must not read as local"
+fi
+
 pass "xymonclient-openbsd.sh: the remote-df sentinel is wired to mount(8) and both reports"


### PR DESCRIPTION
#396 (the fs_mounts-contract test this builds on) is now merged, so this PR is just its own two commits: decode `\134` in mount points, and pass the probe dir to awk via `ENVIRON`.

`/proc/mounts` escapes space, tab, newline and backslash as `\040 \011 \012 \134`; the clients
decode only `\040`. Two commits make a backslash survive end to end. Tab/newline stay escaped by
design: the row format is tab- and newline-delimited.

- `fs_mounts()` (Linux) decodes `\134` after `\040`, by split/concat -- a gsub replacement
  backslash yields one backslash under mawk, two under gawk/busybox. The unavailable-row fallback
  moves from `echo` to `printf`: dash's `echo` truncates a decoded path at `\c`.
- `probe_dir_is_local()` (all five clients) gets the probe dir via `ENVIRON` instead of `awk -v`,
  which escape-processes the value and can misread a dir on a hard-blocking mount as local.

Evidence: verified against real mounts holding a space, a backslash and a tab; identical output
under mawk, gawk, busybox awk and one-true-awk. The new sentinel check (a `\t`-escape path, decoded
by every awk in `-v`) fails the old `-v` code under all four awks and passes the fixed one, with the
fixture intact under dash, bash and busybox sh.

---
**Also overlaps #390** (do_disk unavailable-mount) on `fs_mounts` and `tests/client/fs-mounts.sh`. Suggested order **#397 → #390**; see #390 for how the two `fs_mounts` changes combine (this PR's escape decoding + #390's device field).
