### PR TITLE
docs: say who writes Changes and RELEASENOTES, where it is visible

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,12 +1,10 @@
 # Releasing Xymon
 
-How to cut a release, what happens at each step, and why it is built this
-way. The process is two workflows plus five small manual actions; the
-manual actions are the review gates, everything mechanical is automated.
+Two workflows plus five manual actions. The manual actions are the review
+gates; everything mechanical is automated.
 
-This file lives under `.github/` on purpose: `.gitattributes` excludes
-`.git*` from `git archive`, so maintainer documentation never ends up in
-the release tarballs users download.
+This file lives under `.github/` on purpose: `.gitattributes` excludes `.git*`
+from `git archive`, so maintainer documentation stays out of release tarballs.
 
 ## Overview
 
@@ -23,93 +21,77 @@ the release tarballs users download.
 
 ## The changelog
 
-`Changes` and `RELEASENOTES` are prepared on the **`Changes`** branch
-between releases. The ritual there: merge `main` in, then one catch-up commit
-adding entries for the pull requests merged since. Bring the branch up
-to date and merge it into `main` before running the prep workflow (step
-1 of the checklist below) — the tarball ships whatever the tag contains.
+`Changes` and `RELEASENOTES` are prepared on the **`Changes`** branch, never in
+a pull request. The ritual: merge `main` in, add one catch-up commit with an
+entry per pull request merged since, then merge `Changes` back into `main`.
 
-The two files have different jobs.
+**Merge back after every catch-up, not only at release.** Releases are years
+apart; main's changelog is what people actually read, and drift left to
+accumulate is where entries go missing or land in the wrong section.
 
-**`Changes`** is the full list — one line per merged pull request, so
-`grep` finds it later. Entries start with a verb and say what the change
-does for someone running Xymon, in at most 100 characters; tighten the
-wording rather than folding the line, since a folded entry returns half
-a sentence to `grep`:
+**`Changes`** — the full list, one line per merged pull request so `grep` finds
+it later. Start with a verb, say what the change does for someone running
+Xymon, at most 100 characters. Tighten rather than fold: a folded entry returns
+half a sentence to `grep`.
 
 ```
 * Fix single-service graphs matching unrelated RRD files (#139) (Thanks, Mark Felder)
 ```
 
-Credit follows the work, as `(Thanks, Name)` — the person's name, not
-their login. In order: whoever wrote the change; whoever reported the
-problem, if a maintainer wrote the fix; whoever reviewed it, when there
-is nobody else to name. A change ported from an external patch set
-keeps its origin attribution — `(from J. Cleaver)` for the Terabithia
-patches. A cosmetic change with no user-visible behavior gets no entry.
+Credit as `(Thanks, Name)` — the person's name, not their login — in order:
+whoever wrote the change; whoever reported the problem, if a maintainer wrote
+the fix; whoever reviewed it, when there is nobody else to name. A change
+ported from an external patch set keeps its origin, `(from J. Cleaver)` for the
+Terabithia patches. A cosmetic change with no user-visible behaviour gets no
+entry.
 
-**`RELEASENOTES`** is what an administrator needs to know *before
-upgrading*: a default that changed, a setting that stops working, a
-dependency that is now required. Prose, not bullets, and no pull-request
-numbers — the reader is planning an upgrade, not tracing a commit. Most
-changes do not belong here; if it cannot break a working installation,
-it needs no entry.
+**`RELEASENOTES`** — what an administrator needs to know *before upgrading*: a
+default that changed, a setting that stops working, a dependency now required.
+Prose, no pull-request numbers. Most changes do not belong here; if it cannot
+break a working installation, it needs no entry.
 
-The next version's `Changes from X -> Y` heading sits open with a
-placeholder date between releases; the date is filled in when the
-release is cut (step 1 below). Neither that nor the RELEASENOTES
-version bump happens in feature pull requests.
+The next `Changes from X -> Y` heading sits open with a placeholder date. That
+date and the `RELEASENOTES` version bump happen at release, never in a pull
+request.
 
 ## Step by step
 
 ### 1. Close out the changelog
 
