### PR TITLE
xymond: bind the address --listen names, not every interface

### DIFF
--- a/tests/lib/port-blocker.c
+++ b/tests/lib/port-blocker.c
@@ -10,28 +10,61 @@
  * tests/lib/xymond-daemon.sh cannot tell one Xymon-speaking listener from
  * another, so anything that accepts connections reads as "the daemon is up".
  * Refusing the connection is what makes a test of the bind retry deterministic.
+ *
+ * With a port argument it does the opposite job: try to bind that port the
+ * way xymond would, and report whether the port is actually reserved.
+ * Callers use it to check the blocker is blocking before relying on it.
+ *
+ *   port-blocker          hold an ephemeral port, print it, serve nothing
+ *   port-blocker PORT     exit 0 if PORT could be bound (so it is NOT
+ *                         reserved), 1 if the bind was refused
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-int main(void)
+static void addr_for(struct sockaddr_in *addr, int port)
+{
+	memset(addr, 0, sizeof(*addr));
+	addr->sin_family = AF_INET;
+	addr->sin_addr.s_addr = inet_addr("127.0.0.1");
+	addr->sin_port = htons(port);
+}
+
+/* Bind PORT as xymond does, SO_REUSEADDR and all. 0 when the bind succeeded,
+   which means nothing was holding the port. */
+static int port_is_free(int port)
+{
+	struct sockaddr_in addr;
+	int sock, one = 1, rc;
+
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) { perror("socket"); exit(2); }
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+	addr_for(&addr, port);
+	rc = bind(sock, (struct sockaddr *)&addr, sizeof(addr));
+	close(sock);
+
+	return (rc == 0);
+}
+
+int main(int argc, char **argv)
 {
 	int sock;
 	struct sockaddr_in addr;
 	socklen_t alen = sizeof(addr);
 
+	if (argc > 1) return port_is_free(atoi(argv[1])) ? 0 : 1;
+
 	sock = socket(AF_INET, SOCK_STREAM, 0);
 	if (sock < 0) { perror("socket"); return 1; }
 
-	memset(&addr, 0, sizeof(addr));
-	addr.sin_family = AF_INET;
-	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-	addr.sin_port = htons(0);
+	addr_for(&addr, 0);
 	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) { perror("bind"); return 1; }
 	if (getsockname(sock, (struct sockaddr *)&addr, &alen) < 0) { perror("getsockname"); return 1; }
 

