### PR TITLE
aix: filter pseudo filesystems by type, and keep df off remote mounts

### DIFF
--- a/RELEASENOTES
+++ b/RELEASENOTES
@@ -13,6 +13,13 @@ Changes file.
 Changes for 4.3.31
 ==================
 
+The AIX client now requires AIX 7.1 or later. It keeps df off remote mounts by
+default (XYMONCLIENT_FS_DF_LOCAL_ONLY, as on the other clients), which AIX df
+spells "-T local" -- a flag 6.1 and earlier do not have. On those releases the
+client reported every filesystem and a hard-mounted NFS server that stopped
+answering could hang the whole client run, with no remote-df sentinel to bound
+it; that is the behaviour now left behind rather than worked around.
+
 xymonnet tests with a configured cipher-list restriction now report an SSL error
 when OpenSSL rejects the restriction, instead of silently using the default
 cipher list. Such tests may therefore turn red after upgrading Xymon, or after

--- a/client/xymonclient-aix.sh
+++ b/client/xymonclient-aix.sh
@@ -21,6 +21,7 @@ echo "[who]"
 who
 echo "[df]"
 # --- filesystem filter (configurable; see xymonclient.cfg.DIST) --------------
+# Requires AIX 7.1: "df -T local" below does not exist before it (RELEASENOTES).
 # AIX df cannot exclude by type, so excluded types are dropped from its output
 # by mount point, via the vfs column of mount(8). Default set, minus
 # INCLUDE_TYPES, plus EXCLUDE_TYPES, like the other clients.
@@ -48,8 +49,31 @@ EXCLMP=$(mount | FSEXCL="$FSEXCL" awk '
 	{ if ($3 ~ /^\//) { vfs = $4; dev = $1 ":" $2; mp = $3 } else { vfs = $3; dev = $1; mp = $2 } }
 	vfs in T { print dev " " mp }
 ')
+# XYMONCLIENT_FS_DF_LOCAL_ONLY: defaults to "yes", like the other clients. AIX
+# df has no -l, but "-T local" is the same selection and the same cure: a df
+# that never touches a remote mount cannot wedge on one. A hard-mounted NFS
+# server that stops answering otherwise hangs df here for as long as it takes
+# the host to reboot, and the whole client run with it. Set to "no" to report
+# remote filesystems too, accepting that risk - AIX has no remote-df sentinel
+# to bound it, unlike the Linux, BSD and macOS clients.
+DFLOCALONLY="${XYMONCLIENT_FS_DF_LOCAL_ONLY:-yes}"
+case "$DFLOCALONLY" in
+	yes|no) ;;
+	*)
+		echo "xymonclient-aix: invalid XYMONCLIENT_FS_DF_LOCAL_ONLY '$DFLOCALONLY', using yes" >&2
+		DFLOCALONLY=yes
+		;;
+esac
+
+# Spelled out per branch, not expanded from a variable: an unquoted expansion
+# splits on IFS, and a caller with a non-default IFS would hand df "-T local"
+# as one argument.
 # The sed stuff is to make sure lines are not split into two.
-df -Ik | sed -e '/^[^ 	][^ 	]*$/{
+if [ "$DFLOCALONLY" = yes ]; then
+	df -Ik -T local
+else
+	df -Ik
+fi | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
 }' | EXCLMP="$EXCLMP" awk '
@@ -65,9 +89,24 @@ s/[ 	]*\n[ 	]*/ /
 '
 
 echo "[inode]"
-/usr/sysv/bin/df -i | sed -e 's!Mount Dir!Mount_Dir!' | awk '
-NR<2 { printf "%-20s %10s %10s %10s %10s %s\n", $2, $5, $3, $4, $6, "Mounted on" }
-NR>=2 && $5>0 { printf "%-20s %10d %10d %10d %10s %s\n", $2, $5, $3, $4, $6, $1}
+# The System V df spells local-only "-l". It has to be guarded too: it stats
+# every filesystem it reports, so leaving it open would only move the hang
+# here from the disk report above.
+if [ "$DFLOCALONLY" = yes ]; then
+	/usr/sysv/bin/df -i -l
+else
+	/usr/sysv/bin/df -i
+fi | sed -e 's!Mount Dir!Mount_Dir!' | awk '
+NR<2 { hdr = sprintf("%-20s %10s %10s %10s %10s %s", $2, $5, $3, $4, $6, "Mounted on"); next }
+$5>0 {
+	# Header held back as in the disk report, for a smaller gain: an inode
+	# section with no rows is green either way, unix_inode_report() exempting
+	# an empty one for the Solaris host whose filesystems are all ZFS. What
+	# the empty spelling buys is the server naming the reason ("No filesystems
+	# reporting inode data") instead of echoing a header for zero filesystems.
+	if (hdr != "") { print hdr; hdr = "" }
+	printf "%-20s %10d %10d %10d %10s %s\n", $2, $5, $3, $4, $6, $1
+}
 '
 
 echo "[mount]"

--- a/client/xymonclient-aix.sh
+++ b/client/xymonclient-aix.sh
@@ -20,11 +20,49 @@ uptime
 echo "[who]"
 who
 echo "[df]"