-On the `Changes` branch: check every merged pull request has its entry,
-fill the release date into the top `Changes from X -> Y (XX Xxx XXXX)`
-heading and the RELEASENOTES version, then merge the branch into
-`main`. Nothing later touches these files — `dorelease.sh` regenerates
-`md5.dat` and manpage stamps only — so a release cut without this step
-ships a changelog missing everything since the previous release, with a
-placeholder where the date should be.
+On `Changes`: check every merged pull request has its entry, fill the release
+date into the top `Changes from X -> Y (XX Xxx XXXX)` heading and the
+`RELEASENOTES` version, then merge into `main`. Nothing later touches these
+files — `dorelease.sh` regenerates `md5.dat` and manpage stamps only — so a
+release cut without this ships a placeholder where the date should be.
 
 ### 2. Run the prep workflow
 
-GitHub → Actions → **Pre-tag release prep** → *Run workflow* → enter the
-version as `X.Y.Z` (for example `4.3.30`).
+GitHub → Actions → **Pre-tag release prep** → *Run workflow* → version as
+`X.Y.Z`.
 
-What it does: recreates the branch `release/X.Y.Z` from the current
-`main`, runs `build/dorelease.sh X.Y.Z` — which regenerates
-`build/md5.dat` and stamps "Version X.Y.Z + date" into every manpage and
-its HTML — commits the result, force-pushes the branch, and opens a pull
-request against `main`. It also dispatches the build workflow onto the
-branch so the PR gets CI checks, and writes the follow-up commands into
-the run summary.
+It recreates `release/X.Y.Z` from `main`, runs `build/dorelease.sh X.Y.Z`
+(regenerating `build/md5.dat` and stamping "Version X.Y.Z + date" into every
+manpage and its HTML), commits, force-pushes, and opens a pull request against
+`main`. It also dispatches the build workflow so the PR gets CI, and writes the
+follow-up commands into the run summary.
 
-Why a PR instead of committing to `main` directly: a human reviews the
-generated diff before it becomes real. The diff should contain only
-version stamps and `md5.dat` lines; anything else means the generation
-went wrong, and you caught it before releasing.
+A PR rather than a direct commit so a human sees the generated diff first: it
+should contain only version stamps and `md5.dat` lines. Anything else means the
+generation went wrong.
 
-Reruns are safe: the branch is always recreated from `main`, never
-patched on top of an old prep, and an existing `rel-X.Y.Z` tag makes the
-workflow refuse to run at all.
+Reruns are safe — the branch is always recreated from `main`, and an existing
+`rel-X.Y.Z` tag makes the workflow refuse outright.
 
 ### 3. Review and merge the prep PR
 
-Check that the diff is only version stamps and `md5.dat`, and that the
-checks are green, then merge.
+Diff is only version stamps and `md5.dat`, checks green, merge.
 
