### PR TITLE
xtree: enable the POSIX binary-tree variant (O(log n)) where available (TBT 61)

### DIFF
--- a/build/genconfig.sh
+++ b/build/genconfig.sh
@@ -97,14 +97,18 @@ else
 fi
 
 
-# This is experimental for 4.3.x
-#echo "Checking for POSIX binary tree functions"
-#$CC -c -o build/testfile.o $CFLAGS build/test-bintree.c 1>/dev/null 2>&1
-#if test $? -eq 0; then
-#	echo "#define HAVE_BINARY_TREE 1" >>include/config.h
-#else
+# Use the POSIX/SVr4 binary-tree routines (tsearch/tfind/tdelete/twalk) where the
+# platform provides them: xtree then runs O(log n) instead of the O(n^2) sorted-
+# array fallback. This probe was parked in 2014 as experimental for 4.3.x and
+# never revisited; both xtree variants are now covered by the ASan tests, and the
+# probe still falls back to the array where <search.h> is absent.
+echo "Checking for POSIX binary tree functions"
+$CC -c -o build/testfile.o $CFLAGS build/test-bintree.c 1>/dev/null 2>&1
+if test $? -eq 0; then
+	echo "#define HAVE_BINARY_TREE 1" >>include/config.h
+else
 	echo "#undef HAVE_BINARY_TREE" >>include/config.h
-#fi
+fi
 
 
 

--- a/lib/tree.c
+++ b/lib/tree.c
@@ -52,6 +52,7 @@ void *xtreeNew(int(*xtreeCompare)(const char *a, const char *b))
 	xtree_t *newtree;
 
 	newtree = (xtree_t *)calloc(1, sizeof(xtree_t));
+	if (!newtree) return NULL;
 	newtree->compare = xtreeCompare;
 	newtree->root = NULL;
 
@@ -83,6 +84,7 @@ xtreeStatus_t xtreeAdd(void *treehandle, char *key, void *userdata)
 	if (!tree) return XTREE_STATUS_NOTREE;
 
 	rec = (treerec_t *)calloc(1, sizeof(treerec_t));
+	if (!rec) return XTREE_STATUS_MEM_EXHAUSTED;
 	rec->key = key;
 	rec->userdata = userdata;
 	rec->compare = tree->compare;

--- a/tests/server/xtree-tsearch-oom.sh
+++ b/tests/server/xtree-tsearch-oom.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xtree-tsearch-oom.sh
+#
+# The POSIX binary-tree (tsearch) xtree variant allocated its record wrapper and
+# the tree handle with calloc() and never checked the result: xtreeAdd() did
+# `rec = calloc(...); rec->key = key;` and xtreeNew() did `newtree = calloc(...);
+# newtree->compare = ...`, both dereferencing NULL on out-of-memory. They must
+# report instead - XTREE_STATUS_MEM_EXHAUSTED from xtreeAdd(), NULL from
+# xtreeNew() - and leave the tree unchanged.
+#
+# tree.c is compiled with its calloc() redirected to a wrapper a flag can fail
+# on demand (tsearch()'s own internal node allocation is libc malloc, untouched).
+# The unfixed code NULL-derefs, so a plain build catches it everywhere; an ASan
+# leg additionally proves nothing is leaked.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/xymon-xtree-toom.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+# tsearch variant. Skip where <search.h>'s POSIX tree API is absent - the same
+# condition under which this variant is not built.
+echo '#define HAVE_BINARY_TREE 1' >"$work/config.h"
+cat >"$work/probe.c" <<'EOF'
+#include <search.h>
+#include <stdlib.h>
+static int c(const void*a,const void*b){(void)a;(void)b;return 0;}
+int main(void){void*r=NULL;int x=1;(void)tsearch(&x,&r,c);return 0;}
+EOF
+"$CC" -o "$work/probe" "$work/probe.c" 2>/dev/null || skip "POSIX binary-tree API (tsearch) not available"
+
+cat >"$work/harness.c" <<'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "config.h"
+#include "tree.h"
+
+/* tree.c is compiled with -Dcalloc=xt_calloc so its record/handle allocations
+   land here; a one-shot flag fails the next one. This file is compiled without
+   the -D, so the wrapper reaches the real calloc. */
+int xt_fail_calloc = 0;
+void *xt_calloc(size_t a, size_t b) { if (xt_fail_calloc) { xt_fail_calloc = 0; return NULL; } return calloc(a, b); }
+
+int main(void)
+{
+	int va = 1, vb = 2, vc = 3;
+	void *tree;
+
+	/* xtreeNew() out of memory must return NULL, not dereference it. */
+	xt_fail_calloc = 1;
+	if (xtreeNew(strcmp) != NULL) return 20;
+
+	tree = xtreeNew(strcmp);
+	if (!tree) return 21;
+	if (xtreeAdd(tree, "a", &va) != XTREE_STATUS_OK) return 10;
+
+	/* xtreeAdd()'s record calloc out of memory must report, not crash. */
+	xt_fail_calloc = 1;
+	if (xtreeAdd(tree, "b", &vb) != XTREE_STATUS_MEM_EXHAUSTED) return 11;
+	if (xtreeFind(tree, "a") == xtreeEnd(tree)) return 12;	/* unchanged */
+	if (xtreeFind(tree, "b") != xtreeEnd(tree)) return 13;	/* not added */
+
+	/* A normal add still works afterwards. */
+	if (xtreeAdd(tree, "c", &vc) != XTREE_STATUS_OK) return 14;
+
+	xtreeDestroy(tree);
+	return 0;
+}
+EOF
+
+build_and_run() {  # build_and_run <label> [extra-cflags]
+	local label=$1 extra=${2:-}
+	# shellcheck disable=SC2086
+	"$CC" -g $extra -I"$work" -iquote "$ROOT/lib" -Dcalloc=xt_calloc \
+		-c -o "$work/tree-$label.o" "$ROOT/lib/tree.c" 2>"$work/cc-$label.log" \
+		|| { cat "$work/cc-$label.log" >&2; fail "$label: tree.c does not compile"; }
+	# shellcheck disable=SC2086
+	"$CC" -g $extra -I"$work" -iquote "$ROOT/lib" \
+		-c -o "$work/harness-$label.o" "$work/harness.c" 2>>"$work/cc-$label.log" \
+		|| { cat "$work/cc-$label.log" >&2; fail "$label: harness does not compile"; }
+	# shellcheck disable=SC2086
+	"$CC" -g $extra -o "$work/t-$label" "$work/harness-$label.o" "$work/tree-$label.o" 2>>"$work/cc-$label.log" \
+		|| { cat "$work/cc-$label.log" >&2; fail "$label: link failed"; }
+	"$work/t-$label" >"$work/out-$label" 2>&1 \
+		|| fail "$label: tsearch xtreeAdd/xtreeNew out-of-memory path crashed or misbehaved (rc=$?): $(tail -15 "$work/out-$label")"
+}
+
+build_and_run plain
+if asan_usable; then
+	build_and_run asan "-fsanitize=address"
+fi
+
+echo "OK $(basename "$0")"


