### PR TITLE
msgcache: answer ping with our identity and the age of the last delivered pull

### DIFF
--- a/client/msgcache.c
+++ b/client/msgcache.c
@@ -48,6 +48,7 @@ char *client_response = NULL;		/* The latest response to a "client" message */
 char *logfile = NULL;
 int maxage = 600;			/* Maximum time we will cache messages */
 sender_t *serverlist = NULL;		/* Who is allowed to grab our messages */
+time_t lastpull = 0;			/* When a server last collected from us */
 
 typedef struct conn_t {
 	time_t tstamp;
@@ -57,6 +58,9 @@ typedef struct conn_t {
 	int sockfd;
 	strbuffer_t *msgbuf;
 	int sentbytes;
+	unsigned long pollid;		/* Server bit this pull serves (0 = client/none) */
+	unsigned long *batch;		/* seqs carried by the in-flight pull, committed on success */
+	int nbatch;
 	struct conn_t *next;
 } conn_t;
 conn_t *chead = NULL;
@@ -64,12 +68,14 @@ conn_t *ctail = NULL;
 
 typedef struct msgqueue_t {
 	time_t tstamp;
+	unsigned long seq;		/* Monotonic id, lets a delivered batch be matched back */
 	strbuffer_t *msgbuf;
 	unsigned long sentto;
 	struct msgqueue_t *next;
 } msgqueue_t;
 msgqueue_t *qhead = NULL;
 msgqueue_t *qtail = NULL;
+unsigned long msgseq = 0;		/* Assigns msgqueue_t.seq */
 
 
 void sigmisc_handler(int signum)
@@ -124,6 +130,31 @@ void grabdata(conn_t *conn)
 	 * save the contents of the message - this is the client configuration
 	 * that we'll return the next time a client sends us the "client" message.
 	 */
+
+	if ((strncmp(STRBUF(conn->msgbuf), "ping", 4) == 0) &&
+	    ((STRBUFLEN(conn->msgbuf) == 4) || isspace((unsigned char)STRBUF(conn->msgbuf)[4]))) {
+		/*
+		 * Not client data: answered before the queueing below, and in
+		 * its own buffer - client_response holds the pushed config.
+		 * "pingpong" is client data and must still be forwarded.
+		 * The server pulls from us and we never call it, so the last
+		 * pull's age is all we can honestly report; the clamp keeps a
+		 * backwards clock off the -1 sentinel.
+		 */
+		char id[128];
+		long age = -1;
+
+		if (lastpull) {
+			age = (long)(getcurrenttime(NULL) - lastpull);
+			if (age < 0) age = 0;
+		}
+		snprintf(id, sizeof(id), "msgcache %s\nlastpull %ld\n", VERSION, age);
+		clearstrbuffer(conn->msgbuf);
+		addtobuffer(conn->msgbuf, id);
+		conn->ctype = C_CLIENT_OTHER;
+		conn->action = C_WRITING;
+		return;
+	}
 
 	if (strncmp(STRBUF(conn->msgbuf), "pullclient", 10) == 0) {
 		char *clientcfg;
@@ -189,6 +220,7 @@ void grabdata(conn_t *conn)
 		msgqueue_t *newq = calloc(1, sizeof(msgqueue_t));
 		dbgprintf("Queuing outbound message\n");
 		newq->tstamp = conn->tstamp;
+		newq->seq = ++msgseq;
 		newq->msgbuf = conn->msgbuf;
 		conn->msgbuf = NULL;
 		if (qtail) {
@@ -212,42 +244,67 @@ void grabdata(conn_t *conn)
 		}
 	}
 	else {
-		/* A server has asked us for our list of messages */
+		/*
+		 * A server has asked us for our list of messages. We record the
+		 * batch's message ids here but do NOT mark them sent yet: the
+		 * sentto bits are committed in senddata() only once the whole
+		 * batch is written, so a pull whose write fails is re-delivered
+		 * rather than silently dropped, and lastpull tracks real delivery.
+		 */
 		time_t now = getcurrenttime(NULL);
 		msgqueue_t *mwalk;
+		int nunsent = 0;
 
-		if (!qhead) {
-			/* No queued messages */
-			conn->action = C_DONE;
+		conn->pollid = pollid;
+
+		/* Build a message of all the queued data */
+		clearstrbuffer(conn->msgbuf);
+
+		/* Index line first, and count what this pull will carry */
+		for (mwalk = qhead; (mwalk); mwalk = mwalk->next) {
+			if ((mwalk->sentto & pollid) == 0) {
+				/* 34 bytes at its widest, INT_MIN:LONG_MIN */
+				char idx[64];
+				snprintf(idx, sizeof(idx), "%d:%ld ",
+					STRBUFLEN(mwalk->msgbuf), (long)(now - mwalk->tstamp));
+				addtobuffer(conn->msgbuf, idx);
+				nunsent++;
+			}
 		}
-		else {
-			/* Build a message of all the queued data */
-			clearstrbuffer(conn->msgbuf);
 
-			/* Index line first */
-			for (mwalk = qhead; (mwalk); mwalk = mwalk->next) {
-				if ((mwalk->sentto & pollid) == 0) {
-					char idx[20];
-					sprintf(idx, "%d:%ld ", 
-						STRBUFLEN(mwalk->msgbuf), (long)(now - mwalk->tstamp));
-					addtobuffer(conn->msgbuf, idx);
-				}
-			}
+		if (STRBUFLEN(conn->msgbuf) > 0) addtobuffer(conn->msgbuf, "\n");
 
-			if (STRBUFLEN(conn->msgbuf) > 0) addtobuffer(conn->msgbuf, "\n");
-
-			/* Then the stream of messages */
-			for (mwalk = qhead; (mwalk); mwalk = mwalk->next) {
-				if ((mwalk->sentto & pollid) == 0) {
-					if (pollid) mwalk->sentto |= pollid;
-					addtostrbuffer(conn->msgbuf, mwalk->msgbuf);
-				}
-			}
-
-			if (STRBUFLEN(conn->msgbuf) == 0) {
-				/* No data for this server */
+		/* Remember the batch (walked in queue order = ascending seq) so
+		   senddata() can commit exactly these on a successful write. */
+		conn->nbatch = 0;
+		if (pollid && nunsent) {
+			conn->batch = calloc(nunsent, sizeof(unsigned long));
+			if (!conn->batch) {
+				/* Without the batch we cannot say what was delivered, and
+				   handing the messages over anyway would re-send all of
+				   them on the next pull. Drop this pull instead: nothing
+				   is claimed and nothing is stamped, so the server just
+				   collects on its next poll. */
+				errprintf("Out of memory for a %d-message pull batch - dropping this pull\n", nunsent);
+				clearstrbuffer(conn->msgbuf);
 				conn->action = C_DONE;
+				return;
 			}
+		}
+
+		/* Then the stream of messages */
+		for (mwalk = qhead; (mwalk); mwalk = mwalk->next) {
+			if ((mwalk->sentto & pollid) == 0) {
+				if (conn->batch) conn->batch[conn->nbatch++] = mwalk->seq;
+				addtostrbuffer(conn->msgbuf, mwalk->msgbuf);
+			}
+		}
+
+		if (STRBUFLEN(conn->msgbuf) == 0) {
+			/* Nothing to hand over: an empty poll is still a successful
+			   collection (everything already delivered), so stamp here. */
+			conn->action = C_DONE;
+			lastpull = now;
 		}
 	}
 }
@@ -263,13 +320,34 @@ void senddata(conn_t *conn)
 	n = write(conn->sockfd, startp, togo);
 
 	if (n <= -1) {
-		/* Write failure */
+		/* Write failure: drop the batch without committing its sentto
+		   bits, so the server re-pulls exactly these messages next time. */
 		errprintf("Connection lost during write to %s\n", inet_ntoa(conn->caddr.sin_addr));
 		conn->action = C_DONE;
+		if (conn->batch) { xfree(conn->batch); conn->batch = NULL; conn->nbatch = 0; }
 	}
 	else {
 		conn->sentbytes += n;
-		if (conn->sentbytes == STRBUFLEN(conn->msgbuf)) conn->action = C_DONE;
+		if (conn->sentbytes == STRBUFLEN(conn->msgbuf)) {
+			conn->action = C_DONE;
+			/* Complete only now: the whole batch is out. Commit the
+			   sentto bits for exactly the delivered messages. The queue
+			   and the batch are both ordered by ascending seq, so a single
+			   merge pass suffices; messages pruned in flight simply do not
+			   match and are skipped. */
+			if (conn->ctype == C_SERVER && conn->batch) {
+				msgqueue_t *m = qhead;
+				int i = 0;
+				while (m && (i < conn->nbatch)) {
+					if (m->seq == conn->batch[i]) { m->sentto |= conn->pollid; m = m->next; i++; }
+					else if (m->seq < conn->batch[i]) m = m->next;
+					else i++;
+				}
+				xfree(conn->batch); conn->batch = NULL; conn->nbatch = 0;
+			}
+			/* Complete only now: the whole batch is out */
+			if (conn->ctype == C_SERVER) lastpull = getcurrenttime(NULL);
+		}
 	}
 }
 
@@ -438,6 +516,7 @@ int main(int argc, char *argv[])
 			}
 
 			freestrbuffer(zombie->msgbuf);
+			if (zombie->batch) xfree(zombie->batch);
 			xfree(zombie);
 		}
 		ctail = chead;

