### PR TITLE
client: report an unmeasured mount as all dashes, not 100% full

### DIFF
--- a/client/xymonclient-darwin.sh
+++ b/client/xymonclient-darwin.sh
@@ -326,7 +326,9 @@ fs_guarded() {
 		# still knows which device is behind the mount point, and that is the
 		# first thing an operator needs. The sizes are reported as "-": they
 		# were not measured, and a number here would be trended as a reading.
-		# The capacity stays 100% because that is what turns the column red.
+		# The capacity is "-" like the sizes: nothing measured it either. A
+		# server too old to know the marker reads 0% and stays green - the
+		# cost of not reporting a number nobody measured.
 		# The mount list rides the mount-table stream behind an @@ separator:
 		# a -v assignment cannot carry newlines on BSD awk (fs_setop makes
 		# the same move). A spaced device is re-encoded (\040) to keep the
@@ -339,8 +341,8 @@ fs_guarded() {
 				d = ($0 in dev) ? dev[$0] : "-"
 				n = split(d, dp, / /)
 				if (n > 1) { d = dp[1]; for (j = 2; j <= n; j++) d = d "\\040" dp[j] }
-				if (inode == "inode") printf "%s - - - 100%% - - 100%% %s\n", d, $0
-				else printf "%s - - - 100%% %s\n", d, $0
+				if (inode == "inode") printf "%s - - - - - - - %s\n", d, $0
+				else printf "%s - - - - %s\n", d, $0
 			}'
 	else
 		printf '%s\n' "$_rout"

--- a/client/xymonclient-freebsd.sh
+++ b/client/xymonclient-freebsd.sh
@@ -306,14 +306,16 @@ run_df() {
 	_tag=disk; [ "$_flag" = -i ] && _tag=inode
 	_rout=`df_sentinel "$_tag" "$@"`
 	if [ $? -eq 124 ]; then
-		# Unavailable: surface each remote mount as a failed (100%) row rather
+		# Unavailable: surface each remote mount as an unmeasured row rather
 		# than dropping it, since the server reads an absent filesystem as
 		# green. This turns one filesystem red instead of purpling the host.
 		# The row names the server. df could not answer, but the mount table
 		# still knows which device is behind the mount point, and that is the
 		# first thing an operator needs. The sizes are reported as "-": they
 		# were not measured, and a number here would be trended as a reading.
-		# The capacity stays 100% because that is what turns the column red.
+		# The capacity is "-" like the sizes: nothing measured it either. A
+		# server too old to know the marker reads 0% and stays green - the
+		# cost of not reporting a number nobody measured.
 		# The inode report is read column-wise (iused, ifree and %iused are
 		# fields 6-8), so its marker row carries those columns too.
 		# The mount list rides the mount-table stream behind an @@ separator:
@@ -328,8 +330,8 @@ run_df() {
 				d = ($0 in dev) ? dev[$0] : "-"
 				n = split(d, dp, / /)
 				if (n > 1) { d = dp[1]; for (j = 2; j <= n; j++) d = d "\\040" dp[j] }
-				if (inode == "-i") printf "%s - - - 100%% - - 100%% %s\n", d, $0
-				else printf "%s - - - 100%% %s\n", d, $0
+				if (inode == "-i") printf "%s - - - - - - - %s\n", d, $0
+				else printf "%s - - - - %s\n", d, $0
 			}'
 	else
 		printf '%s\n' "$_rout"
@@ -370,6 +372,8 @@ fi
 echo "[inode]"
 # Same failure guard. Drop filesystems with no inode limit (df prints "-" in the
 # %iused column, field 8): they cannot run out of inodes, so the row is noise.
+# The unavailable-mount marker is dashed there too and must survive: a no-limit
+# filesystem still counts inodes ("0 0 0 -"), the marker counts nothing.
 # tmpfs is excluded by type instead: its itotal is the 2^31-1 sentinel (not "-"),
 # identical on a 4GB and a 128GB box, so the row-level guard cannot catch it.
 if emit_df inode Inode -i zfs tmpfs; then
@@ -378,6 +382,7 @@ N
 s/[ 	]*\n[ 	]*/ /
 }' | awk '
 NR<2{printf "%-20s %10s %10s %10s %10s %s\n", $1, "itotal", $6, $7, $8, $9}
+(NR>=2 && $8 == "-" && $6 == "-"){printf "%-20s %10s %10s %10s %10s %s\n", $1, "-", "-", "-", "-", $9}
 (NR>=2 && $8 != "-" && $6 == "-"){printf "%-20s %10s %10s %10s %10s %s\n", $1, "-", "-", "-", $8, $9}
 (NR>=2 && $8 != "-" && $6 != "-"){printf "%-20s %10d %10d %10d %10s %s\n", $1, $6+$7, $6, $7, $8, $9}'
 fi

--- a/client/xymonclient-linux.sh
+++ b/client/xymonclient-linux.sh
@@ -417,7 +417,7 @@ run_df()
 	_tag=disk; [ "$DFINODES" = yes ] && _tag=inode
 	_rout=$(df_sentinel "$_tag" "$@")
 	if [ $? -eq 124 ]; then
-		# Unavailable: surface each remote mount as a failed (100%) row rather
+		# Unavailable: surface each remote mount as an unmeasured row rather
 		# than dropping it, since the server reads an absent filesystem as
 		# green. This turns one filesystem red instead of purpling the host.
 		#
@@ -425,7 +425,9 @@ run_df()
 		# still knows which device is behind the mount point, and that is the
 		# first thing an operator needs. The sizes are reported as "-": they
 		# were not measured, and a number here would be trended as a reading.
-		# The capacity stays 100% because that is what turns the column red.
+		# The capacity is "-" like the sizes: nothing measured it either. A
+		# server too old to know the marker reads 0% and stays green - the
+		# cost of not reporting a number nobody measured.
 		# The mount list rides the mount-table stream behind an @@ separator:
 		# a -v assignment cannot carry newlines on BSD awk (fs_setop makes
 		# the same move). A spaced device is re-encoded (\040) to keep the
@@ -439,7 +441,7 @@ run_df()
 				d = ($0 in dev) ? dev[$0] : "-"
 				n = split(d, dp, / /)
 				if (n > 1) { d = dp[1]; for (j = 2; j <= n; j++) d = d "\\040" dp[j] }
-				printf "%s - - - 100%% %s\n", d, $0
+				printf "%s - - - - %s\n", d, $0
 			}'
 	else
 		printf '%s\n' "$_rout"
