### PR TITLE
xymonnet: drop a dead read of the certificate after releasing it

### DIFF
--- a/tests/network/contest-cert-lifetime.sh
+++ b/tests/network/contest-cert-lifetime.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/network/contest-cert-lifetime.sh
+#
+# Nothing in setup_ssl() may read the peer certificate after releasing it.
+#
+# The certificate block ends with X509_free(peercert). The cipher-list section
+# that follows (entered whenever sslincludecipherlist is set, the default) then
+# recomputed the signature algorithm from that certificate -- a read through a
+# pointer this function no longer owns, and a dead one: certsigalg was already
+# emitted above and the new value was never used.
+#
+# Not a use-after-free today: SSL_get_peer_certificate() returns an
+# incremented reference, so the session still holds one and the object
+# survives. It becomes one the moment the session is released first, which is
+# why the ordering is worth pinning rather than left to hold by accident.
+#
+# setup_ssl() needs the OpenSSL headers, a real handshake and the network to
+# run, so -- like tests/server/combostatus-overflow.sh -- this binds to the
+# source: the freed certificate must not be read again. The invariant checked
+# is stronger than "delete one line": X509_free(peercert) must be the last
+# code mention of peercert in the file, so a future read of the certificate
+# through that name fails here too. It is textual, so it does not catch a
+# use-after-free routed through a different pointer aliased to peercert -- that
+# needs a real handshake under ASan, out of reach for an in-tree guard.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SRC="$ROOT/xymonnet/contest.c"
+
+[ -f "$SRC" ] || skip "xymonnet/contest.c absent"
+
+# The specific dead read that caused it must be gone.
+grep -q 'X509_get_signature_type(peercert)' "$SRC" \
+	&& fail "contest.c reads peercert with X509_get_signature_type after it is freed (use-after-free)"
+
+# There must be exactly one free of peercert...
+frees=$(grep -c 'X509_free(peercert)' "$SRC")
+[ "$frees" -eq 1 ] || fail "contest.c has $frees X509_free(peercert) calls, expected exactly 1"
+
+# ...and it must be the last time peercert is named: nothing may touch the
+# certificate after it is freed.
+free_line=$(grep -n 'X509_free(peercert)' "$SRC" | cut -d: -f1)
+# Ignore comment-prefixed lines: a future comment naming peercert after the
+# free is harmless and must not read as a use-after-free.
+last_line=$(grep -n 'peercert' "$SRC" | grep -vE ':[[:space:]]*(\*|/\*|//)' | tail -1 | cut -d: -f1)
+[ "$free_line" = "$last_line" ] \
+	|| fail "contest.c references peercert at line $last_line, after it is freed at line $free_line (use-after-free)"
+
+pass "contest.c frees the peer certificate last -- nothing reads it after X509_free(peercert)"

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -805,7 +805,9 @@ static void setup_ssl(tcptest_t *item)
 	if (sslincludecipherlist) {
 		int b1, b2;
 		b1 = SSL_get_cipher_bits(item->ssldata, &b2);
-		certsigalg = OBJ_nid2ln(X509_get_signature_type(peercert));
+		/* The signature algorithm is reported in the certificate block above.
+		   Recomputing it here read the certificate back after this function had
+		   released its reference to it, and the result was never used. */
 		snprintf(msglin, sizeof(msglin), "\nCipher used: %s (%d bits)\n", SSL_get_cipher_name(item->ssldata), b1);
 		addtobuffer(sslinfo, msglin);
 		item->mincipherbits = b1; 


### PR DESCRIPTION
`setup_ssl()` reads the certificate fields, then releases its reference at the end of the certificate block:

```c
X509_free(peercert);

/* We list the available ciphers in the SSL cert data */
if (sslincludecipherlist) {          /* default on */
    ...
    certsigalg = OBJ_nid2ln(X509_get_signature_type(peercert));   /* reads a cert this function no longer owns */
```

Two things are wrong with that line, and the second is the reason to delete it.

**It is dead.** `certsigalg` was already computed earlier and emitted in the "Server certificate:" block; the value assigned here is never read again — the cipher section reports `SSL_get_cipher_name()`, not `certsigalg`. Removing the line changes no output.

**It reads through a pointer this function has released.** `SSL_get_peer_certificate()` returns the certificate with its reference count incremented, so `X509_free()` drops *our* reference and the code goes on using the pointer anyway.

## What this is not

An earlier version of this description called it a use-after-free that a hostile endpoint could exploit. That was wrong, and worth stating plainly rather than quietly editing out: the session keeps its own reference to the peer certificate, and the session is alive here — the surrounding lines use `item->ssldata`. So the object is not freed, nothing is reallocated, and there is nothing for a peer to shape.

What remains is an ownership violation: correct today only because something else happens to hold the object alive. It becomes a genuine use-after-free the moment the session is released before this block — which is exactly the kind of reordering nobody would expect to be load-bearing.

## The test

`tests/network/contest-cert-lifetime.sh` encodes an invariant stronger than "this line is gone": `X509_free(peercert)` must be the **last** mention of `peercert` in the file. That is the property worth keeping — after the release, this code has no claim on the certificate — and it forecloses the reordering above.

| check | result |
|---|---|
| `contest.c` compiles with the fix, no new warning | yes (`certsigalg` still used above, no "set but unused") |
| `tests/network/contest-cert-lifetime.sh` | PASS |
| same test against pre-fix `contest.c` | FAIL |
| `tests/buildsystem/test-suite-portability.sh` | PASS |

Found by a source pass for unfixed siblings of the milestone-2 memory-safety fixes. #488 had picked up the same one-line deletion while working nearby; it has been removed there so this PR owns the change.
