### PR TITLE
xymond_history: confine drop/rename names, bound their path builds

### DIFF
--- a/tests/xymond/history-drop-confine.sh
+++ b/tests/xymond/history-drop-confine.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/history-drop-confine.sh
+#
+# xymond_history builds paths under histdir/histlogdir from the hostname and
+# testname carried on the drop/rename messages, neither of which xymond
+# validates as a path component. The dot-to-underscore pass neutralises "." and
+# ".." in a hostname, but the testname is used raw -- so
+#
+#     droptest <host> ../../<dir>
+#
+# reached dropdirectory() with a path that climbs out of histlogdir and
+# recursively removed it (#287, the class the xymond_filestore hardening
+# closed). This drives the real worker and checks the filesystem: an escaping
+# name must be refused, and a legitimate drop must still work.
+#
+# Workers read their messages from stdin (xymond_worker.c).
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/build-worker.sh
+. "$(dirname "$0")/../lib/build-worker.sh"
+
+ROOT=$(find_root)
+
+work=$(mktempdir)
+build_xymond_worker "$work" xymond_history \
+	xymond/xymond_history.c xymond/xymond_worker.c
+
+mkdir -p "$work/etc"
+cp "$ROOT/xymond/etcfiles/xymonserver.cfg.DIST" "$work/etc/xymonserver.cfg"
+
+# A drop/rename runs dropdirectory() in a forked child; wait for it before
+# inspecting the filesystem.
+drive() {  # drive <message-without-trailing-@@>
+	printf '%s\n@@\n' "$1" \
+	| XYMONHOME="$work" XYMONVAR="$work/var" \
+		"$work/xymond_history" --env="$work/etc/xymonserver.cfg" \
+		--histdir="$work/var/hist" --histlogdir="$work/var/histlogs" \
+		>/dev/null 2>>"$work/worker.log"
+	# dropdirectory(background=1) forks; give the child a moment to finish.
+	sleep 0.3
+}
+
+setup() {
+	rm -rf "$work/var"
+	mkdir -p "$work/var/hist" "$work/var/histlogs/myhost/conn"
+	printf 'histlog\n' >"$work/var/histlogs/myhost/conn/10000000"
+	printf 'STATUS-EVENTS\n' >"$work/var/hist/myhost.conn"
+	# A directory one level above histlogdir, the target an escaping name climbs to.
+	mkdir -p "$work/var/SIBLING"
+	printf 'PRECIOUS\n' >"$work/var/SIBLING/keep"
+}
+
+# ---- sanity: a legitimate droptest removes exactly its own histlog ----------
+setup
+: >"$work/worker.log"
+drive '@@droptest#1|1|10.0.0.1|myhost|conn'
+[ ! -e "$work/var/histlogs/myhost/conn" ] \
+	|| { cat "$work/worker.log" >&2; fail "a legitimate droptest did not remove the test's histlog dir"; }
+[ ! -e "$work/var/hist/myhost.conn" ] \
+	|| fail "a legitimate droptest did not remove the status-event file"
+
+# ---- an escaping testname must not climb out of histlogdir ------------------
+# droptest <host> ../../SIBLING -> dropdirectory(histlogs/myhost/../../SIBLING)
+# i.e. $work/var/SIBLING, one level above histlogdir. Must be refused.
+setup
+: >"$work/worker.log"
+drive '@@droptest#1|1|10.0.0.1|myhost|../../SIBLING'
+[ -e "$work/var/SIBLING/keep" ] \
+	|| fail "droptest with an escaping testname recursively removed a directory above histlogdir"
+grep -qE 'begins with a dot|path separator' "$work/worker.log" \
+	|| fail "an escaping droptest testname was not refused by name"
+
+# ---- the same escape via renametest, and via a leading-dot testname ---------
+setup
+: >"$work/worker.log"
+drive '@@renametest#1|1|10.0.0.1|myhost|conn|../../SIBLING/pwned'
+[ -e "$work/var/SIBLING/keep" ] && [ ! -e "$work/var/SIBLING/pwned" ] \
+	|| fail "renametest with an escaping newtestname moved a path out of histlogdir"
+grep -qE 'begins with a dot|path separator' "$work/worker.log" \
+	|| fail "an escaping renametest name was not refused by name"
+
+setup
+: >"$work/worker.log"
+drive '@@droptest#1|1|10.0.0.1|myhost|.hidden'
+grep -q 'begins with a dot' "$work/worker.log" \
+	|| fail "a leading-dot testname was not refused by name"
+
+# ---- a testname holding a separator (no leading dot) hits the other branch --
+setup
+: >"$work/worker.log"
+drive '@@droptest#1|1|10.0.0.1|myhost|foo/bar'
+[ -e "$work/var/histlogs/myhost/conn" ] \
+	|| fail "a droptest refused for a bad testname still dropped the wrong dir"
+grep -q 'path separator' "$work/worker.log" \
+	|| fail "a testname holding '/' was not refused by name"
+
+# ---- drophost / renamehost reject a hostname holding a separator ------------
+setup
+: >"$work/worker.log"
+drive '@@drophost#1|1|10.0.0.1|../../SIBLING'
+[ -e "$work/var/SIBLING/keep" ] \
+	|| fail "drophost with an escaping hostname removed a directory above histlogdir"
+grep -qE 'begins with a dot|path separator' "$work/worker.log" \
+	|| fail "an escaping drophost hostname was not refused by name"
+
+setup
+: >"$work/worker.log"
+drive '@@renamehost#1|1|10.0.0.1|myhost|../../SIBLING'
+[ -e "$work/var/SIBLING/keep" ] \
+	|| fail "renamehost with an escaping newhostname touched a path above histlogdir"
+grep -qE 'begins with a dot|path separator' "$work/worker.log" \
+	|| fail "an escaping renamehost name was not refused by name"
+
+# ---- a status hostname holding a separator must not escape histdir ----------
+# The host-events writer builds histdir/<hostname> with the hostname raw, so a
+# configured name like "../pwned" (xymond warns but still monitors it) wrote a
+# file above histdir. name_confined() on the stachg path refuses it; every real
+# host name (dots allowed, no leading dot, no separator) still records.
+setup
+: >"$work/worker.log"
+drive '@@stachg#1|1|10.0.0.1|origin|../pwned|conn|0|red|1|red|1000|green|0|0|0|0'
+[ ! -e "$work/var/pwned" ] \
+	|| fail "a status hostname of '../pwned' wrote a host-events file outside histdir"
+grep -q 'begins with a dot' "$work/worker.log" \
+	|| fail "an escaping status hostname was not refused by name"
+
+# A legitimate dotted hostname must still record (confinement must not over-refuse).
+setup
+: >"$work/worker.log"
+drive '@@stachg#1|1|10.0.0.1|origin|www.example.com|conn|0|red|1|red|1000|green|0|0|0|0'
+[ -e "$work/var/hist/www,example,com.conn" ] \
+	|| { cat "$work/worker.log" >&2; fail "a legitimate dotted hostname was refused - name_confined over-refuses"; }
+
+# ---- an over-long status testname must not overflow the path buffers --------
+# xymond caps neither a testname's length nor a '/' in it, so a ~5000-char
+# testname reaches the statusevents/histlog/hostevents writers on the stachg
+# channel. Unbounded, the sprintf() into their char[PATH_MAX] buffers smashed
+# the stack; bounded, the write is skipped and the worker survives.
+setup
+: >"$work/worker.log"
+big=$(awk 'BEGIN { while (i++ < 5000) printf "a" }')
+set +e
+printf '@@stachg#1|1|10.0.0.1|origin|myhost|%s|0|red|1|red|1000|green|0|0|0|0\nBODY\n@@\n' "$big" \
+	| XYMONHOME="$work" XYMONVAR="$work/var" \
+		"$work/xymond_history" --env="$work/etc/xymonserver.cfg" \
+		--histdir="$work/var/hist" --histlogdir="$work/var/histlogs" \
+		>/dev/null 2>>"$work/worker.log"
+rc=$?
+set -e
+[ "$rc" -le 1 ] || fail "xymond_history exited $rc (overflow?) on an over-long status testname"
+[ -z "$(find "$work/var/hist" "$work/var/histlogs" -name '*aaaa*')" ] \
+	|| fail "an over-long testname was built into a path rather than refused"
+grep -q 'does not fit' "$work/worker.log" \
+	|| fail "an over-long status testname was not reported as not fitting"
+
+echo "OK $(basename "$0")"

