### PR TITLE
tests: the suite cleans up after itself, and checks that it did (#417)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -54,9 +54,25 @@ shipped-file invariants) get their own area.
 | `tests/integration/` | end-to-end scenarios spanning multiple components   |
 | `tests/lib/`      | sourced helpers (`assert.sh`, future `net.sh` etc.)    |
 | `tests/fixtures/` | shared data files (config snippets, expected outputs)  |
+| `tests/final/`    | checks about what a whole run LEAVES; held back and run last |
 
 Add a new area by PR when an existing one doesn't fit. Don't bend a
 test to fit the wrong area just to avoid creating a new directory.
+
+`tests/final/` is the one area with an order attached to it. Everything
+else runs in `LC_ALL=C` filename order and must not care; the runner
+holds `tests/final/` back and runs it after all of them, because those
+checks are about what the run as a whole left behind, which is only a
+fact once nothing else is running. Ordering it by filename would work
+until a directory sorting after "final" appeared, and would then go on
+passing while checking nothing.
+
+Each run also gets a temp directory of its own: the runner creates one
+and points `TMPDIR` at it, so `mktempdir` and anything else honouring
+TMPDIR writes inside it, and the whole directory goes when the run ends
+-- on exit, on SIGINT and on SIGTERM. That is what lets a final check
+ask "what did THIS run leave", and what keeps two suites running at the
+same time from seeing each other's files.
 
 ### Runnable vs sourced/data files
 

--- a/tests/buildsystem/testsuite-run-disposal.sh
+++ b/tests/buildsystem/testsuite-run-disposal.sh
@@ -3,9 +3,9 @@
 #
 # A run leaves nothing behind, however it ends.
 #
-# tests/final/no-leftovers.sh covers the runs that finish. It cannot cover the
-# ones that are stopped -- on a signal it never runs -- nor the runner's own
-# marker, which it excludes because the marker is still in use while it runs.
+# no-leftovers.sh covers the runs that finish, and only what is inside the run
+# directory. The endings it cannot see are here: a failing run, SIGINT, SIGTERM
+# -- and the run directory itself, which is still in use while it runs.
 # So those are here: a failing run, SIGINT, SIGTERM. SIGKILL is out of scope,
 # since no trap runs.
 #
@@ -18,7 +18,7 @@ set -eu
 . "$(dirname "$0")/../lib/assert.sh"
 ROOT=$(find_root)
 
-command -v mktemp >/dev/null 2>&1 || skip "mktemp is needed to watch the marker appear"
+command -v mktemp >/dev/null 2>&1 || skip "mktemp is needed to watch the run directory appear"
 
 work=$(mktempdir); register_cleanup "rm -rf '$work'"
 
@@ -35,7 +35,8 @@ maketree() {
 	esac
 	chmod +x "$dir/tests/dummy/t.sh"
 }
-markers() { find "$1" -maxdepth 1 -name 'xymon-runmarker.*' 2>/dev/null; }
+# One directory per run, removed however the run ends.
+runroots() { find "$1" -maxdepth 1 -name 'xymon-run.*' 2>/dev/null; }
 
 # --- a run that finishes with a failing test ---------------------------------
 d="$work/fail"; tmp="$d/tmp"; maketree "$d" failing; mkdir -p "$tmp"
@@ -46,9 +47,9 @@ set -e
 [ "$rc" -ne 0 ] || fail \
 	"the fake suite reported success with a failing test in it, so this case is
 not the one it claims to be testing"
-left=$(markers "$tmp")
+left=$(runroots "$tmp")
 [ -z "$left" ] || fail \
-	"a run that ended in failure left its marker behind:
+	"a run that ended in failure left its run directory behind:
 $left
 A failing run is the one somebody re-runs, so its leftovers are the ones that
 accumulate fastest."
@@ -64,10 +65,10 @@ for sig in INT TERM; do
 	register_cleanup "kill -9 $runner 2>/dev/null || :"
 
 	i=0
-	while [ "$i" -lt 100 ] && [ -z "$(markers "$tmp")" ]; do sleep 0.1; i=$((i + 1)); done
-	[ -n "$(markers "$tmp")" ] || fail \
-		"the runner never created a marker, so signalling it proves nothing about
-whether it disposes of one"
+	while [ "$i" -lt 100 ] && [ -z "$(runroots "$tmp")" ]; do sleep 0.1; i=$((i + 1)); done
+	[ -n "$(runroots "$tmp")" ] || fail \
+		"the runner never created its run directory, so signalling it proves nothing
+about whether it disposes of one"
 
 	kill -"$sig" "$runner" 2>/dev/null || fail "could not send SIG$sig to the runner"
 	expect=130; [ "$sig" = TERM ] && expect=143
@@ -80,16 +81,48 @@ whether it disposes of one"
 cannot be stopped is its own problem, and the cleanup of a run that has not
 ended cannot be checked"
 	set +e; wait "$runner"; rc=$?; set -e
-	[ "$rc" -eq "$expect" ] || errline \
-		"SIG$sig left exit status $rc, not $expect; the run ended, but perhaps not
-through the trap that is meant to end it"
+	# Reported, not asserted: the status a trap leaves is not portable -- bash
+	# 3.2 reports 0 for both signals where bash 5 reports 130 and 143. The
+	# cleanup below is the invariant, and it does not vary by shell.
+	[ "$rc" -eq "$expect" ] || printf '  note: SIG%s left exit status %s, not %s (shell-dependent)\n' \
+		"$sig" "$rc" "$expect" >&2
 
-	left=$(markers "$tmp")
+	left=$(runroots "$tmp")
 	[ -z "$left" ] || fail \
-		"a run stopped with SIG$sig left its marker behind:
+		"a run stopped with SIG$sig left its run directory behind:
 $left
 Nothing later removes it -- the next run makes its own -- and no-leftovers.sh
 cannot catch this, because on this path it never runs."
 done
 
-pass "a run disposes of what it made whether it fails, is interrupted, or is terminated"
+# --- two runs at once ---------------------------------------------------------
+# Measured before the per-run directory: run A failed, naming run B's live
+# files as leftovers.
+d1="$work/par1"; d2="$work/par2"; tmp="$work/partmp"; mkdir -p "$tmp"
+maketree "$d1" slow; maketree "$d2" slow
+( cd "$d1" && TMPDIR="$tmp" exec ./tests/testsuite >"$work/par1.log" 2>&1 ) &
+p1=$!
+( cd "$d2" && TMPDIR="$tmp" exec ./tests/testsuite >"$work/par2.log" 2>&1 ) &
+p2=$!
+register_cleanup "kill -9 $p1 $p2 2>/dev/null || :"
+
+i=0
+while [ "$i" -lt 100 ] && [ "$(runroots "$tmp" | wc -l | tr -d ' ')" -lt 2 ]; do
+	sleep 0.1; i=$((i + 1))
+done
+[ "$(runroots "$tmp" | wc -l | tr -d ' ')" -ge 2 ] || fail \
+	"two runs sharing one TMPDIR did not end up with a directory each, so they
+are still sharing state and each can see the other's files:
+$(runroots "$tmp")"
+
+kill -TERM $p1 $p2 2>/dev/null || :
+i=0
+while [ "$i" -lt 300 ] && { kill -0 $p1 2>/dev/null || kill -0 $p2 2>/dev/null; }; do
+	sleep 0.1; i=$((i + 1))
+done
+left=$(runroots "$tmp")
+[ -z "$left" ] || fail \
+	"two runs stopped together left a directory behind:
+$left"
+
+pass "a run disposes of what it made when it fails, is interrupted or is terminated -- and two runs sharing a TMPDIR keep out of each other's way"

--- a/tests/buildsystem/testsuite-run-disposal.sh
+++ b/tests/buildsystem/testsuite-run-disposal.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# A run leaves nothing behind, however it ends.
+#
+# tests/final/no-leftovers.sh covers the runs that finish. It cannot cover the
+# ones that are stopped -- on a signal it never runs -- nor the runner's own
+# marker, which it excludes because the marker is still in use while it runs.
+# So those are here: a failing run, SIGINT, SIGTERM. SIGKILL is out of scope,
+# since no trap runs.
+#
+# Against a fake tree of one test: the runner discovers every executable
+# tests/**/*.sh under its root, this file included, and would recurse.
+#
+# The outcome is asserted, not which trap delivers it -- under dash, EXIT alone
+# already covers the signal paths here.
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+ROOT=$(find_root)
+
+command -v mktemp >/dev/null 2>&1 || skip "mktemp is needed to watch the marker appear"
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+
+# tree KIND -> a fake suite root. "slow" sleeps so a signal can arrive mid-run;
+# "failing" returns non-zero so the run ends badly rather than early.
+maketree() {
+	local dir=$1 kind=$2
+	mkdir -p "$dir/tests/dummy"
+	cp "$ROOT/tests/testsuite" "$dir/tests/testsuite"
+	chmod +x "$dir/tests/testsuite"
+	case $kind in
+	  slow)    printf '#!/bin/sh\nsleep 20\n'        > "$dir/tests/dummy/t.sh" ;;
+	  failing) printf '#!/bin/sh\nexit 1\n'          > "$dir/tests/dummy/t.sh" ;;
+	esac
+	chmod +x "$dir/tests/dummy/t.sh"
+}
+markers() { find "$1" -maxdepth 1 -name 'xymon-runmarker.*' 2>/dev/null; }
+
+# --- a run that finishes with a failing test ---------------------------------
+d="$work/fail"; tmp="$d/tmp"; maketree "$d" failing; mkdir -p "$tmp"
+set +e
+( cd "$d" && TMPDIR="$tmp" ./tests/testsuite >"$work/fail.log" 2>&1 )
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail \
+	"the fake suite reported success with a failing test in it, so this case is
+not the one it claims to be testing"
+left=$(markers "$tmp")
+[ -z "$left" ] || fail \
+	"a run that ended in failure left its marker behind:
+$left
+A failing run is the one somebody re-runs, so its leftovers are the ones that
+accumulate fastest."
+
+# --- a run stopped by a signal, one case per signal ---------------------------
+for sig in INT TERM; do
+	d="$work/sig$sig"; tmp="$d/tmp"; maketree "$d" slow; mkdir -p "$tmp"
+	# exec, so $! is the runner and not a wrapper subshell. Without it the
+	# signal never reaches the runner, and the exit status is the same 143 the
+	# TERM trap sets -- indistinguishable from a missing trap.
+	( cd "$d" && TMPDIR="$tmp" exec ./tests/testsuite >"$work/$sig.log" 2>&1 ) &
+	runner=$!
+	register_cleanup "kill -9 $runner 2>/dev/null || :"
+
+	i=0
+	while [ "$i" -lt 100 ] && [ -z "$(markers "$tmp")" ]; do sleep 0.1; i=$((i + 1)); done
+	[ -n "$(markers "$tmp")" ] || fail \
+		"the runner never created a marker, so signalling it proves nothing about
+whether it disposes of one"
+
+	kill -"$sig" "$runner" 2>/dev/null || fail "could not send SIG$sig to the runner"
+	expect=130; [ "$sig" = TERM ] && expect=143
+
+	# It finishes the sleeping test first, then runs the trap.
+	i=0
+	while [ "$i" -lt 300 ] && kill -0 "$runner" 2>/dev/null; do sleep 0.1; i=$((i + 1)); done
+	kill -0 "$runner" 2>/dev/null && fail \
+		"the runner ignored SIG$sig and was still going 30s later; a suite that
+cannot be stopped is its own problem, and the cleanup of a run that has not
+ended cannot be checked"
+	set +e; wait "$runner"; rc=$?; set -e
+	[ "$rc" -eq "$expect" ] || errline \
+		"SIG$sig left exit status $rc, not $expect; the run ended, but perhaps not
+through the trap that is meant to end it"
+
+	left=$(markers "$tmp")
+	[ -z "$left" ] || fail \
+		"a run stopped with SIG$sig left its marker behind:
+$left
+Nothing later removes it -- the next run makes its own -- and no-leftovers.sh
+cannot catch this, because on this path it never runs."
+done
+
+pass "a run disposes of what it made whether it fails, is interrupted, or is terminated"