-Note: the checks on this PR come from an explicitly dispatched run, not
-from a normal `pull_request` event (pushes made with the workflow's
-`GITHUB_TOKEN` never trigger workflows — GitHub's recursion guard). They
-will not re-run automatically if someone pushes to the branch by hand;
-the branch is workflow-owned, so don't do that — rerun the prep workflow
-instead.
+The checks come from an explicitly dispatched run, not a `pull_request` event
+(pushes made with the workflow's `GITHUB_TOKEN` never trigger workflows). They
+will not re-run if someone pushes by hand; the branch is workflow-owned, so
+rerun the prep workflow instead.
 
 ### 4. Tag the merge commit
-
-The prep run's summary gives you the exact commands, with the PR URL
-already filled in:
 
 ```sh
 git fetch origin
@@ -117,84 +99,64 @@ git tag rel-X.Y.Z "$(gh pr view <PR-URL> --json mergeCommit -q .mergeCommit.oid)
 git push origin rel-X.Y.Z
 ```
 
-The tag is the deliberate "I approve this release" gate — nothing is
-released without it. Tag the PR's merge commit, not `origin/main`:
-tagging `main`'s tip would silently include any commits that happened to
-land after the merge.
+The tag is the "I approve this release" gate — nothing ships without it. Tag
+the PR's merge commit, not `origin/main`, whose tip may have moved on.
 
-Pushing the tag triggers the release workflow, which builds
-`xymon-X.Y.Z.tar.gz` (`git archive` of the tag, `gzip -n -9`), generates
-its `.sha256`, and creates a **draft** GitHub release with both attached.
+Pushing it triggers the release workflow: `xymon-X.Y.Z.tar.gz` (`git archive`
+of the tag, `gzip -n -9`), its `.sha256`, and a **draft** release with both
+attached.
 
 ### 5. Publish the draft release
 
-Open the draft release, check the generated notes and the attached
-files, publish. This is the last look before it is public.
+Check the generated notes and attached files, publish.
 
 ## Reproducibility
 
-The same tag always produces a byte-identical tarball:
+The same tag always produces a byte-identical tarball, which is what makes the
+published `.sha256` meaningful:
 
-- `git archive` of a tag takes every file's mtime from the tagged
-  commit's date — fixed once tagged. Lightweight and annotated tags give
-  identical bytes.
-- `gzip -n` strips the gzip header's embedded filename and timestamp,
-  the one wall-clock-dependent bit.
-- Manpage and HTML dates come from `SOURCE_DATE_EPOCH` (the prep
-  commit's author date), not from the clock of whoever runs the prep.
-- The generator scripts pin `LC_ALL=C`, so sort order and date formats
-  do not depend on the caller's locale.
-
-This is what makes the published `.sha256` meaningful: anyone can
-rebuild from the tag and verify the download matches.
+- `git archive` takes every mtime from the tagged commit's date. Lightweight
+  and annotated tags give identical bytes.
+- `gzip -n` strips the header's embedded filename and timestamp.
+- Manpage and HTML dates come from `SOURCE_DATE_EPOCH` (the prep commit's
+  author date), not the clock of whoever runs it.
+- The generators pin `LC_ALL=C`, so sort order and date formats do not depend
+  on the caller's locale.
 
 ## Testing locally
 
-The whole pipeline minus the GitHub glue (PR creation, draft release)
-can be dry-run in one command, in a throwaway worktree — nothing is
-modified or pushed:
+The pipeline minus the GitHub glue, in a throwaway worktree — nothing modified
+or pushed. Run it twice; the checksum must match. Needs `mandoc`.
 
 ```sh
 ./build/dryrelease.sh 9.9.9
 ```
 
-Run it twice: the checksum must be identical. Requires `mandoc`
-(`apt-get install mandoc`).
-
 ## Invariants — don't break these
 
-- **The tag must be named `rel-X.Y.Z`.** The release workflow triggers
-  on `rel-*`; any other name releases nothing.
+- **The tag must be `rel-X.Y.Z`.** The release workflow triggers on `rel-*`;
+  any other name releases nothing.
 - **`build/md5.dat` keeps the hashes of every version ever shipped.**
-  `build/setup-newfiles.c` overwrites an installed web file at upgrade
-  time only if its hash matches a known stock version — that is how
-  upgrades distinguish "untouched old file" from "locally modified by
-  the admin". `generate-md5.sh` folds the old `md5.dat` in on purpose;
-  regenerating it from scratch would break upgrade detection.
-- **The prep job is pinned to `ubuntu-24.04`**, because the manual page
-  converter's output differs between versions and would churn the
-  generated HTML.
-- **The prep scripts are fail-fast** (`set -euo pipefail` throughout,
-  digest checks in `generate-md5.sh`). A half-failed generation aborts
-  the workflow before anything is committed or pushed; keep it that way
-  when editing them.
+  `build/setup-newfiles.c` overwrites an installed web file at upgrade only if
+  its hash matches a known stock version — that is how upgrades tell "untouched
+  old file" from "locally modified". `generate-md5.sh` folds the old file in on
+  purpose; regenerating from scratch breaks upgrade detection.
+- **The prep job is pinned to `ubuntu-24.04`** — the manpage converter's output
+  differs between versions and would churn the generated HTML.
+- **The prep scripts are fail-fast** (`set -euo pipefail`, digest checks in
+  `generate-md5.sh`). A half-failed generation aborts before anything is
+  committed; keep it that way.
 
 ## Troubleshooting
 
-- **Prep fails with "Tag rel-X.Y.Z already exists"** — that version was
-  already released; you want a new version number.
-- **Prep fails with "dorelease.sh produced no changes"** — `main`
-  already contains the prep for this version, most likely because the
-  prep PR was already merged. Just continue at step 4 (tag it).
-- **Rerunning prep after the previous prep PR was closed unmerged** —
-  fine; a fresh PR is opened (the workflow only treats *open* PRs as
-  existing).
-- **Rerunning prep while a prep PR is open** — fine; the branch is
-  force-pushed and the open PR updates in place.
-- **Two draft releases for the same tag** — re-running the release
-  workflow on a tag that already produced a draft creates a *second*
-  draft rather than updating the first. GitHub's "release by tag"
-  lookup ignores drafts, so `action-gh-release` can't find the existing
-  one to reuse. Delete the stale draft and keep the latest; this can't
-  happen once a release is published (published releases are found and
-  updated in place).
+- **"Tag rel-X.Y.Z already exists"** — that version shipped; pick a new one.
+- **"dorelease.sh produced no changes"** — `main` already has the prep, most
+  likely because the prep PR was merged. Continue at step 4.
+- **Rerunning prep after the prep PR was closed unmerged** — fine, a fresh PR
+  opens (only *open* PRs count as existing).
+- **Rerunning prep while a prep PR is open** — fine, the branch is force-pushed
+  and the PR updates in place.
+- **Two draft releases for one tag** — re-running the release workflow on a tag
+  that already produced a draft creates a second one; GitHub's "release by tag"
+  lookup ignores drafts, so `action-gh-release` cannot reuse the first. Delete
+  the stale draft. Cannot happen once a release is published.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to Xymon
+
+Patches are welcome. This file covers what is easy to get wrong because it is
+not visible from the source tree.
+
+## Where a change gets written down
+
+**Do not edit `Changes` or `RELEASENOTES` in a pull request.** Both are written
+by the release manager, on the `Changes` branch, after your pull request
+merges. If your change needs an entry, put the wording in the pull request
+description and it will be placed for you.
+
+Entries added in a pull request land in the wrong release section and have to
+be moved, and two pull requests inserting at the top of the same section
+conflict for no reason.
+
+`Changes` is the full list, one line per merged pull request. `RELEASENOTES` is
+only what an administrator needs *before upgrading* — a changed default, a
+setting that stops working, a new dependency; most changes need no entry there.
+Construction rules for both are in
+[`.github/RELEASING.md`](.github/RELEASING.md).
+
+## Manual pages
+
+Every manual page exists twice: the man(7) source next to the code it documents
+(`common/hosts.cfg.5`, `xymond/analysis.cfg.5`, ...) and a generated HTML copy
+under `docs/manpages/`. The source is the original — never edit the HTML by
+hand, it is overwritten at the next regeneration.
+
+No tooling is needed: edit the source and push. If the HTML is out of date, the
+"manual pages match their sources" check fails and its log says how to recover,
+run id filled in. With `mandoc` and `python3` you can instead run
+`build/makehtml.sh common/hosts.cfg.5` and commit both halves; the converter's
+output differs between mandoc versions and the check pins one, so if it still
+disagrees, its artifact wins.
+
+Either way, do not bump the version or date in the `.TH` line — that happens at
+release — and keep `git diff --check` quiet.
+
+## Pull requests
+
+- One change per pull request. A fix and the cleanup you noticed next to it are
+  two pull requests.
+- Say what you verified, and how. "Built and ran the test suite" is useful;
+  "should work" is not. If you could not test something, say that too — it is
+  not held against you, and it tells a reviewer where to look.
+- `tests/` holds the regression suite. If your change fixes something a test
+  could have caught, adding one is worth more than the fix.
+- Keep the description accurate as it evolves. A reviewer reading it after
+  three force-pushes should not be reading the original plan.
+
+## Style
+
+Match the file you are editing. The tree spans two decades and several hands;
+consistency within a file beats consistency across the project.

--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+Maintained by the release manager on the Changes branch; do not edit this
+file in a pull request. Rules and release process: .github/RELEASING.md
+
+
 Changes from 4.3.29 -> 4.3.30 (05 Sep 2019)
 ===========================================
 

--- a/RELEASENOTES
+++ b/RELEASENOTES
@@ -9,6 +9,9 @@ changes you should be aware of when upgrading.
 For a full list of changes and enhancements, please see the 
 Changes file.
 
+Maintained by the release manager on the Changes branch; do not edit this
+file in a pull request. Rules and release process: .github/RELEASING.md
+
 
 Changes for 4.3.31
 ==================


### PR DESCRIPTION
Documentation only — no code.

`CONTRIBUTING.md` existed **only on the `Changes` branch**. GitHub serves that file from the default branch, so the "Contributing guidelines" link on every pull request has been dead, and the one document stating the rule was invisible to anyone working on `main`. Nothing on `main` referenced `.github/RELEASING.md` either — `git grep -l RELEASING main` returns nothing — so the release process was reachable only by knowing to look on another branch first.

Three pull requests edited `RELEASENOTES` anyway:

| commit | |
|---|---|
| `8e35fa642` | filed its note under **4.3.30** for a change shipping in 4.3.31 (#438 moves it) |
| `127458775` | NetBSD inode note |
| `ced0e14e3` | AIX remote-df note |

The wording was part of the failure. The old text said the files were *"handled by the release manager on this branch"* — which only parses while you read it on the `Changes` branch — and its only explicit prohibition was against opening a new section or bumping the version. That reads as permission to add a paragraph to an existing section, which is what all three did. It now leads with the rule:

> **Do not edit `Changes` or `RELEASENOTES` in a pull request.** Both are written by the release manager, on the `Changes` branch, after your pull request merges. If your change needs an entry, put the wording in the pull request description and it will be placed for you.

### Merge the changelog back more often

`RELEASING.md` gains one rule: `Changes` merges into `main` after **every catch-up**, not only at release.

```
main's newest section:     Changes from 4.3.29 -> 4.3.30 (05 Sep 2019)  —   0 entries for 4.3.31
Changes' newest section:   Changes from 4.3.30 -> 4.3.31 (XX Xxx XXXX)  — 157 entries
```

Main's changelog stops in September 2019 because the merge was attached to the release step and releases are years apart. Anyone browsing the repo sees seven years of nothing. Nothing in the ritual depends on that; merging after each catch-up keeps `main` current and makes the release-time merge a formality.

### Also

`Changes` and `RELEASENOTES` each gain a two-line header naming their owner and pointing at `RELEASING.md` — plain text, so it survives in the release tarball where no link works. In `RELEASENOTES` it sits after the reader-facing preamble, since that file's audience is administrators. Both files are otherwise byte-preserved: pure additions, and `Changes` is not UTF-8, so it was edited in binary (`file` reports the same type before and after).

Both docs are shortened — `RELEASING.md` 200 → 162 lines, `CONTRIBUTING.md` 60 → 55 — with every command, workflow name, path and invariant checked as still present.

**Not included:** a pull-request template. Deliberate.
