### PR TITLE
tests: don't trip the bash 3.2 parser the suite pins as its floor

### DIFF
--- a/tests/buildsystem/test-suite-portability.sh
+++ b/tests/buildsystem/test-suite-portability.sh
@@ -25,14 +25,22 @@ work=$(mktempdir)
 # non-vacuity probe below is what keeps the rules honest instead.
 # Every shell script under tests/, not just the *.sh ones: the runner itself
 # carries no extension, and it is the file that has to run on every platform.
-files=$(
-	find "$ROOT/tests" -type f \( -name '*.sh' -o -perm -100 \) ! -name "$(basename "$0")" |
+# A `case` inside $(...) trips the bash 3.2 command-substitution parser -- the
+# very shell this suite pins as the floor (macOS ships 3.2), where the `)` of a
+# case pattern is mistaken for the end of the substitution. Keep the filter in a
+# function the substitution only calls, so no case is parsed inside $(...).
+_emit_shell_scripts() {
+	local f
 	while IFS= read -r f; do
 		case $f in
 			*.sh) printf '%s\n' "$f" ;;
 			*) head -n 1 "$f" 2>/dev/null | grep -q '^#!.*sh' && printf '%s\n' "$f" ;;
 		esac
-	done | sort -u
+	done
+}
+files=$(
+	find "$ROOT/tests" -type f \( -name '*.sh' -o -perm -100 \) ! -name "$(basename "$0")" |
+	_emit_shell_scripts | sort -u
 )
 [ -n "$files" ] || fail "found no test scripts to check"
 


### PR DESCRIPTION
## Problem

`tests/buildsystem/test-suite-portability.sh` enforces *"bash 3.2 is the floor"* (macOS ships 3.2, and the suite runs under `/usr/bin/env bash`). But its own script-collection step built a `case` **inside a `$(…)` command substitution**:

```sh
files=$(
    find "$ROOT/tests" … |
    while IFS= read -r f; do
        case $f in
            *.sh) printf '%s\n' "$f" ;;   # ← bash 3.2 chokes here
            *)    head -n1 "$f" | grep -q '^#!.*sh' && printf '%s\n' "$f" ;;
        esac
    done | sort -u
)
```

That is exactly the construct the **bash 3.2 command-substitution parser mis-handles** — the `)` of a case pattern is taken for the end of the `$(…)`. On macOS the script prints:

```
test-suite-portability.sh: line 32: syntax error near unexpected token `;;'
```

…and, because that error is inside the substitution, **exits 0 without running any of its checks** — a silent, *vacuous* pass on the very platform these portability rules exist to protect. Linux/BSD CI use bash 4+, which parse it fine, so it went unnoticed. Found while running the suite natively on a macOS (bash 3.2.57) host.

## Fix

Hoist the per-file filter into a top-level function the substitution only *calls*, so no `case` is parsed inside `$(…)`. Logic is unchanged.

## Verification

- **macOS bash 3.2.57**: `bash -n` parses clean; running it now emits `PASS` and actually executes its checks (previously a no-op that printed the error and exited 0).
- **bash 4+ (Linux/BSD CI)**: behaviour unchanged.

No product code touched — test-harness only. Independent of any other open PR.