+# --- filesystem filter (configurable; see xymonclient.cfg.DIST) --------------
+# AIX df cannot exclude by type, so excluded types are dropped from its output
+# by mount point, via the vfs column of mount(8). Default set, minus
+# INCLUDE_TYPES, plus EXCLUDE_TYPES, like the other clients.
+: "${XYMONCLIENT_FS_INCLUDE_TYPES=}"
+: "${XYMONCLIENT_FS_EXCLUDE_TYPES=}"
+# noglob: a configured type like "procf*" stays literal.
+case $- in *f*) _restoreglob=no ;; *) _restoreglob=yes; set -f ;; esac
+FSEXCL=""
+for _t in procfs ahafs namefs autofs cdrfs; do
+	for _i in $XYMONCLIENT_FS_INCLUDE_TYPES; do [ "$_t" = "$_i" ] && continue 2; done
+	FSEXCL="$FSEXCL $_t"
+done
+[ "$_restoreglob" = yes ] && set +f
+# EXCLUDE_TYPES last: a type in both lists stays excluded.
+FSEXCL="$FSEXCL $XYMONCLIENT_FS_EXCLUDE_TYPES"
+# The excluded mounts, as "device mountpoint" pairs: an excluded overlay type
+# (namefs) can share its mount point with a real filesystem, and only the
+# overlay row may go. mount prints two header lines; a local row carries the
+# vfs type in column 3, a remote row (leading node column, so column 3 is the
+# slash-starting mount point) in column 4, its device rendering as node:path
+# in df. The lists reach awk via ENVIRON: -v would apply awk escape processing.
+EXCLMP=$(mount | FSEXCL="$FSEXCL" awk '
+	BEGIN { n = split(ENVIRON["FSEXCL"], t, " "); for (i = 1; i <= n; i++) T[t[i]] = 1 }
+	NR <= 2 { next }
+	{ if ($3 ~ /^\//) { vfs = $4; dev = $1 ":" $2; mp = $3 } else { vfs = $3; dev = $1; mp = $2 } }
+	vfs in T { print dev " " mp }
+')
 # The sed stuff is to make sure lines are not split into two.
 df -Ik | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
-}'
+}' | EXCLMP="$EXCLMP" awk '
+	BEGIN { n = split(ENVIRON["EXCLMP"], m, "\n"); for (i = 1; i <= n; i++) M[m[i]] = 1 }
+	NR == 1 { hdr = $0; next }
+	!(($1 " " $NF) in M) {
+		# Header held back: with every row excluded the report must come out
+		# empty - the server flags an empty disk report, a header-only one
+		# reads as all-green.
+		if (hdr != "") { print hdr; hdr = "" }
+		print
+	}
+'
 
 echo "[inode]"
 /usr/sysv/bin/df -i | sed -e 's!Mount Dir!Mount_Dir!' | awk '

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -58,6 +58,12 @@ LOGFETCHOPTS=""
 # XYMONCLIENT_FS_INCLUDE_TYPES=""
 # XYMONCLIENT_FS_EXCLUDE_TYPES=""
 # XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
+#
+# AIX (xymonclient-aix.sh) - excludes procfs/ahafs/namefs/autofs/cdrfs from
+# the disk report, by mount point via mount(8) since AIX df cannot exclude by
+# type; the inode report and DF_LOCAL_ONLY are not covered:
+# XYMONCLIENT_FS_INCLUDE_TYPES=""
+# XYMONCLIENT_FS_EXCLUDE_TYPES=""
 
 
 # Local Mode (Only) Options

--- a/client/xymonclient.cfg.DIST
+++ b/client/xymonclient.cfg.DIST
@@ -61,9 +61,13 @@ LOGFETCHOPTS=""
 #
 # AIX (xymonclient-aix.sh) - excludes procfs/ahafs/namefs/autofs/cdrfs from
 # the disk report, by mount point via mount(8) since AIX df cannot exclude by
-# type; the inode report and DF_LOCAL_ONLY are not covered:
+# type; the inode report needs no type filter, its own guard already skipping
+# rows without inode accounting. DF_LOCAL_ONLY covers both reports and matters
+# more here than elsewhere: AIX has no remote-df sentinel, so "no" leaves a
+# wedged NFS mount able to hang the run:
 # XYMONCLIENT_FS_INCLUDE_TYPES=""
 # XYMONCLIENT_FS_EXCLUDE_TYPES=""
+# XYMONCLIENT_FS_DF_LOCAL_ONLY="yes"
 
 
 # Local Mode (Only) Options

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -43,8 +43,7 @@ macOS, mount attributes are matched as well; on AIX, matching is
 against the vfs column of mount(8)). The default exclusions
 and the mechanism are per-OS, and clients not listed here do not use
 the variable. Including remote filesystems also requires
