### PR TITLE
tools: ship a sysusers.d definition of the xymon account

### DIFF
--- a/tools/xymon.sysusers
+++ b/tools/xymon.sysusers
@@ -1,0 +1,20 @@
+# systemd sysusers.d(5) definition of the account Xymon runs as.
+#
+# Packagers: install this as /usr/lib/sysusers.d/xymon.conf. The home
+# directory has to match the layout you install into -- it is XYMONTOPDIR
+# for a client-only install and the server tree otherwise -- so adjust
+# that field rather than assuming this default fits.
+#
+# Why it is worth having rather than a useradd in a post-install script:
+# systemd-sysusers is idempotent, runs in image builds and chroots where
+# useradd may not, and on rpm-based distributions it is what generates
+# the user(xymon)/group(xymon) Provides that satisfy the Requires rpm
+# derives from files owned by that user.
+#
+# The name, GECOS and home below match what rpm/xymon.spec already
+# creates, so the two definitions in this tree agree. Wiring that spec
+# to use this file instead of its own useradd is the obvious next step.
+#
+#Type Name  ID  GECOS        Home directory
+g     xymon -
+u     xymon -   "Xymon user" /usr/lib/xymon


### PR DESCRIPTION
### Status — parked as a draft, and the placement looks wrong

Not low-value: misplaced. It adds a file no make target installs, so it is
reference material rather than a build change — and a `sysusers.d` snippet is
distribution policy (uid range, home, shell and GECOS conventions differ per
distribution), which makes it packaging's business rather than the source
tree's. The packaging that consumes it already ships its own copy.

Two concrete symptoms: the GECOS here (`"Xymon user"`) matches `rpm/xymon.spec`
in this tree, while xymon-rpm uses `"Xymon monitor"` — merging it would give the
account two definitions that disagree. And the spec it agrees with was last
touched in 2014 and still installs SysV `/etc/init.d` scripts.

The right shape is bigger than this PR: install it from a make target *and*
have `rpm/xymon.spec` consume it instead of its inline `useradd` — worth doing
as part of deciding what to do with that spec at all, given it is a decade
stale and there is now maintained RPM packaging elsewhere.

---

Upstream defines the `xymon` account nowhere, so every packaging invents it — and they disagree with each other:

- The Terabithia RPMs run `useradd` from two different scriptlets that specify **different home directories**.
- Debian goes through `adduser` in debhelper.
- [xymon-monitoring/xymon-rpm](https://github.com/xymon-monitoring/xymon-rpm) ships a `sysusers.d` snippet it wrote itself.

There is nothing upstream to be consistent with, so nobody is.

### Why sysusers.d specifically

It is not an RPM thing: `systemd-sysusers` is consumed by Fedora, Debian (via `dh_installsysusers`), Arch and openSUSE alike. It is idempotent, it works in image builds and chroots where `useradd` may not, and on rpm-based distributions it is what generates the `user(xymon)`/`group(xymon)` **Provides** that satisfy the `Requires` rpm derives automatically from any file owned by that user — which is otherwise a genuine packaging problem to solve by hand.

### Deliberately not installed

The file lands in `tools/`, alongside the other integration files, rather than being installed by `make install`. Where it belongs — `/usr/lib/sysusers.d/` — is the distribution's business, not `XYMONHOME`'s, and the home directory depends on the layout being installed into (it is `XYMONTOPDIR` for a client-only install and the server tree otherwise). The file carries a comment saying exactly that, so a packager adjusts it rather than assuming the default fits.

Three lines of content. The value is ending the divergence, not the typing.

