### PR TITLE
xymond: listen on several addresses, and keep a loopback among them

### DIFF
--- a/docs/manpages/man8/xymond.8.html
+++ b/docs/manpages/man8/xymond.8.html
@@ -97,10 +97,28 @@ Section: Maintenance Commands (8)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a
       entries together into one and return all of it to the client.
     <p class="Pp"></p>
   </dd>
-  <dt id="listen"><a class="permalink" href="#listen"><b>--listen</b>=<i>IP</i>[:<i>PORT</i>]</a></dt>
+  <dt id="listen"><a class="permalink" href="#listen"><b>--listen</b>=<i>IP</i>[:<i>PORT</i>][,<i>IP</i>[:<i>PORT</i>]...]</a></dt>
   <dd>Specifies the IP-address and port where xymond will listen for incoming
       connections. By default, xymond listens on IP 0.0.0.0 (i.e. all IP-
       addresses available on the host) and port 1984.
+    <br/>
+    More than one address may be given, separated by commas, and each is bound
+      separately &#x2014; so a server can answer on a chosen interface and on
+      the loopback at the same time. An entry with no port uses the default
+      port.
+    <br/>
+    Unless <b>--no-loopback</b> is given, xymond also listens on 127.0.0.1, on
+      the port of the first address, whenever the addresses named do not already
+      cover the loopback. This is so the client running on the Xymon server
+      itself keeps reporting when a physical interface goes away. It is best
+      effort: if that extra socket cannot be bound, xymond says so and carries
+      on with the addresses it was asked for.
+    <p class="Pp"></p>
+  </dd>
+  <dt id="no-loopback"><a class="permalink" href="#no-loopback"><b>--no-loopback</b></a></dt>
+  <dd>Do not add the automatic 127.0.0.1 listener described under
+      <b>--listen</b>. Use this when xymond must answer on the addresses named
+      and nowhere else.
     <p class="Pp"></p>
   </dd>
   <dt id="lqueue"><a class="permalink" href="#lqueue"><b>--lqueue</b>=<i>NUMBER</i></a></dt>

--- a/tests/lib/port-blocker.c
+++ b/tests/lib/port-blocker.c
@@ -10,28 +10,61 @@
  * tests/lib/xymond-daemon.sh cannot tell one Xymon-speaking listener from
  * another, so anything that accepts connections reads as "the daemon is up".
  * Refusing the connection is what makes a test of the bind retry deterministic.
+ *
+ * With a port argument it does the opposite job: try to bind that port the
+ * way xymond would, and report whether the port is actually reserved.
+ * Callers use it to check the blocker is blocking before relying on it.
+ *
+ *   port-blocker          hold an ephemeral port, print it, serve nothing
+ *   port-blocker PORT     exit 0 if PORT could be bound (so it is NOT
+ *                         reserved), 1 if the bind was refused
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-int main(void)
+static void addr_for(struct sockaddr_in *addr, int port)
+{
+	memset(addr, 0, sizeof(*addr));
+	addr->sin_family = AF_INET;
+	addr->sin_addr.s_addr = inet_addr("127.0.0.1");
+	addr->sin_port = htons(port);
+}
+
+/* Bind PORT as xymond does, SO_REUSEADDR and all. 0 when the bind succeeded,
+   which means nothing was holding the port. */
+static int port_is_free(int port)
+{
+	struct sockaddr_in addr;
+	int sock, one = 1, rc;
+
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) { perror("socket"); exit(2); }
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+	addr_for(&addr, port);
+	rc = bind(sock, (struct sockaddr *)&addr, sizeof(addr));
+	close(sock);
+
+	return (rc == 0);
+}
+
+int main(int argc, char **argv)
 {
 	int sock;
 	struct sockaddr_in addr;
 	socklen_t alen = sizeof(addr);
 
+	if (argc > 1) return port_is_free(atoi(argv[1])) ? 0 : 1;
+
 	sock = socket(AF_INET, SOCK_STREAM, 0);
 	if (sock < 0) { perror("socket"); return 1; }
 
-	memset(&addr, 0, sizeof(addr));
-	addr.sin_family = AF_INET;
-	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-	addr.sin_port = htons(0);
+	addr_for(&addr, 0);
 	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) { perror("bind"); return 1; }
 	if (getsockname(sock, (struct sockaddr *)&addr, &alen) < 0) { perror("getsockname"); return 1; }
 

