### PR TITLE
xymonserver.cfg: send over loopback, identify by the real address

### DIFF
--- a/tests/server/serverconfig-local-client.sh
+++ b/tests/server/serverconfig-local-client.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/serverconfig-local-client.sh
+#
+# On the Xymon server, "where do I send" and "who am I" are different
+# questions, and the shipped config must not answer them with one value.
+#
+#   XYMSRV       where the client on this host sends. Loopback, so it keeps
+#                reporting when a physical interface goes away.
+#   MACHINEADDR  how this host identifies itself in what it sends. Never
+#                loopback: every machine has 127.0.0.0/8, so an address from
+#                that range names no one.
+#
+# Both defaulted to $XYMONSERVERIP, and that shared default is the whole
+# coupling -- which is why xymonserver.cfg.DIST used to carry the warning
+# "use the real one, not 127.0.0.1" on XYMONSERVERIP. The warning was
+# protecting MACHINEADDR, and it kept XYMSRV off loopback as a side effect.
+#
+# The client's own config is separate (client/xymonclient.cfg.DIST), so none
+# of this reaches a remote client: there XYMSRV is the server's address and
+# must stay that way. Checked here too, since the whole point is that the two
+# files answer differently.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SRVCFG="$ROOT/xymond/etcfiles/xymonserver.cfg.DIST"
+CLICFG="$ROOT/client/xymonclient.cfg.DIST"
+[ -f "$SRVCFG" ] || skip "xymonserver.cfg.DIST not present in this checkout"
+[ -f "$CLICFG" ] || skip "xymonclient.cfg.DIST not present in this checkout"
+
+# setting FILE NAME -- the value assigned to NAME, unquoted, comments stripped.
+setting() {
+	sed -n "s/^$2=\"\{0,1\}\([^\"#]*\)\"\{0,1\}.*/\1/p" "$1" | head -1 | sed 's/[[:space:]]*$//'
+}
+
+srv_xymsrv=$(setting "$SRVCFG" XYMSRV)
+srv_machineaddr=$(setting "$SRVCFG" MACHINEADDR)
+cli_xymsrv=$(setting "$CLICFG" XYMSRV)
+
+# --- the server sends over loopback -------------------------------------------
+
+case "$srv_xymsrv" in
+	127.*) ;;
+	*) fail "the server's XYMSRV is '$srv_xymsrv', so the client on the server reaches xymond over a physical interface and stops reporting when it goes down" ;;
+esac
+
+# --- but does not identify itself as loopback ---------------------------------
+
+case "$srv_machineaddr" in
+	127.*) fail "the server's MACHINEADDR is '$srv_machineaddr'; no address in 127.0.0.0/8 identifies a machine" ;;
+esac
+[ "$srv_xymsrv" != "$srv_machineaddr" ] || \
+	fail "XYMSRV and MACHINEADDR are both '$srv_xymsrv'; they answer different questions and must not share a value"
+
+# --- and a remote client still sends to the server -----------------------------
+
+case "$cli_xymsrv" in
+	127.*) fail "the client config's XYMSRV is '$cli_xymsrv'; a remote client must send to the server, not to itself" ;;
+esac
+
+# --- the built-in fallback is unchanged ---------------------------------------
+
+# lib/environ.c is shared by both, so its default must stay the server address:
+# a client whose config omits XYMSRV has to reach the server, not loopback.
+assert_contains '{ "XYMSRV", "$XYMONSERVERIP" }' "$(cat "$ROOT/lib/environ.c")" \
+	"the compiled-in XYMSRV default is shared with clients and must remain the server address"
+
+pass "the server sends over loopback and still identifies itself by its real address"

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -6,7 +6,8 @@ XYMONCLIENTHOME="@XYMONTOPDIR@/client"		# XYMONHOME directory for the client
 
 
 XYMONSERVERHOSTNAME="@XYMONHOSTNAME@"		# The hostname of your server
-XYMONSERVERIP="@XYMONHOSTIP@"			# The IP-address of your server. Use the real one, not 127.0.0.1 .
+XYMONSERVERIP="@XYMONHOSTIP@"			# The IP-address of your server. The real one: it is how this host
+						# identifies itself (MACHINEADDR), and no address in 127.0.0.0/8 names a machine.
 XYMONSERVEROS="@XYMONHOSTOS@"			# The operating system of your server. linux,freebsd,solaris,hpux,aix,osf
 
 XYMONSERVERWWWNAME="@XYMONHOSTNAME@"		# The name used for this hosts' webserver
@@ -36,7 +37,10 @@ DELAYYELLOW=""			# Format: status:delay[,status:delay - e.g. "cpu:15,disk:30"
 
 # General settings
 XYMONDPORT="1984"		# Portnumber where xymond listens
