### PR TITLE
Restore Changes and RELEASENOTES on main

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,3 @@
-Maintained by the release manager on the Changes branch; do not edit this
-file in a pull request. Rules and release process: .github/RELEASING.md
-
-
 Changes from 4.3.29 -> 4.3.30 (05 Sep 2019)
 ===========================================
 

--- a/RELEASENOTES
+++ b/RELEASENOTES
@@ -9,9 +9,6 @@ changes you should be aware of when upgrading.
 For a full list of changes and enhancements, please see the 
 Changes file.
 
-Maintained by the release manager on the Changes branch; do not edit this
-file in a pull request. Rules and release process: .github/RELEASING.md
-
 
 Changes for 4.3.31
 ==================


### PR DESCRIPTION
`Changes` and `RELEASENOTES` are maintained on the **`Changes`** branch. main carries what the last release shipped and receives the next set when that branch is merged in — it is not where entries get written.

Four pull requests wrote `RELEASENOTES` entries here anyway:

| commit | |
|---|---|
| `8e35fa642` | added a paragraph to the **4.3.30** section — a release that shipped in September 2019 |
| `b2f2ce1c9` | SSL cipher-list note |
| `127458775` | NetBSD inode note |
| `ced0e14e3` | AIX remote-df note |

Between them they opened a 4.3.31 section on main and altered a closed one.

**Nothing is lost.** All four paragraphs are already on the `Changes` branch — three verbatim, and the NetBSD one reworded there to fit the surrounding text (it also covers `XYMONCLIENT_FS_DF_LOCAL_ONLY`, which the version here does not). Checked paragraph by paragraph before removing them.

This also drops the two-line header #439 added to both files; it belongs on the branch that owns them, and is now there.

After this, `RELEASENOTES` is byte-identical to `6f0c18e02` (Release 4.3.30) — 24130 bytes, no 4.3.31 section — and `Changes` is back to its pre-#439 state. The `CONTRIBUTING.md` and `RELEASING.md` half of #439 stands.

---

### Also: the changelog merges into main only at release

#439 added a rule that `Changes` should merge back into `main` after **every** catch-up. That was wrong, and this removes it.

Between releases main should carry exactly what the last release shipped. Merging more often means a section describing a released version can move or be reworded underneath it — which is the thing these rules exist to prevent, and precisely what happened to 4.3.30.

`RELEASING.md` now reads:

> **`Changes` merges into `main` only at release** (step 1 below). Between releases main carries exactly what the last release shipped, so a section describing a released version cannot move or be reworded underneath it. Only the open section changes, and it changes on one branch.
