### PR TITLE
build: add XYMONCACHEWWWDIR so rep and snap can relocate together

### DIFF
--- a/common/xymonserver.cfg.5
+++ b/common/xymonserver.cfg.5
@@ -208,19 +208,26 @@ Default: $XYMONHOME/www/
 Directory for Xymon notes-files. The $XYMONNOTESSKIN URL must map to this directory.
 Default: $XYMONHOME/www/notes/
 
+.IP "\fBXYMONCACHEWWWDIR\fR"
+Parent directory for regenerable web output, namely the on-demand availability
+reports and snapshots (XYMONREPDIR and XYMONSNAPDIR default to subdirectories of
+it). It is kept separate from the persistent web files so that a packaging can
+place this throwaway, safe-to-delete data on a volatile filesystem such as
+/var/cache. Default: $XYMONWWWDIR
+
 .IP "\fBXYMONREPDIR\fR"
 Directory for Xymon availability reports. The $XYMONREPURL URL must map to this directory.
 Note also that your webserver must have write-access to this directory, if you want to
 use the
 .I report.cgi(1)
-CGI script to generate reports on-demand. Default: $XYMONHOME/www/rep/
+CGI script to generate reports on-demand. Default: $XYMONCACHEWWWDIR/rep/ (i.e. $XYMONHOME/www/rep/)
 
 .IP "\fBXYMONSNAPDIR\fR"
 Directory for Xymon snapshots. The $XYMONSNAPURL URL must map to this directory.
 Note also that your webserver must have write-access to this directory, if you want to
 use the
 .I snapshot.cgi(1)
-CGI script to generate snapshots on-demand. Default: $XYMONHOME/www/snap/
+CGI script to generate snapshots on-demand. Default: $XYMONCACHEWWWDIR/snap/ (i.e. $XYMONHOME/www/snap/)
 
 .IP "\fBXYMONVAR\fR"
 Directory for all data stored about the monitored items.

--- a/docs/manpages/man5/xymonserver.cfg.5.html
+++ b/docs/manpages/man5/xymonserver.cfg.5.html
@@ -259,18 +259,28 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       directory. Default: $XYMONHOME/www/notes/
     <p class="Pp"></p>
   </dd>
+  <dt id="XYMONCACHEWWWDIR"><a class="permalink" href="#XYMONCACHEWWWDIR"><b>XYMONCACHEWWWDIR</b></a></dt>
+  <dd>Parent directory for regenerable web output, namely the on-demand
+      availability reports and snapshots (XYMONREPDIR and XYMONSNAPDIR default
+      to subdirectories of it). It is kept separate from the persistent web
+      files so that a packaging can place this throwaway, safe-to-delete data on
+      a volatile filesystem such as /var/cache. Default: $XYMONWWWDIR
+    <p class="Pp"></p>
+  </dd>
   <dt id="XYMONREPDIR"><a class="permalink" href="#XYMONREPDIR"><b>XYMONREPDIR</b></a></dt>
   <dd>Directory for Xymon availability reports. The $XYMONREPURL URL must map to
       this directory. Note also that your webserver must have write-access to
       this directory, if you want to use the <i><a href="../man1/report.cgi.1.html">report.cgi</a>(1)</i> CGI script to
-      generate reports on-demand. Default: $XYMONHOME/www/rep/
+      generate reports on-demand. Default: $XYMONCACHEWWWDIR/rep/ (i.e.
+      $XYMONHOME/www/rep/)
     <p class="Pp"></p>
   </dd>
   <dt id="XYMONSNAPDIR"><a class="permalink" href="#XYMONSNAPDIR"><b>XYMONSNAPDIR</b></a></dt>
   <dd>Directory for Xymon snapshots. The $XYMONSNAPURL URL must map to this
       directory. Note also that your webserver must have write-access to this
       directory, if you want to use the <i><a href="../man1/snapshot.cgi.1.html">snapshot.cgi</a>(1)</i> CGI script to