@@ -471,11 +473,14 @@ emit_df()
 	# bogus counts (e.g. a negative IUsed on 9p). The header (NR==1) is kept; for
 	# the disk report the awk is a pass-through. (awk is already required above,
 	# so this adds no new dependency.)
+	# The unavailable-mount marker is dashed there too and must survive: a
+	# no-limit filesystem still counts inodes ("0 0 0 -"), the marker counts
+	# nothing.
 	printf '%s\n' "$DFOUT" | sed -e '/^[^ 	][^ 	]*$/{
 N
 s/[ 	]*\n[ 	]*/ /
 }' -e "s&^rootfs&${ROOTFS}&" \
-	| awk -v ino="$1" 'NR == 1 || ino != "yes" || $5 != "-"'
+	| awk -v ino="$1" 'NR == 1 || ino != "yes" || $5 != "-" || $2 == "-"'
 }
 ROOTFS=`readlink -m /dev/root`
 emit_df no Disk

--- a/client/xymonclient-netbsd.sh
+++ b/client/xymonclient-netbsd.sh
@@ -295,14 +295,16 @@ run_df() {
 	_tag=disk; [ "$_flag" = -i ] && _tag=inode
 	_rout=`df_sentinel "$_tag" "$@"`
 	if [ $? -eq 124 ]; then
-		# Unavailable: surface each remote mount as a failed (100%) row rather
+		# Unavailable: surface each remote mount as an unmeasured row rather
 		# than dropping it, since the server reads an absent filesystem as
 		# green. This turns one filesystem red instead of purpling the host.
 		# The row names the server. df could not answer, but the mount table
 		# still knows which device is behind the mount point, and that is the
 		# first thing an operator needs. The sizes are reported as "-": they
 		# were not measured, and a number here would be trended as a reading.
-		# The capacity stays 100% because that is what turns the column red.
+		# The capacity is "-" like the sizes: nothing measured it either. A
+		# server too old to know the marker reads 0% and stays green - the
+		# cost of not reporting a number nobody measured.
 		# The inode report is read column-wise (iused, ifree and %iused are
 		# fields 6-8), so its marker row carries those columns too.
 		# The mount list rides the mount-table stream behind an @@ separator:
@@ -317,8 +319,8 @@ run_df() {
 				d = ($0 in dev) ? dev[$0] : "-"
 				n = split(d, dp, / /)
 				if (n > 1) { d = dp[1]; for (j = 2; j <= n; j++) d = d "\\040" dp[j] }
-				if (inode == "-i") printf "%s - - - 100%% - - 100%% %s\n", d, $0
-				else printf "%s - - - 100%% %s\n", d, $0
+				if (inode == "-i") printf "%s - - - - - - - %s\n", d, $0
+				else printf "%s - - - - %s\n", d, $0
 			}'
 	else
 		printf '%s\n' "$_rout"

--- a/client/xymonclient-openbsd.sh
+++ b/client/xymonclient-openbsd.sh
@@ -303,14 +303,16 @@ run_df() {
 	_tag=disk; [ "$_flag" = -i ] && _tag=inode
 	_rout=`df_sentinel "$_tag" "$@"`
 	if [ $? -eq 124 ]; then
-		# Unavailable: surface each remote mount as a failed (100%) row rather
+		# Unavailable: surface each remote mount as an unmeasured row rather
 		# than dropping it, since the server reads an absent filesystem as
 		# green. This turns one filesystem red instead of purpling the host.
 		# The row names the server. df could not answer, but the mount table
 		# still knows which device is behind the mount point, and that is the
 		# first thing an operator needs. The sizes are reported as "-": they
 		# were not measured, and a number here would be trended as a reading.
-		# The capacity stays 100% because that is what turns the column red.
+		# The capacity is "-" like the sizes: nothing measured it either. A
+		# server too old to know the marker reads 0% and stays green - the
+		# cost of not reporting a number nobody measured.
 		# The inode report is read column-wise (iused, ifree and %iused are
 		# fields 6-8), so its marker row carries those columns too.
 		# The mount list rides the mount-table stream behind an @@ separator:
@@ -325,8 +327,8 @@ run_df() {
 				d = ($0 in dev) ? dev[$0] : "-"
 				n = split(d, dp, / /)
 				if (n > 1) { d = dp[1]; for (j = 2; j <= n; j++) d = d "\\040" dp[j] }
-				if (inode == "-i") printf "%s - - - 100%% - - 100%% %s\n", d, $0
-				else printf "%s - - - 100%% %s\n", d, $0
+				if (inode == "-i") printf "%s - - - - - - - %s\n", d, $0
+				else printf "%s - - - - %s\n", d, $0
 			}'
 	else
 		printf '%s\n' "$_rout"

--- a/tests/client/fs-filter-common.sh
+++ b/tests/client/fs-filter-common.sh
@@ -385,7 +385,10 @@ fsf_assert_loud() {
 	case "$1" in
 		*"collection failed"*) return 0 ;;
 	esac
-	printf '%s\n' "$1" | grep -Eq '^[^ ]+ +- +- +- +100% ' && return 0
+	# The unavailable-mount marker: every column "-". The legacy shape carried
+	# 100% in the capacity column and is still accepted, since a client can be
+	# older than the server reading it.
+	printf '%s\n' "$1" | grep -Eq '^[^ ]+ +- +- +- +(-|100%) ' && return 0
 	fail "${2:-}: the report carries no marker, leaving the server an empty section it cannot explain: '$1'"
 }
 

--- a/tests/client/fs-sentinel-darwin.sh
+++ b/tests/client/fs-sentinel-darwin.sh
@@ -109,7 +109,7 @@ assert_contains "/net" "$out" "a healthy hard-blocking mount is reported through
 # With real rows, not the marker: everything the sentinel hands df has to be
 # something df accepts, and a probe that fails on its own arguments looks
 # exactly like a server that stopped answering.
-assert_not_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" \
+assert_not_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$out" \
 	"a healthy server must produce real rows, never the unavailable marker"
 assert_contains "/Volumes/USBHFS" "$out" "a local filesystem is still reported by the per-path loop"
 assert_contains "/dev/disk" "$out" "and the table still carries real rows"
@@ -139,14 +139,14 @@ rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 out=$(run_cycle DF_HANG=1)
 df_section=$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')
 inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
-assert_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$df_section" \
+assert_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$df_section" \
 	"a wedged server must surface the mount in the disk report, not drop it"
-assert_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$inode_section" \
+assert_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$inode_section" \
 	"and in the inode report, whose columns are read positionally"
 # Shape, not just presence: the inode awk reads iused/ifree/%iused from fields
 # 6-8, so a marker row in the disk layout would be reformatted into nonsense
 # that still contains the mount name.
-assert_contains "100% /net" "$inode_section" \
+assert_match '\-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$inode_section" \
 	"the inode marker row must carry the inode columns, not the disk ones"
 assert_contains "/Volumes/USBHFS" "$df_section" \
 	"a wedged remote server must not stale or block the local set"
@@ -159,7 +159,7 @@ out=$(run_cycle DF_HANG=1)
 after=$(wc -l < "$DF_CALLS")
 assert_equal "$((before + 2))" "$((after))" \
 	"while both probes are wedged, a cycle must run only the two plain dfs"
-assert_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the mount stays unavailable while wedged"
+assert_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$out" "the mount stays unavailable while wedged"
 for _tag in disk inode; do end_stub "$(cat "$TMP/probe/df-probe-$_tag.pid")"; done
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 
@@ -180,7 +180,7 @@ chmod +x "$STUB/mount"
 out=$(run_cycle DF_HANG=1 XYMONTMP="$TMP/remoteprobe")
 assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
 	"a probe dir on a hard-blocking filesystem must never be touched"
-assert_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the remote set reports unavailable instead"
+assert_match 'remote:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$out" "the remote set reports unavailable instead"
 
 
 # Same guard, mount list unavailable rather than hostile. Asked directly: with

--- a/tests/client/fs-sentinel-freebsd.sh
+++ b/tests/client/fs-sentinel-freebsd.sh
@@ -121,7 +121,7 @@ assert_contains "/net" "$out" "a healthy hard-blocking mount is reported through
 # With real rows, not the marker: everything the sentinel hands df has to be
 # something df accepts, and a probe that fails on its own arguments looks
 # exactly like a server that stopped answering.
-assert_not_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" \
+assert_not_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$out" \
 	"a healthy server must produce real rows, never the unavailable marker"
 assert_contains "/ssh" "$out" "a remote type that cannot hard-block stays in the plain df"
 assert_contains "/dev/ada0p2" "$out" "and the local set is reported as before"
@@ -141,14 +141,14 @@ rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 out=$(run_cycle DF_HANG=1)
 df_section=$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')
 inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
-assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$df_section" \
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$df_section" \
 	"a wedged server must surface the mount in the disk report, not drop it"
-assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$inode_section" \
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$inode_section" \
 	"and in the inode report, whose columns are read positionally"
 # Shape, not just presence: the inode awk reads iused/ifree/%iused from fields
 # 6-8, so a marker row in the disk layout would be reformatted into nonsense
 # that still contains the mount name.
-assert_contains "100% /net" "$inode_section" \
+assert_match '\-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$inode_section" \
 	"the inode marker row must carry the inode columns, not the disk ones"
 assert_contains "/dev/ada0p2" "$df_section" \
 	"a wedged remote server must not stale or block the local set"
@@ -161,7 +161,7 @@ out=$(run_cycle DF_HANG=1)
 after=$(wc -l < "$DF_CALLS")
 assert_equal "$((before + 2))" "$((after))" \
 	"while both probes are wedged, a cycle must run only the two plain dfs"
-assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the mount stays unavailable while wedged"
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$out" "the mount stays unavailable while wedged"
 for _tag in disk inode; do end_stub "$(cat "$TMP/probe/df-probe-$_tag.pid")"; done
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 
@@ -181,7 +181,7 @@ chmod +x "$STUB/mount"
 out=$(run_cycle DF_HANG=1 XYMONTMP="$TMP/remoteprobe")
 assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
 	"a probe dir on a hard-blocking filesystem must never be touched"
-assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the remote set reports unavailable instead"
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$out" "the remote set reports unavailable instead"
 
 
 # Same guard, mount list unavailable rather than hostile. Asked directly: with

--- a/tests/client/fs-sentinel-linux.sh
+++ b/tests/client/fs-sentinel-linux.sh
@@ -190,9 +190,10 @@ rm -f "$TMP"/probe/*
 out=$(DF_HANG=1 run_cycle DF_HANG=1)
 assert_contains '/dev/sda1 1000 400 600 40% /' "$out" \
 	"a wedged remote server must not stale or block the local set"
-assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
+assert_contains 'srv:/exp - - - - /remote/nfs' "$out" \
 	"an unreachable mount must be surfaced, not dropped (the server reads absent as green)"
-assert_contains ' 100% /remote/nfs' "$out" "the unavailable row must read as full so the column goes red"
+assert_not_contains '100% /remote/nfs' "$out" \
+	"the unavailable row must not claim a capacity it never measured"
 [ -f "$TMP/probe/df-probe-disk.pid" ] || fail "the wedged df must be left recorded as the sentinel"
 
 # --- still wedged: exactly one outstanding df --------------------------------
@@ -204,7 +205,7 @@ out=$(DF_HANG=1 run_cycle DF_HANG=1)
 after=$(wc -l < "$DF_CALLS")
 assert_equal "$((before + 1))" "$((after))" \
 	"while one df is wedged, a cycle must run only the local df -- not a second remote one"
-assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" "the mount stays unavailable while wedged"
+assert_contains 'srv:/exp - - - - /remote/nfs' "$out" "the mount stays unavailable while wedged"
 
 # --- recovery ----------------------------------------------------------------
 # End the wedge and wait for it to actually be gone: while the recorded df is
@@ -229,7 +230,7 @@ assert_equal '0' "$(find "$TMP/probe" -type f | awk 'END { print NR }')" \
 # and then reported unavailable.
 rm -f "$TMP"/probe/*
 out=$(run_cycle XYMONCLIENT_FS_EXCLUDE_TYPES=nfs4)
-assert_not_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
+assert_not_contains 'srv:/exp - - - - /remote/nfs' "$out" \
 	"an excluded type was probed anyway and its healthy mount reported unavailable"
 assert_not_contains '/remote/nfs' "$out" "an excluded type must not be reported at all"
 assert_contains '/dev/sda1 1000 400 600 40% /' "$out" "the local set must still be reported"
@@ -282,7 +283,7 @@ wait "$_first" 2>/dev/null || true
 rm -f "$STUB/mv"
 assert_equal '1' "$(($(wc -l < "$DF_REMOTE")))" \
 	"a cycle reading the pid file mid-publication must not start a second probe"
-assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
+assert_contains 'srv:/exp - - - - /remote/nfs' "$out" \
 	"and it must report the mount unavailable, not drop it"
 _recorded=$(cat "$TMP/probe/df-probe-disk.pid" 2>/dev/null)
 assert_equal "$(head -1 "$DF_REMOTE")" "$_recorded" \
@@ -329,7 +330,7 @@ wait "$_first" 2>/dev/null || true
 rm -f "$STUB/ln" "$LN_HELD"
 assert_equal '1' "$(($(wc -l < "$DF_REMOTE")))" \
 	"a cycle reading the pid file between the link and the claim started a second probe"
-assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
+assert_contains 'srv:/exp - - - - /remote/nfs' "$out" \
 	"the cycle that read the fresh claim must report unavailable, not drop the mount"
 _recorded=$(cat "$TMP/probe/df-probe-disk.pid" 2>/dev/null)
 assert_equal "$(head -1 "$DF_REMOTE")" "$_recorded" \
@@ -350,14 +351,14 @@ printf 'claim:%s\n' "$holder" > "$TMP/probe/df-probe-disk.pid"
 out=$(run_cycle)
 assert_equal '0' "$(($(wc -l < "$DF_REMOTE")))" \
 	"a probe already claimed by a live cycle was started a second time"
-assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
+assert_contains 'srv:/exp - - - - /remote/nfs' "$out" \
 	"a probe claimed by another cycle must report unavailable, not start a second df"
 kill "$holder" 2>/dev/null || true; wait "$holder" 2>/dev/null || true
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 
 # --- df fails ----------------------------------------------------------------
 out=$(DF_FAIL=1 run_cycle DF_FAIL=1)
-assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
+assert_contains 'srv:/exp - - - - /remote/nfs' "$out" \
 	"a remote df that exits nonzero must report unavailable, not a partial set"
 
 # --- every hard-blocked mount is surfaced, not just one -----------------------
@@ -367,9 +368,9 @@ assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 printf 'ext4\t/\t/dev/sda1\nnfs4\t/remote/nfs\tsrv:/exp\nnfs4\t/remote/nfs2\tsrv2:/exp\n' > "$MOUNTS"
 out=$(DF_HANG=1 run_cycle DF_HANG=1)
-assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" \
+assert_contains 'srv:/exp - - - - /remote/nfs' "$out" \
 	"the first hard-blocked mount must be surfaced"
-assert_contains 'srv2:/exp - - - 100% /remote/nfs2' "$out" \
+assert_contains 'srv2:/exp - - - - /remote/nfs2' "$out" \
 	"and the second: a multi-mount list must survive the handover to awk"
 while read -r _p; do end_stub "$_p"; done < "$DF_REMOTE"
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
@@ -382,7 +383,7 @@ rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 printf 'ext4\t/\t/dev/sda1\nnfs4\t/remote/nfs\tsrv:/team share\n' > "$MOUNTS"
 out=$(DF_HANG=1 run_cycle DF_HANG=1)
-assert_contains 'srv:/team\040share - - - 100% /remote/nfs' "$out" \
+assert_contains 'srv:/team\040share - - - - /remote/nfs' "$out" \
 	"a spaced device must be \\040-encoded so the columns hold"
 assert_not_contains 'srv:/team share' "$out" \
 	"the decoded device must not reach the report: it splits the row"
@@ -398,7 +399,7 @@ printf 'ext4\t/\t/dev/sda1\nnfs4\t/remote/nfs\tsrv:/exp\nnfs4\t%s\tsrv:/probe\n'
 out=$(run_cycle XYMONTMP="$TMP/remoteprobe" DF_HANG=1)
 assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
 	"a probe dir on a hard-blocking filesystem must never be touched"
-assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" "the remote set must report unavailable instead"
+assert_contains 'srv:/exp - - - - /remote/nfs' "$out" "the remote set must report unavailable instead"
 
 # Same guard, asked directly. Driving it through the block cannot reach it: with
 # no mount list there is no remote set either, so df_sentinel is never called.
@@ -448,7 +449,7 @@ _after=$(wc -l < "$DF_CALLS")
 rmdir "$TMP/probe/df-probe-disk.pid"
 assert_equal 1 "$((_after - _before))" \
 	"an unrecordable pid must stop the remote df from starting (only the plain df may run)"
-assert_contains "srv:/exp - - - 100% /remote/nfs" "$pidout" \
+assert_contains "srv:/exp - - - - /remote/nfs" "$pidout" \
 	"an unrecordable pid must report the remote set unavailable, not drop it"
 
 # --- the inode report is guarded too, under its own tag ----------------------
@@ -457,14 +458,14 @@ assert_contains "srv:/exp - - - 100% /remote/nfs" "$pidout" \
 # no-inode-limit drop, which throws away rows whose IUse% column is "-".
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 out=$(DF_HANG=1 run_full DF_HANG=1)
-assert_contains 'srv:/exp - - - 100% /remote/nfs' "$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')" \
+assert_contains 'srv:/exp - - - - /remote/nfs' "$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')" \
 	"a wedged server must surface the mount in the disk report"
-assert_contains 'srv:/exp - - - 100% /remote/nfs' "$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')" \
+assert_contains 'srv:/exp - - - - /remote/nfs' "$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')" \
 	"and in the inode report: an absent filesystem reads as green there too"
 # The columns, not just the mount name: this row is read positionally, and a
 # marker that says 0% used is a green row however it names the device. The
 # sizes are "-" because nothing measured them; only the capacity is asserted.
-assert_contains 'srv:/exp - - - 100% /remote/nfs' \
+assert_contains 'srv:/exp - - - - /remote/nfs' \
 	"$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')" \
 	"the inode marker must read as full, or the column stays green"
 [ -f "$TMP/probe/df-probe-disk.pid" ] || fail "the disk probe must be recorded"
@@ -493,7 +494,7 @@ rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 # INCLUDE_TYPES naming the type as well -- what every case above passes, and
 # what xymonclient-linux.sh documents. Getting this wrong in the other
 # direction would be worse than useless: a probe of a type the admin excluded
-# comes back empty-and-nonzero and reports the mount 100% full.
+# comes back empty-and-nonzero and reports the mount as unmeasured.
 out=$(env DF_CALLS="$DF_CALLS" DF_REMOTE="$DF_REMOTE" XYMONTMP="$TMP/probe" \
 	XYMONCLIENT_FS_DF_LOCAL_ONLY=no XYMONCLIENT_FS_REMOTE_DF_BUDGET=2 \
 	DF_HANG=1 PATH="$STUB:$PATH" /bin/sh "$TMP/df-section.sh" 2>/dev/null || true)
@@ -516,13 +517,13 @@ assert_contains '/remote/sshfs' "$out" \
 # a cycle is visible and bounded. So an unreadable name must NOT restart.
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"; : > "$DF_CALLS"
 out=$(DF_HANG=1 run_cycle DF_HANG=1)
-assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" "the wedge is recorded to begin with"
+assert_contains 'srv:/exp - - - - /remote/nfs' "$out" "the wedge is recorded to begin with"
 before=$(wc -l < "$DF_CALLS")
 out=$(DF_HANG=1 run_cycle DF_HANG=1 FS_PROCNAME=)
 after=$(wc -l < "$DF_CALLS")
 assert_equal "$((before + 1))" "$((after))" \
 	"with the name unreadable the wedged df must be assumed ours -- not restarted"
-assert_contains 'srv:/exp - - - 100% /remote/nfs' "$out" "and the mount stays unavailable while it is"
+assert_contains 'srv:/exp - - - - /remote/nfs' "$out" "and the mount stays unavailable while it is"
 
 # A name that is neither ours nor empty is a recycled pid, and must restart.
 : > "$DF_CALLS"

--- a/tests/client/fs-sentinel-netbsd.sh
+++ b/tests/client/fs-sentinel-netbsd.sh
@@ -121,7 +121,7 @@ assert_contains "/net" "$out" "a healthy hard-blocking mount is reported through
 # With real rows, not the marker: everything the sentinel hands df has to be
 # something df accepts, and a probe that fails on its own arguments looks
 # exactly like a server that stopped answering.
-assert_not_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" \
+assert_not_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$out" \
 	"a healthy server must produce real rows, never the unavailable marker"
 assert_contains "/ssh" "$out" "a remote type that cannot hard-block stays in the plain df"
 assert_contains "/dev/ld0a" "$out" "and the local set is reported as before"
@@ -141,14 +141,14 @@ rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 out=$(run_cycle DF_HANG=1)
 df_section=$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')
 inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
-assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$df_section" \
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$df_section" \
 	"a wedged server must surface the mount in the disk report, not drop it"
-assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$inode_section" \
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$inode_section" \
 	"and in the inode report, whose columns are read positionally"
 # Shape, not just presence: the inode awk reads iused/ifree/%iused from fields
 # 6-8, so a marker row in the disk layout would be reformatted into nonsense
 # that still contains the mount name.
-assert_contains "100% /net" "$inode_section" \
+assert_match '\-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$inode_section" \
 	"the inode marker row must carry the inode columns, not the disk ones"
 assert_contains "/dev/ld0a" "$df_section" \
 	"a wedged remote server must not stale or block the local set"
@@ -161,7 +161,7 @@ out=$(run_cycle DF_HANG=1)
 after=$(wc -l < "$DF_CALLS")
 assert_equal "$((before + 2))" "$((after))" \
 	"while both probes are wedged, a cycle must run only the two plain dfs"
-assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the mount stays unavailable while wedged"
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$out" "the mount stays unavailable while wedged"
 for _tag in disk inode; do end_stub "$(cat "$TMP/probe/df-probe-$_tag.pid")"; done
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 
@@ -181,7 +181,7 @@ chmod +x "$STUB/mount"
 out=$(run_cycle DF_HANG=1 XYMONTMP="$TMP/remoteprobe")
 assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
 	"a probe dir on a hard-blocking filesystem must never be touched"
-assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the remote set reports unavailable instead"
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$out" "the remote set reports unavailable instead"
 
 
 # Same guard, mount list unavailable rather than hostile. Asked directly: with

--- a/tests/client/fs-sentinel-openbsd.sh
+++ b/tests/client/fs-sentinel-openbsd.sh
@@ -121,7 +121,7 @@ assert_contains "/net" "$out" "a healthy hard-blocking mount is reported through
 # With real rows, not the marker: everything the sentinel hands df has to be
 # something df accepts, and a probe that fails on its own arguments looks
 # exactly like a server that stopped answering.
-assert_not_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" \
+assert_not_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$out" \
 	"a healthy server must produce real rows, never the unavailable marker"
 assert_contains "/ssh" "$out" "a remote type that cannot hard-block stays in the plain df"
 assert_contains "/dev/sd0a" "$out" "and the local set is reported as before"
@@ -141,14 +141,14 @@ rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 out=$(run_cycle DF_HANG=1)
 df_section=$(printf '%s\n' "$out" | sed -n '/^\[df\]/,/^\[inode\]/p')
 inode_section=$(printf '%s\n' "$out" | sed -n '/^\[inode\]/,$p')
-assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$df_section" \
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$df_section" \
 	"a wedged server must surface the mount in the disk report, not drop it"
-assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$inode_section" \
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$inode_section" \
 	"and in the inode report, whose columns are read positionally"
 # Shape, not just presence: the inode awk reads iused/ifree/%iused from fields
 # 6-8, so a marker row in the disk layout would be reformatted into nonsense
 # that still contains the mount name.
-assert_contains "100% /net" "$inode_section" \
+assert_match '\-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$inode_section" \
 	"the inode marker row must carry the inode columns, not the disk ones"
 assert_contains "/dev/sd0a" "$df_section" \
 	"a wedged remote server must not stale or block the local set"
@@ -161,7 +161,7 @@ out=$(run_cycle DF_HANG=1)
 after=$(wc -l < "$DF_CALLS")
 assert_equal "$((before + 2))" "$((after))" \
 	"while both probes are wedged, a cycle must run only the two plain dfs"
-assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the mount stays unavailable while wedged"
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$out" "the mount stays unavailable while wedged"
 for _tag in disk inode; do end_stub "$(cat "$TMP/probe/df-probe-$_tag.pid")"; done
 rm -f "$TMP"/probe/*; : > "$DF_REMOTE"
 
@@ -181,7 +181,7 @@ chmod +x "$STUB/mount"
 out=$(run_cycle DF_HANG=1 XYMONTMP="$TMP/remoteprobe")
 assert_equal '0' "$(find "$TMP/remoteprobe" -type f | awk 'END { print NR }')" \
 	"a probe dir on a hard-blocking filesystem must never be touched"
-assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+100%[[:space:]]+/net' "$out" "the remote set reports unavailable instead"
+assert_match 'srv:/exp[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+-[[:space:]]+/net' "$out" "the remote set reports unavailable instead"
 
 
 # Same guard, mount list unavailable rather than hostile. Asked directly: with

--- a/tests/server/disk-unavailable-honest-message.sh
+++ b/tests/server/disk-unavailable-honest-message.sh
@@ -37,7 +37,9 @@ require_bin XYMOND_CLIENT xymond/xymond_client
 
 work=$(mktempdir)
 mkdir -p "$work/home"
-: > "$work/analysis.cfg"
+# An absolute free-space rule on the AIX pseudo mount: "-" parses as 0, and
+# "0 units free" trips an absolute threshold that nothing measured.
+printf 'HOST=*\n\tDISK /proc 5000U 1000U\n' > "$work/analysis.cfg"
 
 # Two client reports through one worker run: a Linux host carrying the marker
 # next to a healthy and a genuinely full filesystem, then an AIX host whose
@@ -107,5 +109,7 @@ assert_match "aix,test\.disk green" "$out" \
 	"the AIX all-dash /proc row turned the disk column non-green"
 assert_not_contains "/proc is unreachable" "$out" \
 	"the AIX all-dash /proc row was mistaken for the unavailable-mount marker"
+assert_not_contains "/proc (0 units free)" "$out" \
+	"a row nothing measured was judged against an absolute threshold, where \"-\" reads as 0 free"
 
 pass "an unreachable mount is named in the alert instead of being reported as a full disk"

--- a/tests/server/disk-unavailable-honest-message.sh
+++ b/tests/server/disk-unavailable-honest-message.sh
@@ -4,14 +4,17 @@
 # tests/server/disk-unavailable-honest-message.sh
 #
 # An unreachable mount arrives as the client's marker row,
-# "srv:/exp - - - 100% /remote/nfs": "-" sizes because nothing measured them,
-# 100% so the disk column goes red on any server. Routing that 100% through
-# the ordinary percent threshold made the alert text lie about the failure:
+# "srv:/exp - - - - /remote/nfs": every column "-", because nothing measured
+# any of them. Clients before that sent the same row with 100% in the capacity
+# column, to turn the disk column red on a server that did not know the marker;
+# both shapes must be recognised, since clients upgrade after servers. Routing
+# that 100% through the ordinary percent threshold made the alert text lie:
 # "&red /remote/nfs (100% used) has reached the PANIC level (95%)" reads as a
 # full disk, when the truth is a mount that did not answer.
 #
 # unix_disk_report()/unix_inode_report() must recognise the marker by its
-# values ("-" in the free column plus the marker's 100%) and name the failure
+# values ("-" in the free column, and "-" or the legacy 100% in the capacity
+# column) and name the failure
 # instead. Pinned here, by driving the real xymond_client in --local
 # --no-update mode (statuses print to stdout instead of being sent):
 #
@@ -21,9 +24,10 @@
 #   - a genuinely full filesystem (real sizes, 100%) still takes the normal
 #     threshold path and reports the PANIC text -- the honest message must
 #     not swallow real alerts
-#   - an AIX-style all-dash row ("-" in the percent column too, as df -Ik
-#     writes for /proc) is NOT mistaken for the marker: its status stays
-#     green with no "unreachable" line
+#   - a client still sending the legacy 100% form is recognised the same way
+#   - an AIX-style all-dash row (as df -Ik writes for /proc) is NOT mistaken
+#     for the marker: AIX has no sentinel, so an all-dash row there is a
+#     pseudo filesystem, and its status stays green with no "unreachable" line
 
 set -euo pipefail
 # shellcheck source=tests/lib/assert.sh
@@ -43,12 +47,20 @@ out=$(printf '%s' '@@client|1755640000|127.0.0.1|unix.test|linux|linux|
 [df]
 Filesystem 1024-blocks Used Available Capacity Mounted on
 /dev/sda1 1000000 400000 600000 40% /
-srv:/exp - - - 100% /remote/nfs
+srv:/exp - - - - /remote/nfs
 /dev/sdb1 1000000 1000000 0 100% /full
 [inode]
 Filesystem Inodes IUsed IFree IUse% Mounted on
 /dev/sda1 65536 1024 64512 2% /
-srv:/exp - - - 100% /remote/nfs
+srv:/exp - - - - /remote/nfs
+@@
+@@client|1755640000|127.0.0.1|legacy.test|linux|linux|
+[df]
+Filesystem 1024-blocks Used Available Capacity Mounted on
+old:/exp - - - 100% /legacy/nfs
+[inode]
+Filesystem Inodes IUsed IFree IUse% Mounted on
+old:/exp - - - 100% /legacy/nfs
 @@
 @@client|1755640000|127.0.0.1|aix.test|aix|aix|
 [df]
@@ -81,8 +93,16 @@ assert_not_contains "/remote/nfs (100% used)" "$out" \
 assert_contains "&red /full (100% used) has reached the PANIC level" "$out" \
 	"a genuinely full filesystem no longer alerts through the threshold path"
 
-# The AIX all-dash /proc row has no 100% -- it is not the marker, and must
-# not start alerting.
+# A client that has not been upgraded yet still sends the legacy shape.
+assert_contains "&red /legacy/nfs is unreachable (not measured)" "$out" \
+	"a client still sending the legacy 100% marker is no longer recognised"
+assert_not_contains "/legacy/nfs (100% used)" "$out" \
+	"the legacy marker fell through to the percent threshold and claimed a full disk"
+assert_contains "ID=/legacy/nfs" "$out" \
+	"the legacy marker is recognised in the disk report but not the inode one"
+
+# AIX writes the same all-dash row for /proc, where it means a pseudo
+# filesystem rather than an unreachable mount -- it must not start alerting.
 assert_match "aix,test\.disk green" "$out" \
 	"the AIX all-dash /proc row turned the disk column non-green"
 assert_not_contains "/proc is unreachable" "$out" \

--- a/xymond/xymond_client.c
+++ b/xymond/xymond_client.c
@@ -636,6 +636,13 @@ void unix_disk_report(char *hostname, char *clientclass, enum ostype_t os,
 					addtobuffer(monmsg, msgline);
 					addalertgroup(group);
 				}
+				else if (unmeasured && nocapacity) {
+					/* Nothing was measured, and it is not the marker (that is
+					 * handled above), so this is a row the client could not
+					 * fill in - AIX writes it for a pseudo filesystem. No
+					 * reading, no verdict: atol("-") is 0, and "0 units free"
+					 * would trip an absolute threshold that nothing measured. */
+				}
 				else if ( (abspanic && (levelabs <= paniclevel)) || 
 				     (!abspanic && (levelpct >= paniclevel)) ) {
 					if (diskcolor < COL_RED) diskcolor = COL_RED;
@@ -833,6 +840,13 @@ void unix_inode_report(char *hostname, char *clientclass, enum ostype_t os,
 					sprintf(msgline, "&red <!-- ID=%s --> %s is unreachable (not measured)\n", fsname, fsname);
 					addtobuffer(monmsg, msgline);
 					addalertgroup(group);
+				}
+				else if (unmeasured && nocapacity) {
+					/* Nothing was measured, and it is not the marker (that is
+					 * handled above), so this is a row the client could not
+					 * fill in - AIX writes it for a pseudo filesystem. No
+					 * reading, no verdict: atol("-") is 0, and "0 units free"
+					 * would trip an absolute threshold that nothing measured. */
 				}
 				else if ( (abspanic && (levelabs <= paniclevel)) || 
 				     (!abspanic && (levelpct >= paniclevel)) ) {

--- a/xymond/xymond_client.c
+++ b/xymond/xymond_client.c
@@ -585,7 +585,7 @@ void unix_disk_report(char *hostname, char *clientclass, enum ostype_t os,
 		}
 		else {
 			char *fsname = NULL, *levelstr = NULL;
-			int abswarn, abspanic, unmeasured = 0;
+			int abswarn, abspanic, unmeasured = 0, nocapacity = 0;
 			long levelpct = -1, levelabs = -1, warnlevel, paniclevel;
 
 			p = strdup(bol);
@@ -606,7 +606,11 @@ void unix_disk_report(char *hostname, char *clientclass, enum ostype_t os,
 					levelabs = atol(levelstr);
 				}
 				strcpy(p, bol);
-				levelstr = getcolumn(p, capacol); if (levelstr) levelpct = atol(levelstr);
+				levelstr = getcolumn(p, capacol);
+				if (levelstr) {
+					nocapacity = (strcmp(levelstr, "-") == 0);
+					levelpct = atol(levelstr);
+				}
 
 				dbgprintf("Disk check: FS='%s' level %ld%%/%ldU (thresholds: %lu/%lu, abs: %d/%d)\n",
 					fsname, levelpct, levelabs, 
@@ -615,11 +619,17 @@ void unix_disk_report(char *hostname, char *clientclass, enum ostype_t os,
 				if (ignored) {
 					/* Forget about this one */
 				}
-				else if (unmeasured && (levelpct == 100)) {
-					/* The client's unavailable-mount marker: "-" sizes because
-					 * nothing measured them, 100% so the column still goes red
-					 * on a server without this check. An all-dash row (AIX
-					 * /proc) has no 100% and stays out. */
+				else if (unmeasured && (nocapacity ? (os != OS_AIX) : (levelpct == 100))) {
+					/* The client's unavailable-mount marker: every column
+					 * "-", because nothing measured any of them. The legacy
+					 * shape carried 100% instead, to turn the column red on a
+					 * server that did not know the marker; it still arrives
+					 * from clients not yet upgraded.
+					 *
+					 * Not on AIX, where df -Ik writes an all-dash row for
+					 * /proc: a pseudo filesystem, not an unreachable mount.
+					 * AIX has no sentinel, so it never sends a marker - give
+					 * it one and this exclusion has to go with it. */
 					if (diskcolor < COL_RED) diskcolor = COL_RED;
 
 					sprintf(msgline, "&red %s is unreachable (not measured)\n", fsname);
@@ -780,7 +790,7 @@ void unix_inode_report(char *hostname, char *clientclass, enum ostype_t os,
 		}
 		else {
 			char *fsname = NULL, *levelstr = NULL;
-			int abswarn, abspanic, unmeasured = 0;
+			int abswarn, abspanic, unmeasured = 0, nocapacity = 0;
 			long levelpct = -1, levelabs = -1, warnlevel, paniclevel;
 
 			p = strdup(bol);
@@ -801,7 +811,11 @@ void unix_inode_report(char *hostname, char *clientclass, enum ostype_t os,
 					levelabs = atol(levelstr);
 				}
 				strcpy(p, bol);
-				levelstr = getcolumn(p, capacol); if (levelstr) levelpct = atol(levelstr);
+				levelstr = getcolumn(p, capacol);
+				if (levelstr) {
+					nocapacity = (strcmp(levelstr, "-") == 0);
+					levelpct = atol(levelstr);
+				}
 
 				dbgprintf("Inode check: FS='%s' level %ld%%/%ldU (thresholds: %lu/%lu, abs: %d/%d)\n",
 					fsname, levelpct, levelabs, 
@@ -810,10 +824,10 @@ void unix_inode_report(char *hostname, char *clientclass, enum ostype_t os,
 				if (ignored) {
 					/* Forget about this one */
 				}
-				else if (unmeasured && (levelpct == 100)) {
+				else if (unmeasured && (nocapacity ? (os != OS_AIX) : (levelpct == 100))) {
 					/* The unavailable-mount marker, passed through by the
-					 * clients' inode reformatters -- same shape as in the
-					 * disk report. */
+					 * clients' inode reformatters -- same two shapes, and the
+					 * same AIX exception, as the disk report. */
 					if (inodecolor < COL_RED) inodecolor = COL_RED;
 
 					sprintf(msgline, "&red <!-- ID=%s --> %s is unreachable (not measured)\n", fsname, fsname);


### PR DESCRIPTION
The unavailable-mount marker reported `-` for the sizes because nothing measured them, then `100%` for a capacity nothing measured either. All five clients now emit `dev - - - - mountpoint`; AIX has no sentinel and emits no marker.

The server accepts the all-dash and the legacy `100%` shape both — clients upgrade after servers, and an unrecognised marker falls through to the threshold path and reports a full disk. AIX is excluded by OS: `df -Ik` writes an all-dash row for `/proc`, which is a pseudo filesystem, never a marker.

**Cost:** a server too old to know the marker at all now reads 0% and stays green, where the fabricated `100%` turned it red.

**Inode filters.** A filesystem with no inode limit is dropped on the `-` in its `%iused` column (btrfs, zfs, 9p) and the marker is dashed there too — but a no-limit filesystem still counts inodes (`/dev/sda15 0 0 0 - /boot/efi`) and the marker counts nothing. Linux and FreeBSD keyed on the percent column alone and swallowed the marker; NetBSD, OpenBSD and macOS already keyed on the counts.

**Known limitation, narrower than it first looks.** The marker is a shape, not a signature: `df` prints the same all-dash row when `statfs()` fails. But no client passes `-a`, and plain `df -P` omits a mount it cannot stat (asked for one explicitly, df errors with no row) — verified on a host with root-only docker `overlay` mounts: they appear under `df -aP` and are absent from `df -P`. So a privilege-denied mount yields no row at all, not a forged marker; it goes unmonitored rather than falsely red.

What remains unverified is the BSD/macOS inode reformatters, whose rule keys on the iused column being `-`: if some df there prints `-` in both the iused and %iused columns for a real filesystem, that row would reformat into the marker shape. I have no BSD host to check. The scheme this replaced (`unavailable:<mp> 1 1 0 100% <mp>`, retired in #390) keyed on the device equalling the mount point, which a real df row cannot produce.

Independent of #407 — verified by applying this commit to `main` alone: builds, and the AIX row still stays green because the OS check, not the AIX filter, is what separates them.

**Second commit: no reading, no verdict.** A row dashed in both the size and capacity columns was still judged against the thresholds — `atol("-")` is 0, so it arrived as "0 units free". Harmless under a percentage rule, but an absolute one panics: with `DISK /proc 5000U 1000U`, an AIX `/proc` row reported `&red /proc (0 units free) has reached the PANIC level`. Predates this branch — `main` does the same. Such a row now takes no threshold path; one with dashed counts but a real capacity is still judged on that capacity.

Reviewed by codex (28 commands, 115k tokens): one finding, a coverage gap — the legacy shape reached `unix_disk_report()` only. Confirmed by breaking the same branch in `unix_inode_report()`, which left the test passing; the legacy row now goes through both reports and the sabotage is caught.

| check | result |
|---|---|
| full suite, server build | 90 passed / 0 skipped / 0 failed |
| new shape, legacy shape, AIX all-dash | all three driven through `xymond_client` in one run |
| no-inode-limit row (`0 0 0 -`) still dropped | yes |



