### PR TITLE
Make pickdata() require and respect an explicit argument count

### DIFF
--- a/lib/matching.c
+++ b/lib/matching.c
@@ -173,7 +173,15 @@ pcre2_code **compile_exprs(char *id, const char **patterns, int count)
 	return result;
 }
 
-int pickdata(char *buf, pcre2_code *expr, int dupok, ...)
+/* nargs: how many char** destinations the caller passed -- NOT optional.
+ * pcre2_match() returns 1 + (highest capture group that matched), a count that
+ * depends on the DATA: an optional group fires only for some inputs. If it ever
+ * exceeds the fixed argument list, the loop pulls a va_arg that was never passed
+ * and dereferences a garbage pointer -- likely resulting in memory-unsafe read,
+ * xfree() or write operation (issue #433: a Linux iface name with an underscore,
+ * e.g. "veth_0", makes an ifstat pattern capture one group more than its call
+ * site supplied). Clamp res to what the caller vouched for. */
+int pickdata(char *buf, pcre2_code *expr, int dupok, int nargs, ...)
 {
 	int res, i;
 	pcre2_match_data *ovector;
@@ -192,8 +200,9 @@ int pickdata(char *buf, pcre2_code *expr, int dupok, ...)
 		pcre2_match_data_free(ovector);
 		return 0;
 	}
+	if (res > nargs + 1) res = nargs + 1; /* loop runs i = 1 .. res-1 */
 
