### PR TITLE
xymonnet: wait for the direction SSL_connect asked for, not for writability

### DIFF
--- a/tests/lib/tcp-silent-peer.c
+++ b/tests/lib/tcp-silent-peer.c
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later                                  */
+/*
+ * tests/lib/tcp-silent-peer.c
+ *
+ * Accept connections on a 127.0.0.1 port and then say nothing at all, so a
+ * TLS client's handshake never completes. Prints the port on stdout so the
+ * test can name it.
+ *
+ * Holds every connection open rather than closing it: a close would let the
+ * client fail fast, and the point is to keep it waiting so the cost of
+ * waiting can be measured.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <time.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#define MAXHELD 64
+
+int main(int argc, char *argv[])
+{
+	int sock, held[MAXHELD], nheld = 0;
+	struct sockaddr_in addr;
+	socklen_t alen = sizeof(addr);
+	time_t deadline;
+	int seconds = (argc > 1) ? atoi(argv[1]) : 30;
+
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) { perror("socket"); return 1; }
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	addr.sin_port = 0;
+	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) { perror("bind"); return 1; }
+	if (getsockname(sock, (struct sockaddr *)&addr, &alen) < 0) { perror("getsockname"); return 1; }
+	if (listen(sock, 16) < 0) { perror("listen"); return 1; }
+
+	printf("%d\n", ntohs(addr.sin_port));
+	fflush(stdout);
+
+	deadline = time(NULL) + seconds;
+	while (time(NULL) < deadline) {
+		fd_set rfds;
+		struct timeval tv;
+		int r;
+
+		FD_ZERO(&rfds); FD_SET(sock, &rfds);
+		tv.tv_sec = 1; tv.tv_usec = 0;
+		r = select(sock + 1, &rfds, NULL, NULL, &tv);
+		if ((r > 0) && FD_ISSET(sock, &rfds)) {
+			int c = accept(sock, NULL, NULL);
+			if (c >= 0) {
+				if (nheld < MAXHELD) held[nheld++] = c;
+				else close(c);
+			}
+		}
+	}
+
+	while (nheld > 0) close(held[--nheld]);
+	close(sock);
+	return 0;
+}

--- a/tests/network/tls-handshake-cpu.sh
+++ b/tests/network/tls-handshake-cpu.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# The companion to tls-handshake-wait.sh, which reads the source. This one
+# runs the probe against a peer that accepts the connection and then says
+# nothing, so SSL_connect() never completes, and measures what waiting costs.
+#
+# The property is not speed. The handshake takes as long as the peer takes
+# either way -- over 20 paired runs the wall-clock difference was +0.30s
+# with a 95% CI of -0.34..+0.93, i.e. nothing. What changes is CPU: spinning
+# on SSL_connect() burned 6.8s on a 6.3s run, saturating a core for the whole
+# stall, and it scaled with the wait (6.8s at --timeout=5, 11.7s at 10).
+# Blocking in select() costs ~0.
+#
+# So the assertion is a CPU ceiling far below the timeout. A source test
+# cannot express that: which fd set the socket joins is visible in the code,
+# but whether the process then sleeps or spins is only visible by running it.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+"$CC" -o "$work/peer" "$root/tests/lib/tcp-silent-peer.c" 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "tcp-silent-peer does not compile"; }
+
+"$work/peer" 40 > "$work/port" &
+peer=$!
+register_cleanup "kill $peer 2>/dev/null || :"
+
+i=0
+while [ "$i" -lt 50 ]; do
+	[ -s "$work/port" ] && break
+	kill -0 "$peer" 2>/dev/null || fail "the peer exited before naming its port"
+	sleep 0.1
+	i=$((i + 1))
+done
+port=$(cat "$work/port")
+[ -n "$port" ] || fail "the peer never named a port"
+
+timeout_s=5
+ceiling_ms=1500		# ~30% of the timeout; the fix measures ~0, the bug ~7000
+
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[stalled]
+   expect "never arrives"
+   options ssl
+   port $port
+CFG
+printf '127.0.0.1\tpeer\t# stalled\n' > "$work/home/etc/hosts.cfg"
+
+TIMEFORMAT='%U %S'
+cpu=$( { time XYMONHOME="$work/home" "$XYMONNET" --no-update --noping \
+	--dns=ip --timeout=$timeout_s >"$work/out.txt" 2>&1 ; } 2>&1 | tail -1 )
+kill "$peer" 2>/dev/null || :
+
+set -- $cpu
+[ $# -eq 2 ] || fail "could not measure CPU (got '$cpu')"
+ms=$(awk -v u="$1" -v s="$2" 'BEGIN { printf "%d", (u + s) * 1000 }')
+
+[ "$ms" -le "$ceiling_ms" ] || fail \
+	"the probe burned ${ms}ms of CPU while waiting ${timeout_s}s for a handshake
+that never completes (ceiling ${ceiling_ms}ms). That is a busy loop on
+SSL_connect(): it re-asks immediately instead of waiting for the direction
+OpenSSL asked for, so a stalled TLS handshake occupies a core for its whole
+duration (#452)."
+
+pass "a stalled TLS handshake costs ${ms}ms of CPU, not a spinning core (#452)"

--- a/tests/network/tls-handshake-wait.sh
+++ b/tests/network/tls-handshake-wait.sh
@@ -95,7 +95,10 @@ grep -Eq 'if \(item->open &&.*SSLSETUP_PENDING' <<<"$reg" || fail \
 # handshake, and that branch used to `break` out of the loop over items -- which
 # would skip every socket after this one in the same pass. Harmless while the
 # branch was unreachable mid-handshake; not harmless now.
-read_arm=$(awk '/if \(item->sslrunning == SSLSETUP_PENDING\) setup_ssl\(item\)/{c=1} c{print} c&&/res = socket_read\(/{exit}' "$SRC")
+# Anchored on the construct, not on one spelling of it: this arm is a single
+# line today and may become a block, and a guard that only recognises the
+# current layout stops guarding without saying so.
+read_arm=$(awk '/if \(item->sslrunning == SSLSETUP_PENDING\)/{c=1} c{print} c&&/res = socket_read\(/{exit}' "$SRC")
 [ -n "$read_arm" ] || fail \
 	"contest.c no longer has the pending-handshake arm of the read branch (#452)"
 grep -qE '\bbreak;' <<<"$read_arm" && fail \

--- a/tests/network/tls-handshake-wait.sh
+++ b/tests/network/tls-handshake-wait.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/network/tls-handshake-wait.sh
+#
+# Guard for xymon-monitoring/xymon#452: while a TLS handshake is pending,
+# xymonnet must wait for the direction SSL_connect() actually asked for.
+#
+# do_tcp_tests() registers each socket with select() for read OR write, never
+# both. Mid-handshake readpending is still 0 -- do_talk stays false until the
+# handshake completes -- so the plain rule asks for writability while
+# SSL_connect() is blocked on a read. A connected socket is almost always
+# writable, so select() returns immediately, every iteration, until the peer
+# finally answers: a busy-wait for the length of one handshake round trip,
+# multiplied by --concurrency.
+#
+# Measured on a peer that accepts and then never speaks, 8s timeout, same tree
+# and container either way: 897 pselect6 / 152880 read before, 20 / 488 after.
+#
+# A behavioural run needs a stalled TLS peer plus syscall counting, which this
+# suite has no vocabulary for and which would be timing-dependent; the build CI
+# already compiles these files, so this is a static guard that the wiring
+# survives future edits -- the same trade tls13-support.sh makes. Skips only
+# when the sources are absent (an autopkgtest run with no tree); a present tree
+# that has lost the wiring is a regression and fails.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SRC="$ROOT/xymonnet/contest.c"
+HDR="$ROOT/xymonnet/contest.h"
+
+for f in "$SRC" "$HDR"; do
+	[ -f "$f" ] || skip "$(basename "$f") absent"
+done
+
+# grep, not assert_contains: the latter echoes the whole haystack on failure,
+# and dumping 200 lines of header buries the one line that matters.
+grep -Eq '^[[:space:]]*int[[:space:]]+sslwantwrite;' "$HDR" || fail \
+	"contest.h lost the sslwantwrite flag -- the handshake cannot record its direction (#452)"
+
+# The flag is only meaningful if it is SET from the WANT_READ/WANT_WRITE arm of
+# SSL_connect()'s error switch. A whole-file grep is a false green: the
+# assignment could survive anywhere, including in dead code. Extract just that
+# arm -- from the case labels up to and including its break -- and assert the
+# assignment lives INSIDE it.
+# Strip comments here too: this arm is commented with the identifiers being
+# asserted, so prose could satisfy a claim about the code beside it.
+want_arm=$(awk '/case SSL_ERROR_WANT_READ:/{c=1} c{print} c&&/break;/{exit}' "$SRC" \
+	| sed -e 's,/\*.*\*/,,' -e '/^[[:space:]]*\/\*/d' -e '/^[[:space:]]*\*/d')
+[ -n "$want_arm" ] || fail \
+	"contest.c no longer has the SSL_connect WANT_READ/WANT_WRITE arm (#452)"
+# Assert the MAPPING, not the token. `sslwantwrite = 0` or a comparison
+# against WANT_READ would both keep the word while inverting or flattening the
+# meaning, and either sends select() the wrong way.
+grep -Eq 'sslwantwrite[[:space:]]*=[[:space:]]*\(?[A-Za-z_]+[[:space:]]*==[[:space:]]*SSL_ERROR_WANT_WRITE' <<<"$want_arm" || fail \
+	"contest.c no longer derives the handshake direction from an == SSL_ERROR_WANT_WRITE test -- a constant or an inverted comparison sends select() the wrong way (#452)"
+
+# The registration itself. Two ways to lose the fix while keeping the token:
+# dropping the SSLSETUP_PENDING branch (falls back to the writability rule and
+# spins again), or ordering it AFTER the readpending branch (unreachable,
+# because readpending is 0 exactly when this matters). Extract the whole
+# if/else-if chain and assert both the presence and the order.
+reg=$(awk '/FD_ZERO\(&readfds\)/{c=1} c{print} c&&/item->fd > maxfd/{exit}' "$SRC")
+[ -n "$reg" ] || fail "contest.c no longer has the select() fd-registration block (#452)"
+
+# Assert against code, not prose. The block is commented, and those comments
+# name the very identifiers being asserted -- so grepping the raw text lets a
+# comment satisfy an assertion about the condition beside it. Deleting the
+# item->open gate while leaving the comment that explains it is exactly the
+# plausible edit, and it passed until this strip was added.
+reg=$(sed -e 's,/\*.*\*/,,' -e '/^[[:space:]]*\/\*/d' -e '/^[[:space:]]*\*/d' <<<"$reg")
+
+grep -q 'SSLSETUP_PENDING' <<<"$reg" || fail \
+	"contest.c no longer special-cases a pending handshake when registering the socket -- it will busy-wait (#452)"
+grep -Eq 'sslwantwrite[[:space:]]*\?[[:space:]]*&writefds[[:space:]]*:[[:space:]]*&readfds' <<<"$reg" || fail \
+	"contest.c no longer maps sslwantwrite to writefds and its negation to readfds -- an inverted ternary keeps the token and waits the wrong way (#452)"
+
+pending_at=$(grep -n 'SSLSETUP_PENDING' <<<"$reg" | head -1 | cut -d: -f1)
+readpending_at=$(grep -n 'item->readpending' <<<"$reg" | head -1 | cut -d: -f1)
+[ -n "$pending_at" ] && [ -n "$readpending_at" ] || fail \
+	"contest.c fd-registration block no longer contains both branches (#452)"
+[ "$pending_at" -lt "$readpending_at" ] || fail \
+	"contest.c tests readpending before the pending-handshake case -- the handshake branch is unreachable, since readpending is 0 precisely while the handshake runs (#452)"
+
+# Gated on item->open: before the connection completes, writability is still how
+# completion is detected, so an ungated branch would wait to read a ServerHello
+# from a socket that has not finished connecting.
+grep -Eq 'if \(item->open &&.*SSLSETUP_PENDING' <<<"$reg" || fail \
+	"contest.c no longer gates the pending-handshake branch on item->open -- connect() completion is detected by writability (#452)"
+
+# Registering by direction makes the read branch the normal path for a pending
+# handshake, and that branch used to `break` out of the loop over items -- which
+# would skip every socket after this one in the same pass. Harmless while the
+# branch was unreachable mid-handshake; not harmless now.
+read_arm=$(awk '/if \(item->sslrunning == SSLSETUP_PENDING\) setup_ssl\(item\)/{c=1} c{print} c&&/res = socket_read\(/{exit}' "$SRC")
+[ -n "$read_arm" ] || fail \
+	"contest.c no longer has the pending-handshake arm of the read branch (#452)"
+grep -qE '\bbreak;' <<<"$read_arm" && fail \
+	"contest.c breaks out of the item loop while a handshake is pending -- every socket after this one is skipped for the pass (#452)"
+
+# Registering pending handshakes for readability means a handshake can now
+# COMPLETE in the read arm, where the write arm has not run: sendtxt unsent,
+# readpending unset, silenttest not honoured. Falling through into the read
+# there is the regression, and forbidding `break` alone does not catch it.
+grep -q 'if (!item->readpending)' <<<"$read_arm" || fail \
+	"contest.c reads immediately after a handshake completes in the read arm -- the write arm never ran, so the send is skipped and a silenttest still collects a banner (#452)"
+
+pass "xymonnet waits for the direction SSL_connect asked for (#452)"

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -213,6 +213,7 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 	/* If ALPN is configured, SSL is also necessarily enabled */
 	newtest->sslrunning = (((newtest->svcinfo->flags & TCP_SSL) || (newtest->svcinfo->flags & TCP_ALPN)) ? SSLSETUP_PENDING : 0);
 	newtest->sslagain = 0;
