### PR TITLE
build: let the web server config be installed where httpd reads it

### DIFF
--- a/build/Makefile.rules
+++ b/build/Makefile.rules
@@ -180,12 +180,20 @@ clean:
 
 install: $(INSTALLTARGETS)
 
-# Where the generated web-server drop-in goes; xymond/Makefile installs
-# it there. Unset, it stays in Xymon's own etc directory as it always
-# has. Exported rather than added to the install-xymond recursion line:
-# that line is long and shared, so every feature needing one more
-# variable would otherwise collide textually with every other one.
+# Where the generated web-server drop-in goes, and under what name;
+# xymond/Makefile installs it there. Unset, it stays in Xymon's own etc
+# directory as it always has. The name defaults to the upstream filename,
+# so INSTALLHTTPDCONFDIR alone is unchanged; a packaging that renames it
+# (Debian installs it as "xymon", Terabithia as "<server>.conf") sets
+# INSTALLHTTPDCONFNAME and drops its own rename. Exported rather than added
+# to the install-xymond recursion line: that line is long and shared, so
+# every feature needing one more variable would otherwise collide textually
+# with every other one.
+ifndef INSTALLHTTPDCONFNAME
+INSTALLHTTPDCONFNAME = xymon-apache.conf
+endif
 export INSTALLHTTPDCONFDIR
+export INSTALLHTTPDCONFNAME
 
 install-servermsg:
 	@echo ""
@@ -195,7 +203,7 @@ install-servermsg:
 ifeq ($(strip $(INSTALLHTTPDCONFDIR)),)
 	@echo "A sample Apache configuration is in ${XYMONHOME}/etc/xymon-apache.conf"
 else
-	@echo "The Apache configuration was installed as $(INSTALLHTTPDCONFDIR)/xymon-apache.conf"
+	@echo "The Apache configuration was installed as $(INSTALLHTTPDCONFDIR)/$(INSTALLHTTPDCONFNAME)"
 endif
 	@echo "If you have your Administration CGI scripts in a separate directory,"
 	@echo "then you must also setup the password-file with the htpasswd command."

--- a/build/Makefile.rules
+++ b/build/Makefile.rules
@@ -180,12 +180,23 @@ clean:
 
 install: $(INSTALLTARGETS)
 
+# Where the generated web-server drop-in goes; xymond/Makefile installs
+# it there. Unset, it stays in Xymon's own etc directory as it always
+# has. Exported rather than added to the install-xymond recursion line:
+# that line is long and shared, so every feature needing one more
+# variable would otherwise collide textually with every other one.
+export INSTALLHTTPDCONFDIR
+
 install-servermsg:
 	@echo ""
 	@echo "Installation complete."
 	@echo ""
 	@echo "You must configure your webserver for the Xymon webpages and CGI-scripts."
+ifeq ($(strip $(INSTALLHTTPDCONFDIR)),)
 	@echo "A sample Apache configuration is in ${XYMONHOME}/etc/xymon-apache.conf"
+else
+	@echo "The Apache configuration was installed as $(INSTALLHTTPDCONFDIR)/xymon-apache.conf"
+endif
 	@echo "If you have your Administration CGI scripts in a separate directory,"
 	@echo "then you must also setup the password-file with the htpasswd command."
 	@echo ""

--- a/configure.server
+++ b/configure.server
@@ -582,6 +582,9 @@ fi
 if test "$INSTALLHTTPDCONFDIR" != ""; then
 	echo "INSTALLHTTPDCONFDIR = $INSTALLHTTPDCONFDIR"   >>Makefile
 fi
+if test "$INSTALLHTTPDCONFNAME" != ""; then
+	echo "INSTALLHTTPDCONFNAME = $INSTALLHTTPDCONFNAME"   >>Makefile
+fi
 if test "$INSTALLWWWDIR" != ""; then
 	echo "INSTALLWWWDIR = $INSTALLWWWDIR"   >>Makefile
 fi

--- a/configure.server
+++ b/configure.server
@@ -579,6 +579,9 @@ fi
 if test "$INSTALLWEBDIR" != ""; then
 	echo "INSTALLWEBDIR = $INSTALLWEBDIR"   >>Makefile
 fi
