### PR TITLE
RELEASENOTES: file the UTF-8 charset note under 4.3.31

### DIFF
--- a/RELEASENOTES
+++ b/RELEASENOTES
@@ -31,6 +31,13 @@ is omitted from both the disk and inode reports by default. Set
 XYMONCLIENT_FS_INCLUDE_TYPES="ptyfs" to restore the previous disk-report
 behavior and include that filesystem in both reports.
 
+The default web charset is now UTF-8: HTMLCONTENTTYPE defaults to
+"text/html; charset=UTF-8" so non-ASCII status content renders correctly
+without relying on the web server to supply a default charset (which Debian's
+Apache does but FreeBSD's does not). Sites whose hosts emit a different encoding
+(e.g. iso-8859-1, euc-jp) and relied on browser auto-detection should set
+HTMLCONTENTTYPE explicitly in xymonserver.cfg.
+
 
 Changes for 4.3.30
 ==================
@@ -40,13 +47,6 @@ including problems with hostnames with dashes in them.
 
 Combostatus tests propagated up from other combostatus tests should now
 display properly.
-
-The default web charset is now UTF-8: HTMLCONTENTTYPE defaults to
-"text/html; charset=UTF-8" so non-ASCII status content renders correctly
-without relying on the web server to supply a default charset (which Debian's
-Apache does but FreeBSD's does not). Sites whose hosts emit a different encoding
-(e.g. iso-8859-1, euc-jp) and relied on browser auto-detection should set
-HTMLCONTENTTYPE explicitly in xymonserver.cfg.
 
 
 Changes for 4.3.29


### PR DESCRIPTION
The `HTMLCONTENTTYPE` default changed in **4.3.31**, but its note sits in the **4.3.30** section — so someone reading what 4.3.30 shipped is told about a change that was not in it, and someone planning the 4.3.31 upgrade does not see it at all.

It arrived with `8e35fa642` (*fix(web): default HTMLCONTENTTYPE to UTF-8 charset (#34) (#108)*), which added the paragraph to the wrong section.

**Text unchanged — the paragraph only moves.** The diff is 7 lines out, 7 lines in, byte-identical.

The `Changes` branch already files it under 4.3.31, so after this main's 4.3.30, 4.3.29 and 4.3.28 sections are byte-identical to it:

| section | main after this | `Changes` |
|---|---|---|
| 4.3.30 | `d0396c3ea6c5` | `d0396c3ea6c5` |
| 4.3.29 | `daef78ccb464` | `daef78ccb464` |
| 4.3.28 | `c96c88a51bf8` | `c96c88a51bf8` |

That removes a divergence that would otherwise have to be resolved when `Changes` merges into main at release.

Per `.github/RELEASING.md` `RELEASENOTES` is prepared on the `Changes` branch; this is a correction to what is already on main, not a new entry.