--- a/xymond/xymond_history.c
+++ b/xymond/xymond_history.c
@@ -37,6 +37,29 @@ static char rcsid[] = "$Id$";
 int rotatefiles = 0;
 time_t nextfscheck = 0;
 
+/*
+ * The drop/rename and status handlers build paths under histdir/histlogdir
+ * from the channel's hostname and testname, which xymond does not validate as
+ * path components - a raw testname "../.." reached the recursive
+ * dropdirectory() and climbed out of histlogdir (#287). Refuse "", a leading
+ * '.', and a '/' or '\\' separator on each component before it becomes a path,
+ * as xymond_filestore does; real host and test names pass unchanged.
+ */
+static int name_confined(char *dir, char *component)
+{
+	if (component[0] == '\0') {
+		errprintf("Empty name under %s, refusing it\n", dir);
+		return 0;
+	}
+	if (component[0] == '.') {
+		errprintf("Name '%s' under %s begins with a dot, refusing it\n", component, dir);
+		return 0;
+	}
+	if ((strchr(component, '/') == NULL) && (strchr(component, '\\') == NULL)) return 1;
+	errprintf("Name '%s' under %s holds a path separator, refusing it\n", component, dir);
+	return 0;
+}
+
 void sig_handler(int signum)
 {
 	/*
@@ -88,7 +111,7 @@ int main(int argc, char *argv[])
 	/* Don't save the error buffer */
 	save_errbuf = 0;
 
-	sprintf(pidfn, "%s/xymond_history.pid", xgetenv("XYMONSERVERLOGS"));
+	snprintf(pidfn, sizeof(pidfn), "%s/xymond_history.pid", xgetenv("XYMONSERVERLOGS"));
 	if (xgetenv("XYMONALLHISTLOG")) save_allevents = (strcmp(xgetenv("XYMONALLHISTLOG"), "TRUE") == 0);
 	if (xgetenv("XYMONHOSTHISTLOG")) save_hostevents = (strcmp(xgetenv("XYMONHOSTHISTLOG"), "TRUE") == 0);
 	if (xgetenv("SAVESTATUSLOG")) save_histlogs = (strncmp(xgetenv("SAVESTATUSLOG"), "FALSE", 5) != 0);
@@ -101,7 +124,7 @@ int main(int argc, char *argv[])
 			histlogdir = strchr(argv[argi], '=')+1;
 		}
 		else if (argnmatch(argv[argi], "--pidfile=")) {
-			strcpy(pidfn, strchr(argv[argi], '=')+1);
+			snprintf(pidfn, sizeof(pidfn), "%s", strchr(argv[argi], '=')+1);
 		}
 		else if (argnmatch(argv[argi], "--minimum-free=")) {
 			/* Percent of filesystem space; 0 disables the check, and
@@ -169,7 +192,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	sprintf(alleventsfn, "%s/allevents", histdir);
+	snprintf(alleventsfn, sizeof(alleventsfn), "%s/allevents", histdir);
 	if (save_allevents) {
 		alleventsfd = fopen(alleventsfn, "a");
 		if (alleventsfd == NULL) {
@@ -261,6 +284,11 @@ int main(int argc, char *argv[])
 				continue;
 			}
 
+			/* Confine before any path is built: the host-events file is
+			   histdir/<hostname> with the name raw, so a configured "../evil"
+			   escaped histdir. Real names (dots inside a hostname included) pass. */
+			if (!name_confined(histdir, hostname) || !name_confined(histdir, testname)) continue;
+
 			p = hostnamecommas = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = ',';
 
 			handle = xtreeFind(columndefs, testname);
@@ -286,7 +314,18 @@ int main(int argc, char *argv[])
 				MEMDEFINE(oldcol);
 				MEMDEFINE(timestamp);
 
-				sprintf(statuslogfn, "%s/%s.%s", histdir, hostnamecommas, testname);
+				/* Bounded: an unbounded sprintf() of the length-uncapped
+				   testname overflowed this PATH_MAX buffer; a name that does
+				   not fit is skipped, not written past. */
+				if ((size_t)snprintf(statuslogfn, sizeof(statuslogfn), "%s/%s.%s", histdir, hostnamecommas, testname) >= sizeof(statuslogfn)) {
+					errprintf("Status history name does not fit under %s (host %.64s), not writing it\n",
+						  histdir, hostnamecommas);
+					if (hostnamecommas) xfree(hostnamecommas);
+					MEMUNDEFINE(statuslogfn);
+					MEMUNDEFINE(oldcol);
+					MEMUNDEFINE(timestamp);
+					continue;
+				}
 				stat(statuslogfn, &st);
 				statuslogfd = fopen(statuslogfn, "r+");
 				logexists = (statuslogfd != NULL);
@@ -446,18 +485,30 @@ int main(int argc, char *argv[])
 			if (save_histlogs && saveit->saveit && !logdirfull) {
 				char *hostdash;
 				char fname[PATH_MAX];
-				FILE *histlogfd;
+				FILE *histlogfd = NULL;
+				int n, triedopen = 0;
 
 				MEMDEFINE(fname);
 
+				/* Bounded like above: build in stages, checking each fit; on
+				   truncation nothing is written. */
 				p = hostdash = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = '_';
-				sprintf(fname, "%s/%s", histlogdir, hostdash);
-				mkdir(fname, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
-				p = fname + sprintf(fname, "%s/%s/%s", histlogdir, hostdash, testname);
-				mkdir(fname, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
-				p += sprintf(p, "/%s", histlogtime(tstamp));
+				if ((size_t)snprintf(fname, sizeof(fname), "%s/%s", histlogdir, hostdash) < sizeof(fname)) {
+					mkdir(fname, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
+					n = snprintf(fname, sizeof(fname), "%s/%s/%s", histlogdir, hostdash, testname);
+					if ((n > 0) && ((size_t)n < sizeof(fname))) {
+						mkdir(fname, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
+						if ((size_t)snprintf(fname + n, sizeof(fname) - (size_t)n, "/%s", histlogtime(tstamp)) < sizeof(fname) - (size_t)n) {
+							triedopen = 1;
+							histlogfd = fopen(fname, "w");
+						}
+						else
+							errprintf("Histlog name does not fit under %s (host %.64s), not writing it\n", histlogdir, hostdash);
+					}
+					else
+						errprintf("Histlog name does not fit under %s (host %.64s), not writing it\n", histlogdir, hostdash);
+				}
 
-				histlogfd = fopen(fname, "w");
 				if (histlogfd) {
 					/*
 					 * When a host gets disabled or goes purple, the status
@@ -528,7 +579,7 @@ int main(int argc, char *argv[])
 
 					if (!ok) remove(fname);
 				}
-				else {
+				else if (triedopen) {
 					errprintf("Cannot create histlog file '%s' : %s\n", fname, strerror(errno));
 				}
 				xfree(hostdash);
@@ -551,8 +602,8 @@ int main(int argc, char *argv[])
 
 				MEMDEFINE(hostlogfn);
 
-				sprintf(hostlogfn, "%s/%s", histdir, hostname);
-				hostlogfd = fopen(hostlogfn, "a");
+				hostlogfd = ((size_t)snprintf(hostlogfn, sizeof(hostlogfn), "%s/%s", histdir, hostname) < sizeof(hostlogfn))
+					? fopen(hostlogfn, "a") : NULL;
 				if (hostlogfd) {
 					fprintf(hostlogfd, "%s %d %d %d %s %s %d\n",
 						testname, (int)tstamp, (int)lastchg, (int)(tstamp - lastchg),
@@ -580,6 +631,8 @@ int main(int argc, char *argv[])
 
 			hostname = metadata[3];
 
+			if (!name_confined(histdir, hostname)) continue;
+
 			if (save_histlogs) {
 				char *hostdash;
 				char testdir[PATH_MAX];
@@ -588,8 +641,10 @@ int main(int argc, char *argv[])
 
 				/* Remove all directories below the host-specific histlog dir */
 				p = hostdash = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = '_';
-				sprintf(testdir, "%s/%s", histlogdir, hostdash);
-				dropdirectory(testdir, 1);
+				if ((size_t)snprintf(testdir, sizeof(testdir), "%s/%s", histlogdir, hostdash) < sizeof(testdir))
+					dropdirectory(testdir, 1);
+				else
+					errprintf("Histlog dir for %s under %s does not fit, not removing it\n", hostname, histlogdir);
 				xfree(hostdash);
 
 				MEMUNDEFINE(testdir);
@@ -601,9 +656,10 @@ int main(int argc, char *argv[])
 
 				MEMDEFINE(hostlogfn);
 
-				sprintf(hostlogfn, "%s/%s", histdir, hostname);
-				if ((stat(hostlogfn, &st) == 0) && S_ISREG(st.st_mode)) {
-					unlink(hostlogfn);
+				if ((size_t)snprintf(hostlogfn, sizeof(hostlogfn), "%s/%s", histdir, hostname) < sizeof(hostlogfn)) {
+					if ((stat(hostlogfn, &st) == 0) && S_ISREG(st.st_mode)) {
+						unlink(hostlogfn);
+					}
 				}
 
 				MEMUNDEFINE(hostlogfn);
@@ -627,7 +683,8 @@ int main(int argc, char *argv[])
 				if (dirfd) {
 					while ((de = readdir(dirfd)) != NULL) {
 						if (strncmp(de->d_name, hostlead, strlen(hostlead)) == 0) {
-							sprintf(statuslogfn, "%s/%s", histdir, de->d_name);
+							if ((size_t)snprintf(statuslogfn, sizeof(statuslogfn), "%s/%s", histdir, de->d_name) >= sizeof(statuslogfn))
+								continue;
 							if ((stat(statuslogfn, &st) == 0) && S_ISREG(st.st_mode)) {
 								unlink(statuslogfn);
 							}
@@ -648,6 +705,8 @@ int main(int argc, char *argv[])
 			hostname = metadata[3];
 			testname = metadata[4];
 
+			if (!name_confined(histdir, hostname) || !name_confined(histdir, testname)) continue;
+
 			if (save_histlogs) {
 				char *hostdash;
 				char testdir[PATH_MAX];
@@ -655,8 +714,10 @@ int main(int argc, char *argv[])
 				MEMDEFINE(testdir);
 
 				p = hostdash = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = '_';
-				sprintf(testdir, "%s/%s/%s", histlogdir, hostdash, testname);
-				dropdirectory(testdir, 1);
+				if ((size_t)snprintf(testdir, sizeof(testdir), "%s/%s/%s", histlogdir, hostdash, testname) < sizeof(testdir))
+					dropdirectory(testdir, 1);
+				else
+					errprintf("Histlog dir for %s/%s under %s does not fit, not removing it\n", hostname, testname, histlogdir);
 				xfree(hostdash);
 
 				MEMUNDEFINE(testdir);
@@ -670,8 +731,9 @@ int main(int argc, char *argv[])
 				MEMDEFINE(statuslogfn);
 
 				p = hostnamecommas = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = ',';
-				sprintf(statuslogfn, "%s/%s.%s", histdir, hostnamecommas, testname);
-				if ((stat(statuslogfn, &st) == 0) && S_ISREG(st.st_mode)) unlink(statuslogfn);
+				if ((size_t)snprintf(statuslogfn, sizeof(statuslogfn), "%s/%s.%s", histdir, hostnamecommas, testname) < sizeof(statuslogfn)) {
+					if ((stat(statuslogfn, &st) == 0) && S_ISREG(st.st_mode)) unlink(statuslogfn);
+				}
 				xfree(hostnamecommas);
 
 				MEMUNDEFINE(statuslogfn);
@@ -684,6 +746,8 @@ int main(int argc, char *argv[])
 			hostname = metadata[3];
 			newhostname = metadata[4];
 
+			if (!name_confined(histdir, hostname) || !name_confined(histdir, newhostname)) continue;
+
 			if (save_histlogs) {
 				char *hostdash;
 				char *newhostdash;
@@ -694,9 +758,9 @@ int main(int argc, char *argv[])
 
 				p = hostdash = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = '_';
 				p = newhostdash = strdup(newhostname); while ((p = strchr(p, '.')) != NULL) *p = '_';
-				sprintf(olddir, "%s/%s", histlogdir, hostdash);
-				sprintf(newdir, "%s/%s", histlogdir, newhostdash);
-				rename(olddir, newdir);
+				if (((size_t)snprintf(olddir, sizeof(olddir), "%s/%s", histlogdir, hostdash) < sizeof(olddir)) &&
+				    ((size_t)snprintf(newdir, sizeof(newdir), "%s/%s", histlogdir, newhostdash) < sizeof(newdir)))
+					rename(olddir, newdir);
 				xfree(newhostdash);
 				xfree(hostdash);
 
@@ -709,9 +773,9 @@ int main(int argc, char *argv[])
 
 				MEMDEFINE(hostlogfn); MEMDEFINE(newhostlogfn);
 
-				sprintf(hostlogfn, "%s/%s", histdir, hostname);
-				sprintf(newhostlogfn, "%s/%s", histdir, newhostname);
-				rename(hostlogfn, newhostlogfn);
+				if (((size_t)snprintf(hostlogfn, sizeof(hostlogfn), "%s/%s", histdir, hostname) < sizeof(hostlogfn)) &&
+				    ((size_t)snprintf(newhostlogfn, sizeof(newhostlogfn), "%s/%s", histdir, newhostname) < sizeof(newhostlogfn)))
+					rename(hostlogfn, newhostlogfn);
 
 				MEMUNDEFINE(hostlogfn); MEMUNDEFINE(newhostlogfn);
 			}
@@ -738,8 +802,9 @@ int main(int argc, char *argv[])
 					while ((de = readdir(dirfd)) != NULL) {
 						if (strncmp(de->d_name, hostlead, strlen(hostlead)) == 0) {
 							char *testname = strchr(de->d_name, '.');
-							sprintf(statuslogfn, "%s/%s", histdir, de->d_name);
-							sprintf(newlogfn, "%s/%s%s", histdir, newhostnamecommas, testname);
+							if (((size_t)snprintf(statuslogfn, sizeof(statuslogfn), "%s/%s", histdir, de->d_name) >= sizeof(statuslogfn)) ||
+							    ((size_t)snprintf(newlogfn, sizeof(newlogfn), "%s/%s%s", histdir, newhostnamecommas, testname) >= sizeof(newlogfn)))
+								continue;
 							rename(statuslogfn, newlogfn);
 						}
 					}
@@ -761,6 +826,9 @@ int main(int argc, char *argv[])
 			testname = metadata[4];
 			newtestname = metadata[5];
 
+			if (!name_confined(histdir, hostname) || !name_confined(histdir, testname) ||
+			    !name_confined(histdir, newtestname)) continue;
+
 			if (save_histlogs) {
 				char *hostdash;
 				char olddir[PATH_MAX];
@@ -769,9 +837,9 @@ int main(int argc, char *argv[])
 				MEMDEFINE(olddir); MEMDEFINE(newdir);
 
 				p = hostdash = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = '_';
-				sprintf(olddir, "%s/%s/%s", histlogdir, hostdash, testname);
-				sprintf(newdir, "%s/%s/%s", histlogdir, hostdash, newtestname);
-				rename(olddir, newdir);
+				if (((size_t)snprintf(olddir, sizeof(olddir), "%s/%s/%s", histlogdir, hostdash, testname) < sizeof(olddir)) &&
+				    ((size_t)snprintf(newdir, sizeof(newdir), "%s/%s/%s", histlogdir, hostdash, newtestname) < sizeof(newdir)))
+					rename(olddir, newdir);
 				xfree(hostdash);
 
 				MEMUNDEFINE(newdir); MEMUNDEFINE(olddir);
@@ -785,9 +853,9 @@ int main(int argc, char *argv[])
 				MEMDEFINE(statuslogfn); MEMDEFINE(newstatuslogfn);
 
 				p = hostnamecommas = strdup(hostname); while ((p = strchr(p, '.')) != NULL) *p = ',';
-				sprintf(statuslogfn, "%s/%s.%s", histdir, hostnamecommas, testname);
-				sprintf(newstatuslogfn, "%s/%s.%s", histdir, hostnamecommas, newtestname);
-				rename(statuslogfn, newstatuslogfn);
+				if (((size_t)snprintf(statuslogfn, sizeof(statuslogfn), "%s/%s.%s", histdir, hostnamecommas, testname) < sizeof(statuslogfn)) &&
+				    ((size_t)snprintf(newstatuslogfn, sizeof(newstatuslogfn), "%s/%s.%s", histdir, hostnamecommas, newtestname) < sizeof(newstatuslogfn)))
+					rename(statuslogfn, newstatuslogfn);
 				xfree(hostnamecommas);
 
 				MEMUNDEFINE(newstatuslogfn); MEMUNDEFINE(statuslogfn);


### PR DESCRIPTION
~~Stacked on #221 — merge that first (until then this PR also shows #221's two commits).~~
**Resolved:** #221 merged 2026-08-21. This PR no longer depends on anything and its diff shows only its own commit; #401 is stacked on it.

Same #287 class as #221, in the sibling worker. Handlers build paths under histdir/histlogdir from the channel's hostname/testname, which xymond does not validate as path components:

- `droptest <host> ../../<dir>` reaches the recursive `dropdirectory()` with a path that climbs out of histlogdir (a sibling directory was deleted).
- a configured host `../evil` (xymond warns but still monitors it) made the `@@stachg` host-events writer `fopen()` `histdir/../evil`, outside histdir.
- a ~5000-char testname (xymond caps neither length nor `/`) overflowed an unbounded `sprintf` into `char[PATH_MAX]` — a stack smash.

`name_confined()` (same contract as xymond_filestore: refuse `""`, leading `.`, `/`, `\`) now gates host and test names in the four drop/rename handlers and on the stachg path before any unlink/rename/dropdirectory/fopen; it accepts every real name (dots inside a hostname are fine). Every path build becomes `snprintf` with a truncation check.

| check | result |
|---|---|
| tests/xymond/history-drop-confine.sh (patched) | PASS |
| `droptest ../../SIBLING` on base | deletes a dir above histlogdir |
| `../evil` hostname on base | writes a file outside histdir |
| ~5000-char testname on base | SIGABRT (stack smash) |
| `www.example.com` | still records (no over-refusal) |

Follow-ups, not here: no O_NOFOLLOW/O_EXCL hardening of the histlog `fopen("w")` writer or of `dropdirectory()` (lib/files.c follows child symlinks); `name_confined()` is duplicated per the repo's per-worker altitude. Consistent with #221, `/`, `\` and leading-dot names are refused in history operations.