--- a/tests/lib/xymond-daemon.sh
+++ b/tests/lib/xymond-daemon.sh
@@ -83,8 +83,15 @@ free_port() {
 # not arrive at its last startup with the retries already spent. Every other
 # failure fails at once, so a xymond that cannot bind anywhere still fails
 # instead of looping.
+# XYMOND_START_TIMEOUT bounds the whole call, retries included, in seconds.
+# A count of probe attempts does not: each one costs whatever the client costs,
+# and on NetBSD and OpenBSD that is about two seconds rather than nothing, so
+# the old budget of six attempts times a hundred probes came to twenty minutes
+# of silence before anything was reported. Wall-clock is what the reader cares
+# about, and checking it needs no timeout(1), which the BSDs do not all ship.
 start_xymond() {
-	local attempt=0 i
+	local attempt=0 deadline now
+	deadline=$(( $(date +%s) + ${XYMOND_START_TIMEOUT:-120} ))
 
 	while :; do
 		PORT=$(free_port) || fail "no free port for xymond"
@@ -94,22 +101,35 @@ start_xymond() {
 		# cannot tell this xymond from any other Xymon-speaking listener that
 		# holds the port, and a dead child with a stranger on its port would
 		# otherwise read as a successful startup.
-		i=0
-		while [ "$i" -lt 100 ]; do
-			"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 &&
+		#
+		# XYMON_TIMEOUT, because a probe that has to wait is the normal case
+		# here, not the exception. A port held by a socket that is bound but
+		# not listening is refused at once on Linux, and on the BSDs the SYN
+		# is dropped instead -- so the client sits out its compiled 15s
+		# default, per phase, and one collision costs 47 seconds. Three of
+		# those exhausted the budget before the retry could reach a free port.
+		while :; do
+			XYMON_TIMEOUT=${XYMOND_PING_TIMEOUT:-2} \
+				"$XYMONCLIENT" "127.0.0.1:$PORT" "ping" >/dev/null 2>&1 &&
 				kill -0 "$XYMOND_PID" 2>/dev/null && return 0
 			kill -0 "$XYMOND_PID" 2>/dev/null || break
+			now=$(date +%s)
+			[ "$now" -lt "$deadline" ] || break
 			sleep 0.1
-			i=$((i+1))
 		done
 
 		kill -0 "$XYMOND_PID" 2>/dev/null && break
+		now=$(date +%s)
+		[ "$now" -lt "$deadline" ] || break
 		grep -q 'Cannot bind to listen socket' "$work/xymond.log" 2>/dev/null || break
 		[ "$attempt" -lt 5 ] || break
 		attempt=$((attempt+1))
 	done
 
 	cat "$work/xymond.log" >&2
+	now=$(date +%s)
+	[ "$now" -lt "$deadline" ] ||
+		fail "xymond did not start within ${XYMOND_START_TIMEOUT:-120}s (last port 127.0.0.1:$PORT, $((attempt + 1)) launch(es); daemon still running, so it never answered a ping) -- see the xymond log above"
 	kill -0 "$XYMOND_PID" 2>/dev/null &&
 		fail "xymond did not answer on 127.0.0.1:$PORT" ||
 		fail "xymond exited during startup"

--- a/tests/server/xymond-listen-address.sh
+++ b/tests/server/xymond-listen-address.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-listen-address.sh
+#
+# --listen binds the address it names, and refuses one it cannot parse.
+#
+# Both faults were invisible to this suite: every other daemon test passes
+# --listen=127.0.0.1:PORT and then talks to 127.0.0.1, which a wildcard bind
+# answers just as well. Only xymond-port-retry.sh noticed, and only on the
+# BSDs, which upstream CI does not run -- so the fix had no test that would
+# fail on a revert.
+#
+# An unparseable address must stop the daemon rather than quietly become the
+# wildcard (needs nothing from the host, so it runs everywhere); a parseable
+# one must be the only address bound (needs a non-loopback address here, and
+# skips where there is none).
+#
+# Needs a built tree: xymond and the xymon client.
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-daemon.sh
+. "$(dirname "$0")/../lib/xymond-daemon.sh"
+
+require_bin XYMOND xymond/xymond
+require_bin XYMONCLIENT common/xymon
+require_shm_segments "$(grep -c 'setup_channel(C_[A-Z_]*, CHAN_MASTER)' "$(find_root)/xymond/xymond.c")"
+
+work=$(mktempdir)
+mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.cfg"
+
+require_cfg XYMONSERVER_CFG xymond/etcfiles/xymonserver.cfg
+sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
+    -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
+	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
+
+# A non-loopback address of this host. It is the only way to ask whether the
+# daemon bound more than it was told: a second loopback address cannot answer
+# that, and 0.0.0.0 is what the bug produced. A host with none skips that half.
+#
+# "|| true" on both: ip(8) is Linux-only and a minimal container may have
+# neither tool, and under "set -e -o pipefail" a command that is not found
+# takes the script down with rc=127 before it can print anything.
+EXTIP=$(ip -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -1 || true)
+[ -n "$EXTIP" ] || EXTIP=$(ifconfig -a 2>/dev/null | awk '/[ \t]inet /{print $2}' | sed 's/^addr://' | grep -v '^127\.' | head -1 || true)
+
+# answers ADDR PORT : does a xymond answer a ping there?
+answers() {
+	case "$(XYMON_TIMEOUT=2 "$XYMONCLIENT" "$1:$2" "ping" 2>&1)" in
+		*xymond*) return 0 ;;
+	esac
+	return 1
+}
+
+# launch ARGS... : start a daemon and wait for it to say it is up, or to die
+# trying. Returns non-zero if it never came up.
+launch() {
+	"$XYMOND" --no-daemon "$@" \
+		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
+		--pidfile="$work/xymond.pid" --checkpoint-file="$work/chk.out" \
+		> "$work/xymond.log" 2>&1 &
+	LPID=$!
+	local i=0
+	while [ "$i" -lt 100 ]; do
+		grep -q 'Setup complete' "$work/xymond.log" 2>/dev/null && return 0
+		kill -0 "$LPID" 2>/dev/null || return 1
+		sleep 0.1
+		i=$((i+1))
+	done
+	return 1
+}
+stop() { kill "$LPID" 2>/dev/null || true; wait "$LPID" 2>/dev/null || true; }
+
+P=$(free_port)
+
+# --- an unparseable address stops the daemon ----------------------------------
+
+# 999.999.999.999 rather than a hostname-shaped string: it is invalid to any
+# parser, so this stays a test of "refuse what you cannot parse" even if
+# --listen ever learns to resolve names.
+if launch --listen="999.999.999.999:$P"; then
+	stop
+	fail "xymond started with an unparseable --listen address -- it is binding the wildcard instead of refusing, the way it did before the address was checked"
+fi
+stop
+answers 127.0.0.1 "$P" && fail "something is answering on 127.0.0.1:$P after a rejected --listen"
+assert_contains "Cannot parse listen address" "$(cat "$work/xymond.log")" \
+	"a rejected address must say so"
+
+# --- a parseable address is the only one bound --------------------------------
+
+launch --listen="127.0.0.1:$P" || { cat "$work/xymond.log" >&2; fail "xymond did not start on 127.0.0.1:$P"; }
+answers 127.0.0.1 "$P" || fail "xymond does not answer on the address it was given (127.0.0.1:$P)"
+if [ -n "$EXTIP" ]; then
+	answers "$EXTIP" "$P" && fail "xymond answers on $EXTIP:$P but was told to listen on 127.0.0.1 only -- it is binding every interface"
+fi
+stop
+
+pass "xymond binds the address --listen names, and refuses one it cannot parse"

--- a/tests/server/xymond-loopback-fallback.sh
+++ b/tests/server/xymond-loopback-fallback.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-loopback-fallback.sh
+#
+# A listen address that cannot be bound is fatal when the operator named it,
+# and is not when xymond added it itself.
+#
+# The loopback listener is an extra the daemon adds, so refusing to start over
+# it would be the worse failure; an address that was asked for is the opposite.
+# One `return` inverts either direction, so both are pinned. The named half
+# runs everywhere; the loopback half needs a non-loopback address to name
+# instead, and skips where there is none.
+#
+# The port is held by port-blocker.c, which binds without listening. That
+# reserves it on the BSDs too: SO_REUSEADDR lets a wildcard and a specific bind
+# overlap, but not two binds of the same address and port.
+#
+# Needs a built tree: xymond, the xymon client, and a C compiler.
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-daemon.sh
+. "$(dirname "$0")/../lib/xymond-daemon.sh"
+
+require_bin XYMOND xymond/xymond
+require_bin XYMONCLIENT common/xymon
+require_shm_segments "$(grep -c 'setup_channel(C_[A-Z_]*, CHAN_MASTER)' "$(find_root)/xymond/xymond.c")"
+require_c_buildenv "$(find_root)"
+
+work=$(mktempdir)
+mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.cfg"
+
+require_cfg XYMONSERVER_CFG xymond/etcfiles/xymonserver.cfg
+sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
+    -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
+	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
+
+# "|| true" on both: ip(8) is Linux-only and a minimal container may have
+# neither tool, and under "set -e -o pipefail" a command that is not found
+# takes the script down with rc=127 before it can print anything.
+EXTIP=$(ip -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -1 || true)
+[ -n "$EXTIP" ] || EXTIP=$(ifconfig -a 2>/dev/null | awk '/[ \t]inet /{print $2}' | sed 's/^addr://' | grep -v '^127\.' | head -1 || true)
+
+answers() {
+	case "$(XYMON_TIMEOUT=2 "$XYMONCLIENT" "$1:$2" "ping" 2>&1)" in
+		*xymond*) return 0 ;;
+	esac
+	return 1
+}
+
+launch() {
+	"$XYMOND" --no-daemon "$@" \
+		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
+		--pidfile="$work/xymond.pid" --checkpoint-file="$work/chk.out" \
+		> "$work/xymond.log" 2>&1 &
+	LPID=$!
+	local i=0
+	while [ "$i" -lt 100 ]; do
+		grep -q 'Setup complete' "$work/xymond.log" 2>/dev/null && return 0
+		kill -0 "$LPID" 2>/dev/null || return 1
+		sleep 0.1
+		i=$((i+1))
+	done
+	return 1
+}
+stop() { kill "$LPID" 2>/dev/null || true; wait "$LPID" 2>/dev/null || true; }
+
+# --- hold a loopback port ------------------------------------------------------
+
+"$CC" -o "$work/port-blocker" "$(find_root)/tests/lib/port-blocker.c" 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "port-blocker does not compile"; }
+"$work/port-blocker" > "$work/blocked.port" &
+BLOCKER_PID=$!
+register_cleanup "kill $BLOCKER_PID 2>/dev/null || true"
+
+i=0
+while [ "$i" -lt 50 ]; do
+	[ -s "$work/blocked.port" ] && break
+	kill -0 "$BLOCKER_PID" 2>/dev/null || fail "port-blocker exited before naming its port"
+	sleep 0.1
+	i=$((i+1))
+done
+[ -s "$work/blocked.port" ] || fail "port-blocker never named its port"
+BP=$(cat "$work/blocked.port")
+
+# The premise, asked the way xymond asks: nothing else may bind that port.
+if "$work/port-blocker" "$BP"; then
+	fail "127.0.0.1:$BP is still bindable while port-blocker holds it, so neither collision below would happen"
+fi
+
+# --- a named address that cannot bind is fatal --------------------------------
+
+if launch --listen="127.0.0.1:$BP"; then
+	stop
+	fail "xymond started although the address it was told to listen on (127.0.0.1:$BP) could not be bound -- an address the operator named must not be silently dropped"
+fi
+stop
+assert_contains "Cannot bind to listen socket" "$(cat "$work/xymond.log")" \
+	"the daemon must fail on the bind, not for some other reason"
+# It must stop AT the named address, not carry on to the loopback extra. Made
+# fatal-by-accident this reads the same: with the return dropped, the daemon
+# falls through, tries the loopback on the compiled default port, and exits
+# only because that port happened to be busy too -- so "it did not start" alone
+# does not distinguish the two. Where the default port is free it would start,
+# on an address nobody asked for, and the check above catches that instead.
+assert_not_contains "Continuing without a loopback listener" "$(cat "$work/xymond.log")" \
+	"a named address that cannot bind must stop the daemon there, not fall through to the loopback it adds itself"
+
+# --- the loopback extra that cannot bind is not -------------------------------
+
+if [ -n "$EXTIP" ]; then
+	# Same blocked port, but named on a different address: the operator's
+	# address binds, and the loopback xymond adds for itself collides.
+	launch --listen="$EXTIP:$BP" \
+		|| { cat "$work/xymond.log" >&2; fail "xymond refused to start because the loopback listener it adds itself could not bind -- that extra is best-effort, and a busy 127.0.0.1:$BP must not stop a server whose own address is free"; }
+	answers "$EXTIP" "$BP" || fail "the named address must answer ($EXTIP:$BP)"
+	assert_contains "Continuing without a loopback listener" "$(cat "$work/xymond.log")" \
+		"dropping the loopback listener must be logged, not silent"
+	stop
+fi
+
+pass "a named listen address that cannot bind is fatal; the loopback xymond adds itself is not"