+if test "$INSTALLHTTPDCONFDIR" != ""; then
+	echo "INSTALLHTTPDCONFDIR = $INSTALLHTTPDCONFDIR"   >>Makefile
+fi
 if test "$INSTALLWWWDIR" != ""; then
 	echo "INSTALLWWWDIR = $INSTALLWWWDIR"   >>Makefile
 fi

--- a/xymond/Makefile
+++ b/xymond/Makefile
@@ -203,7 +203,12 @@ install-cfg:
 	cd etcfiles; (echo "hosts.cfg"; echo "alerts.cfg"; echo "analysis.cfg"; echo "combo.cfg"; echo "client-local.cfg"; echo "holidays.cfg"; echo "rrddefinitions.cfg"; echo snmpmibs.cfg; echo xymonmenu.cfg; $(APACHECONFINETC)) | ../../build/setup-newfiles $(INSTALLROOT)$(INSTALLETCDIR)/
 ifneq ($(strip $(INSTALLHTTPDCONFDIR)),)
 	mkdir -p $(INSTALLROOT)$(INSTALLHTTPDCONFDIR)
-	cd etcfiles; echo xymon-apache.conf | ../../build/setup-newfiles $(INSTALLROOT)$(INSTALLHTTPDCONFDIR)/
+	# Under INSTALLHTTPDCONFNAME (default xymon-apache.conf). setup-newfiles
+	# keeps the source basename, so it cannot rename; this matches its
+	# no-md5 behaviour -- install only if absent, never clobber an admin's
+	# edited file -- while honouring the chosen name.
+	test -f $(INSTALLROOT)$(INSTALLHTTPDCONFDIR)/$(INSTALLHTTPDCONFNAME) || \
+		cp -p etcfiles/xymon-apache.conf $(INSTALLROOT)$(INSTALLHTTPDCONFDIR)/$(INSTALLHTTPDCONFNAME)
 endif
 	cd $(INSTALLROOT)$(XYMONHOME); rm -f xymon.sh; ln -sf bin/xymon.sh .
 	cd wwwfiles; find . | grep -v RCS | grep -v ".svn" | grep -v DIST | ../../build/setup-newfiles $(INSTALLROOT)$(INSTALLWWWDIR)/ ../../build/md5.dat

--- a/xymond/Makefile
+++ b/xymond/Makefile
@@ -156,6 +156,17 @@ clean:
 	rm -f etcfiles/xymon-apache.conf etcfiles/xymonserver.cfg etcfiles/hosts.cfg etcfiles/alerts.cfg etcfiles/tasks.cfg etcfiles/cgioptions.cfg etcfiles/analysis.cfg etcfiles/combo.cfg etcfiles/graphs.cfg etcfiles/client-local.cfg etcfiles/rrddefinitions.cfg
 	(find etcfiles/ -name "*~"; find wwwfiles/ -name "*~"; find webfiles/ -name "*~") | xargs rm -f
 
+# xymon-apache.conf is generated here and has always been installed into
+# Xymon's own etc directory -- which is not a directory any web server
+# reads, so every packaging moves it afterwards. Setting
+# INSTALLHTTPDCONFDIR installs it where httpd actually looks instead.
+# Unset, nothing changes.
+ifeq ($(strip $(INSTALLHTTPDCONFDIR)),)
+APACHECONFINETC = echo xymon-apache.conf
+else
+APACHECONFINETC = true
+endif
+
 install: install-bin install-man install-cfg
 
 install-bin:
@@ -189,7 +200,11 @@ install-cfg:
 	cd etcfiles; ../../build/merge-sects client-local.cfg $(INSTALLROOT)$(INSTALLETCDIR)/client-local.cfg
 	cd etcfiles; ../../build/merge-sects graphs.cfg $(INSTALLROOT)$(INSTALLETCDIR)/graphs.cfg
 	cd etcfiles; ../../build/merge-lines columndoc.csv $(INSTALLROOT)$(INSTALLETCDIR)/columndoc.csv