-XYMONCLIENT_FS_DF_LOCAL_ONLY=no on the clients implementing it
-(AIX always reports them).
+XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
 .br
 On Linux: types normally excluded as pseudo (\fBnodev\fR) filesystems.
 Defaults to \fBzfs virtiofs tmpfs\fR \(em real local filesystems
@@ -93,8 +92,7 @@ On AIX: names types from the default exclude set (\fBprocfs ahafs
 namefs autofs cdrfs\fR) to surface again. Empty by default. AIX df
 cannot exclude by type, so the disk report drops excluded types by
 mount point, from the vfs column of mount(8); the inode report is not
-covered (its own guard already skips rows without inode accounting),
-and neither is XYMONCLIENT_FS_DF_LOCAL_ONLY.
+covered, its own guard already skipping rows without inode accounting.
 
 .IP "\fBXYMONCLIENT_FS_EXCLUDE_TYPES\fR"
 Whitespace-separated filesystem types (attributes as well, on macOS)
@@ -149,10 +147,19 @@ column of mount(8) \(em AIX df names no filesystem types \(em and
 applied to the disk report only.
 
 .IP "\fBXYMONCLIENT_FS_DF_LOCAL_ONLY\fR"
-Linux, FreeBSD, NetBSD, OpenBSD and macOS; other clients (AIX included)
-ignore it.
+Linux, FreeBSD, NetBSD, OpenBSD, macOS and AIX; other clients ignore it.
 Set to \fByes\fR (the default) to pass \fB\-l\fR to df and report
-local filesystems only. Set to \fBno\fR to report remote filesystems
+local filesystems only. AIX df has no \fB\-l\fR; it is given
+\fB\-T local\fR, which selects the same set. That flag needs AIX 7.1,
+which is the client's floor. Its
+inode df (\fB/usr/sysv/bin/df\fR) is given \fB\-l\fR, that command's
+spelling of the same thing, since guarding one report and not the other
+would leave the same mount able to wedge the run.
+.br
+With \fBno\fR on AIX, a remote filesystem whose server does not supply
+all the statistics is reported as df writes it \(em blanks rather than
+values \(em and is dropped from the inode report, which needs a usable
+count. Set to \fBno\fR to report remote filesystems
 as well. Invalid values produce a warning and use the safe default.
 On macOS, where df is invoked per path, the same effect is achieved by
 keeping only mounts flagged "local" (MNT_LOCAL, what \fBdf \-l\fR
@@ -161,8 +168,9 @@ With \fBno\fR, a stale or hard-blocked remote mount can wedge df
 indefinitely (an uninterruptible D-state wait): the client run never
 finishes, so the whole host goes purple \(em no data for all metrics,
 not just disk \(em until the mount recovers or the host reboots.
-On all five clients this is bounded by the remote-df sentinel described
-below (XYMONCLIENT_FS_REMOTE_DF_BUDGET).
+On Linux, FreeBSD, NetBSD, OpenBSD and macOS this is bounded by the
+remote-df sentinel described below (XYMONCLIENT_FS_REMOTE_DF_BUDGET).
+AIX has no sentinel, so \fBno\fR carries that risk in full there.
 .IP
 A df that \fIexits\fR non-zero with no output (a real error, not a hang)
 is marked failed (yellow) rather than left empty, so a failed filesystem

--- a/common/xymonclient.cfg.5
+++ b/common/xymonclient.cfg.5
@@ -39,10 +39,12 @@ Directory used for temporary files. Default: $XYMONHOME/tmp/
 Whitespace-separated filesystem types to include in the client's disk
 (and, where supported, inode) reports even when the client's defaults
 would exclude them. Types are matched as exact df type tokens (on
-macOS, mount attributes are matched as well). The default exclusions
+macOS, mount attributes are matched as well; on AIX, matching is
+against the vfs column of mount(8)). The default exclusions
 and the mechanism are per-OS, and clients not listed here do not use
 the variable. Including remote filesystems also requires
-XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
+XYMONCLIENT_FS_DF_LOCAL_ONLY=no on the clients implementing it
+(AIX always reports them).
 .br
 On Linux: types normally excluded as pseudo (\fBnodev\fR) filesystems.
 Defaults to \fBzfs virtiofs tmpfs\fR \(em real local filesystems
@@ -86,11 +88,19 @@ explicit XYMONCLIENT_FS_EXCLUDE_TYPES entry that matches it (for
 instance "apfs") still removes it. Including "nobrowse" switches that
 default drop off entirely \(em devfs and the autofs map come back too
 \(em so pair it with XYMONCLIENT_FS_EXCLUDE_TYPES="devfs autofs".
+.br
+On AIX: names types from the default exclude set (\fBprocfs ahafs
+namefs autofs cdrfs\fR) to surface again. Empty by default. AIX df
+cannot exclude by type, so the disk report drops excluded types by
+mount point, from the vfs column of mount(8); the inode report is not
+covered (its own guard already skips rows without inode accounting),
+and neither is XYMONCLIENT_FS_DF_LOCAL_ONLY.
 
 .IP "\fBXYMONCLIENT_FS_EXCLUDE_TYPES\fR"
 Whitespace-separated filesystem types (attributes as well, on macOS)
 to exclude in addition to the client's default exclusions. Matching is
-on the exact df type token. If a type appears in both include and
+on the exact df type token (on AIX, on the vfs column of mount(8)).
+If a type appears in both include and
 exclude settings, exclusion takes precedence on every OS.
 .br
 On Linux: nodev types (overlay, fuse, ...) are already excluded
@@ -132,8 +142,15 @@ entry and the "root data" exemption above. Useful entries include
 Ventura and later) and \fBfusefs\fR (macFUSE volumes mounted
 "-o local"). Beware attributes most mounts carry: excluding "local"
 drops everything.
+.br
+On AIX: adds types to the default exclude set (\fBprocfs ahafs namefs
+autofs cdrfs\fR). Empty by default. Tokens are matched against the vfs
+column of mount(8) \(em AIX df names no filesystem types \(em and
+applied to the disk report only.
 
 .IP "\fBXYMONCLIENT_FS_DF_LOCAL_ONLY\fR"
+Linux, FreeBSD, NetBSD, OpenBSD and macOS; other clients (AIX included)
+ignore it.
 Set to \fByes\fR (the default) to pass \fB\-l\fR to df and report
 local filesystems only. Set to \fBno\fR to report remote filesystems
 as well. Invalid values produce a warning and use the safe default.
@@ -144,8 +161,8 @@ With \fBno\fR, a stale or hard-blocked remote mount can wedge df
 indefinitely (an uninterruptible D-state wait): the client run never
 finishes, so the whole host goes purple \(em no data for all metrics,
 not just disk \(em until the mount recovers or the host reboots.
-On Linux this is bounded by the remote-df sentinel described below; the
-other clients still carry the risk in full.
+On all five clients this is bounded by the remote-df sentinel described
+below (XYMONCLIENT_FS_REMOTE_DF_BUDGET).
 .IP
 A df that \fIexits\fR non-zero with no output (a real error, not a hang)
 is marked failed (yellow) rather than left empty, so a failed filesystem

--- a/docs/manpages/man5/xymonclient.cfg.5.html
+++ b/docs/manpages/man5/xymonclient.cfg.5.html
@@ -65,10 +65,11 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
   <dd>Whitespace-separated filesystem types to include in the client's disk
       (and, where supported, inode) reports even when the client's defaults
       would exclude them. Types are matched as exact df type tokens (on macOS,
-      mount attributes are matched as well). The default exclusions and the
-      mechanism are per-OS, and clients not listed here do not use the variable.
-      Including remote filesystems also requires
-      XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
+      mount attributes are matched as well; on AIX, matching is against the vfs
+      column of mount(8)). The default exclusions and the mechanism are per-OS,
+      and clients not listed here do not use the variable. Including remote
+      filesystems also requires XYMONCLIENT_FS_DF_LOCAL_ONLY=no on the clients
+      implementing it (AIX always reports them).
     <br/>
     On Linux: types normally excluded as pseudo (<b>nodev</b>) filesystems.
       Defaults to <b>zfs virtiofs tmpfs</b> &#x2014; real local filesystems that
@@ -112,13 +113,21 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       switches that default drop off entirely &#x2014; devfs and the autofs map
       come back too &#x2014; so pair it with
       XYMONCLIENT_FS_EXCLUDE_TYPES=&quot;devfs autofs&quot;.
+    <br/>
+    On AIX: names types from the default exclude set (<b>procfs ahafs</b>
+      <b>namefs autofs cdrfs</b>) to surface again. Empty by default. AIX df
+      cannot exclude by type, so the disk report drops excluded types by mount
+      point, from the vfs column of mount(8); the inode report is not covered
+      (its own guard already skips rows without inode accounting), and neither
+      is XYMONCLIENT_FS_DF_LOCAL_ONLY.
     <p class="Pp"></p>
   </dd>
   <dt id="XYMONCLIENT_FS_EXCLUDE_TYPES"><a class="permalink" href="#XYMONCLIENT_FS_EXCLUDE_TYPES"><b>XYMONCLIENT_FS_EXCLUDE_TYPES</b></a></dt>
   <dd>Whitespace-separated filesystem types (attributes as well, on macOS) to
       exclude in addition to the client's default exclusions. Matching is on the
-      exact df type token. If a type appears in both include and exclude
-      settings, exclusion takes precedence on every OS.
+      exact df type token (on AIX, on the vfs column of mount(8)). If a type
+      appears in both include and exclude settings, exclusion takes precedence
+      on every OS.
     <br/>
     On Linux: nodev types (overlay, fuse, ...) are already excluded by default,
       so an effective entry names a type that is not a nodev default &#x2014; a
@@ -158,20 +167,26 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       LiveFiles on Ventura and later) and <b>fusefs</b> (macFUSE volumes mounted
       &quot;-o local&quot;). Beware attributes most mounts carry: excluding
       &quot;local&quot; drops everything.
+    <br/>
+    On AIX: adds types to the default exclude set (<b>procfs ahafs namefs</b>
+      <b>autofs cdrfs</b>). Empty by default. Tokens are matched against the vfs
+      column of mount(8) &#x2014; AIX df names no filesystem types &#x2014; and
+      applied to the disk report only.
     <p class="Pp"></p>
   </dd>
   <dt id="XYMONCLIENT_FS_DF_LOCAL_ONLY"><a class="permalink" href="#XYMONCLIENT_FS_DF_LOCAL_ONLY"><b>XYMONCLIENT_FS_DF_LOCAL_ONLY</b></a></dt>
-  <dd>Set to <b>yes</b> (the default) to pass <b>-l</b> to df and report local
-      filesystems only. Set to <b>no</b> to report remote filesystems as well.
-      Invalid values produce a warning and use the safe default. On macOS, where
-      df is invoked per path, the same effect is achieved by keeping only mounts
-      flagged &quot;local&quot; (MNT_LOCAL, what <b>df -l</b> selects
-      elsewhere). With <b>no</b>, a stale or hard-blocked remote mount can wedge
-      df indefinitely (an uninterruptible D-state wait): the client run never
-      finishes, so the whole host goes purple &#x2014; no data for all metrics,
-      not just disk &#x2014; until the mount recovers or the host reboots. On
-      Linux this is bounded by the remote-df sentinel described below; the other
-      clients still carry the risk in full.</dd>
+  <dd>Linux, FreeBSD, NetBSD, OpenBSD and macOS; other clients (AIX included)
+      ignore it. Set to <b>yes</b> (the default) to pass <b>-l</b> to df and
+      report local filesystems only. Set to <b>no</b> to report remote
+      filesystems as well. Invalid values produce a warning and use the safe
+      default. On macOS, where df is invoked per path, the same effect is
+      achieved by keeping only mounts flagged &quot;local&quot; (MNT_LOCAL, what
+      <b>df -l</b> selects elsewhere). With <b>no</b>, a stale or hard-blocked
+      remote mount can wedge df indefinitely (an uninterruptible D-state wait):
+      the client run never finishes, so the whole host goes purple &#x2014; no
+      data for all metrics, not just disk &#x2014; until the mount recovers or
+      the host reboots. On all five clients this is bounded by the remote-df
+      sentinel described below (XYMONCLIENT_FS_REMOTE_DF_BUDGET).</dd>
   <dt></dt>
   <dd>A df that <i>exits</i> non-zero with no output (a real error, not a hang)
       is marked failed (yellow) rather than left empty, so a failed filesystem

--- a/docs/manpages/man5/xymonclient.cfg.5.html
+++ b/docs/manpages/man5/xymonclient.cfg.5.html
@@ -68,8 +68,7 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       mount attributes are matched as well; on AIX, matching is against the vfs
       column of mount(8)). The default exclusions and the mechanism are per-OS,
       and clients not listed here do not use the variable. Including remote
-      filesystems also requires XYMONCLIENT_FS_DF_LOCAL_ONLY=no on the clients
-      implementing it (AIX always reports them).
+      filesystems also requires XYMONCLIENT_FS_DF_LOCAL_ONLY=no.
     <br/>
     On Linux: types normally excluded as pseudo (<b>nodev</b>) filesystems.
       Defaults to <b>zfs virtiofs tmpfs</b> &#x2014; real local filesystems that
@@ -117,9 +116,8 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     On AIX: names types from the default exclude set (<b>procfs ahafs</b>
       <b>namefs autofs cdrfs</b>) to surface again. Empty by default. AIX df
       cannot exclude by type, so the disk report drops excluded types by mount
-      point, from the vfs column of mount(8); the inode report is not covered
-      (its own guard already skips rows without inode accounting), and neither
-      is XYMONCLIENT_FS_DF_LOCAL_ONLY.
+      point, from the vfs column of mount(8); the inode report is not covered,
+      its own guard already skipping rows without inode accounting.
     <p class="Pp"></p>
   </dd>
   <dt id="XYMONCLIENT_FS_EXCLUDE_TYPES"><a class="permalink" href="#XYMONCLIENT_FS_EXCLUDE_TYPES"><b>XYMONCLIENT_FS_EXCLUDE_TYPES</b></a></dt>
@@ -175,18 +173,28 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <p class="Pp"></p>
   </dd>
   <dt id="XYMONCLIENT_FS_DF_LOCAL_ONLY"><a class="permalink" href="#XYMONCLIENT_FS_DF_LOCAL_ONLY"><b>XYMONCLIENT_FS_DF_LOCAL_ONLY</b></a></dt>
-  <dd>Linux, FreeBSD, NetBSD, OpenBSD and macOS; other clients (AIX included)
-      ignore it. Set to <b>yes</b> (the default) to pass <b>-l</b> to df and
-      report local filesystems only. Set to <b>no</b> to report remote
-      filesystems as well. Invalid values produce a warning and use the safe
-      default. On macOS, where df is invoked per path, the same effect is
-      achieved by keeping only mounts flagged &quot;local&quot; (MNT_LOCAL, what
-      <b>df -l</b> selects elsewhere). With <b>no</b>, a stale or hard-blocked
-      remote mount can wedge df indefinitely (an uninterruptible D-state wait):
-      the client run never finishes, so the whole host goes purple &#x2014; no
-      data for all metrics, not just disk &#x2014; until the mount recovers or
-      the host reboots. On all five clients this is bounded by the remote-df
-      sentinel described below (XYMONCLIENT_FS_REMOTE_DF_BUDGET).</dd>
+  <dd>Linux, FreeBSD, NetBSD, OpenBSD, macOS and AIX; other clients ignore it.
+      Set to <b>yes</b> (the default) to pass <b>-l</b> to df and report local
+      filesystems only. AIX df has no <b>-l</b>; it is given <b>-T local</b>,
+      which selects the same set. That flag needs AIX 7.1, which is the client's
+      floor. Its inode df (<b>/usr/sysv/bin/df</b>) is given <b>-l</b>, that
+      command's spelling of the same thing, since guarding one report and not
+      the other would leave the same mount able to wedge the run.
+    <br/>
+    With <b>no</b> on AIX, a remote filesystem whose server does not supply all
+      the statistics is reported as df writes it &#x2014; blanks rather than
+      values &#x2014; and is dropped from the inode report, which needs a usable
+      count. Set to <b>no</b> to report remote filesystems as well. Invalid
+      values produce a warning and use the safe default. On macOS, where df is
+      invoked per path, the same effect is achieved by keeping only mounts
+      flagged &quot;local&quot; (MNT_LOCAL, what <b>df -l</b> selects
+      elsewhere). With <b>no</b>, a stale or hard-blocked remote mount can wedge
+      df indefinitely (an uninterruptible D-state wait): the client run never
+      finishes, so the whole host goes purple &#x2014; no data for all metrics,
+      not just disk &#x2014; until the mount recovers or the host reboots. On
+      Linux, FreeBSD, NetBSD, OpenBSD and macOS this is bounded by the remote-df
+      sentinel described below (XYMONCLIENT_FS_REMOTE_DF_BUDGET). AIX has no
+      sentinel, so <b>no</b> carries that risk in full there.</dd>
   <dt></dt>
   <dd>A df that <i>exits</i> non-zero with no output (a real error, not a hang)
       is marked failed (yellow) rather than left empty, so a failed filesystem

--- a/tests/client/fs-filter-aix.sh
+++ b/tests/client/fs-filter-aix.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/client/fs-filter-aix.sh
+#
+# xymonclient-aix.sh under the type-filter subset of the XYMONCLIENT_FS_*
+# contract. AIX df has no type exclusion, so the client's dialect is unique:
+# it reads the vfs column of mount(8) and drops excluded types from df's
+# output by mount point. Pinned here, against a stub df and an AIX-format
+# stub mount:
+#
+#   - the default set (procfs ahafs namefs autofs cdrfs) is dropped from the
+#     [df] section; real local (jfs2) and remote (nfs3) rows stay
+#   - the drop is keyed on the device+mountpoint pair, so an excluded overlay
+#     (namefs) sharing its mount point with a real filesystem takes only the
+#     overlay row with it
+#   - excluding every filesystem yields an EMPTY [df] section, which the
+#     server flags - a header-only section would read as all-green
+#   - INCLUDE_TYPES surfaces a default-excluded type again
+#   - EXCLUDE_TYPES drops a real type; a type in both lists stays excluded
+#   - a configured token like "procf*" is matched literally, never expanded
+#     against files in the working directory
+#
+# NOT claimed: the full #170 contract. DF_LOCAL_ONLY and the remote-df
+# sentinel are not implemented on AIX, and the [inode] section is untouched
+# (its own guard already skips rows without inode accounting, and its
+# /usr/sysv/bin/df is an absolute path a PATH stub cannot reach).
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/client/fs-filter-common.sh
+. "$(dirname "$0")/fs-filter-common.sh"
+
+fsf_setup aix XYMONCLIENT_AIX
+
+# --- stubs --------------------------------------------------------------------
+
+# AIX df -Ik: pseudo mounts print dashes, real mounts print numbers. One row
+# per default-excluded type, so a type dropped from the client's list shows up
+# as a reappearing row.
+cat > "$STUB/df" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" >> "$DF_LOG"
+cat <<'TABLE'
+Filesystem 1024-blocks Used Free %Used Mounted on
+/dev/hd4 1048576 319992 728584 31% /
+/proc - - - - /proc
+/aha - - - - /aha
+/dev/cd0 693248 693248 0 100% /cdrom
+/var/somefile 1048576 319992 862080 17% /namefs
+/dev/autofs - - - - /autodir
+/var/overlay 1048576 319992 728584 42% /data
+/dev/hd5 2097152 1048576 1048576 62% /data
+srv:/export 2097152 1048576 1048576 50% /mnt
+TABLE
+EOF
+chmod +x "$STUB/df"
+
+# AIX mount: two header lines; local rows have the vfs type in column 3,
+# remote rows carry the node first and the type in column 4.
+cat > "$STUB/mount" <<'EOF'
+#!/bin/sh
+cat <<'TABLE'
+  node       mounted        mounted over    vfs       date        options
+-------- ---------------  ---------------  ------ ------------ ---------------
+         /dev/hd4         /                jfs2   Jul 17 08:04 rw,log=/dev/hd8
+         /proc            /proc            procfs Jul 17 08:04 rw
+         /aha             /aha             ahafs  Jul 17 08:04 rw
+         /dev/cd0         /cdrom           cdrfs  Jul 17 08:04 ro
+         /var/somefile    /namefs          namefs Jul 17 08:04 rw
+         /dev/autofs      /autodir         autofs Jul 17 08:04 rw
+         /var/overlay     /data            namefs Jul 17 08:04 rw
+         /dev/hd5         /data            jfs2   Jul 17 08:04 rw
+ srv      /export         /mnt             nfs3   Jul 17 09:00 rw,bg
+TABLE
+EOF
+chmod +x "$STUB/mount"
+
+# Files the "procf*" / "jfs*" tokens would expand to, if the client let a
+# configured type undergo pathname expansion in the directory it runs from.
+: > "$TMP/procfs"
+: > "$TMP/jfs2"
+
+FSF="$TMP/df-section.sh"
+fsf_extract "$FSF" "" '\[inode\]'
+
+run_df() {
+	( cd "$TMP" && env "$@" $FSF_SHELL "$FSF" ) 2> "$STDERR_LOG" \
+		|| fail "extracted [df] block exited non-zero: $(cat "$STDERR_LOG")"
+}
+
+# --- the default set ----------------------------------------------------------
+
+out=$(run_df)
+assert_contains "%Used Mounted on" "$out" "the df header row must survive the filter"
+assert_contains "31% /" "$out" "the real jfs2 filesystem must be reported"
+assert_contains "50% /mnt" "$out" "a remote nfs3 mount is not in the type exclude set and must be reported"
+for mp in /proc /aha /cdrom /namefs /autodir; do
+	assert_not_contains " $mp" "$out" \
+		"the default exclude set no longer drops $mp (procfs ahafs namefs autofs cdrfs)"
+done
+
+# The namefs overlay on /data goes, the jfs2 filesystem under the same mount
+# point stays: the drop is keyed on the device+mountpoint pair, not the path.
+assert_not_contains "/var/overlay" "$out" \
+	"the namefs overlay row must be dropped by type"
+assert_contains "62% /data" "$out" \
+	"a real filesystem sharing its mount point with an excluded overlay was dropped with it"
+
+# --- INCLUDE_TYPES surfaces a default exclusion --------------------------------
+
+out=$(run_df XYMONCLIENT_FS_INCLUDE_TYPES=procfs)
+assert_contains " /proc" "$out" "INCLUDE_TYPES=procfs must surface /proc again"
+assert_not_contains " /aha" "$out" "INCLUDE_TYPES=procfs must not surface other defaults"
+
+# --- EXCLUDE_TYPES drops a real type, and wins over INCLUDE --------------------
+
+out=$(run_df XYMONCLIENT_FS_EXCLUDE_TYPES=jfs2)
+assert_not_contains "31% /" "$out" "EXCLUDE_TYPES=jfs2 must drop the jfs2 filesystem"
+assert_contains "50% /mnt" "$out" "EXCLUDE_TYPES=jfs2 must not drop unrelated mounts"
+
+out=$(run_df XYMONCLIENT_FS_INCLUDE_TYPES=procfs XYMONCLIENT_FS_EXCLUDE_TYPES=procfs)
+assert_not_contains " /proc" "$out" "a type in both lists must stay excluded (EXCLUDE wins)"
+
+# Multiple tokens in one variable are independent list entries.
+out=$(run_df XYMONCLIENT_FS_INCLUDE_TYPES='procfs ahafs')
+assert_contains " /proc" "$out" "the first of two INCLUDE_TYPES tokens must surface its type"
+assert_contains " /aha" "$out" "the second of two INCLUDE_TYPES tokens must surface its type"
+
+out=$(run_df XYMONCLIENT_FS_EXCLUDE_TYPES='jfs2 nfs3')
+assert_not_contains "31% /" "$out" "the first of two EXCLUDE_TYPES tokens must drop its type"
+assert_not_contains " /mnt" "$out" "the second of two EXCLUDE_TYPES tokens must drop its type"
+# ... which excludes every filesystem in the fixture: the section must come
+# out empty, not header-only - the server flags an empty disk report, while a
+# header with no rows reads as all-green.
+assert_equal "[df]" "$out" \
+	"excluding every filesystem left a header-only [df] section, which the server reads as all-green"
+
+# --- configured tokens are literal, never globs --------------------------------
+
+# "procf*" must not expand to the "procfs" file in the working directory: as a
+# literal it matches no type, so /proc stays excluded.
+out=$(run_df XYMONCLIENT_FS_INCLUDE_TYPES='procf*')
+assert_not_contains " /proc" "$out" \
+	"a configured type underwent pathname expansion (procf* matched a file named procfs)"
+
+# Same on the exclude side, where the token travels through the computed list
+# itself: literal "jfs*" matches no type, so the jfs2 filesystem stays.
+out=$(run_df XYMONCLIENT_FS_EXCLUDE_TYPES='jfs*')
+assert_contains "31% /" "$out" \
+	"a configured exclude underwent pathname expansion (jfs* matched a file named jfs2)"
+
+pass "xymonclient-aix.sh: type filtering via mount(8), since AIX df cannot exclude by type"

--- a/tests/client/fs-filter-aix.sh
+++ b/tests/client/fs-filter-aix.sh
@@ -21,10 +21,15 @@
 #   - a configured token like "procf*" is matched literally, never expanded
 #     against files in the working directory
 #
-# NOT claimed: the full #170 contract. DF_LOCAL_ONLY and the remote-df
-# sentinel are not implemented on AIX, and the [inode] section is untouched
-# (its own guard already skips rows without inode accounting, and its
-# /usr/sysv/bin/df is an absolute path a PATH stub cannot reach).
+# DF_LOCAL_ONLY is covered in both reports: the disk df takes "-T local", and
+# the inode df -- /usr/sysv/bin/df -- takes -l for the same thing. Its
+# absolute path cannot be reached by a
+# PATH stub, so the extracted block is repointed at one with sed, the way the
+# Linux test repoints /proc/filesystems.
+#
+# NOT claimed: the remote-df sentinel, which AIX does not have. With
+# DF_LOCAL_ONLY=no a wedged remote mount can still hang the client, and
+# nothing here bounds it.
 
 set -euo pipefail
 # shellcheck source=tests/lib/assert.sh
@@ -39,10 +44,24 @@ fsf_setup aix XYMONCLIENT_AIX
 # AIX df -Ik: pseudo mounts print dashes, real mounts print numbers. One row
 # per default-excluded type, so a type dropped from the client's list shows up
 # as a reappearing row.
+# Arguments are logged one per line: "$*" would flatten "-T local" and
+# "-T" "local" into the same text, and it is exactly that difference the
+# client has to get right -- AIX df rejects the single-argument form.
+#
+# The stub honours "-T local" by dropping the remote row, as AIX df does.
+# Without that the fixture would report a remote filesystem in a run where
+# the real client hides it, and every assertion about the default would be
+# measuring the stub rather than the client.
 cat > "$STUB/df" <<EOF
 #!/bin/sh
-printf '%s\n' "\$*" >> "$DF_LOG"
-cat <<'TABLE'
+printf '%s\n' "\$@" >> "$DF_LOG"
+_local=no
+_prev=
+for _a in "\$@"; do
+	[ "\$_prev" = "-T" ] && [ "\$_a" = "local" ] && _local=yes
+	_prev="\$_a"
+done
+cat <<'TABLE' | { [ "\$_local" = yes ] && grep -v '^srv:/export ' || cat; }
 Filesystem 1024-blocks Used Free %Used Mounted on
 /dev/hd4 1048576 319992 728584 31% /
 /proc - - - - /proc
@@ -85,6 +104,29 @@ chmod +x "$STUB/mount"
 FSF="$TMP/df-section.sh"
 fsf_extract "$FSF" "" '\[inode\]'
 
+# The [df]+[inode] block, with the absolute inode df repointed at a stub that
+# records its operands.
+SYSVDF="$STUB/sysv-df"
+cat > "$SYSVDF" <<EOF
+#!/bin/sh
+printf '%s\\n' "\$@" >> "$TMP/sysvdf.args"
+_l=no
+for _a in "\$@"; do [ "\$_a" = "-l" ] && _l=yes; done
+cat <<'TABLE' | { [ "\$_l" = yes ] && grep -v ' /mnt$' || cat; }
+Filesystem Inodes IUsed IFree IUse% Mount Dir
+/dev/hd4 65536 1024 64512 2% /
+srv:/export 65536 1024 64512 2% /mnt
+TABLE
+EOF
+chmod +x "$SYSVDF"
+FSFI="$TMP/df-inode-section.sh"
+fsf_extract "$FSFI" "s!/usr/sysv/bin/df!$SYSVDF!" '\[mount\]'
+
+run_full() {
+	( cd "$TMP" && env "$@" $FSF_SHELL "$FSFI" ) 2> "$STDERR_LOG" \
+		|| fail "extracted [df]+[inode] block exited non-zero: $(cat "$STDERR_LOG")"
+}
+
 run_df() {
 	( cd "$TMP" && env "$@" $FSF_SHELL "$FSF" ) 2> "$STDERR_LOG" \
 		|| fail "extracted [df] block exited non-zero: $(cat "$STDERR_LOG")"
@@ -94,8 +136,11 @@ run_df() {
 
 out=$(run_df)
 assert_contains "%Used Mounted on" "$out" "the df header row must survive the filter"
+assert_equal "1" "$(printf '%s\n' "$out" | grep -c 'Mounted on')" \
+	"the header must be emitted exactly once, not repeated per surviving row"
 assert_contains "31% /" "$out" "the real jfs2 filesystem must be reported"
-assert_contains "50% /mnt" "$out" "a remote nfs3 mount is not in the type exclude set and must be reported"
+assert_not_contains "50% /mnt" "$out" \
+	"the default must not report a remote mount: df never looked at it (-T local)"
 for mp in /proc /aha /cdrom /namefs /autodir; do
 	assert_not_contains " $mp" "$out" \
 		"the default exclude set no longer drops $mp (procfs ahafs namefs autofs cdrfs)"
@@ -116,7 +161,7 @@ assert_not_contains " /aha" "$out" "INCLUDE_TYPES=procfs must not surface other 
 
 # --- EXCLUDE_TYPES drops a real type, and wins over INCLUDE --------------------
 
-out=$(run_df XYMONCLIENT_FS_EXCLUDE_TYPES=jfs2)
+out=$(run_df XYMONCLIENT_FS_EXCLUDE_TYPES=jfs2 XYMONCLIENT_FS_DF_LOCAL_ONLY=no)
 assert_not_contains "31% /" "$out" "EXCLUDE_TYPES=jfs2 must drop the jfs2 filesystem"
 assert_contains "50% /mnt" "$out" "EXCLUDE_TYPES=jfs2 must not drop unrelated mounts"
 
@@ -128,7 +173,7 @@ out=$(run_df XYMONCLIENT_FS_INCLUDE_TYPES='procfs ahafs')
 assert_contains " /proc" "$out" "the first of two INCLUDE_TYPES tokens must surface its type"
 assert_contains " /aha" "$out" "the second of two INCLUDE_TYPES tokens must surface its type"
 
-out=$(run_df XYMONCLIENT_FS_EXCLUDE_TYPES='jfs2 nfs3')
+out=$(run_df XYMONCLIENT_FS_EXCLUDE_TYPES='jfs2 nfs3' XYMONCLIENT_FS_DF_LOCAL_ONLY=no)
 assert_not_contains "31% /" "$out" "the first of two EXCLUDE_TYPES tokens must drop its type"
 assert_not_contains " /mnt" "$out" "the second of two EXCLUDE_TYPES tokens must drop its type"
 # ... which excludes every filesystem in the fixture: the section must come
@@ -151,4 +196,78 @@ out=$(run_df XYMONCLIENT_FS_EXCLUDE_TYPES='jfs*')
 assert_contains "31% /" "$out" \
 	"a configured exclude underwent pathname expansion (jfs* matched a file named jfs2)"
 
-pass "xymonclient-aix.sh: type filtering via mount(8), since AIX df cannot exclude by type"
+# --- DF_LOCAL_ONLY: "-T local", since AIX df has no -l -------------------------
+
+# A hard-mounted NFS server that stops answering wedges df for the life of the
+# mount, taking the client run with it. AIX has no remote-df sentinel, so the
+# only protection is not asking df about remote mounts at all.
+
+: > "$DF_LOG"
+run_df >/dev/null
+# One argument per line, so "-T local" as a single argument cannot match:
+# AIX df rejects that form, and "$*" logging could not tell the two apart.
+assert_match '(^|
+)-T
+local($|
+)' "$(cat "$DF_LOG")" \
+	"the default must keep df off remote mounts (-T and local, as two arguments)"
+out=$(run_df XYMONCLIENT_FS_DF_LOCAL_ONLY=no)
+assert_contains "50% /mnt" "$out" \
+	"a remote mount must be reported when df is allowed to look at it"
+
+: > "$DF_LOG"
+run_df XYMONCLIENT_FS_DF_LOCAL_ONLY=no >/dev/null
+assert_not_match 'local' "$(cat "$DF_LOG")" \
+	"DF_LOCAL_ONLY=no must let remote filesystems be reported"
+
+: > "$DF_LOG"
+run_df XYMONCLIENT_FS_DF_LOCAL_ONLY=maybe >/dev/null
+assert_match '(^|
+)-T
+local($|
+)' "$(cat "$DF_LOG")" \
+	"an invalid DF_LOCAL_ONLY must fall back to the safe default, not drop the flag"
+assert_contains "invalid XYMONCLIENT_FS_DF_LOCAL_ONLY" "$(cat "$STDERR_LOG")" \
+	"an invalid DF_LOCAL_ONLY must say so on stderr"
+
+# --- the inode df is kept off remote mounts too ------------------------------
+
+# Guarding only the disk report would leave the inode df reaching the same
+# dead mount. /usr/sysv/bin/df spells local-only as "-l", not "-T local".
+
+: > "$TMP/sysvdf.args"
+run_full >/dev/null
+args=$(cat "$TMP/sysvdf.args")
+assert_contains "-i" "$args" "the inode df must still be asked for inode counts"
+assert_match '(^|
+)-l($|
+)' "$args" \
+	"the System V df must be given -l, so the inode report never reaches a remote server"
+out=$(run_full)
+assert_not_contains " /mnt" "$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')" \
+	"a remote mount must not appear in the inode report when df was told local only"
+
+: > "$TMP/sysvdf.args"
+run_full XYMONCLIENT_FS_DF_LOCAL_ONLY=no >/dev/null
+args=$(cat "$TMP/sysvdf.args")
+assert_equal "-i" "$args" \
+	"DF_LOCAL_ONLY=no must ask the inode df about every filesystem"
+
+# With every inode row gone the section must be empty, not header-only. Unlike
+# the disk report the colour is the same either way - unix_inode_report()
+# exempts an empty inode section, for the Solaris host whose filesystems are
+# all ZFS - but an empty one has the server name the reason ("No filesystems
+# reporting inode data") instead of echoing a header for zero filesystems.
+cat > "$SYSVDF" <<EOF
+#!/bin/sh
+cat <<'TABLE'
+Filesystem Inodes IUsed IFree IUse% Mount Dir
+TABLE
+EOF
+chmod +x "$SYSVDF"
+out=$(run_full)
+inode_sec=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p' | sed 1d)
+assert_equal "" "$inode_sec" \
+	"an inode report with no rows must be empty, so the server names the reason instead of echoing a header for zero filesystems"
+
+pass "xymonclient-aix.sh: type filtering via mount(8), and DF_LOCAL_ONLY in both reports"


### PR DESCRIPTION
Two commits, either usable without the other.

**1. Filter pseudo filesystems by type.** AIX is the last client without the `XYMONCLIENT_FS_*` type filter: its raw `df -Ik` sends `/proc`, `/aha` and friends to the server as all-dash rows. AIX df cannot exclude by type, so excluded types are dropped by device+mountpoint pair, read from the vfs column of `mount(8)` — the pair, so an excluded overlay (namefs) sharing a mount point with a real filesystem takes only the overlay row. Default set **procfs ahafs namefs autofs cdrfs**, minus `INCLUDE_TYPES`, plus `EXCLUDE_TYPES`. Excluding everything yields an empty `[df]` section, which the server flags — not a header-only one it reads as all-green.

*Upgrade note:* a `DISK` min-count rule pinned on a pseudo mount now alerts, since its row no longer feeds the count. `INCLUDE_TYPES` is the remedy, as on the sibling clients.

**2. Keep df off remote mounts by default.** A wedged NFS mount hangs df for the life of the mount and takes the client run with it — the host goes purple, every metric. The other clients avoid that with `df -l` and bound `DF_LOCAL_ONLY=no` with a sentinel; AIX had neither. `XYMONCLIENT_FS_DF_LOCAL_ONLY` now works here: AIX df spells it `-T local`, the System V df behind `[inode]` spells it `-l`, and both are guarded, since either left open reaches the same mount. With `no` the risk is unchanged — there is still no sentinel — and the man page says so.

**Declares AIX 7.1 as the floor** (RELEASENOTES): `-T local` does not exist before it, the 6.1 df documenting only `-I -M -P -g -i -k -m -s -v` ([IBM 6.1 Commands Reference](https://public.dhe.ibm.com/systems/power/docs/aix/61/aixcmds2_pdf.pdf), df at p.107).

| check | result |
|---|---|
| full suite (unbuilt tree, as tests.yml) | 40 passed / 51 skipped / 0 failed |
| fs-filter-aix.sh vs stock script | FAIL — no filter, the /proc row is emitted |
| same test with the guards removed one at a time | FAIL for each |

Reviewed twice by codex against the AIX manuals; its findings on the version floor, a header-only inode section, an `IFS`-dependent flag expansion and two overstated comments are fixed here. Mock-tested with stub df/mount: real AIX behaviour still needs confirming, in particular whether `mount(8)` returns while an NFS server is down.