--- a/tests/server/xymond-multi-listen.sh
+++ b/tests/server/xymond-multi-listen.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-multi-listen.sh
+#
+# xymond listens on every address it is given, and keeps a loopback listener
+# unless told not to.
+#
+# One address is not enough for a server: the operator wants a chosen interface
+# AND the loopback, so the client on the server keeps reporting when the
+# interface goes away. Before --listen was fixed that came free, because every
+# --listen bound the wildcard; now the set has to be expressible.
+#
+# Asked of a running daemon, address by address: a list binds every entry, a
+# single address is unchanged, a non-loopback address still leaves 127.0.0.1
+# answering, 0.0.0.0 already covers loopback, and --no-loopback leaves none.
+#
+# Needs a built tree: xymond and the xymon client.
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-daemon.sh
+. "$(dirname "$0")/../lib/xymond-daemon.sh"
+
+require_bin XYMOND xymond/xymond
+require_bin XYMONCLIENT common/xymon
+require_shm_segments "$(grep -c 'setup_channel(C_[A-Z_]*, CHAN_MASTER)' "$(find_root)/xymond/xymond.c")"
+
+work=$(mktempdir)
+mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.cfg"
+
+require_cfg XYMONSERVER_CFG xymond/etcfiles/xymonserver.cfg
+sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
+    -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
+	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
+
+# A second loopback address. Linux gives the whole 127.0.0.0/8 to lo, so
+# 127.0.0.2 is bindable there; the BSDs configure only 127.0.0.1, and a bind
+# elsewhere in the range fails with "Can't assign requested address". Whether
+# it exists is therefore asked, not assumed -- with the daemon itself, which is
+# the only prober that agrees with the daemon by construction.
+LO2=127.0.0.2
+
+# ... and one address that is NOT loopback, which is the only way to ask
+# whether the daemon adds a loopback listener on its own. 127.0.0.2 cannot
+# stand in for it: it is a loopback address, so a daemon told to use it has
+# already satisfied the rule. A machine with no global address cannot answer
+# the question at all.
+# "|| true" on both: neither tool exists everywhere -- ip(8) is Linux, and a
+# minimal container may have neither -- and under "set -e -o pipefail" a
+# command that is not found takes the whole script down with rc=127 before it
+# can print anything, which is exactly what it did on the BSDs.
+EXTIP=$(ip -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -1 || true)
+[ -n "$EXTIP" ] || EXTIP=$(ifconfig -a 2>/dev/null | awk '/[ \t]inet /{print $2}' | sed 's/^addr://' | grep -v '^127\.' | head -1 || true)
+
+# answers ADDR PORT : does a xymond answer a ping there?
+answers() {
+	case "$(XYMON_TIMEOUT=2 "$XYMONCLIENT" "$1:$2" "ping" 2>&1)" in
+		*xymond*) return 0 ;;
+	esac
+	return 1
+}
+
+launch() {
+	"$XYMOND" --no-daemon "$@" \
+		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
+		--pidfile="$work/xymond.pid" --checkpoint-file="$work/chk.out" \
+		> "$work/xymond.log" 2>&1 &
+	MLPID=$!
+	# Wait for it to say it is up, or to die trying.
+	i=0
+	while [ "$i" -lt 100 ]; do
+		grep -q 'Setup complete' "$work/xymond.log" 2>/dev/null && return 0
+		kill -0 "$MLPID" 2>/dev/null || return 1
+		sleep 0.1
+		i=$((i+1))
+	done
+	return 1
+}
+stop() { kill "$MLPID" 2>/dev/null || true; wait "$MLPID" 2>/dev/null || true; }
+
+P1=$(free_port); P2=$(free_port)
+
+# Is LO2 usable on this host at all?
+HAVE_LO2=no
+if launch --no-loopback --listen="$LO2:$P1"; then HAVE_LO2=yes; fi
+stop
+
+# --- a list binds every entry -------------------------------------------------
+
+# Two ports on one address, so this holds wherever the suite runs: what is
+# being asked is whether every entry of the list gets a socket, and a second
+# port answers that as well as a second address would.
+launch --listen="127.0.0.1:$P1,127.0.0.1:$P2" || { cat "$work/xymond.log" >&2; fail "xymond did not start with two listen entries"; }
+answers 127.0.0.1 "$P1" || fail "the first entry in the list does not answer (127.0.0.1:$P1)"
+answers 127.0.0.1 "$P2" || fail "the second entry in the list does not answer (127.0.0.1:$P2)"
+stop
+
+if [ "$HAVE_LO2" = yes ]; then
+	launch --listen="127.0.0.1:$P1,$LO2:$P2" || { cat "$work/xymond.log" >&2; fail "xymond did not start with two listen addresses"; }
+	answers 127.0.0.1 "$P1" || fail "the first address in the list does not answer (127.0.0.1:$P1)"
+	answers "$LO2" "$P2" || fail "the second address in the list does not answer ($LO2:$P2)"
+	stop
+fi
+
+# --- one address is unchanged -------------------------------------------------
+
+launch --listen="127.0.0.1:$P1" || { cat "$work/xymond.log" >&2; fail "xymond did not start with one listen address"; }
+answers 127.0.0.1 "$P1" || fail "a single address must behave as it always did"
+answers 127.0.0.1 "$P2" && fail "a single entry must not answer on another port"
+stop
+
+# --- naming a non-loopback address still leaves loopback answering ------------
+
+if [ -n "$EXTIP" ]; then
+	launch --listen="$EXTIP:$P1" || { cat "$work/xymond.log" >&2; fail "xymond did not start on $EXTIP"; }
+	answers "$EXTIP" "$P1" || fail "the named address must answer ($EXTIP:$P1)"
+	answers 127.0.0.1 "$P1" || fail "a loopback listener must be kept even when only a non-loopback address is named"
+	stop
+fi
+
+# A loopback address named outright is loopback already, so no second socket
+# is added -- and none is needed.
+if [ "$HAVE_LO2" = yes ]; then
+	launch --listen="$LO2:$P1" || { cat "$work/xymond.log" >&2; fail "xymond did not start on $LO2"; }
+	answers "$LO2" "$P1" || fail "a named loopback address must answer"
+	assert_not_contains "Address already in use" "$(cat "$work/xymond.log")" \
+		"a named loopback address already satisfies the rule; no second socket may be attempted"
+	stop
+fi
+
+# --- 0.0.0.0 already covers loopback, and must not be double-bound ------------
+
+launch --listen="0.0.0.0:$P1" || { cat "$work/xymond.log" >&2; fail "xymond did not start on the wildcard"; }
+answers 127.0.0.1 "$P1" || fail "the wildcard must answer on loopback"
+[ "$HAVE_LO2" = no ] || answers "$LO2" "$P1" || fail "the wildcard must answer on every loopback address"
+assert_not_contains "Address already in use" "$(cat "$work/xymond.log")" \
+	"the wildcard already covers loopback, so no second loopback socket may be attempted"
+stop
+
+# --- --no-loopback is how you say you really mean one address -----------------
+
+if [ -n "$EXTIP" ]; then
+	launch --no-loopback --listen="$EXTIP:$P1" || { cat "$work/xymond.log" >&2; fail "xymond did not start with --no-loopback"; }
+	answers "$EXTIP" "$P1" || fail "the named address must still answer under --no-loopback"
+	answers 127.0.0.1 "$P1" && fail "--no-loopback must leave no loopback listener"
+	stop
+fi
+
+pass "xymond binds every address it is given and keeps a loopback listener"

