### PR TITLE
build: install the libraries and headers with make install-devel

### DIFF
--- a/build/Makefile.rules
+++ b/build/Makefile.rules
@@ -26,7 +26,7 @@ endif
 else
 	BUILDTARGETS = lib-build common-build xymongen-build xymonnet-build xymonproxy-build docs-build build-build xymond-build web-build client
 	CLIENTTARGETS = lib-client common-client build-build
-	INSTALLTARGETS = install-xymongen install-xymonnet install-xymonproxy install-xymond install-web install-docs install-client install-servermsg
+	INSTALLTARGETS = install-libs install-xymongen install-xymonnet install-xymonproxy install-xymond install-web install-docs install-client install-servermsg
 	CFLAGS += $(PCREINCDIR)
 	XYMONCLIENTHOME = $(XYMONTOPDIR)/client
 	XYMONHOME = $(XYMONTOPDIR)/server
@@ -34,6 +34,9 @@ endif
 
 ifndef INSTALLBINDIR
 INSTALLBINDIR = $(XYMONHOME)/bin
+endif
+ifndef INSTALLLIBDIR
+INSTALLLIBDIR = $(XYMONHOME)/lib
 endif
 ifndef INSTALLETCDIR
 INSTALLETCDIR = $(XYMONHOME)/etc
@@ -211,6 +214,17 @@ ifndef PKGBUILD
 	chmod 755 $(INSTALLROOT)$(INSTALLBINDIR)
 endif
 
+	mkdir -p $(INSTALLROOT)$(INSTALLLIBDIR)
+ifneq ($(INSTALLLIBDIR),$(XYMONHOME)/lib)
+	rm -f $(INSTALLROOT)$(XYMONHOME)/lib || true
+	ln -s $(INSTALLLIBDIR) $(INSTALLROOT)$(XYMONHOME)/lib || true
+endif
+ifndef PKGBUILD
+	chown $(XYMONUSER) $(INSTALLROOT)$(INSTALLLIBDIR)
+	chgrp `$(IDTOOL) -g $(XYMONUSER)` $(INSTALLROOT)$(INSTALLLIBDIR)
+	chmod 755 $(INSTALLROOT)$(INSTALLLIBDIR)
+endif
+
 	mkdir -p $(INSTALLROOT)$(INSTALLETCDIR)
 ifneq ($(INSTALLETCDIR),$(XYMONHOME)/etc)
 	rm -f $(INSTALLROOT)$(XYMONHOME)/etc || true
@@ -368,6 +382,9 @@ install-custom:
 
 
 client-install: install-client
+
+install-libs: install-dirs
+	XYMONHOME="$(XYMONHOME)" XYMONUSER="$(XYMONUSER)" IDTOOL="$(IDTOOL)" PKGBUILD="$(PKGBUILD)" INSTALLROOT="$(INSTALLROOT)" INSTALLLIBDIR="$(INSTALLLIBDIR)" $(MAKE) -C lib install
 
 install-client: client
 	XYMONHOME="$(XYMONCLIENTHOME)" INSTALLROOT="$(INSTALLROOT)" XYMONUSER="$(XYMONUSER)" IDTOOL="$(IDTOOL)" PKGBUILD="$(PKGBUILD)" LOCALCLIENT="$(LOCALCLIENT)" $(MAKE) -C client install

--- a/build/Makefile.rules
+++ b/build/Makefile.rules
@@ -26,7 +26,7 @@ endif
 else
 	BUILDTARGETS = lib-build common-build xymongen-build xymonnet-build xymonproxy-build docs-build build-build xymond-build web-build client
 	CLIENTTARGETS = lib-client common-client build-build
-	INSTALLTARGETS = install-libs install-xymongen install-xymonnet install-xymonproxy install-xymond install-web install-docs install-client install-servermsg
+	INSTALLTARGETS = install-xymongen install-xymonnet install-xymonproxy install-xymond install-web install-docs install-client install-servermsg
 	CFLAGS += $(PCREINCDIR)
 	XYMONCLIENTHOME = $(XYMONTOPDIR)/client
 	XYMONHOME = $(XYMONTOPDIR)/server
@@ -35,9 +35,28 @@ endif
 ifndef INSTALLBINDIR
 INSTALLBINDIR = $(XYMONHOME)/bin
 endif
