### PR TITLE
Report an unknown verb as a failure, not a success

### DIFF
--- a/client/runclient.sh
+++ b/client/runclient.sh
@@ -133,8 +133,8 @@ case "$CMD" in
 	;;
 
   *)
-	echo "Usage: $0 start|stop|restart|status"
-	break;
+	echo "Usage: $0 start|stop|restart|status" >&2
+	exit 2
 
 esac
 

--- a/xymond/xymon.sh.DIST
+++ b/xymond/xymon.sh.DIST
@@ -97,8 +97,8 @@ case "$1" in
 	;;
 
    *)
-   	echo "Usage: $0 start|stop|restart|reload|status|rotate"
-	break;
+	echo "Usage: $0 start|stop|restart|reload|status|rotate" >&2
+	exit 2
 esac
 
 exit 0


### PR DESCRIPTION
Both `client/runclient.sh` and `xymond/xymon.sh.DIST` end their case statement with

```sh
  *)
	echo "Usage: $0 start|stop|restart|status"
	break;
```

`break` is a loop construct and neither case is inside a loop, so it does nothing. The script falls through to the `exit 0` at the bottom and reports success:

```
$ ./runclient.sh statsu; echo $?
Usage: ./runclient.sh start|stop|restart|status
0
```

A typo in a service manager, an init script or a cron entry therefore looks like the client started. Nothing reports an error, and nothing is running.

`exit 2` replaces it, and the usage line goes to stderr since it is now an error message rather than output.

Two files, two lines. `xymon.sh.DIST` has the identical defect, so fixing only the client half would leave the server script reporting success on a typo.

### Why 2 rather than 1

These scripts already speak LSB where it counts: `status` returns **3** for "not running" and **1** for a stale pidfile, both LSB's meanings. LSB reserves **2** for invalid or excess arguments, which is exactly this case, so 2 leaves the file consistent with itself rather than following the standard for one verb and not another. It is also the usual convention outside init scripts — `argparse` and most `getopt`-based tools exit 2.

One character either way if you prefer 1; nothing else depends on it.

### Testing

In both `dash` and `bash`, against `main` and this branch:

| | unknown verb | `status` on a stopped client |
| --- | --- | --- |
| `main` | **exit 0** | exit 3 |
| this branch | exit 2 | exit 3 |

The valid verbs are untouched, so anything parsing those codes is unaffected. Usage moves to stderr, leaving stdout empty for the failure case.
