### PR TITLE
xymonclient-freebsd: emit an empty inode report when df has no rows (#398)

### DIFF
--- a/client/xymonclient-freebsd.sh
+++ b/client/xymonclient-freebsd.sh
@@ -330,9 +330,16 @@ run_df() {
 emit_df() {
 	_kind="$1"; _label="$2"; shift 2
 	_out=`run_df "$@"`; _rc=$?
-	if [ -z "$_out" ] && [ "$_rc" -ne 0 ]; then
-		echo "xymonclient-freebsd: df $_kind collection failed (status $_rc) with no output; reporting data as unavailable" >&2
-		echo "$_label report collection failed: df exited $_rc with no output"
+	if [ -z "$_out" ]; then
+		# No rows at all. A non-zero exit is a collection failure - surface a
+		# marker so the server goes yellow. A clean exit means nothing matched
+		# (e.g. an inode report whose filesystems are all zfs, which are
+		# excluded): emit nothing, so the server's empty-report path stays green
+		# rather than rejecting a stray header-only row as "columns not found".
+		if [ "$_rc" -ne 0 ]; then
+			echo "xymonclient-freebsd: df $_kind collection failed (status $_rc) with no output; reporting data as unavailable" >&2
+			echo "$_label report collection failed: df exited $_rc with no output"
+		fi
 		return 1
 	fi
 	return 0

--- a/tests/client/fs-filter-common.sh
+++ b/tests/client/fs-filter-common.sh
@@ -222,6 +222,11 @@ _ex=" "; _local=; _named=; _inode=
 $FSF_STUB_PARSE
 if [ -n "\$_inode" ]; then echo "\$*" >> "$INODE_LOG"; else echo "\$*" >> "$DF_LOG"; fi
 [ -n "\${DF_FAIL:-}" ] && exit 1
+# A ZFS-only host: -t no<zfs> excludes every filesystem, and FreeBSD df then
+# exits 0 with no output at all (not the nonzero-empty above). Model that for
+# the inode call, so a test can prove the client emits an empty [inode] rather
+# than a header-only row the server rejects as "columns not found" (#398).
+[ -n "\${DF_INODE_EMPTY_OK:-}" ] && [ -n "\$_inode" ] && exit 0
 # Every fixture entry the argv did not filter out. An operand that is itself
 # excluded leaves df with nothing to process: it exits nonzero having printed
 # nothing, which is the shape that hid the guarded probe being handed the

--- a/tests/client/fs-filter-freebsd.sh
+++ b/tests/client/fs-filter-freebsd.sh
@@ -101,6 +101,15 @@ assert_contains "tmpfs" "$inode_args" \
 assert_not_contains "tmpfs" "$disk_args" \
 	"the disk report keeps tmpfs: RAM-backed capacity is real"
 
+# A ZFS-only host: df -i excludes every filesystem and FreeBSD df then exits 0
+# with no output. The client must emit an EMPTY [inode] section - not a stray
+# header-only row that the server rejects with "Expected strings (%iused and
+# Mounted) not found in df output" (issue #398). The server's own empty-report
+# path then keeps the column green.
+inode_sec=$(fsf_section "$(fsf_report DF_INODE_EMPTY_OK=1)" inode)
+assert_equal "" "$inode_sec" \
+	"an all-zfs host (empty df -i, exit 0) yields an empty [inode] section, no stray header"
+
 # ... and an admin who wants those inode rows back has the documented escape.
 fsf_report XYMONCLIENT_FS_INCLUDE_TYPES=tmpfs >/dev/null
 inode_args=$(printf ' %s ' "$(tr '\n' ' ' < "$INODE_LOG")")


### PR DESCRIPTION
Fixes #398. Extracted from #390 so it can land on its own — the rest of that PR is the #344 unreachable-mount work and unrelated to this.

On a ZFS-only host `df -i` excludes every filesystem (zfs has no inode limit) and FreeBSD df then exits 0 with no output. `emit_df`'s guard only skipped on a *non-zero* exit, so the clean-but-empty case fell through and the inode awk's `NR<2` header rule turned the blank line into a stray `itotal` row. `unix_inode_report()` could not find the `%iused`/`Mounted` columns in it and flagged the host red — defeating its own all-ZFS green path, which fires only on a truly empty report.

`emit_df` now returns 1 whenever df produced no output: a non-zero exit still emits the failure marker (server yellow), a clean exit emits nothing, so the empty-report path keeps the inode column green.

| check | result |
|---|---|
| tests/client/fs-filter-freebsd.sh | PASS |
| same test, client change reverted | FAIL — `expected '', got '   itotal   '`, the issue's exact row |
| @feld on a real ZFS-only host (4191adf29) | `&green No filesystems reporting inode data` |

The stub's `DF_INODE_EMPTY_OK` models FreeBSD's "empty output, exit 0" for the inode call; @feld's confirmation above is what verifies that against the real df.
