### PR TITLE
docs: restore RELEASENOTES on main, move RELEASING.md to the root

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,8 @@ Entries added in a pull request land in the wrong release section and have to
 be moved, and two pull requests inserting at the top of the same section
 conflict for no reason.
 
-`Changes` is the full list, one line per merged pull request. `RELEASENOTES` is
-only what an administrator needs *before upgrading* — a changed default, a
-setting that stops working, a new dependency; most changes need no entry there.
-Construction rules for both are in
-[`.github/RELEASING.md`](.github/RELEASING.md).
+What belongs in each file, and how entries are written, is in
+[`RELEASING.md`](RELEASING.md).
 
 ## Manual pages
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,5 @@
-Maintained by the release manager on the Changes branch; do not edit this
-file in a pull request. Rules and release process: .github/RELEASING.md
+Maintained by the release manager on the Changes branch; do not edit it in a
+pull request. See CONTRIBUTING.md; full rules in RELEASING.md.
 
 
 Changes from 4.3.29 -> 4.3.30 (05 Sep 2019)

--- a/RELEASENOTES
+++ b/RELEASENOTES
@@ -1,5 +1,5 @@
           <<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>
-           * * *   Release notes for Xymon 4.3.31   * * *
+           * * *   Release notes for Xymon 4.3.30   * * *
           <<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>
 
 
@@ -9,30 +9,8 @@ changes you should be aware of when upgrading.
 For a full list of changes and enhancements, please see the 
 Changes file.
 
-Maintained by the release manager on the Changes branch; do not edit this
-file in a pull request. Rules and release process: .github/RELEASING.md
-
-
-Changes for 4.3.31
-==================
-
-The AIX client now requires AIX 7.1 or later. It keeps df off remote mounts by
-default (XYMONCLIENT_FS_DF_LOCAL_ONLY, as on the other clients), which AIX df
-spells "-T local" -- a flag 6.1 and earlier do not have. On those releases the
-client reported every filesystem and a hard-mounted NFS server that stopped
-answering could hang the whole client run, with no remote-df sentinel to bound
-it; that is the behaviour now left behind rather than worked around.
-
-xymonnet tests with a configured cipher-list restriction now report an SSL error
-when OpenSSL rejects the restriction, instead of silently using the default
-cipher list. Such tests may therefore turn red after upgrading Xymon, or after
-an OpenSSL upgrade invalidates a previously accepted restriction. xymonnet tests
-without a cipher-list restriction are unaffected.
-
-The NetBSD client now provides an inode report. The ptyfs (/dev/pts) filesystem
-is omitted from both the disk and inode reports by default. Set
-XYMONCLIENT_FS_INCLUDE_TYPES="ptyfs" to restore the previous disk-report
-behavior and include that filesystem in both reports.
+Maintained by the release manager on the Changes branch; do not edit it in a
+pull request. See CONTRIBUTING.md; full rules in RELEASING.md.
 
 
 Changes for 4.3.30
@@ -43,13 +21,6 @@ including problems with hostnames with dashes in them.
 
 Combostatus tests propagated up from other combostatus tests should now
 display properly.