--- a/tests/server/xymond-port-retry.sh
+++ b/tests/server/xymond-port-retry.sh
@@ -19,9 +19,19 @@
 # six in total, past a budget of five, so a shared counter fails the second.
 #
 # free_port() is replaced with a scripted sequence, and the port it hands out
-# first is held by a socket that refuses connections (tests/lib/port-blocker.c):
-# a listener would read as a successful startup, since the readiness probe
-# cannot tell one Xymon-speaking listener from another.
+# first is held by tests/lib/port-blocker.c: a socket bound but never listened
+# on, so the port is reserved -- an exact same-address:port bind is refused even
+# with SO_REUSEADDR -- while a connect() to it is refused outright, so the
+# readiness probe, which cannot tell one Xymon-speaking listener from another,
+# cannot mistake it for a started daemon.
+#
+# That the port is reserved is checked rather than assumed. It is the premise
+# the whole test rests on, and it is platform-dependent: a bind without listen
+# reserves the port on Linux but not on the BSDs, where SO_REUSEADDR lets a
+# second bind through while nothing is listening. Without the check, a blocker
+# that fails to block does not say so -- xymond takes the port it was supposed
+# to collide with, starts, and the failure arrives ten seconds later as
+# "xymond did not answer", pointing at the daemon instead of at the fixture.
 #
 # Needs a built tree: xymond itself and the xymon client.
 