### PR DESCRIPTION
Independent of the security hardening — surfaced by the `lib/tree.c` audit that also produced #403.

**The problem.** `build/genconfig.sh` has commented out the `tsearch`/`tfind`/`tdelete`/`twalk` probe since 2014 (`dd78f9ac9`, "experimental for 4.3.x" — no stated defect), so every build since has used the sorted-array xtree fallback. That fallback is **O(n²) on arrival-order inserts** — the order xymond actually adds hosts/tests/columns:

| entries | array (shipped) | tsearch |
|--------|-----------------|---------|
| 5,000  | 0.016s | 0.001s |
| 80,000 | **9.19s** | **0.022s** |

~400×, and xymond rebuilds these trees on every config reload.

**The change.** Two commits:
1. Re-enable the `genconfig.sh` probe. If it compiles, xtree uses the O(log n) `tsearch` variant; otherwise it falls back to the array exactly as today — no platform regresses.
2. Check `calloc()` in the tsearch `xtreeAdd`/`xtreeNew` (it checked `tsearch()`'s return but not its own record/handle `calloc`), so the now-live path reports `MEM_EXHAUSTED`/NULL on OOM instead of NULL-dereferencing.

**Why it's safe now.** Both xtree variants are covered by the ASan tests (`xtree-destroy`, `xtree-iterate-deleted`) — that coverage is how the tsearch variant's long-latent destroy-leak was found and fixed in 2026-07, the bug its being uncompiled had hidden. The public xtree API is identical across variants and its only `xtreePos_t` consumer (`xymond_locator.c`) uses opaque handles, so the switch is transparent to callers.

| check | result |
|---|---|
| probe compiles → tsearch selected | yes (here) |
| full `libxymon.a` built as tsearch variant | clean |
| xtree-destroy / xtree-iterate-deleted on tsearch | PASS |
| new xtree-tsearch-oom.sh (fixed / unfixed) | PASS / SIGSEGV |
| non-conformant `<search.h>` | falls back to array |

Scope: autotools (`genconfig`) build only. The **cmake build carries the same hardcoded `HAVE_BINARY_TREE 0`** and would need the equivalent `check_c_source_compiles` probe separately (prototyped and verified locally, not included here). Draft pending the CI matrix, which is the real cross-platform validation — the probe gates per-platform, so any odd libc safely falls back.