-ifndef INSTALLLIBDIR
-INSTALLLIBDIR = $(XYMONHOME)/lib
+# The development kit -- headers, static libraries and xymon.pc -- installs as
+# one relocatable subtree. A source install puts the whole kit under
+# $(XYMONHOME)/sdk; a packager overrides INSTALLINCDIR and INSTALLLIBDIR to
+# split them across FHS trees (/usr/include vs /usr/lib), leaving INSTALLSDKDIR
+# unused.
+ifndef INSTALLSDKDIR
+INSTALLSDKDIR = $(XYMONHOME)/sdk
 endif
+# The include root holds include/ and lib/ side by side: libxymon.h reaches its
+# remaining headers through "../lib/..." includes, so the pair has to move
+# together. It is the sdk dir itself, not an include/ beneath it, or the
+# default -I$(INSTALLINCDIR)/include would double to .../include/include.
+ifndef INSTALLINCDIR
+INSTALLINCDIR = $(INSTALLSDKDIR)
+endif
+# The archives sit beside the lib/ headers they belong to -- the source lib/
+# carries both *.h and *.a -- so the whole kit is a single tree.
+ifndef INSTALLLIBDIR
+INSTALLLIBDIR = $(INSTALLSDKDIR)/lib
+endif
+# The version string, read once from the header for xymon.pc.
+XYMONVERSION := $(shell sed -n 's/.*VERSION "\([^"]*\)".*/\1/p' include/version.h)
 ifndef INSTALLETCDIR
 INSTALLETCDIR = $(XYMONHOME)/etc
 endif
@@ -214,16 +233,6 @@ ifndef PKGBUILD
 	chmod 755 $(INSTALLROOT)$(INSTALLBINDIR)
 endif
 
-	mkdir -p $(INSTALLROOT)$(INSTALLLIBDIR)
-ifneq ($(INSTALLLIBDIR),$(XYMONHOME)/lib)
-	rm -f $(INSTALLROOT)$(XYMONHOME)/lib || true
-	ln -s $(INSTALLLIBDIR) $(INSTALLROOT)$(XYMONHOME)/lib || true
-endif
-ifndef PKGBUILD
-	chown $(XYMONUSER) $(INSTALLROOT)$(INSTALLLIBDIR)
-	chgrp `$(IDTOOL) -g $(XYMONUSER)` $(INSTALLROOT)$(INSTALLLIBDIR)
-	chmod 755 $(INSTALLROOT)$(INSTALLLIBDIR)
-endif
 
 	mkdir -p $(INSTALLROOT)$(INSTALLETCDIR)
 ifneq ($(INSTALLETCDIR),$(XYMONHOME)/etc)
@@ -344,6 +353,56 @@ endif
 install-common: install-dirs
 	XYMONHOME="$(XYMONHOME)" MANROOT="$(MANROOT)" XYMONUSER="$(XYMONUSER)" IDTOOL="$(IDTOOL)" PKGBUILD="$(PKGBUILD)" INSTALLROOT="$(INSTALLROOT)" INSTALLBINDIR="$(INSTALLBINDIR)" INSTALLETCDIR="$(INSTALLETCDIR)" INSTALLEXTDIR="$(INSTALLEXTDIR)" INSTALLTMPDIR="$(INSTALLTMPDIR)" INSTALLWEBDIR="$(INSTALLWEBDIR)" INSTALLWWWDIR="$(INSTALLWWWDIR)" $(MAKE) -C common install
 
