### PR TITLE
tests: draw the xymond test port from below the ephemeral range

### DIFF
--- a/tests/lib/port-blocker.c
+++ b/tests/lib/port-blocker.c
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later                                  */
+/*
+ * tests/lib/port-blocker.c
+ *
+ * Hold a 127.0.0.1 port so that nothing else can bind it, and print the port
+ * on stdout so the test can name it.
+ *
+ * Deliberately does NOT listen(): a connect() to it is refused outright.
+ * A listener would be worse than useless here -- the readiness probe in
+ * tests/lib/xymond-daemon.sh cannot tell one Xymon-speaking listener from
+ * another, so anything that accepts connections reads as "the daemon is up".
+ * Refusing the connection is what makes a test of the bind retry deterministic.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int main(void)
+{
+	int sock;
+	struct sockaddr_in addr;
+	socklen_t alen = sizeof(addr);
+
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) { perror("socket"); return 1; }
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	addr.sin_port = htons(0);
+	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) { perror("bind"); return 1; }
+	if (getsockname(sock, (struct sockaddr *)&addr, &alen) < 0) { perror("getsockname"); return 1; }
+
+	printf("%d\n", ntohs(addr.sin_port));
+	fflush(stdout);
+
+	for (;;) pause();
+}

--- a/tests/lib/xymond-daemon.sh
+++ b/tests/lib/xymond-daemon.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/lib/xymond-daemon.sh
+#
+# Starting a real xymond on a loopback port, for the tests that need one.
+#
+# Three tests carried a byte-identical copy of this, and the logic is subtle
+# enough that three copies is how one of them drifts: the port has to be
+# chosen without the kernel handing it to someone else first, and that is not
+# something any probe can guarantee.
+#
+# Source after tests/lib/assert.sh. The caller provides $XYMOND, $XYMONCLIENT
+# (require_bin), $work (a scratch directory holding xymond.log), and defines
+# xymond_launch(); start_xymond() drives it and exports PORT and XYMOND_PID.
+
+# ephemeral_port_floor -- where the kernel starts handing out ephemeral ports,
+# or nothing when this kernel does not say. Purely an optimization input: see
+# free_port().
+#
+# Asked by knob rather than by OS: the names do not overlap between the BSDs
+# (FreeBSD and macOS spell it portrange.first, OpenBSD portfirst, NetBSD
+# anonportmin), so whichever one answers identifies the kernel by itself and
+# no uname test is needed. /sbin/sysctl as well as sysctl, since NetBSD does
+# not put it on a non-root PATH.
+ephemeral_port_floor() {
+	local v knob s
+
+	v=$(cut -f1 /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null || true)
+	case "$v" in ''|*[!0-9]*) ;; *) printf '%s' "$v"; return 0 ;; esac
+
+	for knob in net.inet.ip.portrange.first net.inet.ip.portfirst net.inet.ip.anonportmin; do
+		for s in sysctl /sbin/sysctl; do
+			v=$("$s" -n "$knob" 2>/dev/null || true)
+			case "$v" in ''|*[!0-9]*) continue ;; esac
+			printf '%s' "$v"
+			return 0
+		done
+	done
+	return 1
+}
+
+# free_port -- a loopback port nothing answers a Xymon ping on.
+#
+# This does NOT make the port safe to bind, and cannot: the probe only sees a
+# listener that answers a ping, so a socket held by anything else reads as
+# free, and the port can be taken in the window before the caller binds it
+# anyway. Correctness lives in start_xymond's bind retry.
+#
+# What this does is make a collision rare, by drawing from just below the
+# kernel's ephemeral range where the kernel will say where that starts. Where
+# it will not, or where there is no unprivileged room below it, no window is
+# invented -- an invented one is how this went wrong before: assuming 32768
+# puts every draw *inside* the ephemeral range on OpenBSD (starts at 1024) and
+# FreeBSD (10000). The historical span is used instead and the retry carries it.
+free_port() {
+	local p tries=0 lo hi
+
+	hi=$(ephemeral_port_floor || true)
+	case "$hi" in ''|*[!0-9]*) hi= ;; esac
+	if [ -n "$hi" ] && [ "$hi" -gt 9216 ]; then
+		lo=$(( hi - 8192 ))
+	else
+		# No usable window below the range: draw from the historical span and
+		# let the bind retry deal with a collision.
+		lo=20000
+		hi=40000
+	fi
+
+	while [ "$tries" -lt 50 ]; do
+		p=$(( lo + (RANDOM % (hi - lo)) ))
+		"$XYMONCLIENT" "127.0.0.1:$p" "ping" >/dev/null 2>&1 || { printf '%s' "$p"; return 0; }
+		tries=$((tries+1))
+	done
+	return 1
+}
+
+# start_xymond [extra xymond arguments] -- pick a port, hand it to the test's
+# xymond_launch(), and wait for the daemon to answer. Sets PORT and XYMOND_PID.
+#
+# A port that turned out to be taken is the one startup failure worth retrying,
+# and the budget is per call: a script that starts the daemon a dozen times must
+# not arrive at its last startup with the retries already spent. Every other
+# failure fails at once, so a xymond that cannot bind anywhere still fails
+# instead of looping.
+start_xymond() {
+	local attempt=0 i
+
+	while :; do
+		PORT=$(free_port) || fail "no free port for xymond"
+		xymond_launch "$PORT" "$@"
+
+		# An answered ping only counts while our own child is alive: the probe
+		# cannot tell this xymond from any other Xymon-speaking listener that
+		# holds the port, and a dead child with a stranger on its port would
+		# otherwise read as a successful startup.
+		i=0
+		while [ "$i" -lt 100 ]; do
+			"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 &&
+				kill -0 "$XYMOND_PID" 2>/dev/null && return 0
+			kill -0 "$XYMOND_PID" 2>/dev/null || break
+			sleep 0.1
+			i=$((i+1))
+		done
+
+		kill -0 "$XYMOND_PID" 2>/dev/null && break
+		grep -q 'Cannot bind to listen socket' "$work/xymond.log" 2>/dev/null || break
+		[ "$attempt" -lt 5 ] || break
+		attempt=$((attempt+1))
+	done
+
+	cat "$work/xymond.log" >&2
+	kill -0 "$XYMOND_PID" 2>/dev/null &&
+		fail "xymond did not answer on 127.0.0.1:$PORT" ||
+		fail "xymond exited during startup"
+}

--- a/tests/server/xymond-checkpoint-roundtrip.sh
+++ b/tests/server/xymond-checkpoint-roundtrip.sh
@@ -71,10 +71,21 @@ sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
 
 # free_port -- a 127.0.0.1 port nothing is listening on. Racy in principle;
 # the window is a few milliseconds and only this test uses the port.
+# Ports are drawn from just below the kernel's ephemeral range. A port
+# inside that range can be handed to an unrelated outbound connection in
+# the window between the probe here and xymond's bind, and the probe
+# cannot see it: it only detects a listener that answers a Xymon ping, not
+# a socket held by anything else.
 free_port() {
-	local p tries=0
+	local p tries=0 lo hi
+	hi=$(cut -f1 /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null)
+	case "$hi" in ''|*[!0-9]*) hi=32768 ;; esac
+	# A boundary at or below the privileged ports is not usable; treat it as
+	# missing rather than computing an empty window to draw from.
+	[ "$hi" -gt 2048 ] || hi=32768
+	lo=$(( hi > 9216 ? hi - 8192 : 1024 ))
 	while [ "$tries" -lt 50 ]; do
-		p=$(( 20000 + (RANDOM % 20000) ))
+		p=$(( lo + (RANDOM % (hi - lo)) ))
 		"$XYMONCLIENT" "127.0.0.1:$p" "ping" >/dev/null 2>&1 || { printf '%s' "$p"; return 0; }
 		tries=$((tries+1))
 	done
@@ -83,6 +94,7 @@ free_port() {
 
 # start_xymond [extra args...] -- boot xymond on a fresh port and wait for it
 # to answer. Sets PORT.
+START_ATTEMPTS=0
 start_xymond() {
 	local i=0
 	PORT=$(free_port) || fail "no free port for xymond"
@@ -95,12 +107,27 @@ start_xymond() {
 
 	while [ "$i" -lt 100 ]; do
 		"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 && return 0
-		kill -0 "$XYMOND_PID" 2>/dev/null || { cat "$work/xymond.log" >&2; fail "xymond exited during startup"; }
+		kill -0 "$XYMOND_PID" 2>/dev/null || break
 		sleep 0.1
 		i=$((i+1))
 	done
+
+	# Picking below the ephemeral range makes losing the port unlikely, not
+	# impossible: something else may already be listening there. That is the
+	# one startup failure worth retrying, and only a few times, so a xymond
+	# that cannot bind anywhere still fails instead of looping.
+	if ! kill -0 "$XYMOND_PID" 2>/dev/null &&
+	   grep -q 'Cannot bind to listen socket' "$work/xymond.log" 2>/dev/null &&
+	   [ "$START_ATTEMPTS" -lt 5 ]; then
+		START_ATTEMPTS=$((START_ATTEMPTS+1))
+		start_xymond "$@"
+		return
+	fi
+
 	cat "$work/xymond.log" >&2
-	fail "xymond did not answer on 127.0.0.1:$PORT"
+	kill -0 "$XYMOND_PID" 2>/dev/null &&
+		fail "xymond did not answer on 127.0.0.1:$PORT" ||
+		fail "xymond exited during startup"
 }
 
 # The host part of a status message spells dots as commas.

--- a/tests/server/xymond-checkpoint-roundtrip.sh
+++ b/tests/server/xymond-checkpoint-roundtrip.sh
@@ -33,6 +33,8 @@
 set -euo pipefail
 # shellcheck source=tests/lib/assert.sh
 . "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-daemon.sh
+. "$(dirname "$0")/../lib/xymond-daemon.sh"
 
 ROOT=$(find_root)
 
@@ -69,65 +71,15 @@ sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
     -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
 	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
 
-# free_port -- a 127.0.0.1 port nothing is listening on. Racy in principle;
-# the window is a few milliseconds and only this test uses the port.
-# Ports are drawn from just below the kernel's ephemeral range. A port
-# inside that range can be handed to an unrelated outbound connection in
-# the window between the probe here and xymond's bind, and the probe
-# cannot see it: it only detects a listener that answers a Xymon ping, not
-# a socket held by anything else.
-free_port() {
-	local p tries=0 lo hi
-	hi=$(cut -f1 /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null)
-	case "$hi" in ''|*[!0-9]*) hi=32768 ;; esac
-	# A boundary at or below the privileged ports is not usable; treat it as
-	# missing rather than computing an empty window to draw from.
-	[ "$hi" -gt 2048 ] || hi=32768
-	lo=$(( hi > 9216 ? hi - 8192 : 1024 ))
-	while [ "$tries" -lt 50 ]; do
-		p=$(( lo + (RANDOM % (hi - lo)) ))
-		"$XYMONCLIENT" "127.0.0.1:$p" "ping" >/dev/null 2>&1 || { printf '%s' "$p"; return 0; }
-		tries=$((tries+1))
-	done
-	return 1
-}
-
-# start_xymond [extra args...] -- boot xymond on a fresh port and wait for it
-# to answer. Sets PORT.
-START_ATTEMPTS=0
-start_xymond() {
-	local i=0
-	PORT=$(free_port) || fail "no free port for xymond"
-	"$XYMOND" --no-daemon --listen="127.0.0.1:$PORT" \
+# This test's xymond argv, for start_xymond() to drive.
+xymond_launch() {
+	local port=$1; shift
+	"$XYMOND" --no-daemon --listen="127.0.0.1:$port" \
 		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
 		--pidfile="$work/xymond.pid" --checkpoint-file="$work/chk" \
 		--flap-count=2 --flap-seconds=3600 "$@" \
 		> "$work/xymond.log" 2>&1 &
 	XYMOND_PID=$!
-
-	while [ "$i" -lt 100 ]; do
-		"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 && return 0
-		kill -0 "$XYMOND_PID" 2>/dev/null || break
-		sleep 0.1
-		i=$((i+1))
-	done
-
-	# Picking below the ephemeral range makes losing the port unlikely, not
-	# impossible: something else may already be listening there. That is the
-	# one startup failure worth retrying, and only a few times, so a xymond
-	# that cannot bind anywhere still fails instead of looping.
-	if ! kill -0 "$XYMOND_PID" 2>/dev/null &&
-	   grep -q 'Cannot bind to listen socket' "$work/xymond.log" 2>/dev/null &&
-	   [ "$START_ATTEMPTS" -lt 5 ]; then
-		START_ATTEMPTS=$((START_ATTEMPTS+1))
-		start_xymond "$@"
-		return
-	fi
-
-	cat "$work/xymond.log" >&2
-	kill -0 "$XYMOND_PID" 2>/dev/null &&
-		fail "xymond did not answer on 127.0.0.1:$PORT" ||
-		fail "xymond exited during startup"
 }
 
 # The host part of a status message spells dots as commas.

--- a/tests/server/xymond-holdtime-gap.sh
+++ b/tests/server/xymond-holdtime-gap.sh
@@ -35,6 +35,8 @@
 set -euo pipefail
 # shellcheck source=tests/lib/assert.sh
 . "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-daemon.sh
+. "$(dirname "$0")/../lib/xymond-daemon.sh"
 
 ROOT=$(find_root)
 
@@ -72,27 +74,6 @@ sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
     -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
 	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
 
-# Ports are drawn from just below the kernel's ephemeral range. A port
-# inside that range can be handed to an unrelated outbound connection in
-# the window between the probe here and xymond's bind, and the probe
-# cannot see it: it only detects a listener that answers a Xymon ping, not
-# a socket held by anything else.
-free_port() {
-	local p tries=0 lo hi
-	hi=$(cut -f1 /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null)
-	case "$hi" in ''|*[!0-9]*) hi=32768 ;; esac
-	# A boundary at or below the privileged ports is not usable; treat it as
-	# missing rather than computing an empty window to draw from.
-	[ "$hi" -gt 2048 ] || hi=32768
-	lo=$(( hi > 9216 ? hi - 8192 : 1024 ))
-	while [ "$tries" -lt 50 ]; do
-		p=$(( lo + (RANDOM % (hi - lo)) ))
-		"$XYMONCLIENT" "127.0.0.1:$p" "ping" >/dev/null 2>&1 || { printf '%s' "$p"; return 0; }
-		tries=$((tries+1))
-	done
-	return 1
-}
-
 # write_checkpoint HELDCOLOR HELDSINCE GAPCOLOR GAPSTART -- a checkpoint where
 # conn currently shows HELDCOLOR (since HELDSINCE) with a gap open: xymond
 # invented HELDCOLOR, and the color before the gap was GAPCOLOR, held from
@@ -107,42 +88,17 @@ write_checkpoint() {
 		"$gapcolor" "$HELDSINCE" "$gapstart" >> "$work/chk"
 }
 
-# start_xymond [extra xymond arguments] -- the cases that need a gap already in
-# place pass --restart; the ones that build it from live messages do not.
-START_ATTEMPTS=0
-start_xymond() {
-	local i=0
-	PORT=$(free_port) || fail "no free port for xymond"
-	"$XYMOND" --no-daemon --listen="127.0.0.1:$PORT" \
+# This test's xymond argv, for start_xymond() to drive: the cases that need a
+# gap already in place pass --restart, the ones that build it from live
+# messages do not.
+xymond_launch() {
+	local port=$1; shift
+	"$XYMOND" --no-daemon --listen="127.0.0.1:$port" \
 		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
 		--pidfile="$work/xymond.pid" --checkpoint-file="$work/chk.out" \
 		"$@" \
 		> "$work/xymond.log" 2>&1 &
 	XYMOND_PID=$!
-
-	while [ "$i" -lt 100 ]; do
-		"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 && return 0
-		kill -0 "$XYMOND_PID" 2>/dev/null || break
-		sleep 0.1
-		i=$((i+1))
-	done
-
-	# Picking below the ephemeral range makes losing the port unlikely, not
-	# impossible: something else may already be listening there. That is the
-	# one startup failure worth retrying, and only a few times, so a xymond
-	# that cannot bind anywhere still fails instead of looping.
-	if ! kill -0 "$XYMOND_PID" 2>/dev/null &&
-	   grep -q 'Cannot bind to listen socket' "$work/xymond.log" 2>/dev/null &&
-	   [ "$START_ATTEMPTS" -lt 5 ]; then
-		START_ATTEMPTS=$((START_ATTEMPTS+1))
-		start_xymond "$@"
-		return
-	fi
-
-	cat "$work/xymond.log" >&2
-	kill -0 "$XYMOND_PID" 2>/dev/null &&
-		fail "xymond did not answer on 127.0.0.1:$PORT" ||
-		fail "xymond exited during startup"
 }
 
 send() { "$XYMONCLIENT" "127.0.0.1:$PORT" "$1" || fail "xymond rejected: $1"; }

--- a/tests/server/xymond-holdtime-gap.sh
+++ b/tests/server/xymond-holdtime-gap.sh
@@ -72,10 +72,21 @@ sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
     -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
 	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
 
+# Ports are drawn from just below the kernel's ephemeral range. A port
+# inside that range can be handed to an unrelated outbound connection in
+# the window between the probe here and xymond's bind, and the probe
+# cannot see it: it only detects a listener that answers a Xymon ping, not
+# a socket held by anything else.
 free_port() {
-	local p tries=0
+	local p tries=0 lo hi
+	hi=$(cut -f1 /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null)
+	case "$hi" in ''|*[!0-9]*) hi=32768 ;; esac
+	# A boundary at or below the privileged ports is not usable; treat it as
+	# missing rather than computing an empty window to draw from.
+	[ "$hi" -gt 2048 ] || hi=32768
+	lo=$(( hi > 9216 ? hi - 8192 : 1024 ))
 	while [ "$tries" -lt 50 ]; do
-		p=$(( 20000 + (RANDOM % 20000) ))
+		p=$(( lo + (RANDOM % (hi - lo)) ))
 		"$XYMONCLIENT" "127.0.0.1:$p" "ping" >/dev/null 2>&1 || { printf '%s' "$p"; return 0; }
 		tries=$((tries+1))
 	done
@@ -98,6 +109,7 @@ write_checkpoint() {
 
 # start_xymond [extra xymond arguments] -- the cases that need a gap already in
 # place pass --restart; the ones that build it from live messages do not.
+START_ATTEMPTS=0
 start_xymond() {
 	local i=0
 	PORT=$(free_port) || fail "no free port for xymond"
@@ -110,12 +122,27 @@ start_xymond() {
 
 	while [ "$i" -lt 100 ]; do
 		"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 && return 0
-		kill -0 "$XYMOND_PID" 2>/dev/null || { cat "$work/xymond.log" >&2; fail "xymond exited during startup"; }
+		kill -0 "$XYMOND_PID" 2>/dev/null || break
 		sleep 0.1
 		i=$((i+1))
 	done
+
+	# Picking below the ephemeral range makes losing the port unlikely, not
+	# impossible: something else may already be listening there. That is the
+	# one startup failure worth retrying, and only a few times, so a xymond
+	# that cannot bind anywhere still fails instead of looping.
+	if ! kill -0 "$XYMOND_PID" 2>/dev/null &&
+	   grep -q 'Cannot bind to listen socket' "$work/xymond.log" 2>/dev/null &&
+	   [ "$START_ATTEMPTS" -lt 5 ]; then
+		START_ATTEMPTS=$((START_ATTEMPTS+1))
+		start_xymond "$@"
+		return
+	fi
+
 	cat "$work/xymond.log" >&2
-	fail "xymond did not answer on 127.0.0.1:$PORT"
+	kill -0 "$XYMOND_PID" 2>/dev/null &&
+		fail "xymond did not answer on 127.0.0.1:$PORT" ||
+		fail "xymond exited during startup"
 }
 
 send() { "$XYMONCLIENT" "127.0.0.1:$PORT" "$1" || fail "xymond rejected: $1"; }

--- a/tests/server/xymond-port-retry.sh
+++ b/tests/server/xymond-port-retry.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-port-retry.sh
+#
+# start_xymond() retries a port that turned out to be taken, and every startup
+# gets that retry budget in full.
+#
+# Choosing a port cannot be made safe: the probe in free_port() only sees a
+# listener that answers a Xymon ping, so a socket held by anything else reads
+# as free, and on OpenBSD there is no unprivileged room below the ephemeral
+# range to draw from at all. The bind retry is therefore the mechanism, not
+# the fallback -- which is why it is worth a test of its own.
+#
+# The budget half is the regression: with one counter for the whole script,
+# a test that starts the daemon a dozen times arrives at its last startup with
+# the retries already spent by earlier ones, and fails on a collision it was
+# meant to survive. Two startups are driven here, each needing three retries:
+# six in total, past a budget of five, so a shared counter fails the second.
+#
+# free_port() is replaced with a scripted sequence, and the port it hands out
+# first is held by a socket that refuses connections (tests/lib/port-blocker.c):
+# a listener would read as a successful startup, since the readiness probe
+# cannot tell one Xymon-speaking listener from another.
+#
+# Needs a built tree: xymond itself and the xymon client.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-daemon.sh
+. "$(dirname "$0")/../lib/xymond-daemon.sh"
+
+require_bin XYMOND xymond/xymond
+require_bin XYMONCLIENT common/xymon
+require_shm_segments "$(grep -c 'setup_channel(C_[A-Z_]*, CHAN_MASTER)' "$(find_root)/xymond/xymond.c")"
+require_c_buildenv "$(find_root)"
+
+work=$(mktempdir)
+mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.cfg"
+
+require_cfg XYMONSERVER_CFG xymond/etcfiles/xymonserver.cfg
+sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
+    -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
+	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
+
+xymond_launch() {
+	local port=$1; shift
+	"$XYMOND" --no-daemon --listen="127.0.0.1:$port" \
+		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
+		--pidfile="$work/xymond.pid" --checkpoint-file="$work/chk.out" \
+		"$@" \
+		> "$work/xymond.log" 2>&1 &
+	XYMOND_PID=$!
+}
+
+# --- the blocker: a socket holding one port, refusing connections -------------
+
+"$CC" -o "$work/port-blocker" "$(find_root)/tests/lib/port-blocker.c" 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "port-blocker does not compile"; }
+"$work/port-blocker" > "$work/blocked.port" &
+BLOCKER_PID=$!
+register_cleanup "kill $BLOCKER_PID 2>/dev/null || true"
+
+i=0
+while [ "$i" -lt 50 ]; do
+	[ -s "$work/blocked.port" ] && break
+	kill -0 "$BLOCKER_PID" 2>/dev/null || fail "port-blocker exited before naming its port"
+	sleep 0.1
+	i=$((i+1))
+done
+[ -s "$work/blocked.port" ] || fail "port-blocker never named its port"
+BLOCKER_PORT=$(cat "$work/blocked.port")
+
+# --- free_port hands out the blocked port three times, then a real one --------
+
+# Keep the genuine picker under a second name before scripting the one the
+# driver calls.
+eval "real_free_port() $(declare -f free_port | tail -n +2)"
+
+# The counter lives in a file: start_xymond calls free_port in a command
+# substitution, so a shell variable it set would be lost with the subshell.
+echo 0 > "$work/fp.calls"
+free_port() {
+	local n
+	n=$(( $(cat "$work/fp.calls") + 1 ))
+	echo "$n" > "$work/fp.calls"
+	case "$n" in
+		1|2|3|5|6|7) printf '%s' "$BLOCKER_PORT" ;;
+		*) real_free_port ;;
+	esac
+}
+free_port_calls() { cat "$work/fp.calls"; }
+
+# --- startup 1: three collisions, then success --------------------------------
+
+start_xymond
+[ "$PORT" != "$BLOCKER_PORT" ] || fail "xymond claims to run on the blocked port $BLOCKER_PORT"
+assert_equal "4" "$(free_port_calls)" \
+	"the first startup must retry the blocked port three times, then take the fourth"
+"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 \
+	|| fail "xymond did not answer on the port it recovered onto ($PORT)"
+
+kill "$XYMOND_PID" 2>/dev/null || true
+wait "$XYMOND_PID" 2>/dev/null || true
+
+# --- startup 2: three more collisions. Six in total, past a budget of five ----
+
+start_xymond
+[ "$PORT" != "$BLOCKER_PORT" ] || fail "xymond claims to run on the blocked port $BLOCKER_PORT"
+assert_equal "8" "$(free_port_calls)" \
+	"the second startup must get a fresh budget, not the leftovers of the first"
+"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 \
+	|| fail "the second startup did not answer on the port it recovered onto ($PORT)"
+
+kill "$XYMOND_PID" 2>/dev/null || true
+wait "$XYMOND_PID" 2>/dev/null || true
+
+pass "start_xymond retries a taken port, and each startup gets the retry budget in full"

--- a/tests/server/xymondboard-color-history.sh
+++ b/tests/server/xymondboard-color-history.sh
@@ -51,16 +51,28 @@ sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
     -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
 	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
 
+# Ports are drawn from just below the kernel's ephemeral range. A port
+# inside that range can be handed to an unrelated outbound connection in
+# the window between the probe here and xymond's bind, and the probe
+# cannot see it: it only detects a listener that answers a Xymon ping, not
+# a socket held by anything else.
 free_port() {
-	local p tries=0
+	local p tries=0 lo hi
+	hi=$(cut -f1 /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null)
+	case "$hi" in ''|*[!0-9]*) hi=32768 ;; esac
+	# A boundary at or below the privileged ports is not usable; treat it as
+	# missing rather than computing an empty window to draw from.
+	[ "$hi" -gt 2048 ] || hi=32768
+	lo=$(( hi > 9216 ? hi - 8192 : 1024 ))
 	while [ "$tries" -lt 50 ]; do
-		p=$(( 20000 + (RANDOM % 20000) ))
+		p=$(( lo + (RANDOM % (hi - lo)) ))
 		"$XYMONCLIENT" "127.0.0.1:$p" "ping" >/dev/null 2>&1 || { printf '%s' "$p"; return 0; }
 		tries=$((tries+1))
 	done
 	return 1
 }
 
+START_ATTEMPTS=0
 start_xymond() {
 	local i=0
 	PORT=$(free_port) || fail "no free port for xymond"
@@ -73,12 +85,27 @@ start_xymond() {
 
 	while [ "$i" -lt 100 ]; do
 		"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 && return 0
-		kill -0 "$XYMOND_PID" 2>/dev/null || { cat "$work/xymond.log" >&2; fail "xymond exited during startup"; }
+		kill -0 "$XYMOND_PID" 2>/dev/null || break
 		sleep 0.1
 		i=$((i+1))
 	done
+
+	# Picking below the ephemeral range makes losing the port unlikely, not
+	# impossible: something else may already be listening there. That is the
+	# one startup failure worth retrying, and only a few times, so a xymond
+	# that cannot bind anywhere still fails instead of looping.
+	if ! kill -0 "$XYMOND_PID" 2>/dev/null &&
+	   grep -q 'Cannot bind to listen socket' "$work/xymond.log" 2>/dev/null &&
+	   [ "$START_ATTEMPTS" -lt 5 ]; then
+		START_ATTEMPTS=$((START_ATTEMPTS+1))
+		start_xymond "$@"
+		return
+	fi
+
 	cat "$work/xymond.log" >&2
-	fail "xymond did not answer on 127.0.0.1:$PORT"
+	kill -0 "$XYMOND_PID" 2>/dev/null &&
+		fail "xymond did not answer on 127.0.0.1:$PORT" ||
+		fail "xymond exited during startup"
 }
 
 send() { "$XYMONCLIENT" "127.0.0.1:$PORT" "$1" || fail "xymond rejected: $1"; }

--- a/tests/server/xymondboard-color-history.sh
+++ b/tests/server/xymondboard-color-history.sh
@@ -22,6 +22,8 @@
 set -euo pipefail
 # shellcheck source=tests/lib/assert.sh
 . "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-daemon.sh
+. "$(dirname "$0")/../lib/xymond-daemon.sh"
 
 ROOT=$(find_root)
 
@@ -51,61 +53,14 @@ sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
     -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
 	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
 
-# Ports are drawn from just below the kernel's ephemeral range. A port
-# inside that range can be handed to an unrelated outbound connection in
-# the window between the probe here and xymond's bind, and the probe
-# cannot see it: it only detects a listener that answers a Xymon ping, not
-# a socket held by anything else.
-free_port() {
-	local p tries=0 lo hi
-	hi=$(cut -f1 /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null)
-	case "$hi" in ''|*[!0-9]*) hi=32768 ;; esac
-	# A boundary at or below the privileged ports is not usable; treat it as
-	# missing rather than computing an empty window to draw from.
-	[ "$hi" -gt 2048 ] || hi=32768
-	lo=$(( hi > 9216 ? hi - 8192 : 1024 ))
-	while [ "$tries" -lt 50 ]; do
-		p=$(( lo + (RANDOM % (hi - lo)) ))
-		"$XYMONCLIENT" "127.0.0.1:$p" "ping" >/dev/null 2>&1 || { printf '%s' "$p"; return 0; }
-		tries=$((tries+1))
-	done
-	return 1
-}
-
-START_ATTEMPTS=0
-start_xymond() {
-	local i=0
-	PORT=$(free_port) || fail "no free port for xymond"
-	"$XYMOND" --no-daemon --listen="127.0.0.1:$PORT" \
+xymond_launch() {
+	local port=$1; shift
+	"$XYMOND" --no-daemon --listen="127.0.0.1:$port" \
 		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
 		--pidfile="$work/xymond.pid" --checkpoint-file="$work/chk.out" \
 		"$@" \
 		> "$work/xymond.log" 2>&1 &
 	XYMOND_PID=$!
-
-	while [ "$i" -lt 100 ]; do
-		"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 && return 0
-		kill -0 "$XYMOND_PID" 2>/dev/null || break
-		sleep 0.1
-		i=$((i+1))
-	done
-
-	# Picking below the ephemeral range makes losing the port unlikely, not
-	# impossible: something else may already be listening there. That is the
-	# one startup failure worth retrying, and only a few times, so a xymond
-	# that cannot bind anywhere still fails instead of looping.
-	if ! kill -0 "$XYMOND_PID" 2>/dev/null &&
-	   grep -q 'Cannot bind to listen socket' "$work/xymond.log" 2>/dev/null &&
-	   [ "$START_ATTEMPTS" -lt 5 ]; then
-		START_ATTEMPTS=$((START_ATTEMPTS+1))
-		start_xymond "$@"
-		return
-	fi
-
-	cat "$work/xymond.log" >&2
-	kill -0 "$XYMOND_PID" 2>/dev/null &&
-		fail "xymond did not answer on 127.0.0.1:$PORT" ||
-		fail "xymond exited during startup"
 }
 
 send() { "$XYMONCLIENT" "127.0.0.1:$PORT" "$1" || fail "xymond rejected: $1"; }


### PR DESCRIPTION
`build (server)` fails at random with a test that never touched the code under
review. On #411 it looked like this:

```
tests/server/xymond-holdtime-gap.sh
  Setting up network listener on 127.0.0.1:34136:34136
  Cannot bind to listen socket (Address already in use)
  FAIL: xymond exited during startup
```

85 tests passed; that one could not get its port. Re-running the same commit
passed, which is the signature of a race rather than a defect.

## Why

Three tests start a real xymond and pick its port the same way:

```sh
p=$(( 20000 + (RANDOM % 20000) ))
"$XYMONCLIENT" "127.0.0.1:$p" "ping" >/dev/null 2>&1 || { printf '%s' "$p"; return 0; }
```

That draws from 20000-39999, which **overlaps the kernel's ephemeral range** --
`/proc/sys/net/ipv4/ip_local_port_range` is `32768 60999` on the runners, and
34136 sits inside it. So the kernel is free to hand the same port to an
unrelated outbound connection, and it does when the runner is busy.

The probe cannot see that happen. It only detects a listener that answers a
Xymon ping; a socket held by anything else reads as free. And there is a window
between the probe and xymond's bind in which the port can be taken regardless.

## The fix

Draw from just below the ephemeral range instead, reading where that range
starts rather than assuming:

```sh
hi=$(cut -f1 /proc/sys/net/ipv4/ip_local_port_range 2>/dev/null)
case "$hi" in ''|*[!0-9]*) hi=32768 ;; esac
[ "$hi" -gt 2048 ] || hi=32768
lo=$(( hi > 9216 ? hi - 8192 : 1024 ))
p=$(( lo + (RANDOM % (hi - lo)) ))
```

The kernel does not assign below that boundary, so the collision this fixes
cannot recur. `cut` failing or returning junk falls back to 32768, the common
default, and a boundary at or below the privileged ports is treated the same
way rather than leaving an empty window to draw from.

That leaves one case: a port below the range that something else is already
listening on, which the ping probe still cannot detect. `start_xymond` now
retries up to five times when -- and only when -- xymond died with `Cannot bind
to listen socket`. Every other startup failure fails immediately as before, and
both existing failure messages are preserved, so a xymond that cannot bind
anywhere still fails instead of looping.

The suite runs tests one at a time, so no test competes with another for a
port; the competitor is always something outside the suite.

## Verified

Built `--server` in a Debian 13 container with CI's own configure environment,
then:

- all three affected tests pass unchanged
- with a listener deliberately occupying the first port handed out,
  the patched test still passes -- the retry fires and recovers
- the same control against today's `main` fails with the exact CI error,
  confirming the control reproduces the bug rather than something else

## Scope

Test-harness only -- no shipped code changes. Independent of my other open PRs;
it touches no file any of them touch.