@@ -72,6 +82,12 @@ while [ "$i" -lt 50 ]; do
 done
 [ -s "$work/blocked.port" ] || fail "port-blocker never named its port"
 BLOCKER_PORT=$(cat "$work/blocked.port")
+
+# The premise: nothing else may bind that port. Asked the way xymond asks,
+# SO_REUSEADDR and all.
+if "$work/port-blocker" "$BLOCKER_PORT"; then
+	fail "port $BLOCKER_PORT is still bindable while port-blocker holds it, so the collision this test drives would never happen"
+fi
 
 # --- free_port hands out the blocked port three times, then a real one --------
 

--- a/xymond/xymond.8
+++ b/xymond/xymond.8
@@ -70,10 +70,25 @@ client, looking for a hostname, classname or OS match (in that order).
 This option causes xymond to merge all matching entries together into
 one and return all of it to the client.
 
-.IP "\fB\-\-listen\fR=\fIIP\fR[:\fIPORT\fR]"
+.IP "\fB\-\-listen\fR=\fIIP\fR[:\fIPORT\fR][,\fIIP\fR[:\fIPORT\fR]...]"
 Specifies the IP-address and port where xymond will listen for incoming
 connections. By default, xymond listens on IP 0.0.0.0 (i.e. all IP-
 addresses available on the host) and port 1984.
