### PR TITLE
xymond: accept alternative df column names

### DIFF
--- a/lib/misc.c
+++ b/lib/misc.c
@@ -700,13 +700,37 @@ char *nextcolumn(char *s)
 	return result;
 }
 
+/*
+ * Does "heading" name the column "wanted" asks for? "wanted" may list
+ * alternatives separated by "|", for a column two df versions spell
+ * differently ("Avail|Available"). Whole names only, so "Availability" is not
+ * "Avail". Never written to: it arrives as a string literal.
+ */
+static int columnmatch(char *heading, char *wanted)
+{
+	char *p = wanted, *sep;
+	size_t n, hlen = strlen(heading);
+
+	while (p) {
+		sep = strchr(p, '|');
+		n = (sep ? (size_t)(sep - p) : strlen(p));
+		/* n > 0: an empty alternative matches nothing. Without it, it would
+		   match an empty heading, which nextcolumn() returns as a zero-length
+		   token rather than NULL. */
+		if ((n > 0) && (n == hlen) && (strncasecmp(heading, p, n) == 0)) return 1;
+		p = (sep ? sep + 1 : NULL);
+	}
+
+	return 0;
+}
+
 int selectcolumn(char *heading, char *wanted)
 {
 	char *hdr;
 	int result = 0;
 
 	hdr = nextcolumn(heading);
-	while (hdr && strcasecmp(hdr, wanted)) {
+	while (hdr && !columnmatch(hdr, wanted)) {
 		result++;
 		hdr = nextcolumn(NULL);
 	}

--- a/tests/client/fs-filter-common.sh
+++ b/tests/client/fs-filter-common.sh
@@ -36,6 +36,7 @@
 fsf_setup() {
 	_os=$1
 	_envvar=$2
+	FSF_OS=$_os
 
 	# Indirect-expand ${ENV_VAR:-default}. eval keeps this POSIX (no namerefs).
 	eval "SCRIPT=\"\${$_envvar:-\$(find_root)/client/xymonclient-$_os.sh}\""
@@ -389,11 +390,71 @@ fsf_assert_loud() {
 	fail "${2:-}: the report carries no marker, leaving the server an empty section it cannot explain: '$1'"
 }
 
+# fsf_header_has HEADER WANTED -- is WANTED one of HEADER's column names?
+# WANTED may list alternatives separated by "|". Whole tokens, case-insensitive:
+# the comparison the server makes. Split on "[|]", not "|", which some awks read
+# as an alternation with two empty branches.
+fsf_header_has() {
+	printf '%s\n' "$1" | awk -v want="$2" '
+		BEGIN { n = split(tolower(want), a, "[|]"); for (i = 1; i <= n; i++) if (a[i] != "") W[a[i]] = 1 }
+		{ for (i = 1; i <= NF; i++) if (tolower($i) in W) found = 1 }
+		END { exit found ? 0 : 1 }
+	'
+}
+
+# fsf_header_side SRC FUNC HEADER SECTION -- every column name FUNC is called
+# with in SRC must be present in HEADER.
+fsf_header_side() {
+	_hs_src=$1; _hs_fn=$2; _hs_hdr=$3; _hs_sect=$4
+
+	# "|| true": no match is what the guard below reports, and under
+	# "set -e -o pipefail" a grep that finds nothing kills the caller first.
+	_hs_names=$(grep -h "$_hs_fn(" "$_hs_src" | grep -o '"[^"]*"' | tr -d '"' || true)
+	# Deliberate split on whitespace: a column name is one token, and the count
+	# below says so. noglob is saved and restored, not just switched off --
+	# turning a caller's option back on is the bug this idiom avoids.
+	case $- in *f*) _hs_glob=no ;; *) _hs_glob=yes; set -f ;; esac
+	# shellcheck disable=SC2086
+	set -- $_hs_names
+	[ "$_hs_glob" = yes ] && set +f
+	# Not three names means the extraction no longer describes the call: moved,
+	# reformatted, or a second call added. Which cannot be told from here, so
+	# the message reports the count, not a cause -- and it must break loudly,
+	# since a contract check that stops checking is worse than none.
+	[ $# -eq 3 ] || fail "cannot read the column names $_hs_fn() is called with in $_hs_src: found $# quoted strings on the lines that call it, expected 3 -- the call moved, was reformatted, or there is now more than one, and this check needs teaching about it"
+
+	for _hs_w in "$@"; do
+		fsf_header_has "$_hs_hdr" "$_hs_w" || fail \
+			"contract: $_hs_fn() looks for a column called '$_hs_w', which is not in the [$_hs_sect] header this client sends: '$_hs_hdr'"
+	done
+}
+
+# fsf_header_contract DFHDR INODEHDR -- clients keep their own df's words on
+# purpose, so an operator sees what df prints on the box. The cost is that the
+# server must know each spelling, and nothing checked that it did: netbsd.c
+# asked for "Avail" while every NetBSD client ever sent "Available". This pins
+# the two sides together rather than making the labels uniform.
+fsf_header_contract() {
+	_hc_src="$(find_root)/xymond/client/$FSF_OS.c"
+	# Not a skip: the suite runs from the checkout even when XYMONCLIENT_<OS>
+	# names an installed client, so the handler is always there. Its absence
+	# means it was renamed or removed, and passing would check nothing.
+	[ -f "$_hc_src" ] || fail "$_hc_src is missing, so nothing says which column names the server will look for -- was the handler renamed?"
+
+	fsf_header_side "$_hc_src" unix_disk_report  "$1" df
+	fsf_header_side "$_hc_src" unix_inode_report "$2" inode
+}
+
 # fsf_contract -- the rules every client obeys, asserted on the emitted report.
 fsf_contract() {
 	_out=$(fsf_report)
 	_df=$(fsf_section "$_out" df)
 	_in=$(fsf_section "$_out" inode)
+
+	# The names the server looks for must be in the header the client just
+	# sent. First, because every assertion below reads a report the server
+	# could not parse otherwise.
+	fsf_header_contract "$(printf '%s\n' "$_df" | head -1)" "$(printf '%s\n' "$_in" | head -1)"
 
 	assert_contains "$FSF_LOCAL_MP" "$_df" \
 		"contract: an ordinary local filesystem must be reported (block stderr: $(tr '\n' ' ' < "$STDERR_LOG" | cut -c1-300))"

--- a/tests/server/selectcolumn-synonyms-harness.c
+++ b/tests/server/selectcolumn-synonyms-harness.c
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * tests/server/selectcolumn-synonyms-harness.c
+ *
+ * Driver for selectcolumn() (lib/misc.c), used by selectcolumn-synonyms.sh.
+ *
+ * selectcolumn() finds a named column in a client's df header, and "wanted"
+ * may list alternatives separated by "|".
+ *
+ * Prints "<label>=<column index>" per case; -1 means not found. The shell
+ * owns the pass/fail decision.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "libxymon.h"
+
+/* nextcolumn() writes NULs into the heading, so every case gets a fresh copy. */
+static void probe(const char *label, const char *heading, char *wanted)
+{
+	char buf[256];
+
+	strncpy(buf, heading, sizeof(buf) - 1);
+	buf[sizeof(buf) - 1] = '\0';
+	printf("%s=%d\n", label, selectcolumn(buf, wanted));
+}
+
+int main(int argc, char **argv)
+{
+	/* df -P: POSIX heads the free column "Available". */
+	static const char posix_hdr[] =
+		"Filesystem 1024-blocks Used Available Capacity Mounted on";
+	/* df -h on the same host: the free column is "Avail". */
+	static const char human_hdr[] =
+		"Filesystem Size Used Avail Capacity Mounted on";
+
+	probe("plain_hit",   posix_hdr,  "Capacity");
+	probe("plain_miss",  posix_hdr,  "Avail");
+	probe("syn_first",   human_hdr,  "Avail|Available");
+	probe("syn_second",  posix_hdr,  "Avail|Available");
+	probe("syn_third",   posix_hdr,  "Frei|Libre|Available");
+	probe("syn_miss",    posix_hdr,  "Frei|Libre");
+	probe("case_fold",   posix_hdr,  "aVaIlAbLe");
+	probe("empty_alt",   posix_hdr,  "|Available");
+	/* ... and against an empty heading, which reaches the comparison as a
+	   zero-length token rather than NULL. */
+	probe("empty_both",  "",         "|Available");
+	probe("empty_hdr",   "",         "Avail|Available");
+	/* A longer heading must not match a shorter alternative. */
+	probe("no_prefix",   "Filesystem Availability Capacity", "Avail|Available");
+	/* ... nor a longer alternative match a shorter heading. */
+	probe("no_suffix",   human_hdr,  "Available");
+
+	return 0;
+}

--- a/tests/server/selectcolumn-synonyms.sh
+++ b/tests/server/selectcolumn-synonyms.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/selectcolumn-synonyms.sh
+#
+# selectcolumn() (lib/misc.c) finds the columns xymond reads out of a client's
+# df header, and now takes a "|"-separated list of alternatives -- macOS sends
+# "Avail" or "Available" depending on the client's vintage.
+#
+# Pinned here, against the real function:
+#
+#   - a name with no "|" still hits and misses as before
+#   - any alternative matches, wherever it sits in the list
+#   - matching stays case-insensitive
+#   - an empty alternative matches nothing, an empty heading included: that
+#     heading reaches the comparison as a zero-length token, so a length test
+#     alone would call it a match
+#   - whole names only: "Availability" is not "Avail", and "Available" does not
+#     match a header that says "Avail"
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+here=$(dirname "$0")
+
+MISC_C="$ROOT/lib/misc.c"
+[ -f "$MISC_C" ] || skip "lib/misc.c not present in this checkout"
+# The synonym support is what this file guards; its absence is a regression,
+# not a green skip.
+grep -q "columnmatch" "$MISC_C" \
+	|| fail "selectcolumn() no longer has its alternative-name matching (regressed)"
+
+CC=${CC:-cc}
+command -v "$CC" >/dev/null 2>&1 || skip "no C compiler available (CC=$CC)"
+require_gnu_make
+
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+
+work=$(mktempdir)
+
+"$XYMON_MAKE" -C "$ROOT/lib" libxymoncomm.a >"$work/libbuild.log" 2>&1 \
+	|| { cat "$work/libbuild.log" >&2; fail "cannot refresh libxymoncomm.a"; }
+
+harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
+"$CC" $harness_cflags -o "$work/harness" \
+	"$here/selectcolumn-synonyms-harness.c" \
+	"$ROOT/lib/libxymoncomm.a" $harness_ldflags 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+out=$("$work/harness")
+
+# Column indexes are 0-based: Filesystem 0, blocks 1, Used 2, free 3, Capacity 4.
+assert_contains "plain_hit=4"  "$out" "a name with no alternatives must still be found"
+assert_contains "plain_miss=-1" "$out" "a name that is not in the header must still miss"
+assert_contains "syn_first=3"  "$out" "the first alternative must match"
+assert_contains "syn_second=3" "$out" "the second alternative must match"
+assert_contains "syn_third=3"  "$out" "an alternative after the first two must match"
+assert_contains "syn_miss=-1"  "$out" "a list where nothing matches must still miss"
+assert_contains "case_fold=3"  "$out" "matching must stay case-insensitive"
+assert_contains "empty_alt=3"  "$out" \
+	"an empty alternative must match nothing, and must not stop the ones after it"
+assert_contains "empty_both=-1" "$out" \
+	"an empty alternative must not match an empty heading, which nextcolumn() returns as a zero-length token"
+assert_contains "empty_hdr=-1" "$out" \
+	"an empty heading has no columns to find"
+assert_contains "no_prefix=-1" "$out" \
+	"a longer heading must not match a shorter alternative (Availability is not Avail)"
+assert_contains "no_suffix=-1" "$out" \
+	"a longer alternative must not match a shorter heading (Avail is not Available)"
+
+pass "selectcolumn(): alternative column names, matched whole and case-insensitively"

--- a/xymond/client/darwin.c
+++ b/xymond/client/darwin.c
@@ -54,7 +54,11 @@ void handle_darwin_client(char *hostname, char *clienttype, enum ostype_t os,
 
 	unix_cpu_report(hostname, clienttype, os, hinfo, fromline, timestr, uptimestr, clockstr, msgcachestr, 
 			whostr, 0, psstr, 0, topstr);
-	unix_disk_report(hostname, clienttype, os, hinfo, fromline, timestr, "Avail", "Capacity", "Mounted", dfstr);
+	/* Both spellings, deliberately: the client sends "Available" since it
+	   moved to df -P in 4.3.31, and "Avail" before that. Dropping "Avail"
+	   silently loses every older client, and no test can catch it -- the suite
+	   only runs the client it ships with. */
+	unix_disk_report(hostname, clienttype, os, hinfo, fromline, timestr, "Avail|Available", "Capacity", "Mounted", dfstr);
 	unix_inode_report(hostname, clienttype, os, hinfo, fromline, timestr, "ifree", "%iused", "Mounted", inodestr);
 	unix_procs_report(hostname, clienttype, os, hinfo, fromline, timestr, "COMMAND", NULL, psstr);
 	unix_ports_report(hostname, clienttype, os, hinfo, fromline, timestr, 3, 4, 5, portsstr);

--- a/xymond/client/netbsd.c
+++ b/xymond/client/netbsd.c
@@ -58,7 +58,10 @@ void handle_netbsd_client(char *hostname, char *clienttype, enum ostype_t os,
 
 	unix_cpu_report(hostname, clienttype, os, hinfo, fromline, timestr, uptimestr, clockstr, msgcachestr, 
 			whostr, 0, psstr, 0, topstr);
-	unix_disk_report(hostname, clienttype, os, hinfo, fromline, timestr, "Avail", "Capacity", "Mounted", dfstr);
+	/* "Available": the client has always passed df -P, which POSIX heads that
+	   way. The "Avail" asked for until 4.3.31 never matched anything, and no
+	   alternative is listed because no older spelling was ever sent. */
+	unix_disk_report(hostname, clienttype, os, hinfo, fromline, timestr, "Available", "Capacity", "Mounted", dfstr);
 	unix_inode_report(hostname, clienttype, os, hinfo, fromline, timestr, "ifree", "%iused", "Mounted", inodestr);
 	unix_procs_report(hostname, clienttype, os, hinfo, fromline, timestr, "COMMAND", NULL, psstr);
 	unix_ports_report(hostname, clienttype, os, hinfo, fromline, timestr, 3, 4, 5, portsstr);


### PR DESCRIPTION
Two review findings from #407, one commit each, either usable without the other.

**1. An empty disk or inode report now says which thing happened.** The AIX client emitted an empty `[df]` section whenever nothing survived collection, and `unix_disk_report()` has no reading for that: no column headers found, yellow, "sent incomprehensible disk report". The likeliest cause reads worst -- `df -Ik -T local` rejected below AIX 7.1. It now says `Disk collection failed: df exited N with no output`, the siblings' wording from `emit_df()`, plus the case only AIX can reach, since it filters df's output rather than its input: rows collected and every one excluded. `xymonclient.cfg(5)` already promised this for every client, so the manual needs no change. `[inode]` is untouched -- an empty one is green by design there, for the all-ZFS Solaris host.

Which of the two is reported turns on what df gave back, not on its status: a df that printed rows and still exited non-zero -- one unreadable mount is enough -- has not produced no output, whatever its status says.

`[inode]` gets the same treatment, for a worse reason: an empty inode section is green *by design* -- `unix_inode_report()` exempts it for the host where nothing keeps inode counts -- so a df that died there was reported as healthy, not merely unexplained. The server cannot tell the two apart from an empty section; only the client sees the exit status. `Inode report collection failed: df exited N with no output` is emitted for no output and a non-zero status and for nothing else, so rows carrying no inode accounting stay the legitimately empty report they are. AIX, HP-UX and Solaris are the three clients that can reach that false green; this is one of them.

`fsf_assert_loud()` carried the same claim inverted ("an empty section, which the server reads as no filesystems, all is well"): true of `[inode]`, not of `[df]`. Comment corrected; the rule is unchanged and AIX now satisfies it.

**2. The AIX test runs the shared contract.** It called `fsf_setup` and `fsf_extract` and then wrote everything else itself, so AIX sat outside the rules the other five obey and skipped `fsf_selfcheck`'s non-vacuity probe -- while `fs-filter-common.sh` claimed "a rule added here is a rule every OS gets". It now follows macOS: hand-written mount stub, shared df stub and fixture, `fsf_selfcheck; fsf_contract`. `fsf_write_mount_stub` and the five existing callers are untouched.

One assertion stays in the AIX file rather than moving into the contract: that `INCLUDE_TYPES` surfaces the type it names and no other default. macOS documents the opposite -- including the `nobrowse` attribute switches its whole default drop off -- so it cannot be a rule every client obeys.

Two rules AIX does not implement -- the inode report has no type filter, only its "no usable count" guard -- are skipped by `FSF_INODE_FILTERED=no`. Forced back to yes, the suite fails on exactly the rule it names.

The inode fixture is corrected while that file is rewritten: it answered with the disk report's shape, and the System V df is not shaped that way -- the mount point comes first, under a two-word `Mount Dir` heading, columns `iused avail itotal %iused` ([AIX Commands Reference, df](http://ps-2.kev009.com/wisclibrary/aix52/usr/share/man/info/en_US/a_doc_lib/cmds/aixcmds2/df.htm)). The client reshuffles that into `Filesystem itotal iused avail %iused Mounted on`, which is where `aix.c`'s `avail`, `%iused` and `Mounted` come from -- so the client was right and the fixture was testing it against a table AIX never emits. Field 5 is `itotal`, a bare integer, so `$5>0` is a numeric guard, and "no inode accounting" is an itotal of 0, as the reference shows for `/proc`.

| check | result |
|---|---|
| full suite at each commit | 40 passed / 51 skipped / 0 failed |
| all six `fs-filter-*.sh` | pass |
| 9 client guards removed one at a time | each fails the suite |
| `FSF_INODE_FILTERED` forced to yes | fails on the named rule only |
| `sh -n` under dash, bash, busybox sh | clean; shellcheck adds no new class |

Still open from the #407 review and not addressed here: `df -Ik -T local` and `/usr/sysv/bin/df -i -l` remain unconfirmed on a real AIX 7.1. No stub can prove them -- this one is written to honour the flags.

---

**Related:** #426 (the client scripts' shared filesystem code) and #427 (the plan for the next dedup). No file overlap with either — this one stands alone and can merge in any order.