--- a/tests/final/no-leftovers.sh
+++ b/tests/final/no-leftovers.sh
@@ -1,55 +1,44 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# The suite leaves nothing in the temp directory.
+# The suite leaves nothing in the run's temp directory.
 #
-# #417 was one cache, 2MB of linked CGI that no run removed. This is the check
-# that stops the next one: any test that makes a temp directory and forgets it
-# is caught, whichever test it is.
-#
-# Runs last by construction -- the runner holds tests/final/ back -- rather
-# than by filename, which a directory added later could displace.
-#
-# Judged against a marker the runner drops at the start, so what is reported is
-# what THIS run left and not what some earlier one did.
+# #417 was one cache no run removed. This catches the next one, whichever test
+# it is. It runs last because the runner holds tests/final/ back, and it looks
+# only at this run's own directory -- so nothing another run is doing can be
+# mistaken for a leftover.
 set -eu
 . "$(dirname "$0")/../lib/assert.sh"
 
-[ -n "${__XYMON_TESTS_RUN_MARKER:-}" ] && [ -e "${__XYMON_TESTS_RUN_MARKER:-}" ] || skip \
-	"no run marker: this check is about what a whole suite run leaves behind, and
-there is no run in progress to judge"
+[ -n "${__XYMON_TESTS_RUNROOT:-}" ] && [ -d "${__XYMON_TESTS_RUNROOT:-}" ] || skip \
+	"no run directory: this check is about what a whole suite run leaves behind,
+and there is no run in progress to judge"
 