+# Opt-in, not in INSTALLTARGETS: on main these are static archives and
+# headers that nothing reads at runtime. (devel keeps it in the default
+# list, rightly -- there the binaries link the shared objects it
+# installs.) Out of the default it also cannot land inside $(XYMONHOME)
+# unasked, where a spec globbing the server tree would swallow it into
+# the main package and collide with its own -devel one.
+#
+# It makes its own directories rather than install-dirs doing it: a
+# target nobody invoked should leave nothing behind, not even empty ones.
+#
+# Named for what it installs, as the other targets are -- devel calls
+# this install-libs, which describes the archives but not the 58 headers.
+install-devel:
+	mkdir -p $(INSTALLROOT)$(XYMONHOME) $(INSTALLROOT)$(INSTALLLIBDIR) $(INSTALLROOT)$(INSTALLINCDIR)
+# A back-compat symlink so $(XYMONHOME)/sdk keeps resolving when the kit is
+# relocated as a tree. A package build owns its layout through its own file
+# list and does not want it -- an unpackaged symlink is a hard error to
+# rpmbuild and dpkg -- so skip it under PKGBUILD, as the chown below is.
+ifndef PKGBUILD
+ifneq ($(INSTALLINCDIR),$(XYMONHOME)/sdk)
+	rm -f $(INSTALLROOT)$(XYMONHOME)/sdk || true
+	ln -s $(INSTALLINCDIR) $(INSTALLROOT)$(XYMONHOME)/sdk || true
+endif
+endif
+ifndef PKGBUILD
+	chown $(XYMONUSER) $(INSTALLROOT)$(INSTALLLIBDIR) $(INSTALLROOT)$(INSTALLINCDIR)
+	chgrp `$(IDTOOL) -g $(XYMONUSER)` $(INSTALLROOT)$(INSTALLLIBDIR) $(INSTALLROOT)$(INSTALLINCDIR)
+	chmod 755 $(INSTALLROOT)$(INSTALLLIBDIR) $(INSTALLROOT)$(INSTALLINCDIR)
+endif
+	XYMONHOME="$(XYMONHOME)" XYMONUSER="$(XYMONUSER)" IDTOOL="$(IDTOOL)" PKGBUILD="$(PKGBUILD)" INSTALLROOT="$(INSTALLROOT)" INSTALLLIBDIR="$(INSTALLLIBDIR)" INSTALLINCDIR="$(INSTALLINCDIR)" $(MAKE) -C lib install
+	# A pkg-config file so a consumer builds against the installed tree with
+	# "pkg-config --cflags --libs xymon" and needs to know neither the sibling
+	# header layout nor the static-link chain. Generated with the configured
+	# paths and library flags, so it tracks a relocated install.
+	mkdir -p $(INSTALLROOT)$(INSTALLLIBDIR)/pkgconfig
+	sed -e 's!@XYMONHOME@!$(XYMONHOME)!g' \
+	    -e 's!@INSTALLINCDIR@!$(INSTALLINCDIR)!g' \
+	    -e 's!@INSTALLLIBDIR@!$(INSTALLLIBDIR)!g' \
+	    -e 's!@XYMONVERSION@!$(XYMONVERSION)!g' \
+	    -e 's!@PCREINCDIR@!$(PCREINCDIR)!g' \
+	    -e 's!@RRDINCDIR@!$(RRDINCDIR)!g' \
+	    -e 's!@PCRELIBS@!$(PCRELIBS)!g' \
+	    -e 's!@SSLLIBS@!$(SSLLIBS)!g' \
+	    -e 's!@ZLIBLIBS@!$(ZLIBLIBS)!g' \
+	    -e 's!@NETLIBS@!$(NETLIBS)!g' \
+	    -e 's!@RRDLIBS@!$(RRDLIBS)!g' \
+	    -e 's!@LIBRTDEF@!$(LIBRTDEF)!g' \
+	    $(BUILDTOPDIR)/build/xymon.pc.in > $(INSTALLROOT)$(INSTALLLIBDIR)/pkgconfig/xymon.pc
+	chmod 644 $(INSTALLROOT)$(INSTALLLIBDIR)/pkgconfig/xymon.pc
+
 install-xymongen: install-common
 	XYMONHOME="$(XYMONHOME)" MANROOT="$(MANROOT)" XYMONUSER="$(XYMONUSER)" IDTOOL="$(IDTOOL)" PKGBUILD="$(PKGBUILD)" CGIDIR="$(CGIDIR)" SECURECGIDIR="$(SECURECGIDIR)" INSTALLROOT="$(INSTALLROOT)" INSTALLBINDIR="$(INSTALLBINDIR)" INSTALLETCDIR="$(INSTALLETCDIR)" INSTALLEXTDIR="$(INSTALLEXTDIR)" INSTALLTMPDIR="$(INSTALLTMPDIR)" INSTALLWEBDIR="$(INSTALLWEBDIR)" INSTALLWWWDIR="$(INSTALLWWWDIR)" $(MAKE) -C xymongen install
 
@@ -382,9 +441,6 @@ install-custom:
 
 
 client-install: install-client