-	cd etcfiles; (echo "hosts.cfg"; echo "alerts.cfg"; echo "analysis.cfg"; echo "combo.cfg"; echo "client-local.cfg"; echo "holidays.cfg"; echo "rrddefinitions.cfg"; echo snmpmibs.cfg; echo xymonmenu.cfg; echo xymon-apache.conf) | ../../build/setup-newfiles $(INSTALLROOT)$(INSTALLETCDIR)/
+	cd etcfiles; (echo "hosts.cfg"; echo "alerts.cfg"; echo "analysis.cfg"; echo "combo.cfg"; echo "client-local.cfg"; echo "holidays.cfg"; echo "rrddefinitions.cfg"; echo snmpmibs.cfg; echo xymonmenu.cfg; $(APACHECONFINETC)) | ../../build/setup-newfiles $(INSTALLROOT)$(INSTALLETCDIR)/
+ifneq ($(strip $(INSTALLHTTPDCONFDIR)),)
+	mkdir -p $(INSTALLROOT)$(INSTALLHTTPDCONFDIR)
+	cd etcfiles; echo xymon-apache.conf | ../../build/setup-newfiles $(INSTALLROOT)$(INSTALLHTTPDCONFDIR)/
+endif
 	cd $(INSTALLROOT)$(XYMONHOME); rm -f xymon.sh; ln -sf bin/xymon.sh .
 	cd wwwfiles; find . | grep -v RCS | grep -v ".svn" | grep -v DIST | ../../build/setup-newfiles $(INSTALLROOT)$(INSTALLWWWDIR)/ ../../build/md5.dat
 	cd webfiles; find . | grep -v RCS | grep -v ".svn" | grep -v DIST | ../../build/setup-newfiles $(INSTALLROOT)$(INSTALLWEBDIR)/ ../../build/md5.dat


### PR DESCRIPTION
`xymond/Makefile` generates `xymon-apache.conf` and installs it into
`INSTALLETCDIR` — Xymon's own `etc` directory, which is not a directory any
web server reads. So every packaging moves it afterwards: upstream's own
`debian/rules`, the Terabithia RPMs and `xymon-monitoring/xymon-rpm` each
`mv` it into the httpd drop-in directory as a build step.

`INSTALLHTTPDCONFDIR` installs it there directly.

**Unset, nothing changes at all.** The file goes to `INSTALLETCDIR` exactly as
before, through the same `setup-newfiles` call, so a plain source install is
byte-for-byte what it is today. Set, the file goes to the given directory
instead and is left out of the `etc` batch.

### Naming

The variable is named for the destination rather than for Apache: it is the
directory the web server reads drop-in configuration from, which is where any
packaging needs this file regardless of what is in front of Xymon.
(`INSTALLWEBDIR` was not available — it already means the page templates.)

### Why `export`

It is exported rather than appended to the `install-xymond` recursion line in
`build/Makefile.rules`. That line is long and shared by every sub-make
argument, so every feature that needs one more variable would otherwise
conflict textually with every other one. The `export` also sits next to the
`install-servermsg` message it affects rather than in the `INSTALL*DIR`
defaults block, so this PR occupies a region of `Makefile.rules` no other
open PR touches.

### Testing

On a server build in a clean AlmaLinux 10 container, both ways:

- unset — `xymon-apache.conf` appears in `$XYMONHOME/etc` as always, and
  `make install` prints the usual "A sample Apache configuration is in …"
- `INSTALLHTTPDCONFDIR=/etc/httpd/conf.d` — it appears there, is the
  *generated* file rather than the template (contains the substituted
  `Alias` lines), is no longer dropped into Xymon's `etc`, and the install
  message points at the real location

Merged against #408, #409, #410, #411, #413 and #414 in all 5040 possible
orders with no conflict in any of them.

### Status — parked as a draft

The workaround this removes is a single `mv` in `%install`, and Debian pays the
same single line in `debian/rules`. It is not free for Debian either way: it
renames the file to `xymon` and installs into `/etc/apache2/conf.d`, so
`INSTALLHTTPDCONFDIR` would remove its `mv` only if it accepted the upstream
filename.

One `mv` per packaging is not a strong enough problem to justify a build
variable. If the build should put the generated config where a web server
actually reads it, this is ready and tested; otherwise it can wait.