--- a/tests/client/msgcache-failed-pull.sh
+++ b/tests/client/msgcache-failed-pull.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/msgcache-failed-pull.sh
+#
+# A pull whose delivery is interrupted must not count. msgcache commits the
+# "sent" bits for a batch only once the whole batch has been written, so:
+#
+#   - the messages are re-delivered on the next pull (not silently lost), and
+#   - lastpull is not advanced by a collection that never landed.
+#
+# Regresses the earlier accounting, which marked messages sent while *building*
+# the response: a dropped write then lost the batch, and the following empty
+# retry refreshed lastpull -- reporting a healthy collection in exactly the
+# failure the age is meant to expose.
+#
+# The interrupted pull is driven by a tiny compiled helper: it needs a half
+# close (so msgcache replies) and a RST mid-read (so the write fails), neither
+# of which bash's /dev/tcp can do.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin MSGCACHE client/msgcache
+default="common/xymon"
+if [ -z "${XYMON:-}" ] && [ ! -x "$(find_root)/$default" ] \
+		&& [ -x "$(find_root)/client/xymon" ]; then
+	default="client/xymon"
+fi
+require_bin XYMON "$default"
+require_cc
+
+work=$(mktempdir)
+
+"$CC" -o "$work/interrupt" "$(dirname "$0")/msgcache-interrupt.c" 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "interrupt helper does not compile"; }
+
+# bash /dev/tcp probe: a successful connect means the port is taken.
+port_taken() { ( exec 3<> "/dev/tcp/127.0.0.1/$1" ) 2>/dev/null; }
+free_port() {
+	local p tries=0
+	while [ "$tries" -lt 50 ]; do
+		p=$(( 20000 + (RANDOM % 20000) ))
+		port_taken "$p" || { printf '%s' "$p"; return 0; }
+		tries=$((tries + 1))
+	done
+	return 1
+}
+
+PORT=$(free_port) || skip "no free port for msgcache"
+"$MSGCACHE" --listen=127.0.0.1:"$PORT" --server=127.0.0.1 --no-daemon > "$work/log" 2>&1 &
+MC=$!
+register_cleanup "kill $MC 2>/dev/null || true"
+
+say() { "$XYMON" 127.0.0.1:"$PORT" "$1"; }
+
+# The first successful ping doubles as the startup probe.
+out=
+i=0
+while [ "$i" -lt 50 ]; do
+	if out=$(say 'ping' 2>/dev/null) && [ -n "$out" ]; then break; fi
+	kill -0 "$MC" 2>/dev/null || { cat "$work/log" >&2; fail "msgcache exited during startup"; }
+	sleep 0.1
+	i=$((i + 1))
+done
+[ -n "$out" ] || { cat "$work/log" >&2; fail "msgcache never answered a ping within 5s"; }
+
+# Queue one large client message. It must exceed the kernel socket send buffer
+# so the interrupted pull cannot complete the write in a single shot -- a small
+# message the kernel buffers whole would look delivered even to a reader that
+# never read it. Push it over a raw socket, not the CLI: a multi-megabyte argv
+# would blow ARG_MAX on macOS.
+marker="REDELIVER-ME-$$"
+big=$(head -c 2097152 </dev/zero | tr '\0' X)
+exec 4<> "/dev/tcp/127.0.0.1/$PORT"
+printf '%s %s' "$marker" "$big" >&4
+exec 4<&- 4>&-			# close -> EOF -> msgcache queues the message
+
+# Queued data alone is not a pull.
+out=$(say 'ping')
+assert_contains "lastpull -1" "$out" "queued client data must not advance the pull age"
+
+# Interrupted pull: request the batch, read a little, RST before it is all out.
+# A helper that died before issuing its pull would leave every assertion below
+# passing on a queue nobody ever pulled, so its exit status is part of the test.
+"$work/interrupt" "$PORT" 1 || fail "the interrupt helper failed before it could interrupt a pull (exit $?)"
+
+# A collection that never landed must not count as a pull.
+out=$(say 'ping')
+assert_contains "lastpull -1" "$out" \
+	"a pull whose write was dropped mid-batch must not advance lastpull"
+
+# ...and the batch must survive to be re-delivered on the next real pull.
+out=$(say 'pullclient 1')
+assert_contains "$marker" "$out" \
+	"an interrupted pull must not lose its batch; the next pull re-delivers it"
+
+# Now that a pull has actually landed, the age becomes real.
+out=$(say 'ping')
+assert_not_contains "lastpull -1" "$out" "after a delivered pull the age is a real one"
+assert_match 'lastpull [0-9]+' "$out" "and a non-negative number, not the sentinel"
+
+pass "an interrupted pull neither loses its batch nor advances lastpull; the next pull re-delivers and stamps it"

