### PR TITLE
loadhosts: bound the IP copied into the caller's hostip buffer

### DIFF
--- a/lib/loadhosts.c
+++ b/lib/loadhosts.c
@@ -373,7 +373,12 @@ char *knownhost(char *hostname, char *hostip, enum ghosthandling_t ghosthandling
 			result = (strcasecmp(hivals[XMH_CLIENTALIAS], hostname) == 0) ? strdup(hivalhost) : NULL;
 		}
 
-		if (result && hivals[XMH_IP]) strcpy(hostip, hivals[XMH_IP]);
+		/* hivals[XMH_IP] is off the network (a "hostinfo clone=" reply);
+		   hostip is IP_ADDR_STRLEN at every caller, so bound the copy. */
+		if (result && hivals[XMH_IP]) {
+			strncpy(hostip, hivals[XMH_IP], IP_ADDR_STRLEN - 1);
+			hostip[IP_ADDR_STRLEN - 1] = '\0';
+		}
 
 		return result;
 	}
@@ -396,7 +401,8 @@ char *knownhost(char *hostname, char *hostip, enum ghosthandling_t ghosthandling
 		/*
 		 * Force our version of the hostname. Done here so CLIENT works always.
 		 */
-		strcpy(hostip, walk->ip);
+		strncpy(hostip, walk->ip, IP_ADDR_STRLEN - 1);
+		hostip[IP_ADDR_STRLEN - 1] = '\0';
 		result = strdup(walk->hostname);
 	}
 	else {

--- a/tests/server/loadhosts-ip-length.sh
+++ b/tests/server/loadhosts-ip-length.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/loadhosts-ip-length.sh
+#
+# Regression guard for the stack buffer overflow in knownhost() (lib/loadhosts.c).
+#
+# knownhost() writes the resolved IP into the caller's hostip buffer, which is
+# char hostip[IP_ADDR_STRLEN] (16) at every caller. Two copies did it with an
+# unbounded strcpy(). The dangerous one took the IP from hivals[XMH_IP] -- a
+# field parsed straight out of a "hostinfo clone=" reply off the network -- so
+# a clone response with an IP field longer than 15 characters overran the
+# caller's 16-byte stack buffer. The fix bounds both copies to IP_ADDR_STRLEN.
+#
+# knownhost() pulls in the whole xtree/host-load machinery, so -- like
+# tests/server/combostatus-overflow.sh -- this (1) binds to the real source:
+# the bounded copies must be present and the raw strcpy(hostip, ...) gone, and
+# (2) compiles a faithful copy of the bounded copy with a canary right past a
+# 16-byte hostip and shows an over-length IP is truncated, not overrun. The
+# unbounded form is deliberately NOT executed (it is the overflow under test).
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SRC="$ROOT/lib/loadhosts.c"
+HDR="$ROOT/include/libxymon.h"
+CC=${CC:-cc}
+
+[ -f "$SRC" ] || skip "lib/loadhosts.c absent"
+
+# (1) Bind to the real code: both copies bounded, no raw strcpy into hostip.
+assert_contains "strncpy(hostip, hivals[XMH_IP], IP_ADDR_STRLEN - 1)" "$(cat "$SRC")" \
+	"loadhosts.c knownhost() lost the bounded copy of the network clone IP into hostip"
+assert_contains "strncpy(hostip, walk->ip, IP_ADDR_STRLEN - 1)" "$(cat "$SRC")" \
+	"loadhosts.c knownhost() lost the bounded copy of the tree IP into hostip"
+grep -Eq 'strcpy\(hostip,' "$SRC" \
+	&& fail "loadhosts.c knownhost() still has an unbounded strcpy(hostip, ...) -- it can overrun the caller's hostip[IP_ADDR_STRLEN]"
+
+# strncpy is only safe with the explicit NUL: it does not terminate when the
+# source is IP_ADDR_STRLEN-1 or longer. Both bounded copies must terminate.
+terms=$(grep -cF "hostip[IP_ADDR_STRLEN - 1] = '\\0';" "$SRC" || true)
+[ "$terms" -eq 2 ] \
+	|| fail "loadhosts.c knownhost() must NUL-terminate hostip after each bounded copy; found $terms of 2 -- a bare strncpy leaves hostip unterminated for a 15+ char source"
+
+# The demo hardcodes IP_ADDR_STRLEN; pin it to the header so a change is noticed.
+assert_contains "#define IP_ADDR_STRLEN 16" "$(cat "$HDR")" \
+	"IP_ADDR_STRLEN is no longer 16; update loadhosts-ip-length.sh's demo to match"
+
+# (2) Behavioural demo of the property, if we can compile.
+command -v "$CC" >/dev/null 2>&1 \
+	|| pass "loadhosts.c bounds the hostip copies (static check; no C compiler for the run)"
+
+work=$(mktempdir)
+cat >"$work/t.c" <<'CEOF'
+#include <stdio.h>
+#include <string.h>
+
+#define IP_ADDR_STRLEN 16   /* mirrors include/libxymon.h; pinned by the test above */
+
+/* Mirror knownhost()'s bounded copy into the caller's hostip[IP_ADDR_STRLEN]. */
+static int copy_ip(const char *src)
+{
+	struct { char hostip[IP_ADDR_STRLEN]; char canary; } s;
+	s.canary = '#';
+
+	strncpy(s.hostip, src, IP_ADDR_STRLEN - 1);
+	s.hostip[IP_ADDR_STRLEN - 1] = '\0';
+
+	if (s.canary != '#')                    { fprintf(stderr, "canary clobbered -- copy overran hostip\n"); return 1; }
+	if (strlen(s.hostip) >= IP_ADDR_STRLEN) { fprintf(stderr, "hostip not NUL-bounded: len=%zu\n", strlen(s.hostip)); return 1; }
+	/* A source that fits must survive intact; one that does not must truncate,
+	 * never overrun. */
+	if (strlen(src) < IP_ADDR_STRLEN && strcmp(s.hostip, src) != 0) {
+		fprintf(stderr, "short IP corrupted: '%s' != '%s'\n", s.hostip, src);
+		return 1;
+	}
+	return 0;
+}
+
+int main(void)
+{
+	if (copy_ip("192.0.2.10") != 0) return 1;                 /* fits */
+	if (copy_ip("255.255.255.255") != 0) return 1;            /* 15 chars, the max IPv4 */
+	if (copy_ip("2001:0db8:85a3:0000:0000:8a2e:0370:7334") != 0) return 1; /* 39-char IPv6, would overrun a raw strcpy */
+	if (copy_ip("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA") != 0) return 1; /* pure over-length garbage */
+	return 0;
+}
+CEOF
+
+"$CC" -std=c99 -Wall -Wextra -Werror -o "$work/t" "$work/t.c" 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "loadhosts ip-length probe did not compile"; }
+"$work/t" || fail "loadhosts ip-length probe failed: an over-length IP was not safely truncated into hostip"
+
+pass "knownhost() bounds an over-length IP into hostip[IP_ADDR_STRLEN] without overrunning it"