+.br
+More than one address may be given, separated by commas, and each is bound
+separately \(em so a server can answer on a chosen interface and on the
+loopback at the same time. An entry with no port uses the default port.
+.br
+Unless \fB\-\-no\-loopback\fR is given, xymond also listens on 127.0.0.1, on
+the port of the first address, whenever the addresses named do not already
+cover the loopback. This is so the client running on the Xymon server itself
+keeps reporting when a physical interface goes away. It is best effort: if that
+extra socket cannot be bound, xymond says so and carries on with the addresses
+it was asked for.
+
+.IP "\fB\-\-no\-loopback\fR"
+Do not add the automatic 127.0.0.1 listener described under \fB\-\-listen\fR.
+Use this when xymond must answer on the addresses named and nowhere else.
 
 .IP "\fB\-\-lqueue\fR=\fINUMBER\fR"
 Specifies the listen-queue for incoming connections. You don't need to tune

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -5877,9 +5877,11 @@ int main(int argc, char *argv[])
 			listenip = strdup(p);
 			p = strchr(listenip, ':');
 			if (p) {
+				/* Split for good: putting the colon back left the port
+				   in listenip, so inet_aton() failed and the zeroed
+				   sin_addr bound every interface. */
 				*p = '\0';
 				listenport = atoi(p+1);
-				*p = ':';
 			}
 		}
 		else if (argnmatch(argv[argi], "--timeout=")) {
@@ -6111,7 +6113,12 @@ int main(int argc, char *argv[])
 	/* Set up a socket to listen for new connections */
 	errprintf("Setting up network listener on %s:%d\n", listenip, listenport);
 	memset(&laddr, 0, sizeof(laddr));
-	inet_aton(listenip, (struct in_addr *) &laddr.sin_addr.s_addr);
+	if (inet_aton(listenip, (struct in_addr *) &laddr.sin_addr.s_addr) == 0) {
+		/* Checked: an unnoticed failure left sin_addr zero, and the daemon
+		   listened on everything. */
+		errprintf("Cannot parse listen address '%s'\n", listenip);
+		return 1;
+	}
 	laddr.sin_port = htons(listenport);
 	laddr.sin_family = AF_INET;
 	lsocket = socket(AF_INET, SOCK_STREAM, 0);

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -5808,19 +5808,99 @@ void sig_handler(int signum)
 }
 
 