-	va_start(ap, dupok);
+	va_start(ap, nargs);
 
 	for (i=1; (i < res); i++) {
 		*w = '\0';

--- a/lib/matching.h
+++ b/lib/matching.h
@@ -33,7 +33,7 @@ extern void freeregex(pcre2_code *pcrecode);
 extern int namematch(const char *needle, char *haystack, pcre2_code *pcrecode);
 extern int patternmatch(char *datatosearch, char *pattern, pcre2_code *pcrecode);
 extern pcre2_code **compile_exprs(char *id, const char **patterns, int count);
-extern int pickdata(char *buf, pcre2_code *expr, int dupok, ...);
+extern int pickdata(char *buf, pcre2_code *expr, int dupok, int nargs, ...);
 extern int timematch(char *holidaykey, char *tspec);
 #endif
 

--- a/xymond/rrd/do_ifstat.c
+++ b/xymond/rrd/do_ifstat.c
@@ -206,7 +206,7 @@ int do_ifstat_rrd(char *hostname, char *testname, char *classname, char *pagepat
 		  case OS_ZVM:
 		  case OS_ZVSE:
 		  case OS_ZOS:
-			if (pickdata(bol, ifstat_linux_pcres[0], 1, &ifname)) {
+			if (pickdata(bol, ifstat_linux_pcres[0], 1, /*nargs*/1, &ifname)) {
 				/*
 				 * Linux' netif aliases mess up things. 
 				 * Clear everything when we see an interface name.
@@ -225,9 +225,9 @@ int do_ifstat_rrd(char *hostname, char *testname, char *classname, char *pagepat
 					if (txstr) { xfree(txstr); txstr = NULL; }
 				}
 			}
-			else if (pickdata(bol, ifstat_linux_pcres[1], 1, &rxstr, &txstr)) dmatch |= 6;
-			else if (pickdata(bol, ifstat_linux_pcres[2], 1, &rxstr)) dmatch |= 2;
-			else if (pickdata(bol, ifstat_linux_pcres[3], 1, &txstr)) dmatch |= 4;
+			else if (pickdata(bol, ifstat_linux_pcres[1], 1, /*nargs*/2, &rxstr, &txstr)) dmatch |= 6;
+			else if (pickdata(bol, ifstat_linux_pcres[2], 1, /*nargs*/1, &rxstr)) dmatch |= 2;
+			else if (pickdata(bol, ifstat_linux_pcres[3], 1, /*nargs*/1, &txstr)) dmatch |= 4;
 			break;
 
 		  case OS_FREEBSD:
@@ -236,21 +236,21 @@ int do_ifstat_rrd(char *hostname, char *testname, char *classname, char *pagepat
 			 * See if we match this expression, and if not then fall back to
 			 * the old regex without that field.
 			 */
-			if (pickdata(bol, ifstat_freebsdV8_pcres[0], 0, &ifname, &rxstr, &txstr)) dmatch = 7;
-			else if (pickdata(bol, ifstat_freebsd_pcres[0], 0, &ifname, &rxstr, &txstr)) dmatch = 7;
+			if (pickdata(bol, ifstat_freebsdV8_pcres[0], 0, /*nargs*/3, &ifname, &rxstr, &txstr)) dmatch = 7;
+			else if (pickdata(bol, ifstat_freebsd_pcres[0], 0, /*nargs*/3, &ifname, &rxstr, &txstr)) dmatch = 7;
 			break;
 
 		  case OS_OPENBSD:
-			if (pickdata(bol, ifstat_openbsd_pcres[0], 0, &ifname, &rxstr, &txstr)) dmatch = 7;
+			if (pickdata(bol, ifstat_openbsd_pcres[0], 0, /*nargs*/3, &ifname, &rxstr, &txstr)) dmatch = 7;
 			break;
 
 		  case OS_NETBSD:
-			if (pickdata(bol, ifstat_netbsd_pcres[0], 0, &ifname, &rxstr, &txstr)) dmatch = 7;
+			if (pickdata(bol, ifstat_netbsd_pcres[0], 0, /*nargs*/3, &ifname, &rxstr, &txstr)) dmatch = 7;
 			break;
 
 		  case OS_SOLARIS: 
-			if (pickdata(bol, ifstat_solaris_pcres[0], 0, &ifname, &txstr)) dmatch |= 1;
-			else if (pickdata(bol, ifstat_solaris_pcres[1], 0, &dummy, &rxstr)) dmatch |= 6;
+			if (pickdata(bol, ifstat_solaris_pcres[0], 0, /*nargs*/2, &ifname, &txstr)) dmatch |= 1;
+			else if (pickdata(bol, ifstat_solaris_pcres[1], 0, /*nargs*/2, &dummy, &rxstr)) dmatch |= 6;
 
 			if (ifname && dummy && (strcmp(ifname, dummy) != 0)) {
 				/* They must match, drop the data */
@@ -272,37 +272,37 @@ int do_ifstat_rrd(char *hostname, char *testname, char *classname, char *pagepat
 			break;
 
 		  case OS_AIX: 
-			if (pickdata(bol, ifstat_aix_pcres[0], 1, &ifname)) {
+			if (pickdata(bol, ifstat_aix_pcres[0], 1, /*nargs*/1, &ifname)) {
 				/* Interface names comes first, so any rx/tx data is discarded */
 				dmatch |= 1;
 				if (rxstr) { xfree(rxstr); rxstr = NULL; }
 				if (txstr) { xfree(txstr); txstr = NULL; }
 			}
-			else if (pickdata(bol, ifstat_aix_pcres[1], 1, &txstr, &rxstr)) dmatch |= 6;
+			else if (pickdata(bol, ifstat_aix_pcres[1], 1, /*nargs*/2, &txstr, &rxstr)) dmatch |= 6;
 			break;
 
 		  case OS_HPUX: 
-			if (pickdata(bol, ifstat_hpux_pcres[0], 1, &ifname)) {
+			if (pickdata(bol, ifstat_hpux_pcres[0], 1, /*nargs*/1, &ifname)) {
 				/* Interface names comes first, so any rx/tx data is discarded */
 				dmatch |= 1;
 				if (rxstr) { xfree(rxstr); rxstr = NULL; }
 				if (txstr) { xfree(txstr); txstr = NULL; }
 			}
-			else if (pickdata(bol, ifstat_hpux_pcres[1], 1, &rxstr)) dmatch |= 2;
-			else if (pickdata(bol, ifstat_hpux_pcres[2], 1, &txstr)) dmatch |= 4;
+			else if (pickdata(bol, ifstat_hpux_pcres[1], 1, /*nargs*/1, &rxstr)) dmatch |= 2;
+			else if (pickdata(bol, ifstat_hpux_pcres[2], 1, /*nargs*/1, &txstr)) dmatch |= 4;
 			break;
 
 		  case OS_DARWIN:
-			if (pickdata(bol, ifstat_darwin_pcres[0], 0, &ifname, &rxstr, &txstr)) dmatch = 7;
+			if (pickdata(bol, ifstat_darwin_pcres[0], 0, /*nargs*/3, &ifname, &rxstr, &txstr)) dmatch = 7;
 			break;
 			
  		  case OS_SCO_SV:
-		        if (pickdata(bol, ifstat_sco_sv_pcres[0], 0, &ifname, &rxstr, &txstr)) dmatch = 7;
+		        if (pickdata(bol, ifstat_sco_sv_pcres[0], 0, /*nargs*/3, &ifname, &rxstr, &txstr)) dmatch = 7;
 			break;
 			
 		  case OS_WIN32_BBWIN:
 		  case OS_WIN_POWERSHELL:
-			if (pickdata(bol, ifstat_bbwin_pcres[0], 0, &ifname, &rxstr, &txstr)) dmatch = 7;
+			if (pickdata(bol, ifstat_bbwin_pcres[0], 0, /*nargs*/3, &ifname, &rxstr, &txstr)) dmatch = 7;
 			break;
 
 		  default:

--- a/xymond/rrd/do_ifstat.c
+++ b/xymond/rrd/do_ifstat.c
@@ -19,7 +19,7 @@ static void *ifstat_tpl       = NULL;
 /* eth0   Link encap:                                                 */
 /*        RX bytes: 1829192 (265.8 MiB)  TX bytes: 1827320 (187.7 MiB */
 static const char *ifstat_linux_exprs[] = {
-	"^([a-z0-9]+(_[0-9]+)?:*|lo:?)\\s",
+	"^([a-z0-9]+(?:_[0-9]+)?:*|lo:?)\\s", /* (?:...) non-capturing: 1 group = 1 arg */
 	"^\\s+RX bytes:([0-9]+) .*TX bytes.([0-9]+) ",
 	"^\\s+RX packets\\s+[0-9]+\\s+bytes\\s+([0-9]+) ",
 	"^\\s+TX packets\\s+[0-9]+\\s+bytes\\s+([0-9]+) "

--- a/xymond/rrd/do_netstat.c
+++ b/xymond/rrd/do_netstat.c
@@ -85,20 +85,20 @@ static int handle_pcre_netstat(char *msg, pcre2_code **pcreset, char *outp)
 		else {
 			switch (sect) {
 			  case AT_TCP:
-				if (pickdata(datapart, pcreset[0],  0, &tcpretranspackets, &tcpretransbytes)   ||
-				    pickdata(datapart, pcreset[1],  0, &tcpoutdatapackets, &tcpoutdatabytes)   ||
-				    pickdata(datapart, pcreset[2],  0, &tcpinorderpackets, &tcpinorderbytes)   ||
-				    pickdata(datapart, pcreset[3],  0, &tcpoutorderpackets, &tcpoutorderbytes) ||
-				    pickdata(datapart, pcreset[4],  0, &tcpconnrequests)                       ||
-				    pickdata(datapart, pcreset[5],  0, &tcpconnaccepts)) havedata++;
+				if (pickdata(datapart, pcreset[0],  0, /*nargs*/2, &tcpretranspackets, &tcpretransbytes)   ||
+				    pickdata(datapart, pcreset[1],  0, /*nargs*/2, &tcpoutdatapackets, &tcpoutdatabytes)   ||
+				    pickdata(datapart, pcreset[2],  0, /*nargs*/2, &tcpinorderpackets, &tcpinorderbytes)   ||
+				    pickdata(datapart, pcreset[3],  0, /*nargs*/2, &tcpoutorderpackets, &tcpoutorderbytes) ||
+				    pickdata(datapart, pcreset[4],  0, /*nargs*/1, &tcpconnrequests)                       ||
+				    pickdata(datapart, pcreset[5],  0, /*nargs*/1, &tcpconnaccepts)) havedata++;
 				break;
 
 			  case AT_UDP:
-				if (pickdata(datapart, pcreset[6],  0, &udpreceived)   ||
-				    pickdata(datapart, pcreset[7],  0, &udpsent)       ||
-				    pickdata(datapart, pcreset[8],  0, &udperr1)       ||
-				    pickdata(datapart, pcreset[9],  0, &udperr2)       ||
-				    pickdata(datapart, pcreset[10], 0, &udperr3)) havedata++;
+				if (pickdata(datapart, pcreset[6],  0, /*nargs*/1, &udpreceived)   ||
+				    pickdata(datapart, pcreset[7],  0, /*nargs*/1, &udpsent)       ||
+				    pickdata(datapart, pcreset[8],  0, /*nargs*/1, &udperr1)       ||
+				    pickdata(datapart, pcreset[9],  0, /*nargs*/1, &udperr2)       ||
+				    pickdata(datapart, pcreset[10], 0, /*nargs*/1, &udperr3)) havedata++;
 				break;
 
 			  default:

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -3167,7 +3167,9 @@ hostfilter_rec_t *setup_filter(char *buf, char **fields, int *acklevel, int *hav
 		char *xmhfld = NULL, *xmhval = NULL;
 
 		/* Get filter */
-		if ((strncmp(tok, "XMH_", 4) == 0) && pickdata(tok, xmhptn, 1, &xmhfld, &xmhval)) {
+		if ((strncmp(tok, "XMH_", 4) == 0)
+			&& pickdata(tok, xmhptn, 1, /*nargs*/2, &xmhfld, &xmhval))
+		{
 			enum xmh_item_t fld = xmh_key_idx(xmhfld);
 
 			if ((fld != XMH_LAST) && (*xmhfld) && (*xmhval)) {


### PR DESCRIPTION
The `pickdata()` variable arguments function in *lib/matching.c* relies solely on the return value of pcre2_match() to determine the number of output parameters (= target strings). This is unsafe when a regular expression match yields more (sub)groups than actual destination params were supplied - possibly leading to stack corruption, and subsequent access violations or crashes.

I've seen that happen with Linux interface names containing an underscore ('_'), which seems to be common with some TUN/TAP/veth setups.

This patch changes `pickdata()` to be a preprocessor definition that determines and passes the actual argument count at compile time, turning it into a "safe va func" while preserving existing invocation syntax for the calling code.

See e.g.
https://www.reddit.com/r/C_Programming/comments/17d3x34/what_is_the_best_idiom_for_variadic_functions/ https://www.reddit.com/r/C_Programming/comments/17ov5az/a_way_to_count_number_of_variable_arguments/ https://codeberg.org/NRK/slashtmp/src/branch/master/misc/safe_va_func.c
https://snai.pe/posts/varargs