--- a/tests/lib/xymond-daemon.sh
+++ b/tests/lib/xymond-daemon.sh
@@ -83,8 +83,15 @@ free_port() {
 # not arrive at its last startup with the retries already spent. Every other
 # failure fails at once, so a xymond that cannot bind anywhere still fails
 # instead of looping.
+# XYMOND_START_TIMEOUT bounds the whole call, retries included, in seconds.
+# A count of probe attempts does not: each one costs whatever the client costs,
+# and on NetBSD and OpenBSD that is about two seconds rather than nothing, so
+# the old budget of six attempts times a hundred probes came to twenty minutes
+# of silence before anything was reported. Wall-clock is what the reader cares
+# about, and checking it needs no timeout(1), which the BSDs do not all ship.
 start_xymond() {
-	local attempt=0 i
+	local attempt=0 deadline now
+	deadline=$(( $(date +%s) + ${XYMOND_START_TIMEOUT:-120} ))
 
 	while :; do
 		PORT=$(free_port) || fail "no free port for xymond"
@@ -94,22 +101,35 @@ start_xymond() {
 		# cannot tell this xymond from any other Xymon-speaking listener that
 		# holds the port, and a dead child with a stranger on its port would
 		# otherwise read as a successful startup.
-		i=0
-		while [ "$i" -lt 100 ]; do
-			"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 &&
+		#
+		# XYMON_TIMEOUT, because a probe that has to wait is the normal case
+		# here, not the exception. A port held by a socket that is bound but
+		# not listening is refused at once on Linux, and on the BSDs the SYN
+		# is dropped instead -- so the client sits out its compiled 15s
+		# default, per phase, and one collision costs 47 seconds. Three of
+		# those exhausted the budget before the retry could reach a free port.
+		while :; do
+			XYMON_TIMEOUT=${XYMOND_PING_TIMEOUT:-2} \
+				"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 &&
 				kill -0 "$XYMOND_PID" 2>/dev/null && return 0
 			kill -0 "$XYMOND_PID" 2>/dev/null || break
+			now=$(date +%s)
+			[ "$now" -lt "$deadline" ] || break
 			sleep 0.1
-			i=$((i+1))
 		done
 
 		kill -0 "$XYMOND_PID" 2>/dev/null && break
+		now=$(date +%s)
+		[ "$now" -lt "$deadline" ] || break
 		grep -q 'Cannot bind to listen socket' "$work/xymond.log" 2>/dev/null || break
 		[ "$attempt" -lt 5 ] || break
 		attempt=$((attempt+1))
 	done
 
 	cat "$work/xymond.log" >&2
+	now=$(date +%s)
+	[ "$now" -lt "$deadline" ] ||
+		fail "xymond did not start within ${XYMOND_START_TIMEOUT:-120}s (last port 127.0.0.1:$PORT, $((attempt + 1)) launch(es); daemon still running, so it never answered a ping) -- see the xymond log above"
 	kill -0 "$XYMOND_PID" 2>/dev/null &&
 		fail "xymond did not answer on 127.0.0.1:$PORT" ||
 		fail "xymond exited during startup"

--- a/tests/server/xymond-listen-address.sh
+++ b/tests/server/xymond-listen-address.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-listen-address.sh
+#
+# --listen binds the address it names, and refuses one it cannot parse.
+#
+# Both faults were invisible to this suite: every other daemon test passes
+# --listen=127.0.0.1:PORT and then talks to 127.0.0.1, which a wildcard bind
+# answers just as well. Only xymond-port-retry.sh noticed, and only on the
+# BSDs, which upstream CI does not run -- so the fix had no test that would
+# fail on a revert.
+#
+# An unparseable address must stop the daemon rather than quietly become the
+# wildcard (needs nothing from the host, so it runs everywhere); a parseable
+# one must be the only address bound (needs a non-loopback address here, and
+# skips where there is none).
+#
+# Needs a built tree: xymond and the xymon client.
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-daemon.sh
+. "$(dirname "$0")/../lib/xymond-daemon.sh"
+
+require_bin XYMOND xymond/xymond
+require_bin XYMONCLIENT common/xymon
+require_shm_segments "$(grep -c 'setup_channel(C_[A-Z_]*, CHAN_MASTER)' "$(find_root)/xymond/xymond.c")"
+
+work=$(mktempdir)
+mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.cfg"
+
+require_cfg XYMONSERVER_CFG xymond/etcfiles/xymonserver.cfg
+sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
+    -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
+	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
+
+# A non-loopback address of this host. It is the only way to ask whether the
+# daemon bound more than it was told: a second loopback address cannot answer
+# that, and 0.0.0.0 is what the bug produced. A host with none skips that half.
+#
+# "|| true" on both: ip(8) is Linux-only and a minimal container may have
+# neither tool, and under "set -e -o pipefail" a command that is not found
+# takes the script down with rc=127 before it can print anything.
+EXTIP=$(ip -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -1 || true)
+[ -n "$EXTIP" ] || EXTIP=$(ifconfig -a 2>/dev/null | awk '/[ \t]inet /{print $2}' | sed 's/^addr://' | grep -v '^127\.' | head -1 || true)
+
+# answers ADDR PORT : does a xymond answer a ping there?
+answers() {
+	case "$(XYMON_TIMEOUT=2 "$XYMONCLIENT" "$1:$2" "ping" 2>&1)" in
+		*xymond*) return 0 ;;
+	esac
+	return 1
+}
+
+# launch ARGS... : start a daemon and wait for it to say it is up, or to die
+# trying. Returns non-zero if it never came up.
+launch() {
+	"$XYMOND" --no-daemon "$@" \
+		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
+		--pidfile="$work/xymond.pid" --checkpoint-file="$work/chk.out" \
+		> "$work/xymond.log" 2>&1 &
+	LPID=$!
+	local i=0
+	while [ "$i" -lt 100 ]; do
+		grep -q 'Setup complete' "$work/xymond.log" 2>/dev/null && return 0
+		kill -0 "$LPID" 2>/dev/null || return 1
+		sleep 0.1
+		i=$((i+1))
+	done
+	return 1
+}
+stop() { kill "$LPID" 2>/dev/null || true; wait "$LPID" 2>/dev/null || true; }
+
+P=$(free_port)
+
+# --- an unparseable address stops the daemon ----------------------------------
+
+# 999.999.999.999 rather than a hostname-shaped string: it is invalid to any
+# parser, so this stays a test of "refuse what you cannot parse" even if
+# --listen ever learns to resolve names.
+if launch --listen="999.999.999.999:$P"; then
+	stop
+	fail "xymond started with an unparseable --listen address -- it is binding the wildcard instead of refusing, the way it did before the address was checked"
+fi
+stop
+answers 127.0.0.1 "$P" && fail "something is answering on 127.0.0.1:$P after a rejected --listen"
+assert_contains "Cannot parse listen address" "$(cat "$work/xymond.log")" \
+	"a rejected address must say so"
+
+# --- a parseable address is the only one bound --------------------------------
+
+launch --listen="127.0.0.1:$P" || { cat "$work/xymond.log" >&2; fail "xymond did not start on 127.0.0.1:$P"; }
+answers 127.0.0.1 "$P" || fail "xymond does not answer on the address it was given (127.0.0.1:$P)"
+if [ -n "$EXTIP" ]; then
+	answers "$EXTIP" "$P" && fail "xymond answers on $EXTIP:$P but was told to listen on 127.0.0.1 only -- it is binding every interface"
+fi
+stop
+
+pass "xymond binds the address --listen names, and refuses one it cannot parse"

--- a/tests/server/xymond-port-retry.sh
+++ b/tests/server/xymond-port-retry.sh
@@ -19,9 +19,19 @@
 # six in total, past a budget of five, so a shared counter fails the second.
 #
 # free_port() is replaced with a scripted sequence, and the port it hands out
-# first is held by a socket that refuses connections (tests/lib/port-blocker.c):
-# a listener would read as a successful startup, since the readiness probe
-# cannot tell one Xymon-speaking listener from another.
+# first is held by tests/lib/port-blocker.c: a socket bound but never listened
+# on, so the port is reserved -- an exact same-address:port bind is refused even
+# with SO_REUSEADDR -- while a connect() to it is refused outright, so the
+# readiness probe, which cannot tell one Xymon-speaking listener from another,
+# cannot mistake it for a started daemon.
+#
+# That the port is reserved is checked rather than assumed. It is the premise
+# the whole test rests on, and it is platform-dependent: a bind without listen
+# reserves the port on Linux but not on the BSDs, where SO_REUSEADDR lets a
+# second bind through while nothing is listening. Without the check, a blocker
+# that fails to block does not say so -- xymond takes the port it was supposed
+# to collide with, starts, and the failure arrives ten seconds later as
+# "xymond did not answer", pointing at the daemon instead of at the fixture.
 #
 # Needs a built tree: xymond itself and the xymon client.
 
@@ -72,6 +82,12 @@ while [ "$i" -lt 50 ]; do
 done
 [ -s "$work/blocked.port" ] || fail "port-blocker never named its port"
 BLOCKER_PORT=$(cat "$work/blocked.port")
+
+# The premise: nothing else may bind that port. Asked the way xymond asks,
+# SO_REUSEADDR and all.
+if "$work/port-blocker" "$BLOCKER_PORT"; then
+	fail "port $BLOCKER_PORT is still bindable while port-blocker holds it, so the collision this test drives would never happen"
+fi
 
 # --- free_port hands out the blocked port three times, then a real one --------
 

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -5877,9 +5877,11 @@ int main(int argc, char *argv[])
 			listenip = strdup(p);
 			p = strchr(listenip, ':');
 			if (p) {
+				/* Split for good: putting the colon back left the port
+				   in listenip, so inet_aton() failed and the zeroed
+				   sin_addr bound every interface. */
 				*p = '\0';
 				listenport = atoi(p+1);
-				*p = ':';
 			}
 		}
 		else if (argnmatch(argv[argi], "--timeout=")) {
@@ -6111,7 +6113,12 @@ int main(int argc, char *argv[])
 	/* Set up a socket to listen for new connections */
 	errprintf("Setting up network listener on %s:%d\n", listenip, listenport);
 	memset(&laddr, 0, sizeof(laddr));
-	inet_aton(listenip, (struct in_addr *) &laddr.sin_addr.s_addr);
+	if (inet_aton(listenip, (struct in_addr *) &laddr.sin_addr.s_addr) == 0) {
+		/* Checked: an unnoticed failure left sin_addr zero, and the daemon
+		   listened on everything. */
+		errprintf("Cannot parse listen address '%s'\n", listenip);
+		return 1;
+	}
 	laddr.sin_port = htons(listenport);
 	laddr.sin_family = AF_INET;
 	lsocket = socket(AF_INET, SOCK_STREAM, 0);


### PR DESCRIPTION
`xymond --listen=IP:PORT` has bound **every interface** since 2014, whatever address was named.

The argument was split to read the port and the colon put back, so `inet_aton()` was handed `"IP:PORT"`, failed, and the `memset`-zeroed `sin_addr` meant `INADDR_ANY`. Its return was unchecked. From `bb92be0c4` (2014, *"Dont trash port number input parameter"*) — but `listenip` is a `strdup()` copy, so the restore protected nothing and broke the parse. The doubled port in every startup log was the same fault showing itself.

Now the named address is what gets bound, and one that cannot be parsed is refused instead of quietly becoming "everything". `--listen=IP`, with no port, is unaffected. **Reachability changes on upgrade.**

It surfaced as every BSD lane failing `xymond-port-retry.sh`, which needs a collision that never happened while xymond held the wildcard: Linux refuses a wildcard bind overlapping a specific one, the BSDs permit it. Fixing that exposed a second fault in the same test — a bound-but-not-listening socket is refused at once on Linux but drops the SYN on BSD, so the readiness probe sat out its compiled 15s default per phase, 47s a collision. The probe now bounds `XYMON_TIMEOUT`, the startup budget is wall-clock rather than a count of attempts, and `port-blocker` can be asked whether it is really holding its port.

`tests/server/xymond-listen-address.sh` is the regression test the fix lacked: every other daemon test passes `--listen=127.0.0.1:PORT` then talks to `127.0.0.1`, which a wildcard answers too, so a revert stayed green on Linux. It asks both halves — an unparseable address must stop the daemon, a parseable one must be the only address bound — each checked against a mutation of its own half.

| check | result |
|---|---|
| local suite | 71 passed / 21 skipped / 0 failed |
| revert the fix | `xymond-listen-address.sh` fails |
| `--listen=127.0.0.1:P` | binds `127.0.0.1:P` (was `0.0.0.0`) |
| `--listen=999.999.999.999:P` | refused (was: bind everything) |
| `--listen=IP`, no port | unchanged |
| `--listen=localhost:P` | daemon stops: `Cannot parse listen address 'localhost'` (was: bound every interface and answered) |
| `--listen=<IP not assigned here>:P` | daemon stops: `Cannot bind to listen socket (Cannot assign requested address)` (was: bound every interface and answered) |
| BSD lanes | **11/11 pass** |

BSD runs: [FreeBSD](https://github.com/bonomani/xymon/actions/runs/32693953369) · [NetBSD](https://github.com/bonomani/xymon/actions/runs/32693955866) · [OpenBSD](https://github.com/bonomani/xymon/actions/runs/32693958604). NetBSD 9.3 needed a re-run: its VM did not boot the first time (30 min in `Waiting for VM to be ready`, no build, no tests). On the retry it reports 89 passed / 2 skipped / 0 failed with `xymond-listen-address.sh` green.

**Related:** #429, #425, #426.

### Upgrade note — for the `Changes` branch

Not in this PR: `RELEASENOTES` is prepared on the `Changes` branch once merged. Proposed prose:

> xymond --listen=IP:PORT now listens on the address it was given. It has bound every interface
> since 2014 whatever address was named, because the port was left attached to the address string
> and the parse of it failed unnoticed. A host that named one address -- 127.0.0.1, or one
> interface of several -- has been reachable on all of them; after upgrading it will not be, so
> check that nothing was relying on the wider reach. An address that cannot be parsed is now
> refused at startup instead of quietly becoming "everything". The --listen=IP form, with no
> port, is unaffected.
>
> Two configurations that used to start will now stop, both because the address is finally
> being honoured. A hostname in --listen has never bound that host's address -- inet_aton
> does not resolve names, so the parse failed and every interface was bound -- and is now
> refused; --listen takes a dotted-quad IP, as xymond(8) has always said. An IP that is not
> assigned yet when xymond starts is refused too, where the wildcard fallback used to hide
> it: on a host that starts xymond before its address exists, order the start after the
> interface comes up.

---

### #428 → #432 → #435

| PR | change | base |
|---|---|---|
| **#428** | `--listen` binds the address it names | `upstream/main` |
| **#432** | `--listen` takes a list; a loopback listener is kept | contains #428 |
| **#435** | the server's client sends to `127.0.0.1`; `MACHINEADDR` keeps the real address | config only |

#428 takes away the loopback that the accidental wildcard bind gave anyone naming one address; #432 gives it back deliberately; #435 then uses it.

Each merges cleanly into `upstream/main`, alone or after either other, in any order. #432 *contains* #428, so merging it merges both. **#435 must not land before #432**: it points the local client at `127.0.0.1`, which is only guaranteed once #432 is in — with #428 alone, a server started with an explicit non-loopback `--listen` would stop reporting on itself.

None of the three touches `RELEASENOTES`; per `.github/RELEASING.md` those entries are written on the `Changes` branch once they land. Each body carries its proposed prose.

Gap left as a follow-up: #435's test asserts config content, not end-to-end delivery over loopback.