-
-install-libs: install-dirs
-	XYMONHOME="$(XYMONHOME)" XYMONUSER="$(XYMONUSER)" IDTOOL="$(IDTOOL)" PKGBUILD="$(PKGBUILD)" INSTALLROOT="$(INSTALLROOT)" INSTALLLIBDIR="$(INSTALLLIBDIR)" $(MAKE) -C lib install
 
 install-client: client
 	XYMONHOME="$(XYMONCLIENTHOME)" INSTALLROOT="$(INSTALLROOT)" XYMONUSER="$(XYMONUSER)" IDTOOL="$(IDTOOL)" PKGBUILD="$(PKGBUILD)" LOCALCLIENT="$(LOCALCLIENT)" $(MAKE) -C client install

--- a/build/xymon.pc.in
+++ b/build/xymon.pc.in
@@ -1,0 +1,13 @@
+prefix=@XYMONHOME@
+includedir=@INSTALLINCDIR@
+libdir=@INSTALLLIBDIR@
+
+Name: xymon
+Description: Xymon monitoring system libraries and headers
+Version: @XYMONVERSION@
+# include/ only: libxymon.h reaches its siblings as "../lib/...", so lib/'s
+# generically-named headers (md5.h, sha1.h, Availability.h, ...) stay off the
+# consumer -I path where they would shadow system headers.
+Cflags: -I${includedir}/include @PCREINCDIR@ @RRDINCDIR@
+Libs: -L${libdir} -lxymon -lxymoncomm -lxymontime
+Libs.private: @PCRELIBS@ @SSLLIBS@ @ZLIBLIBS@ @NETLIBS@ @RRDLIBS@ @LIBRTDEF@

--- a/configure.client
+++ b/configure.client
@@ -215,6 +215,12 @@ echo "" >>Makefile
 if test "$INSTALLBINDIR" != ""; then
 	echo "INSTALLBINDIR = $INSTALLBINDIR"   >>Makefile
 fi
+if test "$INSTALLLIBDIR" != ""; then
+	echo "INSTALLLIBDIR = $INSTALLLIBDIR"   >>Makefile
+fi
+if test "$INSTALLINCDIR" != ""; then
+	echo "INSTALLINCDIR = $INSTALLINCDIR"   >>Makefile
+fi
 if test "$INSTALLETCDIR" != ""; then
 	echo "INSTALLETCDIR = $INSTALLETCDIR"   >>Makefile
 fi

--- a/configure.server
+++ b/configure.server
@@ -567,6 +567,12 @@ echo "" >>Makefile
 if test "$INSTALLBINDIR" != ""; then
 	echo "INSTALLBINDIR = $INSTALLBINDIR"   >>Makefile
 fi
+if test "$INSTALLLIBDIR" != ""; then
+	echo "INSTALLLIBDIR = $INSTALLLIBDIR"   >>Makefile
+fi
+if test "$INSTALLINCDIR" != ""; then
+	echo "INSTALLINCDIR = $INSTALLINCDIR"   >>Makefile
+fi
 if test "$INSTALLETCDIR" != ""; then
 	echo "INSTALLETCDIR = $INSTALLETCDIR"   >>Makefile
 fi

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -117,5 +117,10 @@ locator: locator.c $(XYMONCOMMLIB) $(XYMONLIB)
 tree: tree.c
 	$(CC) $(LDFLAGS) $(CFLAGS) -DSTANDALONE -o $@ tree.c
 