-      generate snapshots on-demand. Default: $XYMONHOME/www/snap/
+      generate snapshots on-demand. Default: $XYMONCACHEWWWDIR/snap/ (i.e.
+      $XYMONHOME/www/snap/)
     <p class="Pp"></p>
   </dd>
   <dt id="XYMONVAR"><a class="permalink" href="#XYMONVAR"><b>XYMONVAR</b></a></dt>

--- a/xymond/etcfiles/xymonserver.cfg.DIST
+++ b/xymond/etcfiles/xymonserver.cfg.DIST
@@ -112,8 +112,9 @@ XYMONRAWSTATUSDIR="$XYMONVAR/logs"		# Status logs go here (xymond_filestore --st
 XYMONWWWDIR="$XYMONHOME/www"			# The directory for Xymon webpage files.
 XYMONHTMLSTATUSDIR="$XYMONWWWDIR/html"		# HTML status logs go here (xymond_filestore --status --html)
 XYMONNOTESDIR="$XYMONWWWDIR/notes"		# For notes-files (xymond_filestore --notes)
-XYMONREPDIR="$XYMONWWWDIR/rep"			# Top-level directory for Xymon reports.
-XYMONSNAPDIR="$XYMONWWWDIR/snap"		# Top-level directory for Xymon snapshots.
+XYMONCACHEWWWDIR="$XYMONWWWDIR"			# Parent for regenerable web output (rep, snap). Defaults to XYMONWWWDIR; point it elsewhere (e.g. /var/cache/xymon/www) to keep this throwaway, safe-to-delete data out of the persistent docroot.
+XYMONREPDIR="$XYMONCACHEWWWDIR/rep"		# Top-level directory for Xymon reports.
+XYMONSNAPDIR="$XYMONCACHEWWWDIR/snap"		# Top-level directory for Xymon snapshots.
 
 # For the xymond_history module
 XYMONALLHISTLOG="TRUE"				# Save a common log of all events (used for the all nongreen webpage)


### PR DESCRIPTION
`XYMONREPDIR` and `XYMONSNAPDIR` — the on-demand availability reports and snapshots — are **regenerable, safe-to-delete** web output. But they default to subdirectories of `XYMONWWWDIR`, i.e. straight inside the persistent docroot:

```
XYMONREPDIR="$XYMONWWWDIR/rep"
XYMONSNAPDIR="$XYMONWWWDIR/snap"
```

Relocating them — e.g. onto `/var/cache`, where the FHS puts data that "can be regenerated or recreated" and "deleted without loss" — means overriding two independent variables and keeping them in step.

### What this adds

`XYMONCACHEWWWDIR`, their common parent, **defaulting to `XYMONWWWDIR`**:

```
XYMONCACHEWWWDIR="$XYMONWWWDIR"
XYMONREPDIR="$XYMONCACHEWWWDIR/rep"
XYMONSNAPDIR="$XYMONCACHEWWWDIR/snap"
```

Left at the default the two resolve to `$XYMONWWWDIR/rep` and `$XYMONWWWDIR/snap` **exactly as before — a no-op**. A packaging that wants this throwaway data off the docroot now sets **one** variable and both follow:

```
XYMONCACHEWWWDIR="/var/cache/xymon/www"
```

### Config only, no code

The daemons still read `XYMONREPDIR`/`XYMONSNAPDIR` by their own names (`web/report.c`, `web/snapshot.c`), so nothing in C changes; the indirection resolves when `xymonserver.cfg` is sourced. The man page (`xymonserver.cfg.5`) documents the new variable and notes that rep/snap now derive from it.

### Scope

This is the *volatile/regenerable* third of the `www` tree. It is intentionally separate from the *static* third (`gifs`/`help`/`menu`), which needs a build variable and a small `lib/links.c` change and is handled in #414. The persistent third (`html`/`notes`/`wml`) stays the docroot. The overall three-lifecycle FHS layout is tracked in #442.

Note this does **not** create the directory or move content — rep/snap are auto-populated on demand by the report/snapshot CGIs. A packaging pointing `XYMONCACHEWWWDIR` at a fresh location just needs that directory to exist (or the self-healing `mkdir` discussed in #442).