### PR DESCRIPTION
`knownhost()` writes the resolved IP into the caller's `hostip`, which is `char hostip[IP_ADDR_STRLEN]` (16) at every one of its eleven callers. Two copies did it with an unbounded `strcpy()`:

```c
if (result && hivals[XMH_IP]) strcpy(hostip, hivals[XMH_IP]);
...
strcpy(hostip, walk->ip);
```

The first is network-reachable: `hivals[XMH_IP]` is parsed straight out of a `hostinfo clone=` reply, so a clone response whose IP field exceeds 15 characters overruns the caller's 16-byte stack buffer. The second copies `walk->ip` (itself `char[IP_ADDR_STRLEN]`, so bounded by its source) — it gets the same idiom so the fix isn't two different shapes.

Both now `strncpy` into `IP_ADDR_STRLEN - 1` and terminate.

| check | result |
|---|---|
| `libxymon.a` builds with the fix | yes |
| `tests/server/loadhosts-ip-length.sh` | PASS |
| same test against pre-fix `loadhosts.c` | FAIL (bounded copy absent) |
| `tests/buildsystem/test-suite-portability.sh` | PASS |

The test follows `tests/server/combostatus-overflow.sh`: it binds to the source (both copies bounded, no raw `strcpy(hostip,...)` left; `IP_ADDR_STRLEN` still 16 in the header) and compiles a faithful copy of the bounded write with a canary past a 16-byte `hostip`, feeding a 39-char IPv6 and longer garbage to show they truncate, not overrun. The unbounded form is characterised, not executed.

Found by a source pass for unfixed siblings of the milestone-2 overflow fixes.


---

**Review (codex, high-effort):** confirmed memory-safe and complete — both copies bounded and NUL-terminated, `IP_ADDR_STRLEN` correct at all eleven callers, no uninitialised-`hostip` path. It surfaced one real test gap, now closed: the test also asserts both `hostip[IP_ADDR_STRLEN - 1] = '\0'` terminations are present, so a regression to a bare `strncpy` (unterminated for a 15+ char source) now fails too. Verified: fails on that variant, still passes on the fix.

Out of scope, noted as a follow-up: an over-length clone IP is now *truncated* rather than overflowing (e.g. `123.123.123.1234` → `123.123.123.123`). That is memory-safe; it is not a new trust boundary (the peer controls the IP field at any length), but `knownhost()` still does not validate the clone IP is well-formed. Belongs with the input-validation hardening, not this memory-safety fix.