--- a/tests/client/msgcache-interrupt.c
+++ b/tests/client/msgcache-interrupt.c
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// tests/client/msgcache-interrupt.c
+//
+// Interrupted-pull helper for tests/client/msgcache-failed-pull.sh.
+//
+// Connect to a msgcache, issue "pullclient <id>", half-close the write side so
+// it processes the request and starts replying, read just enough to prove the
+// batch is being delivered, then abandon the connection with a TCP RST. That
+// makes msgcache's remaining write to this socket fail mid-batch -- the case
+// where committing "sent" at build time would lose the batch and later let an
+// empty retry falsely refresh lastpull.
+//
+// Standalone: sockets only, no in-tree headers.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int main(int argc, char **argv)
+{
+	int fd, rl;
+	struct sockaddr_in sa;
+	struct timeval tv;
+	struct linger lg;
+	char req[64], buf[64];
+
+	if (argc < 3) { fprintf(stderr, "usage: %s PORT IDNUM\n", argv[0]); return 2; }
+
+	fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (fd < 0) { perror("socket"); return 1; }
+
+	memset(&sa, 0, sizeof sa);
+	sa.sin_family = AF_INET;
+	sa.sin_port = htons((unsigned short)atoi(argv[1]));
+	sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	if (connect(fd, (struct sockaddr *)&sa, sizeof sa) < 0) { perror("connect"); return 1; }
+
+	rl = snprintf(req, sizeof req, "pullclient %s\n", argv[2]);
+	if ((rl < 0) || (rl >= (int)sizeof req)) { fprintf(stderr, "IDNUM too long\n"); return 2; }
+	if (write(fd, req, (size_t)rl) != rl) { perror("write"); return 1; }
+
+	/* msgcache reads a request until EOF before processing it, so half-closing
+	   the write side is what makes it build the batch and begin sending. */
+	shutdown(fd, SHUT_WR);
+
+	/* Never block forever if the reply does not come. */
+	tv.tv_sec = 5; tv.tv_usec = 0;
+	setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+
+	/* Read a little to prove the batch is being delivered, then stop. */
+	(void)read(fd, buf, sizeof buf);
+
+	/* Abandon the rest: SO_LINGER {on, 0} makes close() send a RST, so
+	   msgcache's next write to this socket fails rather than quietly buffering
+	   the remainder. */
+	lg.l_onoff = 1; lg.l_linger = 0;
+	setsockopt(fd, SOL_SOCKET, SO_LINGER, &lg, sizeof lg);
+	close(fd);
+	return 0;
+}

