### PR TITLE
Add require_cfg function to tests/lib/assert.sh

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -135,10 +135,11 @@ maintenance.
   `git worktree`, `git stash`, or any other git invocation.
 - **Path discovery via env var with default.** When a test needs a
   built binary or an installed artefact, read it from an env var and
-  default to the in-tree path -- `require_bin` (lib/assert.sh) does this
-  for binaries:
+  default to the in-tree path -- `require_bin` and `require_cfg`
+  (lib/assert.sh) do this for binaries and config files:
   ```bash
   require_bin XYMONGREP common/xymongrep          # binaries
+  require_cfg XYMONSERVER_CFG xymond/etcfiles/xymonserver.cfg  # config files
   SCRIPT="${XYMONCLIENT_LINUX:-$ROOT/client/xymonclient-linux.sh}"  # scripts
   ```
   This keeps tests usable in CMake out-of-source builds (the build
@@ -155,8 +156,8 @@ maintenance.
   exported path that points at nothing must `fail` -- a broken build or
   package layout is precisely what the exporting caller (CMake,
   autopkgtest) runs the suite to catch, and skipping would green-light
-  it. `require_bin` implements both halves; installed-script tests
-  guard `$XYMONCLIENT_LINUX` the same way.
+  it. `require_bin` and `require_cfg` implement both halves;
+  installed-script tests guard `$XYMONCLIENT_LINUX` the same way.
 - **License.** GPL-2.0+, matching the rest of the repo. A short
   SPDX-style header at the top of each test is sufficient:
   ```bash
@@ -197,6 +198,7 @@ packages**. The suite maps onto that as a single test entry, roughly:
 ```
 Test-Command: XYMONGREP=/usr/lib/xymon/client/bin/xymongrep \
               XYMONCLIENT_LINUX=/usr/lib/xymon/client/bin/xymonclient-linux.sh \
+              XYMONSERVER_CFG=/etc/xymon/xymonserver.cfg \
               ./tests/testsuite
 Depends: xymon, xymon-client, gcc, make
 Restrictions: skippable

--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -417,3 +417,27 @@ require_bin() {
 	# shellcheck disable=SC2163
 	export "$var"="$cur"
 }
+
+# require_cfg VAR DEFAULT -- ensure $VAR (or DEFAULT if unset) points to a
+# config file; export VAR with the resolved path. Same override contract as
+# require_bin: a missing in-tree default is a skip, but a missing explicit
+# override is a failure because the caller asserted that installed layout.
+require_cfg() {
+	local var=$1 default=$2
+	local cur=${!var:-}
+	local explicit=$cur
+	if [ -z "$cur" ]; then
+		case $default in
+			/*) cur=$default ;;
+			*)  cur=$(find_root)/$default ;;
+		esac
+	fi
+	if [ ! -f "$cur" ]; then
+		if [ -n "$explicit" ]; then
+			fail "$var explicitly set to '$cur' but no file is there -- broken build or package layout, not a skip"
+		fi
+		skip "$var ($cur) not found"
+	fi
+	# shellcheck disable=SC2163
+	export "$var"="$cur"
+}

--- a/tests/server/xymond-checkpoint-roundtrip.sh
+++ b/tests/server/xymond-checkpoint-roundtrip.sh
@@ -64,10 +64,10 @@ printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.
 # a machine that already has Xymon installed. Point it at the test's own
 # directory instead, and create what xymond expects to find under it.
 mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+require_cfg XYMONSERVER_CFG xymond/etcfiles/xymonserver.cfg
 sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
     -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
-	"$ROOT/xymond/etcfiles/xymonserver.cfg" > "$work/xymonserver.cfg" \
-	|| skip "no xymonserver.cfg to run against"
+	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
 
 # free_port -- a 127.0.0.1 port nothing is listening on. Racy in principle;
 # the window is a few milliseconds and only this test uses the port.

--- a/tests/server/xymond-holdtime-gap.sh
+++ b/tests/server/xymond-holdtime-gap.sh
@@ -61,10 +61,10 @@ printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.
 # xymond will not start unless XYMONHOME is a real directory, and the shipped
 # xymonserver.cfg names the install prefix, which need not exist here.
 mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+require_cfg XYMONSERVER_CFG xymond/etcfiles/xymonserver.cfg
 sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
     -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
-	"$ROOT/xymond/etcfiles/xymonserver.cfg" > "$work/xymonserver.cfg" \
-	|| skip "no xymonserver.cfg to run against"
+	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
 
 free_port() {
 	local p tries=0

--- a/tests/server/xymondboard-color-history.sh
+++ b/tests/server/xymondboard-color-history.sh
@@ -46,10 +46,10 @@ register_cleanup stop_xymond
 printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.cfg"
 
 mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+require_cfg XYMONSERVER_CFG xymond/etcfiles/xymonserver.cfg
 sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
     -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
-	"$ROOT/xymond/etcfiles/xymonserver.cfg" > "$work/xymonserver.cfg" \
-	|| skip "no xymonserver.cfg to run against"
+	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
 
 free_port() {
 	local p tries=0


### PR DESCRIPTION
This allows to override local config file in tests via environment variable to use already installed config file.

I try to integrate the testsuite into Debian autopkgtest mechanism and this change allows to run the testsuite with
```bash
env CC=/nonexistent-xymon-autopkgtest-cc \
    MAILACK=/usr/lib/xymon/server/bin/xymon-mailack \
    SVCSTATUS_CGI=/usr/lib/xymon/server/bin/svcstatus.cgi \
    XYMON=/usr/lib/xymon/client/bin/xymon \
    XYMONCLIENT=/usr/lib/xymon/client/bin/xymon \
    XYMONCLIENT_LINUX=/usr/lib/xymon/client/bin/xymonclient-linux.sh \
    XYMOND=/usr/lib/xymon/server/bin/xymond \
    XYMOND_ALERT=/usr/lib/xymon/server/bin/xymond_alert \
    XYMOND_CHANNEL=/usr/lib/xymon/server/bin/xymond_channel \
    XYMOND_CLIENT=/usr/lib/xymon/client/bin/xymond_client \
    XYMOND_HISTORY=/usr/lib/xymon/server/bin/xymond_history \
    XYMOND_HOSTDATA=/usr/lib/xymon/server/bin/xymond_hostdata \
    XYMOND_RRD=/usr/lib/xymon/server/bin/xymond_rrd \
    XYMONGREP=/usr/lib/xymon/client/bin/xymongrep \
    XYMONLAUNCH=/usr/lib/xymon/server/bin/xymonlaunch \
    XYMONSERVER_CFG=/etc/xymon/xymonserver.cfg \
    ./tests/testsuite
```
This change enables the tests
- server/xymond-checkpoint-roundtrip.sh
- server/xymond-holdtime-gap.sh
- server/xymondboard-color-history.sh
for this mechanism.

require_cfg() in lib/assert.sh is implemented as a clone of require_bin() but testing for file existence instead of executability.

Assisted-By: Github Copilot using GPT-5.5.