+	newtest->sslwantwrite = 0;
 
 	newtest->banner = NULL;
 	newtest->bannerbytes = 0;
@@ -709,10 +710,20 @@ static void setup_ssl(tcptest_t *item)
 	}
 	if ((err = SSL_connect(item->ssldata)) != 1) {
 		char sslerrmsg[256];
+		int sslerr = SSL_get_error(item->ssldata, err);
 
-		switch (SSL_get_error (item->ssldata, err)) {
+		switch (sslerr) {
 		  case SSL_ERROR_WANT_READ:
 		  case SSL_ERROR_WANT_WRITE:
+			/*
+			 * Remember which way the handshake is blocked, so the
+			 * select() below can wait for that instead of spinning:
+			 * a connected socket is almost always writable, so a
+			 * WANT_READ registered for writability returns from
+			 * select() immediately, every time, until the peer
+			 * finally answers.
+			 */
+			item->sslwantwrite = (sslerr == SSL_ERROR_WANT_WRITE);
 			item->sslrunning = SSLSETUP_PENDING;
 			break;
 		  case SSL_ERROR_SYSCALL:
@@ -1151,7 +1162,19 @@ restartselect:
 				 * So: On any given socket, we want either a 
 				 * write-event or a read-event - never both.
 				 */
-				if (item->readpending)
+				if (item->open && (item->sslrunning == SSLSETUP_PENDING)) {
+					/*
+					 * Mid-handshake: readpending is still 0 (do_talk
+					 * is false until the handshake completes), so the
+					 * plain rule below would ask for writability while
+					 * SSL_connect() is waiting to read. Wait for what
+					 * it asked for instead. Gated on item->open: before
+					 * the connection completes, writability is still
+					 * how completion is detected.
+					 */
+					FD_SET(item->fd, (item->sslwantwrite ? &writefds : &readfds));
+				}
+				else if (item->readpending)
 					FD_SET(item->fd, &readfds);
 				else 
 					FD_SET(item->fd, &writefds);
@@ -1365,7 +1388,38 @@ restartselect:
 						 * We may be in the process of setting up an SSL connection
 						 */
 						if (item->sslrunning == SSLSETUP_PENDING) setup_ssl(item);
-						if (item->sslrunning == SSLSETUP_PENDING) break;  /* Loop again waiting for more data */
+						if (item->sslrunning == SSLSETUP_PENDING) {
+							/*
+							 * Still handshaking: nothing to read yet.
+							 * continue, not break -- break leaves the whole
+							 * loop over items, abandoning the scan at the
+							 * first socket that is readable but not yet
+							 * handshaken. Measured, that costs iterations
+							 * rather than results: select() returns again
+							 * immediately and the remaining sockets are
+							 * serviced on the next pass. It was unreachable
+							 * during a handshake before (the fd was always in
+							 * writefds); registering by direction above makes
+							 * it the normal path, so leave the scan intact.
+							 */
+							continue;
+						}
+						if (!item->readpending) {
+							/*
+							 * The handshake just finished, here, in the read
+							 * arm -- which only became possible once pending
+							 * handshakes were registered for readability. The
+							 * write arm has not run for this socket yet, so
+							 * nothing has sent sendtxt or decided whether a
+							 * banner is even wanted. Reading now would skip the
+							 * send outright, and would collect a banner for a
+							 * silenttest. Clearing readpending is 0 here means
+							 * select() puts the socket back in writefds, so the
+							 * write arm picks it up on the next pass exactly as
+							 * it did when the handshake completed there.
+							 */
+							continue;
+						}
 
 						/*
 						 * Connection is ready - plain or SSL. Read data.

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -125,6 +125,7 @@ typedef struct tcptest_t {
 	int mincipherbits;              /* Bits in the weakest encryption supported */
 	int sslrunning;			/* Track state of an SSL session */
 	int sslagain;			/* SSL read/write needs more data */
+	int sslwantwrite;		/* Handshake blocked on writability, not readability */
 
 	/* For testing telnet services */
 	unsigned char *telnetbuf;	/* Buffer for telnet option negotiation */


### PR DESCRIPTION
Fixes #452.

`do_tcp_tests()` registers each socket with `select()` for read **or** write, never both, choosing by `readpending`. While a TLS handshake is pending `readpending` is still 0 — `do_talk` stays false until the handshake completes — so the socket is registered for *writability* while `SSL_connect()` is blocked on a *read*. A connected socket is almost always writable, so `select()` returns immediately every iteration and the loop spins through `setup_ssl()` → `SSL_connect()` → `WANT_READ` until the peer answers.

It makes progress, which is why this has gone unnoticed. It just burns a core doing it, for one handshake round trip per test, up to `--concurrency` at a time.

The read path this makes reachable already exists and already handles a pending handshake. It was simply never selected.

**That path ended in `break`**, which leaves the whole loop over active sockets. I built a harness for this — ten healthy TLS peers behind one whose handshake is relayed a byte at a time — and it **did not** show harm. Scaled up to five slow peers interleaved through seventy-five healthy hosts at `--concurrency=256`, it still did not:

| | healthy OK | wall | user CPU |
|---|---|---|---|
| `continue` | 75/75 | 50.24s | 1.89s |
| `break` | 75/75 | 50.09s | 1.61s |

`select()` re-arms immediately and a re-scan is a pointer walk, so the recovery is cheap. `break` costs iterations, not results, and not measurably even those. Changed to `continue` anyway, as the right shape for a scan that should not abandon its remaining work, but **no user-visible harm is claimed for it**.

**A handshake can now complete in the read arm**, where the write arm has not run for that socket — `sendtxt` unsent, `readpending` unset, `silenttest` not honoured. Falling into the read there would skip the send and collect a banner for a silent test. That one *is* a real regression this change would otherwise introduce, and it returns to the loop instead.

### Measured

Peer that accepts the TCP connection and then never speaks; 8s timeout; same tree, same container, same service either way:

| | `pselect6` | `read` | read errors |
|---|---|---|---|
| before | **897** | 152880 | 887 (EAGAIN) |
| after | **20** | 488 | 1 |

### Verified

- a working TLS service still tests correctly — against a real smtps peer: `Service smtps on realtls is OK (up)`, banner `220 real.local ESMTP`
- `./tests/testsuite`: the failing set is identical before and after this change, and none of it is a network test. (Not enumerated here — which tests fail depends on the machine, and a list in a description goes stale without telling anyone.)
- the new test fails on the tree without this change

### On the test

`tests/network/tls-handshake-wait.sh` is a static guard — a behavioural run needs a stalled TLS peer plus syscall counting, which the suite has no vocabulary for and which would be timing-dependent. Same trade `tls13-support.sh` makes.

It **strips comments before asserting**: the block's own comments name the identifiers under assertion, so grepping raw text let a comment satisfy a claim about the condition beside it — deleting the `item->open` gate while leaving the comment explaining it passed until that was fixed.

Mutation-checked. Each of these is caught: dropping the `item->open` gate, dropping the pending-handshake branch, inverting the direction mapping, restoring the `break`.

### Review notes

An independent review pass found the `break`, and separately found that the test's block extraction ran to end-of-file (its terminator counted a literal `FD_SET(item->fd, &writefds)` twice, but this change makes the first one a ternary, so it never matched twice) — which is what made the `item->open` assertion a false green. Both are fixed above. It also suggested caching `SSL_get_error()` in a local rather than calling it twice; done.

### Note for the release manager

Not added to `Changes` per CONTRIBUTING. Suggested wording: *xymonnet no longer busy-waits during TLS handshakes.*

## Added: a behavioural test

`tests/network/tls-handshake-cpu.sh` runs the probe against a peer that accepts the connection and then never speaks, and asserts a CPU ceiling.

The source test pins the fd registration, but whether the process then sleeps or spins is only visible by running it. Measured against a peer that accepts and never completes the handshake, `--timeout=5`: **6.8s** of CPU without this change — a saturated core for the whole stall, scaling with the wait (11.7s at `--timeout=10`) — and a few milliseconds with it. Those are the figures `tests/network/tls-handshake-cpu.sh` records and asserts against.

To be clear about what this is not: it is not a speed fix. Over 20 paired runs the wall-clock difference was +0.30s with a 95% CI of −0.34..+0.93 — nothing. The handshake takes as long as the peer takes either way. What changes is that waiting for it stops occupying a core.

---
### Where this sits

`main` → **#453 (here)** → #454 → the dialogue work.

#488 builds on #454 and needs the direction-aware handshake registration added
here, so this lands first. Merging it retargets #454 onto `main`.