+/*
+ * One listener per configured address: a server wants a chosen interface AND a
+ * loopback, so its own client keeps reporting when the interface goes away.
+ * Accepted connections live in connhead with their own fds, independent of
+ * these.
+ */
+typedef struct xymond_listener_t {
+	int fd;
+	struct in_addr addr;
+	int port;
+} xymond_listener_t;
+
+static xymond_listener_t *listeners = NULL;
+static int listener_count = 0;
+
+/* True when a listener already accepts on 127.0.0.0/8 -- the wildcard, or a
+   loopback address named outright. A second socket over either is redundant,
+   and refused outright on Linux. */
+static int listeners_cover_loopback(void)
+{
+	int i;
+	unsigned long a;
+
+	for (i = 0; i < listener_count; i++) {
+		a = ntohl(listeners[i].addr.s_addr);
+		if ((a == INADDR_ANY) || ((a >> 24) == 127)) return 1;
+	}
+
+	return 0;
+}
+
+/* Bind and listen on one address. Returns 0, or -1 with the reason logged. */
+static int add_listener(struct in_addr addr, int port, int listenq)
+{
+	struct sockaddr_in laddr;
+	xymond_listener_t *grown;
+	int fd, opt = 1;
+
+	fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (fd == -1) {
+		errprintf("Cannot create listen socket (%s)\n", strerror(errno));
+		return -1;
+	}
+	setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+	fcntl(fd, F_SETFL, O_NONBLOCK);
+
+	memset(&laddr, 0, sizeof(laddr));
+	laddr.sin_family = AF_INET;
+	laddr.sin_addr = addr;
+	laddr.sin_port = htons(port);
+
+	if (bind(fd, (struct sockaddr *)&laddr, sizeof(laddr)) == -1) {
+		/* "listen socket" kept: callers and people grep for it. */
+		errprintf("Cannot bind to listen socket %s:%d (%s)\n", inet_ntoa(addr), port, strerror(errno));
+		close(fd);
+		return -1;
+	}
+	if (listen(fd, listenq) == -1) {
+		errprintf("Cannot listen on %s:%d (%s)\n", inet_ntoa(addr), port, strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	grown = (xymond_listener_t *)realloc(listeners, (listener_count + 1) * sizeof(xymond_listener_t));
+	if (grown == NULL) {
+		errprintf("Out of memory adding a listener\n");
+		close(fd);
+		return -1;
+	}
+	listeners = grown;
+	listeners[listener_count].fd = fd;
+	listeners[listener_count].addr = addr;
+	listeners[listener_count].port = port;
+	listener_count++;
+
+	errprintf("Listening on %s:%d\n", inet_ntoa(addr), port);
+
+	return 0;
+}
+
 int main(int argc, char *argv[])
 {
 	conn_t *connhead = NULL, *conntail=NULL;
-	char *listenip = "0.0.0.0";
-	int listenport = 0;
+	char *listenspec = "0.0.0.0";	/* comma-separated IP[:PORT] list */
+	int listenport = 0;		/* the default port for entries without one */
+	int want_loopback = 1;		/* keep a loopback listener unless told not to */
 	char *hostsfn = NULL;
 	char *restartfn = NULL;
 	char *logfn = NULL;
 	int checkpointinterval = 900;
 	int do_purples = 1;
 	time_t nextpurpleupdate;
-	struct sockaddr_in laddr;
-	int lsocket, opt;
+	int lidx, accept_next = 0;
 	int listenq = 512;
 	int argi;
 	struct timeval tv;
@@ -5872,17 +5952,13 @@ int main(int argc, char *argv[])
 			debug = 1;
 		}
 		else if (argnmatch(argv[argi], "--listen=")) {
-			char *p = strchr(argv[argi], '=') + 1;
-
-			listenip = strdup(p);
-			p = strchr(listenip, ':');
-			if (p) {
-				/* Split for good: putting the colon back left the port
-				   in listenip, so inet_aton() failed and the zeroed
-				   sin_addr bound every interface. */
-				*p = '\0';
-				listenport = atoi(p+1);
-			}
+			/* Kept whole: one or more IP[:PORT], comma separated. Split
+			   below, once the default port is known, so that an entry
+			   without a port can inherit it. */
+			listenspec = strdup(strchr(argv[argi], '=') + 1);
+		}
+		else if (strcmp(argv[argi], "--no-loopback") == 0) {
+			want_loopback = 0;
 		}
 		else if (argnmatch(argv[argi], "--timeout=")) {
 			char *p = strchr(argv[argi], '=') + 1;
@@ -6110,31 +6186,48 @@ int main(int argc, char *argv[])
 	last_stats_time = getcurrenttime(NULL);	/* delay sending of the first status report until we're fully running */
 
 
-	/* Set up a socket to listen for new connections */
-	errprintf("Setting up network listener on %s:%d\n", listenip, listenport);
-	memset(&laddr, 0, sizeof(laddr));
-	if (inet_aton(listenip, (struct in_addr *) &laddr.sin_addr.s_addr) == 0) {
-		/* Checked: an unnoticed failure left sin_addr zero, and the daemon
-		   listened on everything. */
-		errprintf("Cannot parse listen address '%s'\n", listenip);
-		return 1;
+	/* Set up the listening sockets, one per address in --listen. */
+	{
+		char *spec = strdup(listenspec);
+		char *entry, *saveptr = NULL;
+
+		for (entry = strtok_r(spec, ",", &saveptr); entry; entry = strtok_r(NULL, ",", &saveptr)) {
+			struct in_addr addr;
+			int port = listenport;
+			char *colon;
+
+			while ((*entry == ' ') || (*entry == '\t')) entry++;
+			colon = strchr(entry, ':');
+			if (colon) { *colon = '\0'; port = atoi(colon+1); }
+
+			/* Checked: an unnoticed failure left sin_addr zero, and the
+			   daemon listened on everything. */
+			if (inet_aton(entry, &addr) == 0) {
+				errprintf("Cannot parse listen address '%s' (expected IP[:PORT])\n", entry);
+				xfree(spec);
+				return 1;
+			}
+			if (add_listener(addr, port, listenq) != 0) { xfree(spec); return 1; }
+		}
+		xfree(spec);
 	}
-	laddr.sin_port = htons(listenport);
-	laddr.sin_family = AF_INET;
-	lsocket = socket(AF_INET, SOCK_STREAM, 0);
-	if (lsocket == -1) {
-		errprintf("Cannot create listen socket (%s)\n", strerror(errno));
-		return 1;
+
+	/* Keep a loopback listener so the server's own client still reaches us.
+	   On the first address's port, not the compiled default -- a client on
+	   loopback wants the same service. Best-effort, unlike an address that was
+	   actually asked for: failing to start over an extra we added ourselves
+	   would be the worse failure. Logged either way. */
+	if (want_loopback && !listeners_cover_loopback()) {
+		struct in_addr lo;
+		int loport = (listener_count > 0) ? listeners[0].port : listenport;
+
+		lo.s_addr = htonl(INADDR_LOOPBACK);
+		if (add_listener(lo, loport, listenq) != 0)
+			errprintf("Continuing without a loopback listener; the client on this host must use a configured address\n");
 	}
-	opt = 1;
-	setsockopt(lsocket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-	fcntl(lsocket, F_SETFL, O_NONBLOCK);
-	if (bind(lsocket, (struct sockaddr *)&laddr, sizeof(laddr)) == -1) {
-		errprintf("Cannot bind to listen socket (%s)\n", strerror(errno));
-		return 1;
-	}
-	if (listen(lsocket, listenq) == -1) {
-		errprintf("Cannot listen (%s)\n", strerror(errno));
+
+	if (listener_count == 0) {
+		errprintf("No listening address configured\n");
 		return 1;
 	}
 
@@ -6391,7 +6484,11 @@ int main(int argc, char *argv[])
 		 * and setup the select() FD sets.
 		 */
 		FD_ZERO(&fdread); FD_ZERO(&fdwrite);
-		FD_SET(lsocket, &fdread); maxfd = lsocket;
+		maxfd = -1;
+		for (lidx = 0; lidx < listener_count; lidx++) {
+			FD_SET(listeners[lidx].fd, &fdread);
+			if (listeners[lidx].fd > maxfd) maxfd = listeners[lidx].fd;
+		}
 
 		for (cwalk = connhead; (cwalk); cwalk = cwalk->next) {
 			switch (cwalk->doingwhat) {
@@ -6598,15 +6695,21 @@ int main(int argc, char *argv[])
 			dbgprintf("conn_t cleanup complete\n");
 		}
 
-		/* Pick up new connections */
-		if (FD_ISSET(lsocket, &fdread)) {
+		/* Take new connections from whichever listener is ready, resuming
+		   where the last scan stopped so a busy address cannot starve the
+		   others. */
+		for (lidx = 0; lidx < listener_count; lidx++) {
 			struct sockaddr_in addr;
 			int addrsz = sizeof(addr);
 			int sock;
+			int li = (accept_next + lidx) % listener_count;
+
+			if (!FD_ISSET(listeners[li].fd, &fdread)) continue;
 
 			dbgprintf("Picking up new connections\n");
 
-			sock = accept(lsocket, (struct sockaddr *)&addr, &addrsz);
+			accept_next = (li + 1) % listener_count;
+			sock = accept(listeners[li].fd, (struct sockaddr *)&addr, &addrsz);
 
 			if (sock >= 0) {
 				/* Make sure our sockets are non-blocking */


### PR DESCRIPTION
One address is not enough for a server: the operator wants a chosen interface **and** the loopback, so the client on the server keeps reporting when the interface goes away. Until #428 that came free by accident — every `--listen` bound the wildcard.

```
--listen=10.0.0.5:1984,127.0.0.1
```

Each entry is `IP[:PORT]` and gets its own socket; an entry without a port uses the default; a single entry behaves as before. A `127.0.0.1` listener is added unless the named addresses already cover loopback (the wildcard, or a `127.x` named outright) or `--no-loopback` says otherwise — on the **first** address's port, not the compiled default, since a client on loopback wants the same service.

That extra is best-effort: refusing to start because a listener xymond added *itself* could not bind would be the worse failure, so it is logged and startup continues. A named address that cannot bind stays fatal.

| launched with | listens on |
|---|---|
| *(no `--listen`)* | `0.0.0.0:1984` |
| `--listen=A:P` | `A:P` **+ `127.0.0.1:P`** |
| `--listen=A:P1,B:P2` | both, as given |
| `--no-loopback --listen=A:P` | `A:P` only |
| `--listen=127.0.0.2:P` | that only — already loopback *(Linux; the BSDs configure only `127.0.0.1`)* |

`lsocket` becomes an array. `select()` arms every listener and `accept()` takes whichever is ready, resuming where the last scan stopped so a busy address cannot starve the others. Accepted connections were already independent of the listening socket. The bind error keeps `Cannot bind to listen socket` in its wording — `tests/lib/xymond-daemon.sh` greps for it.

Tests, written first and failing first. `xymond-multi-listen.sh` asks a running daemon about each address in turn. `xymond-loopback-fallback.sh` pins the fatal/best-effort asymmetry both ways, each half against a mutation of its own — "the daemon did not start" alone was not enough for the named half, which the inverted code satisfies by falling through to the loopback extra and dying on a busy default port.

| check | result |
|---|---|
| local suite | 73 passed / 21 skipped / 0 failed |
| BSD lanes | **11/11 pass**; FreeBSD 15.0 reports **0 skipped**, so the cases needing a non-loopback address really ran |

BSD runs: [FreeBSD](https://github.com/bonomani/xymon/actions/runs/32693960148) · [NetBSD](https://github.com/bonomani/xymon/actions/runs/32693962509) · [OpenBSD](https://github.com/bonomani/xymon/actions/runs/32693962539). NetBSD 10.0 and 10.1 needed a re-run: their VMs did not boot the first time. On the retry both report 91 passed / 2 skipped / 0 failed with all three listen tests green.

**Not here:** runtime reconfiguration. The array makes it possible — adding a listener does not disturb the others, and the loopback one need never close — but SIGHUP reloads only hosts.cfg and the logfile today, and the address set would need somewhere re-readable. Its own change, with its own test.

**Depends on** #428 (its single commit is included here until it merges).

### Upgrade note — for the `Changes` branch

Not in this PR: `RELEASENOTES` is prepared on the `Changes` branch once merged. Proposed prose, to follow #428's:

> xymond --listen also accepts a comma-separated list of addresses, each with an optional port,
> and keeps a listener on 127.0.0.1 alongside them. The client running on a Xymon server
> therefore keeps reporting when a physical interface goes away -- which the old wildcard bind
> provided only by accident, and which the narrowing described above would otherwise have taken
> away. The loopback listener uses the port of the first address given; it is skipped when the
> addresses already cover loopback (0.0.0.0, or a 127.x address named outright), and it is
> best-effort -- if it cannot be bound, xymond logs that and starts anyway, while an address that
> was actually named remains fatal. Use --no-loopback to listen on the named addresses only.

---

### #428 → #432 → #435

| PR | change | base |
|---|---|---|
| **#428** | `--listen` binds the address it names | `upstream/main` |
| **#432** | `--listen` takes a list; a loopback listener is kept | contains #428 |
| **#435** | the server's client sends to `127.0.0.1`; `MACHINEADDR` keeps the real address | config only |

#428 takes away the loopback that the accidental wildcard bind gave anyone naming one address; #432 gives it back deliberately; #435 then uses it.

Each merges cleanly into `upstream/main`, alone or after either other, in any order. #432 *contains* #428, so merging it merges both. **#435 must not land before #432**: it points the local client at `127.0.0.1`, which is only guaranteed once #432 is in — with #428 alone, a server started with an explicit non-loopback `--listen` would stop reporting on itself.

None of the three touches `RELEASENOTES`; per `.github/RELEASING.md` those entries are written on the `Changes` branch once they land. Each body carries its proposed prose.

Gap left as a follow-up: #435's test asserts config content, not end-to-end delivery over loopback.