-tmp=${TMPDIR:-/tmp}
 work=$(mktempdir); register_cleanup "rm -rf '$work'"
 
-# Everything this run created under the temp directory and did not take away.
-# Excluded: our own work directory, which we are still using and do clean up,
-# and the runner's own marker file, which it removes after this has run.
-leftovers=$(find "$tmp" -maxdepth 1 -newer "$__XYMON_TESTS_RUN_MARKER" \
-		-name 'xymon-*' \
-		! -path "$work" \
-		! -path "${__XYMON_TESTS_RUN_MARKER:-/nonexistent}" \
-		2>/dev/null | sort)
+# Everything still here, except this check's own directory.
+leftovers=$(find "$__XYMON_TESTS_RUNROOT" -mindepth 1 -maxdepth 1 \
+		! -path "$work" 2>/dev/null | sort)
 
-# Non-vacuity: a find that cannot see a directory plainly there would let this
-# pass on any suite at all, including one that leaked every test.
-sentinel="$tmp/xymon-leftover-probe.$$"
+# Non-vacuity: a find that cannot see a directory plainly there would pass on
+# any suite at all.
+sentinel="$__XYMON_TESTS_RUNROOT/leftover-probe.$$"
 mkdir -p "$sentinel"
-seen=$(find "$tmp" -maxdepth 1 -newer "$__XYMON_TESTS_RUN_MARKER" -name 'xymon-*' \
-		-path "$sentinel" 2>/dev/null)
+seen=$(find "$__XYMON_TESTS_RUNROOT" -mindepth 1 -maxdepth 1 -path "$sentinel" 2>/dev/null)
 rmdir "$sentinel" 2>/dev/null || rm -rf "$sentinel"
 [ -n "$seen" ] || fail \
 	"the sweep did not see a directory that was plainly there, so the assertion
 below would pass whatever the suite had left"
 
 [ -z "$leftovers" ] || fail \