-
-The default web charset is now UTF-8: HTMLCONTENTTYPE defaults to
-"text/html; charset=UTF-8" so non-ASCII status content renders correctly
-without relying on the web server to supply a default charset (which Debian's
-Apache does but FreeBSD's does not). Sites whose hosts emit a different encoding
-(e.g. iso-8859-1, euc-jp) and relied on browser auto-detection should set
-HTMLCONTENTTYPE explicitly in xymonserver.cfg.
 
 
 Changes for 4.3.29

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,9 +3,6 @@
 Two workflows plus five manual actions. The manual actions are the review
 gates; everything mechanical is automated.
 
-This file lives under `.github/` on purpose: `.gitattributes` excludes `.git*`
-from `git archive`, so maintainer documentation stays out of release tarballs.
-
 ## Overview
 
 ```
@@ -22,12 +19,13 @@ from `git archive`, so maintainer documentation stays out of release tarballs.
 ## The changelog
 
 `Changes` and `RELEASENOTES` are prepared on the **`Changes`** branch, never in
-a pull request. The ritual: merge `main` in, add one catch-up commit with an
-entry per pull request merged since, then merge `Changes` back into `main`.
+a pull request. The ritual there: merge `main` in, then one catch-up commit
+with an entry per pull request merged since.
 
-**Merge back after every catch-up, not only at release.** Releases are years
-apart; main's changelog is what people actually read, and drift left to
-accumulate is where entries go missing or land in the wrong section.
+**`Changes` merges into `main` only at release** (step 1 below). Between
+releases main carries exactly what the last release shipped, so a section
+describing a released version cannot move or be reworded underneath it. Only
+the open section changes, and it changes on one branch.
 
 **`Changes`** — the full list, one line per merged pull request so `grep` finds
 it later. Start with a verb, say what the change does for someone running


### PR DESCRIPTION
Replaces #440, which could not be reopened: its recorded head commit was replaced by a force-push, so GitHub refuses.

`RELEASENOTES` is maintained on the **`Changes`** branch. main carries what the last release shipped and receives the next set when that branch is merged in at release — it is not where entries get written.

Four pull requests wrote entries here anyway:

| commit | |
|---|---|
| `8e35fa642` | added a paragraph to the **4.3.30** section — a release that shipped in September 2019 |
| `b2f2ce1c9` | SSL cipher-list note |
| `127458775` | NetBSD inode note |
| `ced0e14e3` | AIX remote-df note |

Between them they opened a 4.3.31 section on main and altered a closed one.

**Nothing is lost.** All four paragraphs are already on the `Changes` branch — three verbatim, and the NetBSD one reworded there to fit the surrounding text (it also covers `XYMONCLIENT_FS_DF_LOCAL_ONLY`, which the version here does not). Checked paragraph by paragraph before removing them.

After this, every section of `RELEASENOTES` is byte-identical to the last release point (tag `4.3.31-root` → `6f0c18e02`, Release 4.3.30): no 4.3.31 section, and 4.3.30 as it shipped. The only difference from that point is the two-line ownership header, which `Changes` already carries on main — same text, same placement as on the `Changes` branch:

| file | vs release point |
|---|---|
| `RELEASENOTES` | +147 bytes — the header |
| `Changes` | +148 bytes — the header (untouched by this PR) |


### Also: the changelog merges into main only at release

#439 added a rule that `Changes` should merge back into `main` after **every** catch-up. That was wrong, and this removes it.

Between releases main should carry exactly what the last release shipped. Merging more often means a section describing a released version can move or be reworded underneath it — which is the thing these rules exist to prevent, and precisely what happened to 4.3.30.

> **`Changes` merges into `main` only at release** (step 1 below). Between releases main carries exactly what the last release shipped, so a section describing a released version cannot move or be reworded underneath it. Only the open section changes, and it changes on one branch.

---

### Also: RELEASING.md moves to the root

Nothing keeps a release-process document in `.github/`. Surveying 25 projects, only four publish one at all:

| project | location |
|---|---|
| systemd | `docs/RELEASE.md` |
| curl | `docs/RELEASE-PROCEDURE.md` |
| nagios-plugins | `doc/RELEASING` |
| prometheus | `RELEASE.md` (root) |

None uses `.github/`, and all four ship it in their tarball. Here it had exactly **one** inbound reference in the entire repository — the link from `CONTRIBUTING.md` — so it was reachable only by already knowing it existed.

Kept as `RELEASING.md` rather than `RELEASE.md`: `RELEASENOTES` already sits at the root, and two root files starting with `RELEASE` — one upgrade notes for administrators, one process for the release manager — is the confusion this is meant to remove.

The paragraph justifying the `.github/` placement goes with it, and `CONTRIBUTING.md` now links the new path and stops restating what belongs in which file. `RELEASING.md` owns that; two copies of a rule drift.

The header in `RELEASENOTES` now names both documents, and both ship:

```
Maintained by the release manager on the Changes branch; do not edit it in a
pull request. See CONTRIBUTING.md; full rules in RELEASING.md.
```