+install:
+	cp -fp *.so* *.a $(INSTALLROOT)$(INSTALLLIBDIR)/ || :
+	chmod 644 $(INSTALLROOT)$(INSTALLLIBDIR)/*.a || :
+	chmod 755 $(INSTALLROOT)$(INSTALLLIBDIR)/*.so* || :
+
 clean:
 	rm -f *.o *.a *~ loadhosts stackio availability test-endianness md5 sha1 rmd160 locator tree

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -31,6 +31,25 @@ all: test-endianness $(XYMONLIB) $(XYMONCOMMLIB) $(XYMONTIMELIB) $(XYMONCLIENTCO
 
 client: test-endianness $(XYMONCLIENTLIB) $(XYMONCLIENTCOMMLIB) $(XYMONTIMELIB)
 
+install:
+	cp -fp *.a $(INSTALLROOT)$(INSTALLLIBDIR)/
+	chmod 644 $(INSTALLROOT)$(INSTALLLIBDIR)/*.a
+	# Shared objects only if this tree built any: devel does, main does
+	# not, and an unmatched glob must not look like a failure.
+	for f in *.so*; do \
+		test -e "$$f" || continue; \
+		cp -fp "$$f" $(INSTALLROOT)$(INSTALLLIBDIR)/ || exit 1; \
+		chmod 755 $(INSTALLROOT)$(INSTALLLIBDIR)/"$$f" || exit 1; \
+	done
+	# The headers, so the libraries above can actually be built against.
+	# include/ and lib/ have to stay siblings: libxymon.h reaches its
+	# remaining headers as "../lib/...", so a flat directory breaks on
+	# the first include. One -I$(INSTALLINCDIR)/include then works.
+	mkdir -p $(INSTALLROOT)$(INSTALLINCDIR)/include $(INSTALLROOT)$(INSTALLINCDIR)/lib
+	cp -fp ../include/*.h $(INSTALLROOT)$(INSTALLINCDIR)/include/
+	cp -fp *.h $(INSTALLROOT)$(INSTALLINCDIR)/lib/
+	chmod 644 $(INSTALLROOT)$(INSTALLINCDIR)/include/*.h $(INSTALLROOT)$(INSTALLINCDIR)/lib/*.h
+
 test-endianness: test-endianness.c
 	$(CC) $(LDFLAGS) $(CFLAGS) -o $@ $<
 
@@ -116,11 +135,6 @@ locator: locator.c $(XYMONCOMMLIB) $(XYMONLIB)
 
 tree: tree.c
 	$(CC) $(LDFLAGS) $(CFLAGS) -DSTANDALONE -o $@ tree.c
-
-install:
-	cp -fp *.so* *.a $(INSTALLROOT)$(INSTALLLIBDIR)/ || :
-	chmod 644 $(INSTALLROOT)$(INSTALLLIBDIR)/*.a || :
-	chmod 755 $(INSTALLROOT)$(INSTALLLIBDIR)/*.so* || :
 
 clean:
 	rm -f *.o *.a *~ loadhosts stackio availability test-endianness md5 sha1 rmd160 locator tree


### PR DESCRIPTION
`make install` installs no libraries and no headers, so nothing builds against an *installed* Xymon. Every packager digs `include/*.h`, `lib/*.h`, `lib/*.a` out of the build tree by hand.

Two commits, because the first is not mine.

**1. Libraries — partial backport of devel `8dff8464` (@jccleaver).** Just the install machinery (`INSTALLLIBDIR`, the target, `lib/Makefile`'s rule) — 2 of its 8 files. No `.so` building: `main` has no rule that produces one, so the `*.so*` glob matches nothing. (Whether `main` should build a shared library at all is a separate question, tracked in #436.)

**2. Headers, opt-in, pkg-config — on top.** `make install-devel` installs the archives, any `*.so*`, 58 headers, and a generated `xymon.pc`.

- `INSTALLINCDIR` keeps `include/` and `lib/` as siblings — `libxymon.h` reaches its headers through 62 `"../lib/..."` includes, so one `-I$INSTALLINCDIR/include` compiles.
- Out of `INSTALLTARGETS`: on `main` the payload is static archives + headers nothing reads at runtime, and a default-on target would drop them under `$XYMONHOME`, where a spec globbing the server tree swallows them into its main package and collides with its own `-devel`. Makes its own dirs (not via `install-dirs`), so a staging root gets only those + payload.
- `xymon.pc` from `build/xymon.pc.in`, so a consumer needs only `pkg-config --cflags --libs --static xymon`.
- Compat symlinks skipped under `PKGBUILD` — an unpackaged symlink is a hard error to `rpmbuild`/`dpkg`.
- Default is one `$(XYMONHOME)/sdk` tree; overriding `INSTALLINCDIR`/`INSTALLLIBDIR` into FHS trees leaves `INSTALLSDKDIR` unused and gives a byte-identical layout.
- `install-devel`, not `install-libs`: 58 headers are the bulk. `devel` keeps `install-libs` (honest there — it builds `.so`); a matching rename is a separate change.

Tested on AlmaLinux 10, default and relocated: `make install` unchanged; `make install-devel` gives 5 archives + 58 headers + `xymon.pc`; `pkg-config … --static xymon` compiles, links, runs.