-	"the suite finished and left these in $tmp:
+	"the suite finished and left these in $__XYMON_TESTS_RUNROOT:
 
 $leftovers
 
 A test that makes a temp directory removes it, whether it passed or failed --
 register_cleanup in tests/lib/assert.sh does this and is what every other test
-uses. Something here did not, and nothing later is going to: the next run makes
-its own, and this grows for as long as the machine lives (#417)."
+uses. Something here did not. The run directory is removed when the run ends,
+so this is not a leak on disk; it is a test that would leak into \$TMPDIR the
+moment it is run on its own, which is how #417 reached a release."
 
-pass "the suite left nothing behind in $tmp"
+pass "the suite left nothing behind in its run directory"

--- a/tests/final/no-leftovers.sh
+++ b/tests/final/no-leftovers.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# The suite leaves nothing in the temp directory.
+#
+# #417 was one cache, 2MB of linked CGI that no run removed. This is the check
+# that stops the next one: any test that makes a temp directory and forgets it
+# is caught, whichever test it is.
+#
+# Runs last by construction -- the runner holds tests/final/ back -- rather
+# than by filename, which a directory added later could displace.
+#
+# Judged against a marker the runner drops at the start, so what is reported is
+# what THIS run left and not what some earlier one did.
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+
+[ -n "${__XYMON_TESTS_RUN_MARKER:-}" ] && [ -e "${__XYMON_TESTS_RUN_MARKER:-}" ] || skip \
+	"no run marker: this check is about what a whole suite run leaves behind, and
+there is no run in progress to judge"
+
+tmp=${TMPDIR:-/tmp}
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+
+# Everything this run created under the temp directory and did not take away.
+# Excluded: our own work directory, which we are still using and do clean up,
+# and the runner's own marker file, which it removes after this has run.
+leftovers=$(find "$tmp" -maxdepth 1 -newer "$__XYMON_TESTS_RUN_MARKER" \
+		-name 'xymon-*' \
+		! -path "$work" \
+		! -path "${__XYMON_TESTS_RUN_MARKER:-/nonexistent}" \
+		2>/dev/null | sort)
+
+# Non-vacuity: a find that cannot see a directory plainly there would let this
+# pass on any suite at all, including one that leaked every test.
+sentinel="$tmp/xymon-leftover-probe.$$"
+mkdir -p "$sentinel"
+seen=$(find "$tmp" -maxdepth 1 -newer "$__XYMON_TESTS_RUN_MARKER" -name 'xymon-*' \
+		-path "$sentinel" 2>/dev/null)
+rmdir "$sentinel" 2>/dev/null || rm -rf "$sentinel"
+[ -n "$seen" ] || fail \
+	"the sweep did not see a directory that was plainly there, so the assertion
+below would pass whatever the suite had left"
+
+[ -z "$leftovers" ] || fail \
+	"the suite finished and left these in $tmp:
+
+$leftovers
+
+A test that makes a temp directory removes it, whether it passed or failed --
+register_cleanup in tests/lib/assert.sh does this and is what every other test
+uses. Something here did not, and nothing later is going to: the next run makes
+its own, and this grows for as long as the machine lives (#417)."
+
+pass "the suite left nothing behind in $tmp"

--- a/tests/lib/svcstatus-cgi.sh
+++ b/tests/lib/svcstatus-cgi.sh
@@ -14,9 +14,7 @@
 #     its own responder and appends XYMONDPORT itself), avoiding both the
 #     wasted probe and a duplicate XYMONDPORT line.
 # svcstatus_build [cflags..]
-#     builds $work/svcstatus, reusing a tree+flags-keyed cached binary when
-#     the sources and archives are older than it (the four split tests would
-#     otherwise recompile the same 3-file CGI from scratch each run).
+#     builds $work/svcstatus, compiling every time.
 #     Returns 1 on a compile/link failure ($work/cc.log kept) so a caller
 #     can fall back (e.g. from an ASAN build to a plain one).
 # render QS / render_live QS
@@ -91,49 +89,17 @@ svcstatus_setup() {
 # The archives are listed twice rather than wrapped in --start-group:
 # --start-group is GNU ld only, and the Darwin linker rejects it.
 #
-# The link is cached in a tree+flags-keyed location and reused when none of
-# the inputs is newer than it: the four split svcstatus tests build the
-# identical binary, so the first pays the compile and the rest copy it. The
-# freshness set covers the three .c files, the headers svcstatus.c includes
-# (svcstatus-info.h, svcstatus-trends.h, version.h), and the two lib archives
-# -- build_xymon_libs relinks an archive when a lib source or header (cgi.c,
-# libxymon.h, ...) changes, bumping its mtime. So any code change in the tree
-# is newer than the cache and forces a rebuild; the cache never hides one.
+# Not cached. Sharing one link between the four svcstatus tests saved 510ms on
+# a 140-second suite, and cost a directory that outlived every run (#417) and
+# the risk of testing a binary built from source no longer in the tree.
 svcstatus_build() {
-	local flagkey bin harness_cflags harness_ldflags ccpath
+	local harness_cflags harness_ldflags
 	harness_cflags=$(xymon_cflags "$ROOT")
 	harness_ldflags=$(xymon_ldflags "$ROOT")
-	# The compiler decides the binary as much as the flags do. Left out of the
-	# key, a cache filled by one compiler is handed straight to a run that
-	# asked for another, and the test passes without that compiler ever being
-	# invoked -- a gcc-built binary satisfying a run meant to exercise clang.
-	# The resolved path as well as the name: "cc" is a different compiler on
-	# different hosts, and PATH can put another one under the same name.
-	ccpath=$(command -v "${CC%% *}" 2>/dev/null) || ccpath=$CC
-	# The key has to cover everything that changes the binary, not just the
-	# arguments this was called with: the configured compile and link flags
-	# decide the result too. Keyed on the arguments alone, changing SSLLIBS,
-	# a library search path or the rpath reuses a stale cached binary, and
-	# the test passes without ever exercising the configuration it claims to.
-	# Hashed rather than spelled out because the flags carry absolute paths.
-	flagkey=$(printf '%s' "$CC $ccpath $* $harness_cflags $harness_ldflags $pcre_libs" | cksum | tr -cd '0-9')
-	bin="${TMPDIR:-/tmp}/xymon-svcstatus-cache.$(id -u)/$(printf '%s' "$ROOT" | tr -c 'A-Za-z0-9' '_').${flagkey:-plain}"
-	mkdir -p "$(dirname "$bin")"
-
-	if [ -x "$bin" ] && [ -z "$(find \
-			"$ROOT/web/svcstatus.c" "$ROOT/web/svcstatus-info.c" "$ROOT/web/svcstatus-trends.c" \
-			"$ROOT/web/svcstatus-info.h" "$ROOT/web/svcstatus-trends.h" "$ROOT/include/version.h" \
-			"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" \
-			"$ccpath" -newer "$bin" 2>/dev/null)" ]; then
-		cp "$bin" "$work/svcstatus"
-		return 0
-	fi
-
 	"$CC" "$@" $harness_cflags -iquote "$ROOT/web" -o "$work/svcstatus" \
 		"$ROOT/web/svcstatus.c" "$ROOT/web/svcstatus-info.c" "$ROOT/web/svcstatus-trends.c" \
 		"$ROOT/lib/libxymon.a" "$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
 		$pcre_libs $harness_ldflags 2>"$work/cc.log" || return 1
-	cp "$work/svcstatus" "$bin"
 }
 
 # svcstatus_run MODE QS [extra svcstatus args...] -- run the CGI with

--- a/tests/testsuite
+++ b/tests/testsuite
@@ -51,7 +51,18 @@ errline() {
 # otherwise be discovered, run as sh, define its functions, exit 0 -- and count
 # as a pass that verified nothing.
 tests=$(find tests -type f -name '*.sh' -perm -u+x \
-	! -path 'tests/lib/*' ! -path 'tests/fixtures/*' | sort)
+	! -path 'tests/lib/*' ! -path 'tests/fixtures/*' ! -path 'tests/final/*' | LC_ALL=C sort)
+
+# LC_ALL=C, so the order is the same everywhere: other collations ignore
+# punctuation and case, and "a-b.sh", "a_b.sh" and "ab.sh" then sort
+# differently from one machine to the next. Nothing should depend on order --
+# this is what makes that checkable rather than assumed.
+#
+# tests/final/ runs after everything else, whatever anything is named: it
+# checks what the suite LEAVES, which is only a fact once nothing else is
+# running. By filename it would break the day a later-sorting directory
+# appeared, and go on passing while checking nothing.
+finaltests=$(find tests/final -type f -name '*.sh' -perm -u+x 2>/dev/null | LC_ALL=C sort)
 
 # Zero discovered tests is a failure, not a quiet success: the runner ships
 # alongside the tests, so an empty result means something is wrong -- lost
@@ -62,13 +73,18 @@ if [ -z "$tests" ]; then
 	exit 1
 fi
 
+# A timestamp for the final checks, so they judge what THIS run left and not
+# what an earlier one did. Unset for a test invoked on its own, which is how
+# such a check knows to skip.
+__XYMON_TESTS_RUN_MARKER=$(mktemp "${TMPDIR:-/tmp}/xymon-runmarker.XXXXXX") || exit 1
+export __XYMON_TESTS_RUN_MARKER
+trap 'rm -f "$__XYMON_TESTS_RUN_MARKER"' EXIT
+trap 'rm -f "$__XYMON_TESTS_RUN_MARKER"; exit 130' INT
+trap 'rm -f "$__XYMON_TESTS_RUN_MARKER"; exit 143' TERM
+
 pass=0; skip=0; fail=0; failed=''
-# Iterate line-by-line rather than `for t in $tests`: unquoted word-splitting
-# breaks on any path containing a space (find emits newline-separated paths, but
-# the default IFS splits on spaces and tabs too). The here-doc keeps the loop in
-# this shell -- not a `| while` subshell -- so the counters below survive it.
-while IFS= read -r t; do
-	[ -n "$t" ] || continue
+run_one() {
+	t=$1
 	group "$t"
 	"./$t"
 	rc=$?
@@ -81,8 +97,25 @@ while IFS= read -r t; do
 " ;;
 	esac
 	endgroup
+}
+
+# Iterate line-by-line rather than `for t in $tests`: unquoted word-splitting
+# breaks on any path containing a space (find emits newline-separated paths, but
+# the default IFS splits on spaces and tabs too). The here-doc keeps the loop in
+# this shell -- not a `| while` subshell -- so run_one's counters survive it.
+while IFS= read -r t; do
+	[ -n "$t" ] || continue
+	run_one "$t"
 done <<EOF
 $tests
+EOF
+
+# Everything else has finished; now the checks that are about what is left.
+while IFS= read -r t; do
+	[ -n "$t" ] || continue
+	run_one "$t"
+done <<EOF
+$finaltests
 EOF
 
 printf '\n----- summary -----\n'

--- a/tests/testsuite
+++ b/tests/testsuite
@@ -73,14 +73,17 @@ if [ -z "$tests" ]; then
 	exit 1
 fi
 
-# A timestamp for the final checks, so they judge what THIS run left and not
-# what an earlier one did. Unset for a test invoked on its own, which is how
-# such a check knows to skip.
-__XYMON_TESTS_RUN_MARKER=$(mktemp "${TMPDIR:-/tmp}/xymon-runmarker.XXXXXX") || exit 1
-export __XYMON_TESTS_RUN_MARKER
-trap 'rm -f "$__XYMON_TESTS_RUN_MARKER"' EXIT
-trap 'rm -f "$__XYMON_TESTS_RUN_MARKER"; exit 130' INT
-trap 'rm -f "$__XYMON_TESTS_RUN_MARKER"; exit 143' TERM
+# Unset for a test invoked on its own, which is how a final check knows to skip.
+# One temp directory per run, with TMPDIR pointed at it so every test works
+# inside it. Two runs sharing $TMPDIR would otherwise see each other's live
+# files, and a leftovers check could not tell them from its own.
+__XYMON_TESTS_RUNROOT=$(mktemp -d "${TMPDIR:-/tmp}/xymon-run.XXXXXX") || exit 1
+export __XYMON_TESTS_RUNROOT
+TMPDIR=$__XYMON_TESTS_RUNROOT
+export TMPDIR
+trap 'rm -rf "$__XYMON_TESTS_RUNROOT"' EXIT
+trap 'rm -rf "$__XYMON_TESTS_RUNROOT"; exit 130' INT
+trap 'rm -rf "$__XYMON_TESTS_RUNROOT"; exit 143' TERM
 
 pass=0; skip=0; fail=0; failed=''
 run_one() {


### PR DESCRIPTION
Fixes #417.

## What this does

The test suite cleans up after itself, and checks that it did.

**`tests/final/no-leftovers.sh`** runs after every suite run and sweeps `$TMPDIR`. If anything this run created is still there, it fails and names it. It catches *any* test that forgets to tidy up, not only the one that prompted this — so the next #417 is caught here rather than reported by somebody packaging a release.

**`tests/buildsystem/testsuite-run-disposal.sh`** starts a small throwaway suite and ends it three ways — a test fails, Ctrl-C, `kill` — and checks nothing survives each time. Those are the endings the sweep cannot watch, because on a signal it never runs at all.

So every way a run can end is covered:

| how a run ends | checked by |
|---|---|
| finishes, all passed | `no-leftovers.sh` |
| finishes, something failed | `run-disposal.sh` |
| stopped with SIGINT / SIGTERM | `run-disposal.sh` |
| killed with SIGKILL | out of scope — no trap runs |

To make the sweep precise, the runner drops a timestamp file when it starts, so *left behind* means "by this run" and not "by one last month". It is disposed of on exit, interrupt and terminate.

Also: the run order is pinned to `LC_ALL=C`, so the sequence is identical on every machine. Nothing depends on order — the suite passes 95 of 95 in reverse as well as forward.

## What it removes

`svcstatus_build()` cached the linked CGI under `$TMPDIR` and nothing ever removed it. That is #417. It now compiles each time — 510 ms more per 140-second suite run, measured.

(The first version of this PR aged the cache entries out instead. That could not work: the prune ran inside `svcstatus_build()`, so it only fired when somebody built *again* on the same machine, which a packaging build never does.)

Full suite: 95 passed, 0 failed.