### PR TITLE
ci: only run push builds on main, not on every branch push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: build
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: tests
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions:


### PR DESCRIPTION
`build.yml` and `tests.yml` both trigger on `push:` (any branch) **and** `pull_request:`. A pushed PR branch fires both events, so each workflow runs twice for the same commit — once for the branch push, once for the pull request. (Confirmed on a recent PR: the fork ran build+tests on `push`, upstream ran build+tests on `pull_request`.)

Restrict `push:` to `main`:

```yaml
on:
  push:
    branches: [main]
  pull_request:
```

PR branches are then covered once by `pull_request`; only mainline pushes trigger a push build. No behaviour change for `main` or for PRs — just no double-fire on branch pushes.

Note: this is the first of two independent de-dups. It does not touch the separate overlap where `tests.yml` re-runs the subset of the suite that `build.yml`'s server job already runs on a built tree — left for a follow-up.