### PR TITLE
xtree: report out-of-memory from xtreeAdd instead of leaking and crashing

### DIFF
--- a/lib/tree.c
+++ b/lib/tree.c
@@ -381,6 +381,7 @@ xtreeStatus_t xtreeAdd(void *treehandle, char *key, void *userdata)
 	if (mytree->treesz == 0) {
 		/* Empty tree, just add record */
 		mytree->entries = (treerec_t *)calloc(1, sizeof(treerec_t));
+		if (!mytree->entries) return XTREE_STATUS_MEM_EXHAUSTED;
 		mytree->entries[0].key = key;
 		mytree->entries[0].userdata = userdata;
 		mytree->entries[0].deleted = 0;
@@ -408,8 +409,12 @@ xtreeStatus_t xtreeAdd(void *treehandle, char *key, void *userdata)
 
 		/* Must create new record */
 		if (mytree->compare(key, mytree->entries[mytree->treesz - 1].key) > 0) {
-			/* Add after all the others */
-			mytree->entries = (treerec_t *)realloc(mytree->entries, (1 + mytree->treesz)*sizeof(treerec_t));
+			/* Add after all the others. realloc() into a temp: on failure
+			   the old array is still valid, so the tree is left unchanged
+			   rather than leaked and NULL-dereferenced. */
+			treerec_t *grown = (treerec_t *)realloc(mytree->entries, (1 + mytree->treesz)*sizeof(treerec_t));
+			if (!grown) return XTREE_STATUS_MEM_EXHAUSTED;
+			mytree->entries = grown;
 			mytree->entries[mytree->treesz].key = key;
 			mytree->entries[mytree->treesz].userdata = userdata;
 			mytree->entries[mytree->treesz].deleted = 0;
@@ -417,6 +422,7 @@ xtreeStatus_t xtreeAdd(void *treehandle, char *key, void *userdata)
 		else if (mytree->compare(key, mytree->entries[0].key) < 0) {
 			/* Add before all the others */
 			treerec_t *newents = (treerec_t *)malloc((1 + mytree->treesz)*sizeof(treerec_t));
+			if (!newents) return XTREE_STATUS_MEM_EXHAUSTED;
 			newents[0].key = key;
 			newents[0].userdata = userdata;
 			newents[0].deleted = 0;
@@ -446,6 +452,7 @@ xtreeStatus_t xtreeAdd(void *treehandle, char *key, void *userdata)
 
 			/* Ok, must create a new list and copy entries there */
 			newents = (treerec_t *)malloc((1 + mytree->treesz)*sizeof(treerec_t));
+			if (!newents) return XTREE_STATUS_MEM_EXHAUSTED;
 
 			/* Copy record 0..(n-1), i.e. n records */
 			memcpy(&(newents[0]), &(mytree->entries[0]), n*sizeof(treerec_t));

--- a/tests/server/xtree-add-oom.sh
+++ b/tests/server/xtree-add-oom.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xtree-add-oom.sh
+#
+# xtreeAdd (fallback array variant) grew the array with realloc()/malloc()
+# whose result it never checked. On failure realloc() returns NULL *and* leaves
+# the old block allocated: the old code overwrote mytree->entries with that
+# NULL, leaking the array and then dereferencing NULL at
+# entries[treesz].key = key. It must instead report XTREE_STATUS_MEM_EXHAUSTED
+# and leave the tree unchanged.
+#
+# tree.c is compiled to call wrapper allocators (via -Dmalloc=... etc.) that a
+# flag can force to fail, so the out-of-memory branch is driven deterministically.
+# The unfixed code crashes on the failing realloc, so a plain build catches the
+# regression on every platform; an ASan leg additionally proves no leak.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-xtree-oom.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+# Fallback (array) variant only: it is the one that realloc()s the array.
+echo '#undef HAVE_BINARY_TREE' >"$work/config.h"
+
+cat >"$work/harness.c" <<'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "config.h"
+#include "tree.h"
+
+/* tree.c is compiled with -Dmalloc=xt_malloc etc. so its allocations land
+   here; a one-shot flag forces the next call of a kind to fail. This file is
+   compiled WITHOUT the -D, so the wrappers reach the real allocators. */
+int xt_fail_malloc = 0, xt_fail_realloc = 0, xt_fail_calloc = 0;
+void *xt_malloc(size_t n)           { if (xt_fail_malloc)  { xt_fail_malloc = 0;  return NULL; } return malloc(n); }
+void *xt_calloc(size_t a, size_t b) { if (xt_fail_calloc)  { xt_fail_calloc = 0;  return NULL; } return calloc(a, b); }
+void *xt_realloc(void *p, size_t n) { if (xt_fail_realloc) { xt_fail_realloc = 0; return NULL; } return realloc(p, n); }
+
+int main(void)
+{
+	void *tree = xtreeNew(strcmp);
+	char *ka = strdup("a"), *kz = strdup("z"), *km = strdup("m");
+	int va = 1, vz = 2, vm = 3;
+
+	if (xtreeAdd(tree, ka, &va) != XTREE_STATUS_OK) return 10;	/* empty -> 1 */
+
+	/* Append grows via realloc(): force it to fail. Must report, not crash. */
+	xt_fail_realloc = 1;
+	if (xtreeAdd(tree, kz, &vz) != XTREE_STATUS_MEM_EXHAUSTED) return 11;
+	if (xtreeFind(tree, "a") == xtreeEnd(tree)) return 12;	/* unchanged */
+	if (xtreeFind(tree, "z") != xtreeEnd(tree)) return 13;	/* not added */
+	free(kz);						/* rejected key is the caller's */
+
+	/* A real append then a middle insert (malloc()): fail that too. */
+	kz = strdup("z");
+	if (xtreeAdd(tree, kz, &vz) != XTREE_STATUS_OK) return 14;	/* [a,z] */
+	xt_fail_malloc = 1;
+	if (xtreeAdd(tree, km, &vm) != XTREE_STATUS_MEM_EXHAUSTED) return 15;
+	if (xtreeFind(tree, "m") != xtreeEnd(tree)) return 16;	/* not added */
+	if (xtreeFind(tree, "a") == xtreeEnd(tree)) return 17;	/* both survive */
+	if (xtreeFind(tree, "z") == xtreeEnd(tree)) return 18;
+	free(km);
+
+	/* A normal add still works after the two rejections. */
+	km = strdup("m");
+	if (xtreeAdd(tree, km, &vm) != XTREE_STATUS_OK) return 19;
+
+	xtreeDestroy(tree);
+	free(ka); free(kz); free(km);
+	return 0;
+}
+EOF
+
+REDIR="-Dmalloc=xt_malloc -Dcalloc=xt_calloc -Drealloc=xt_realloc"
+
+build_and_run() {  # build_and_run <label> [extra-cflags]
+	local label=$1 extra=${2:-}
+	# tree.c gets the allocator redirect; the harness does not (its wrappers
+	# must reach the real allocators), so compile them separately, then link.
+	# shellcheck disable=SC2086
+	"$CC" -g $extra -I"$work" -iquote "$ROOT/lib" $REDIR \
+		-c -o "$work/tree-$label.o" "$ROOT/lib/tree.c" 2>"$work/cc-$label.log" \
+		|| { cat "$work/cc-$label.log" >&2; fail "$label: tree.c does not compile"; }
+	# shellcheck disable=SC2086
+	"$CC" -g $extra -I"$work" -iquote "$ROOT/lib" \
+		-c -o "$work/harness-$label.o" "$work/harness.c" 2>>"$work/cc-$label.log" \
+		|| { cat "$work/cc-$label.log" >&2; fail "$label: harness does not compile"; }
+	# shellcheck disable=SC2086
+	"$CC" -g $extra -o "$work/t-$label" "$work/harness-$label.o" "$work/tree-$label.o" 2>>"$work/cc-$label.log" \
+		|| { cat "$work/cc-$label.log" >&2; fail "$label: link failed"; }
+	"$work/t-$label" >"$work/out-$label" 2>&1 \
+		|| fail "$label: xtreeAdd out-of-memory path crashed or misbehaved (rc=$?): $(tail -15 "$work/out-$label")"
+}
+
+# Plain build first: the unfixed code NULL-derefs here, so this leg alone
+# guards the regression, and it runs on platforms without a sanitizer.
+build_and_run plain
+
+# ASan leg (where available) additionally catches the leaked old array.
+if asan_usable; then
+	build_and_run asan "-fsanitize=address"
+fi
+
+echo "OK $(basename "$0")"


### PR DESCRIPTION
Independent of the filestore/history hardening — surfaced while auditing `lib/tree.c` (the module the `xtree-*` ASan tests guard).

The fallback (array) `xtreeAdd()` grew its array with `realloc()`/`malloc()` and never checked the result. The `realloc()` is the worst: on failure it returns NULL *and leaves the old block allocated*, so `mytree->entries = realloc(mytree->entries, ...)` **leaked the old array and then dereferenced NULL** at `entries[treesz].key = key`. The prepend/middle `malloc()` and the empty-tree `calloc()` shared the shape.

All four now return `XTREE_STATUS_MEM_EXHAUSTED` (already in the API) without growing the tree — `realloc()` goes through a temp so the old array survives on failure, and `treesz` is bumped only on success, so the tree is left exactly as it was.

| check | result |
|---|---|
| tests/server/xtree-add-oom.sh (patched) | PASS |
| same test on unfixed tree.c | SIGSEGV (rc 139) on the failing realloc |

The test compiles `tree.c` with its allocations redirected to fail-on-demand wrappers, drives the append (`realloc`) and middle (`malloc`) paths into failure, and asserts each reports `MEM_EXHAUSTED` with the tree unchanged and a later add still working. The unfixed code NULL-derefs there, so the plain build catches it on every platform; an ASan leg additionally proves the old array isn't leaked.

Scope: only `xtreeAdd`'s allocation handling. The `tsearch` variant already checks `tsearch()` (but not its own `calloc(rec)`), and the broader audit also noted the non-reentrant `twalk` iterator and the array variant's O(n²)/tombstone growth — left as separate items.