-XYMSRV="$XYMONSERVERIP"		# IP of a single Xymon server
+XYMSRV="127.0.0.1"		# Where the client on THIS host sends. Loopback, so it keeps reporting
+				# when a physical interface goes away -- xymond listens there unless
+				# started with --no-loopback. Not $XYMONSERVERIP: that answers a
+				# different question, see MACHINEADDR below.
 #XYMON_TIMEOUT="15"			# Default request timeout (seconds) for the xymon CLI tool; --timeout= wins
 XYMSERVERS=""			# IP of multiple Xymon servers. If used, XYMSRV must be 0.0.0.0
 FQDN="TRUE"			# Use fully-qualified hostnames internally. Keep it TRUE unless you know better.
@@ -77,7 +81,7 @@ SLEEPBETWEENMSGS="0"            # Delay between sending each combo message, in m
 # Specific to this host
 SERVEROSTYPE="$XYMONSERVEROS"		# Hosttype (operating system). Not used by server-side, but clients use this.
 MACHINEDOTS="$XYMONSERVERHOSTNAME"	# This systems hostname
-MACHINEADDR="$XYMONSERVERIP"		# This systems IP-address
+MACHINEADDR="$XYMONSERVERIP"		# This systems IP-address, as others see it. Never loopback.
 
 # URL's generated/used by xymongen
 XYMONWEBHOST="http://$XYMONSERVERWWWNAME"	# Just the host part of the URL - http://www.foo.com


### PR DESCRIPTION
`XYMSRV` and `MACHINEADDR` answer different questions — *where does the client on this host send*, and *how does this host name itself* — and both defaulted to `$XYMONSERVERIP`.

That shared default is why `xymonserver.cfg` warned **"use the real one, not 127.0.0.1"** on `XYMONSERVERIP`. The warning was protecting `MACHINEADDR`: no address in `127.0.0.0/8` identifies a machine. But it kept `XYMSRV` off loopback as a side effect, so the client on the Xymon server reaches xymond over a physical interface — and stops reporting when that interface goes away. The one host whose reports you would least like to lose.

```
XYMSRV="127.0.0.1"            # where the client on THIS host sends
MACHINEADDR="$XYMONSERVERIP"  # this system's IP-address, as others see it. Never loopback.
```

Deliberately unchanged: **remote clients** (`client/xymonclient.cfg.DIST` keeps its own `XYMSRV` pointing at the server), and **the compiled-in default** (`lib/environ.c` is shared by client and server binaries, so `{ "XYMSRV", "$XYMONSERVERIP" }` stays — a client whose config omits `XYMSRV` must reach the server, not itself).

`tests/server/serverconfig-local-client.sh`, written first and failing first, pins five properties: the server sends to loopback, does not *identify* as loopback, the two do not share a value, the client config still names the server, and the compiled default is unchanged.

| check | result |
|---|---|
| local suite | 71 passed / 21 skipped / 0 failed |

The one configuration needing attention on upgrade is a server whose xymond is started with an explicit `--listen` naming only non-loopback addresses **and** `--no-loopback`; there, set `XYMSRV` back to one of those addresses.

### Upgrade note — for the `Changes` branch

Not in this PR: `RELEASENOTES` is prepared on the `Changes` branch once merged. Proposed prose:

> On a Xymon server, XYMSRV now defaults to 127.0.0.1 rather than the server's own address, so the
> client running on the server keeps reporting when a physical interface goes away. MACHINEADDR is
> unchanged and still carries the real address: it is how the host identifies itself, and no
> address in 127.0.0.0/8 names a machine. The two shared a default until now, which is why
> xymonserver.cfg warned against putting loopback in XYMONSERVERIP -- that warning was protecting
> MACHINEADDR. Remote clients are unaffected; they have their own xymonclient.cfg. If xymond on
> the server is started with an explicit --listen naming only non-loopback addresses AND
> --no-loopback, set XYMSRV back to one of those addresses.

---

### #428 → #432 → #435

| PR | change | base |
|---|---|---|
| **#428** | `--listen` binds the address it names | `upstream/main` |
| **#432** | `--listen` takes a list; a loopback listener is kept | contains #428 |
| **#435** | the server's client sends to `127.0.0.1`; `MACHINEADDR` keeps the real address | config only |

#428 takes away the loopback that the accidental wildcard bind gave anyone naming one address; #432 gives it back deliberately; #435 then uses it.

Each merges cleanly into `upstream/main`, alone or after either other, in any order. #432 *contains* #428, so merging it merges both. **#435 must not land before #432**: it points the local client at `127.0.0.1`, which is only guaranteed once #432 is in — with #428 alone, a server started with an explicit non-loopback `--listen` would stop reporting on itself.

None of the three touches `RELEASENOTES`; per `.github/RELEASING.md` those entries are written on the `Changes` branch once they land. Each body carries its proposed prose.

Gap left as a follow-up: #435's test asserts config content, not end-to-end delivery over loopback.