--- a/tests/client/msgcache-ping.sh
+++ b/tests/client/msgcache-ping.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/msgcache-ping.sh
+#
+# msgcache answers "ping" with what it is and how long ago a server last
+# collected from it -- it never calls the server, so that age is the only
+# honest signal it has.
+#
+# Pinned: the reply names msgcache and says -1 until a pull happens; a
+# lookalike ("pingpong") is forwarded, not answered; queued data alone does
+# not advance the age; the pushed config survives a ping.
+#
+# Driven with the in-tree xymon CLI, not nc: nc's half-close flag differs
+# per variant and is missing on the BSDs.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+require_bin MSGCACHE client/msgcache
+
+# Server builds produce common/xymon; client-only builds ship the same CLI
+# as client/xymon. Probe the server path first, fall back to the client one;
+# an explicit $XYMON (CMake out-of-source, autopkgtest) is used verbatim.
+default="common/xymon"
+if [ -z "${XYMON:-}" ] && [ ! -x "$(find_root)/$default" ] \
+		&& [ -x "$(find_root)/client/xymon" ]; then
+	default="client/xymon"
+fi
+require_bin XYMON "$default"
+
+work=$(mktempdir)
+
+# Probe with bash's own /dev/tcp so the port choice needs no external tool.
+# The connect succeeding means the port is taken.
+port_taken() {
+	( exec 3<> "/dev/tcp/127.0.0.1/$1" ) 2>/dev/null
+}
+
+free_port() {
+	local p tries=0
+	while [ "$tries" -lt 50 ]; do
+		p=$(( 20000 + (RANDOM % 20000) ))
+		port_taken "$p" || { printf '%s' "$p"; return 0; }
+		tries=$((tries + 1))
+	done
+	return 1
+}
+
+PORT=$(free_port) || skip "no free port for msgcache"
+"$MSGCACHE" --listen=127.0.0.1:"$PORT" --server=127.0.0.1 --no-daemon > "$work/log" 2>&1 &
+MC=$!
+register_cleanup "kill $MC 2>/dev/null || true"
+
+say() { "$XYMON" 127.0.0.1:"$PORT" "$1"; }
+
+# Wait for msgcache to answer, not merely for the port to open: the first
+# successful ping doubles as the startup probe. Fail loud on timeout rather
+# than falling through into a misleading protocol assertion.
+out=
+i=0
+while [ "$i" -lt 50 ]; do
+	if out=$(say 'ping' 2>/dev/null) && [ -n "$out" ]; then break; fi
+	kill -0 "$MC" 2>/dev/null || { cat "$work/log" >&2; fail "msgcache exited during startup"; }
+	sleep 0.1
+	i=$((i + 1))
+done
+[ -n "$out" ] || { cat "$work/log" >&2; fail "msgcache never answered a ping within 5s"; }
+
+# --- before any server has collected -----------------------------------------
+assert_contains "msgcache" "$out" "the ping names msgcache, not the daemon it never talks to"
+assert_contains "lastpull -1" "$out" "and reports no pull at all until a server has collected"
+
+# --- a ping lookalike is data, not a ping -------------------------------------
+# "pingpong ..." shares the first four bytes; it must be queued for the server,
+# not answered (and eaten) as a ping.
+out=$(say 'pingpong is client data')
+[ -z "$out" ] || fail "a message merely starting with ping must get no ping reply, got: $out"
+
+out=$(say 'ping')
+assert_contains "lastpull -1" "$out" "queued client data is not a pull; the age must still say never"
+
+# --- a server collects, pushing a client config ------------------------------
+out=$(say 'pullclient 1
+CONFIG-FROM-SERVER')
+assert_contains "pingpong is client data" "$out" \
+	"the pull must deliver the ping lookalike the queue was holding"
+
+out=$(say 'ping')
+assert_not_contains "lastpull -1" "$out" "after a delivered pull, the age must be a real one"
+assert_match 'lastpull [0-9]+' "$out" "and a non-negative number, not a sentinel or garbage"
+
+# --- and it was handed over exactly once -------------------------------------
+# Committing sentto only on a completed write is worth nothing unless the bits
+# are the ones this server pulled: a second pull must come back empty, not
+# re-deliver what it already has.
+out=$(say 'pullclient 1')
+[ -z "$out" ] || fail "a delivered message must not be handed to the same server twice, got: $out"
+
+out=$(say 'ping')
+assert_match 'lastpull [0-9]+' "$out" "an empty pull is still a collection; the age stays real"
+
+# --- and the ping did not eat the config -------------------------------------
+# The reply travels through its own buffer, not through the global holding the
+# pushed config: sharing it would give this client a version string instead.
+out=$(say 'client host.linux linux')
+assert_contains "CONFIG-FROM-SERVER" "$out" \
+	"a client must still get the config the server pushed, after a ping"
+
+pass "msgcache answers exactly ping with its identity and the age of the last delivered pull, forwarding lookalikes and preserving the pushed config"


### PR DESCRIPTION
Single-commit form of #324 — idea and use case @StefCoene's — rebased on current `main` with a review pass folded in. **Supersedes #324** (close that in favour of this).

A client behind msgcache can't tell delivery from a bucket with a hole, and needs to know whether it's safe to apply a new version/config.

Reply (answered locally, never forwarded): `msgcache <version>` + `lastpull <seconds since last delivered pull, -1 if never>`.

For that age to be honest, `sentto` is committed **only once a pull's whole batch is written**, not while the response is built — a pull whose write fails re-delivers its batch instead of losing it, and can't come back empty and refresh `lastpull` without delivering. (Each queued message carries a `seq`; the connection commits exactly its batch on a completed write — one seq-ordered merge, prune-safe, no duplicates.)

- only an exact `ping` is answered; `pingpong` stays client data
- a negative age (clock stepped back) clamps to 0, off the `-1` sentinel
- a batch that can't be allocated drops the pull instead of delivering it unmarked — otherwise the whole batch re-sends on the next pull while `lastpull` says it landed
- pull index line: `sprintf` into `idx[20]` (overrun by a big `--max-age`/backwards clock; `INT_MIN:LONG_MIN` needs 34) → `snprintf` `idx[64]`

| check | result |
|---|---|
| `tests/client/msgcache-ping.sh` | PASS (FAIL against #324's head) |
| `tests/client/msgcache-failed-pull.sh` — RST mid-pull; batch re-delivers, age stays honest | PASS |
| `calloc` forced to fail: pull dropped, `lastpull` stays `-1`, logged | PASS (before: delivered, stamped, duplicated on the next pull) |
| second pull returns nothing (delivered exactly once) | PASS (mutate `conn->pollid = 0`: new assertion FAILs, previous test passed) |
| ASan, 200-char id to the interrupt helper | PASS (before: `stack-buffer-overflow` in `write`) |
| CI build + testsuite | green |


