### PR TITLE
xymonnet: retry a write that SSL_write() did not accept, instead of dropping it

### DIFF
--- a/tests/lib/tls-slow-reader.c
+++ b/tests/lib/tls-slow-reader.c
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later                                  */
+/*
+ * tests/lib/tls-slow-reader.c
+ *
+ * A TLS server that completes the handshake and then does NOT read for a
+ * moment, so a client sending more than the socket buffers hold gets
+ * SSL_ERROR_WANT_WRITE part-way through. After the pause it drains
+ * everything and reports the byte count.
+ *
+ * That count is the whole point: a probe that retries the deferred write
+ * delivers all of it, one that drops the remainder delivers less, and
+ * neither reports an error -- so only the peer can tell them apart.
+ *
+ *   argv[1] certificate   argv[2] key   argv[3] output file
+ *
+ * Prints its port on stdout. Writes the byte count, or "ERR ...", to the
+ * output file.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+int main(int argc, char *argv[])
+{
+	int sock, c;
+	struct sockaddr_in addr;
+	socklen_t alen = sizeof(addr);
+	SSL_CTX *ctx;
+	SSL *ssl;
+	FILE *out;
+	char buf[65536];
+	long total = 0;
+	int rcvbuf = 8192;
+	fd_set rfds;
+	struct timeval tv;
+
+	if (argc < 4) { fprintf(stderr, "usage: %s CERT KEY OUTFILE\n", argv[0]); return 2; }
+
+	SSL_library_init();
+	SSL_load_error_strings();
+	ctx = SSL_CTX_new(SSLv23_server_method());
+	if (!ctx) { fprintf(stderr, "SSL_CTX_new failed\n"); return 1; }
+	if (SSL_CTX_use_certificate_file(ctx, argv[1], SSL_FILETYPE_PEM) <= 0 ||
+	    SSL_CTX_use_PrivateKey_file(ctx, argv[2], SSL_FILETYPE_PEM) <= 0) {
+		fprintf(stderr, "cannot load certificate/key\n");
+		return 1;
+	}
+
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) { perror("socket"); return 1; }
+	/* A small receive buffer makes the sender stall sooner and more reliably. */
+	setsockopt(sock, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) { perror("bind"); return 1; }
+	if (getsockname(sock, (struct sockaddr *)&addr, &alen) < 0) { perror("getsockname"); return 1; }
+	if (listen(sock, 4) < 0) { perror("listen"); return 1; }
+	printf("%d\n", ntohs(addr.sin_port));
+	fflush(stdout);
+
+	tv.tv_sec = 25; tv.tv_usec = 0;
+	FD_ZERO(&rfds); FD_SET(sock, &rfds);
+	if (select(sock + 1, &rfds, NULL, NULL, &tv) <= 0) return 0;
+	c = accept(sock, NULL, NULL);
+	if (c < 0) return 1;
+
+	out = fopen(argv[3], "w");
+	if (!out) { perror("fopen"); return 1; }
+
+	ssl = SSL_new(ctx);
+	SSL_set_fd(ssl, c);
+	if (SSL_accept(ssl) <= 0) {
+		fprintf(out, "ERR handshake failed\n");
+		fclose(out); return 0;
+	}
+
+	/* Do NOT read yet: let the sender fill the pipe and hit WANT_WRITE. */
+	sleep(2);
+
+	for (;;) {
+		int n;
+
+		tv.tv_sec = 8; tv.tv_usec = 0;
+		FD_ZERO(&rfds); FD_SET(c, &rfds);
+		if (!SSL_pending(ssl) && (select(c + 1, &rfds, NULL, NULL, &tv) <= 0)) break;
+		n = SSL_read(ssl, buf, sizeof(buf));
+		if (n <= 0) break;
+		total += n;
+	}
+
+	SSL_write(ssl, "OK\r\n", 4);
+	fprintf(out, "%ld\n", total);
+	fclose(out);
+	SSL_shutdown(ssl);
+	SSL_free(ssl);
+	close(c); close(sock);
+	SSL_CTX_free(ctx);
+	return 0;
+}

--- a/tests/network/ssl-write-defer-behaviour.sh
+++ b/tests/network/ssl-write-defer-behaviour.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# The companion to ssl-write-retry.sh, which reads the source. This one
+# makes SSL_write() actually defer and checks whether the bytes arrive.
+#
+# Forcing the condition needs two things at once: a payload larger than the
+# socket buffers, and a peer that does not read for a moment. Then
+# SSL_write() takes part of it and returns WANT_WRITE for the rest. What
+# happens next is the point -- the remainder is either retried or silently
+# dropped -- and it is invisible in the source: both versions "send" the
+# data and neither reports an error. Only the peer knows what it got.
+#
+# The probe's real sends are a few dozen bytes and would never trigger
+# this, which is why the bug survived: it needs a slow reader on the far
+# side, which is what a loaded mail server looks like.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+command -v openssl >/dev/null 2>&1 || skip "openssl is needed to make a test certificate"
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+openssl req -x509 -newkey rsa:2048 -keyout "$work/k.pem" -out "$work/c.pem" \
+	-days 2 -nodes -subj "/CN=127.0.0.1" >"$work/ssl.log" 2>&1 \
+	|| skip "openssl could not generate a test certificate"
+
+"$CC" -o "$work/peer" "$root/tests/lib/tls-slow-reader.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "tls-slow-reader does not compile against libssl"; }
+
+# Size matters and is not arbitrary. Swept against a build WITHOUT the fix:
+# 1MB was absorbed by the socket buffers and never deferred at all -- the
+# test passed on the bug, a false green. 4MB and 16MB both truncated. 8MB is
+# the smallest round size with margin either side. If this ever stops
+# failing on an unfixed build, the payload has become too small for the
+# host's buffers rather than the bug having gone away.
+payload=${XYMON_TEST_SSLWRITE_BYTES:-8000000}
+
+"$work/peer" "$work/c.pem" "$work/k.pem" "$work/got.txt" > "$work/port" &
+peer=$!
+register_cleanup "kill $peer 2>/dev/null || :"
+
+i=0
+while [ "$i" -lt 50 ]; do
+	[ -s "$work/port" ] && break
+	kill -0 "$peer" 2>/dev/null || fail "the peer exited before naming its port"
+	sleep 0.1
+	i=$((i + 1))
+done
+port=$(cat "$work/port")
+[ -n "$port" ] || fail "the peer never named a port"
+
+# One send far larger than any socket buffer, so SSL_write cannot take it in
+# a single call while the peer is not reading.
+{
+	printf '[bigsend]\n   send "'
+	# dd and tr, not awk. BSD awk's gsub() is quadratic in the length of the
+	# subject: building this string took 5s at 800KB and minutes at 8MB, so
+	# the test hung on macOS long before it reached a socket. gawk's gsub is
+	# linear, which kept CI green and hid it. Same bytes, a fraction of a
+	# second, and no assumption about which awk is installed.
+	dd if=/dev/zero bs="$payload" count=1 2>/dev/null | tr '\0' 'A'
+	printf '"\n   expect "OK"\n   options ssl,banner\n   port %s\n' "$port"
+} > "$work/home/etc/protocols.cfg"
+printf '127.0.0.1\tpeer\t# bigsend\n' > "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --dns=ip \
+	--timeout=25 >"$work/out.txt" 2>&1 || :
+wait "$peer" 2>/dev/null || :
+
+[ -s "$work/got.txt" ] || fail "the peer recorded nothing -- it never completed a TLS handshake"
+got=$(cat "$work/got.txt")
+case $got in
+	ERR*) skip "the peer could not run the TLS exchange: $got" ;;
+esac
+
+[ "$got" -eq "$payload" ] || fail \
+	"the peer received $got of $payload bytes. SSL_write() could not take the
+whole buffer while the peer was not reading, and the remainder was dropped
+instead of retried. The probe reports no error, so this is silent data loss
+against any slow reader (#451)."
+
+pass "a deferred SSL_write is retried, not dropped: all $payload bytes arrived (#451)"

--- a/tests/network/ssl-write-retry.sh
+++ b/tests/network/ssl-write-retry.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/network/ssl-write-retry.sh
+#
+# Guard for xymon-monitoring/xymon#451: when SSL_write() accepts nothing,
+# xymonnet must retry the same buffer rather than drop the payload.
+#
+# socket_write() used to translate SSL_ERROR_WANT_READ/WANT_WRITE into a bare
+# `res = 0` return. At the call site 0 is neither the -1 error case nor the
+# TCP_HTTP short-write case, so for every non-HTTP service the bytes were
+# silently discarded -- and because readpending had already been set, the test
+# then sat waiting for a reply to a command that was never transmitted. HTTP
+# escaped only by accident: sendlen never decreased, so its own branch retried.
+#
+# Four things have to hold together, and each is a separate way to reintroduce
+# the bug, so each is asserted separately:
+#   1. the flag exists,
+#   2. socket_write() sets it on WANT_READ/WANT_WRITE,
+#   3. the call site acts on it *before* the TCP_HTTP branch,
+#   4. the shutdown leaves a socket that still owes a write open -- without
+#      this the retry can never happen, and (1)-(3) are decoration.
+#
+# Static guard: reaching WANT_WRITE through a real probe needs a stalled peer
+# and a multi-megabyte payload, while the shipped probes send a few bytes --
+# which is exactly why the bug was latent. Skips only if the source is absent.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SRC="$ROOT/xymonnet/contest.c"
+HDR="$ROOT/xymonnet/contest.h"
+
+for f in "$SRC" "$HDR"; do
+	[ -f "$f" ] || skip "$(basename "$f") absent"
+done
+
+grep -Eq '^[[:space:]]*int[[:space:]]+sendagain;' "$HDR" || fail \
+	"contest.h lost the sendagain flag -- a dropped write cannot be signalled (#451)"
+
+# contest.c defines socket_write() twice: once for builds without OpenSSL and
+# once for builds with it. Only the second has anything to retry, so select the
+# body by content rather than by position -- picking the first would assert
+# against the plain-write stub and pass no matter what the SSL one does.
+# Strip comments before asserting. Every check below is a string-presence
+# check, and this function and its call site are heavily commented with the
+# very identifiers under assertion -- so a commented-out `item->sendagain = 1`,
+# or prose mentioning sendagain, would satisfy a claim about the code beside
+# it. Deleting a line and leaving the comment that explains it is the realistic
+# edit, and it is exactly the one a token grep cannot see.
+strip_comments() { sed -e 's,/\*.*\*/,,' -e '/^[[:space:]]*\/\*/d' -e '/^[[:space:]]*\*/d'; }
+
+ssl_write_fn=$(awk '
+	/^static int socket_write/ { buf = ""; inbody = 1 }
+	inbody                     { buf = buf $0 "\n" }
+	inbody && /^}/             { if (buf ~ /SSL_write/) { printf "%s", buf; exit } inbody = 0 }
+' "$SRC" | strip_comments)
+[ -n "$ssl_write_fn" ] || fail \
+	"contest.c has no socket_write() that calls SSL_write() (#451)"
+
+grep -q 'sendagain = 1' <<<"$ssl_write_fn" || fail \
+	"socket_write() no longer flags a write that sent nothing -- the payload is dropped silently (#451)"
+
+# Scoped to WANT_WRITE on purpose. Clearing readpending puts the fd in writefds,
+# which is what WANT_WRITE waits for; retrying a WANT_READ there would select on
+# a set that is always ready and busy-wait. If the two labels are ever collapsed
+# back together, that is the bug this pins.
+want_write_arm=$(awk '/case SSL_ERROR_WANT_WRITE:/{c=1} c{print} c&&/break;/{exit}' <<<"$ssl_write_fn")
+grep -q 'sendagain = 1' <<<"$want_write_arm" || fail \
+	"socket_write() no longer sets sendagain under SSL_ERROR_WANT_WRITE (#451)"
+# ...and must return 0, not the negative SSL_write() gave back: the call site
+# tests res == -1 first, so a deferred write left negative is treated as a hard
+# I/O error and the sendagain branch is never reached.
+grep -qE '\bres = 0;' <<<"$want_write_arm" || fail \
+	"socket_write() no longer normalises a deferred write to 0 -- res == -1 is handled first, so the retry branch is unreachable (#451)"
+# WANT_READ is deliberately not retried here: the retry would be registered on
+# the write set, which is always ready, so it would busy-wait. That is what
+# this forbids.
+#
+# It forbids the CURRENT way of getting it wrong, not the idea of retrying. A
+# WANT_READ retry is correct if the socket then waits for READABILITY -- which
+# needs a direction flag and a dispatch that honours it, neither of which
+# exists yet. If that arrives, this assertion is what should change, not the
+# thing to work around.
+want_read_arm=$(awk '/case SSL_ERROR_WANT_READ:/{c=1} c{print} c&&/break;/{exit}' <<<"$ssl_write_fn")
+grep -q 'sendagain = 1' <<<"$want_read_arm" && fail \
+	"socket_write() retries a WANT_READ on the write set -- that fd is always ready, so it busy-waits (#451)"
+
+# Reset per call. A flag that is only ever set latches on: the first deferred
+# write would leave every later socket looking like it still owed bytes.
+grep -q 'sendagain = 0' <<<"$ssl_write_fn" || fail \
+	"socket_write() never clears sendagain -- the flag latches after the first deferred write (#451)"
+
+# The call site must consult it BEFORE the TCP_HTTP branch. Ordered after, the
+# HTTP branch would claim res==0 first and advance nothing, leaving non-HTTP
+# services exactly as broken as before.
+call_site=$(awk '/res = socket_write\(item, outbuf, outlen\)/{c=1} c{print} c&&/TCP_HTTP/{exit}' "$SRC" | strip_comments)
+[ -n "$call_site" ] || fail "contest.c no longer has the socket_write() call site (#451)"
+grep -q 'sendagain' <<<"$call_site" || fail \
+	"the socket_write() call site ignores sendagain -- a deferred write is still indistinguishable from nothing to send (#451)"
+# The branch has to clear readpending, which is what returns the socket to
+# writefds. An empty sendagain branch keeps the token and retries nothing.
+sendagain_branch=$(awk '/else if \(item->sendagain\)/{c=1} c{print} c&&/^[[:space:]]*}/{exit}' <<<"$call_site")
+grep -qE 'readpending[[:space:]]*=[[:space:]]*0' <<<"$sendagain_branch" || fail \
+	"the sendagain branch no longer clears readpending -- the socket never goes back into writefds, so the retry never happens (#451)"
+
+# And the socket must survive to be retried. This is the assertion that matters
+# most: with the shutdown untouched, clearing readpending closes the connection
+# on the same pass and the retry never comes.
+shutdown_cond=$(awk '/If closed and\/or no bannergrabbing/{c=1} c{print} c&&/socket_shutdown\(item\)/{exit}' "$SRC" | strip_comments)
+[ -n "$shutdown_cond" ] || fail "contest.c no longer has the post-write shutdown block (#451)"
+grep -Eq '!item->readpending && !item->sendagain' <<<"$shutdown_cond" || fail \
+	"contest.c closes a socket that still owes a write -- the retry can never happen (#451)"
+
+# Hoisting socket_shutdown() into the timeout path made an old latent hazard
+# reachable: SSLSETUP_PENDING is -1, so `if (item->sslrunning)` is already true
+# from add_tcp_test() while ssldata is still NULL, and a connection that times
+# out before setup_ssl() runs would reach SSL_shutdown(NULL). Guard on the
+# objects instead. Same block selection trick as above -- the non-OpenSSL build
+# has its own socket_shutdown() with nothing to free.
+sd=$(awk '
+	/^static void socket_shutdown/ { buf = ""; inbody = 1 }
+	inbody                        { buf = buf $0 "\n" }
+	inbody && /^}/                { if (buf ~ /SSL_shutdown/) { printf "%s", buf; exit } inbody = 0 }
+' "$SRC" | strip_comments)
+[ -n "$sd" ] || fail "contest.c has no socket_shutdown() that frees an SSL session (#451)"
+grep -q 'if (item->ssldata)' <<<"$sd" || fail \
+	"socket_shutdown() no longer guards on ssldata -- a timeout before setup_ssl() reaches SSL_shutdown(NULL) (#451)"
+# The sslrunning guard must stay OUTSIDE it. setup_ssl()'s failure paths free
+# ssldata/sslctx without clearing them and set sslrunning to 0, so a
+# pointer-only guard frees dangling pointers.
+grep -q 'if (item->sslrunning) {' <<<"$sd" || fail \
+	"socket_shutdown() dropped the sslrunning guard -- setup_ssl()'s failure paths free without clearing, so a pointer-only test double-frees (#451)"
+
+pass "xymonnet retries a write that SSL_write() did not accept (#451)"

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -214,6 +214,7 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 	newtest->sslrunning = (((newtest->svcinfo->flags & TCP_SSL) || (newtest->svcinfo->flags & TCP_ALPN)) ? SSLSETUP_PENDING : 0);
 	newtest->sslagain = 0;
 	newtest->sslwantwrite = 0;
+	newtest->sendagain = 0;
 
 	newtest->banner = NULL;
 	newtest->bannerbytes = 0;
@@ -846,12 +847,37 @@ static int socket_write(tcptest_t *item, char *outbuf, int outlen)
 {
 	int res = 0;
 
+	item->sendagain = 0;
 	if (item->sslrunning) {
 		res = SSL_write(item->ssldata, outbuf, outlen);
 		if (res < 0) {
 			switch (SSL_get_error (item->ssldata, res)) {
-			  case SSL_ERROR_WANT_READ:
 			  case SSL_ERROR_WANT_WRITE:
+				  /*
+				   * Nothing was sent. Returning 0 alone is
+				   * indistinguishable from "there was nothing to
+				   * send", so flag it: the caller must come back
+				   * and retry with the SAME buffer. socket_read()
+				   * uses sslagain for the same purpose.
+				   *
+				   * Only WANT_WRITE is retried. Clearing
+				   * readpending puts the socket back in writefds,
+				   * which is exactly what WANT_WRITE waits for.
+				   */
+				  item->sendagain = 1;
+				  res = 0;
+				  break;
+			  case SSL_ERROR_WANT_READ:
+				  /*
+				   * WANT_READ would need the fd in readfds, and the
+				   * read branch there would consume application data
+				   * rather than retry this write. Left as it behaves
+				   * today -- the payload is not sent and the test
+				   * waits out its timeout -- rather than retried on a
+				   * fd set that is always ready, which would busy-wait.
+				   * Reachable only via renegotiation; TLS 1.3 session
+				   * tickets and KeyUpdate do not produce it.
+				   */
 				  res = 0;
 				  break;
 			}
@@ -905,10 +931,26 @@ static int socket_read(tcptest_t *item, char *inbuf, int inbufsize)
 
 static void socket_shutdown(tcptest_t *item)
 {
+	/*
+	 * Both guards are load-bearing. sslrunning must stay the outer test:
+	 * setup_ssl()'s failure paths free ssldata/sslctx without clearing them
+	 * and set sslrunning to 0, so a pointer-only guard would free dangling
+	 * pointers here. And the inner NULL checks are needed because
+	 * SSLSETUP_PENDING is -1, so sslrunning is already true from
+	 * add_tcp_test() while ssldata is still NULL -- a connection that times
+	 * out before setup_ssl() runs would otherwise reach SSL_shutdown(NULL).
+	 * Clearing them makes a second call harmless either way.
+	 */
 	if (item->sslrunning) {
-		SSL_shutdown(item->ssldata);
-		SSL_free(item->ssldata);
-		SSL_CTX_free(item->sslctx);
+		if (item->ssldata) {
+			SSL_shutdown(item->ssldata);
+			SSL_free(item->ssldata);
+			item->ssldata = NULL;
+		}
+		if (item->sslctx) {
+			SSL_CTX_free(item->sslctx);
+			item->sslctx = NULL;
+		}
 	}
 	shutdown(item->fd, SHUT_RDWR);
 
@@ -1241,16 +1283,22 @@ restartselect:
 					/* 
 					 * Request timed out.
 					 */
-					if (item->readpending) {
-						/* Final read timeout - just shut this socket */
-						socket_shutdown(item);
-						item->errcode = CONTEST_ETIMEOUT;
-					}
-					else {
+					if (!item->readpending && !item->sendagain) {
 						/* Connection timeout */
 						item->open = 0;
-						item->errcode = CONTEST_ETIMEOUT;
 					}
+					/*
+					 * Either way, hand the socket to socket_shutdown():
+					 * it is the only place SSL_free()/SSL_CTX_free()
+					 * happen, and it no-ops on a session that was never
+					 * running. The !readpending arm used to skip it, so
+					 * an SSL session that timed out with nothing pending
+					 * to read -- a handshake that never finished, and now
+					 * also a write still waiting to be retried -- had its
+					 * fd closed with the SSL objects still allocated.
+					 */
+					socket_shutdown(item);
+					item->errcode = CONTEST_ETIMEOUT;
 					get_totaltime(item, &timestamp);
 					close(item->fd);
 					item->fd = -1;
@@ -1343,6 +1391,19 @@ restartselect:
 									item->readpending = 0;
 									item->errcode = CONTEST_EIO;
 								}
+								else if (item->sendagain) {
+									/*
+									 * The SSL layer accepted nothing and wants
+									 * another pass. Leave sendtxt/sendlen alone
+									 * so the retry sends the same bytes, and do
+									 * not wait for a reply to a command that was
+									 * never transmitted -- clearing readpending
+									 * is also what puts this socket back in the
+									 * write set. The shutdown below is taught to
+									 * leave it open.
+									 */
+									item->readpending = 0;
+								}
 								else if (item->svcinfo->flags & TCP_HTTP) {
 									/*
 									 * HTTP tests require us to send the full buffer.
@@ -1358,7 +1419,7 @@ restartselect:
 
 						/* If closed and/or no bannergrabbing, shut down socket */
 						if (item->sslrunning != SSLSETUP_PENDING) {
-							if (!item->open || !item->readpending) {
+							if (!item->open || (!item->readpending && !item->sendagain)) {
 								if (item->open) {
 									socket_shutdown(item);
 								}

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -126,6 +126,7 @@ typedef struct tcptest_t {
 	int sslrunning;			/* Track state of an SSL session */
 	int sslagain;			/* SSL read/write needs more data */
 	int sslwantwrite;		/* Handshake blocked on writability, not readability */
+	int sendagain;			/* Last write sent nothing; retry the same buffer */
 
 	/* For testing telnet services */
 	unsigned char *telnetbuf;	/* Buffer for telnet option negotiation */


### PR DESCRIPTION
Fixes #451. **Stacked on #453** — base is `fix-tls-handshake-busywait`, so this diff shows only its own commit. Merge #453 first; GitHub will retarget this to `main` automatically.

`socket_write()` turned `SSL_ERROR_WANT_READ`/`WANT_WRITE` into a bare `res = 0`. At the call site 0 is neither the `-1` error case nor the `TCP_HTTP` short-write case, so for every non-HTTP service the payload was **silently discarded** — and `readpending` had already been set, so the test then waited for a reply to a command that was never transmitted.

`socket_read()` already had the vocabulary for this in `sslagain`; the write path had none.

### Only `WANT_WRITE` is retried

Clearing `readpending` puts the fd back in `writefds`, which is precisely what `WANT_WRITE` waits for. A `WANT_READ` retried there would select on a set that is always ready and busy-wait; moving the fd to `readfds` instead would land in the read branch, which would consume application data rather than retry the write. So `WANT_READ` keeps today's behaviour — the payload is not sent and the test waits out its timeout.

It is reachable only through renegotiation. TLS 1.3 session tickets and `KeyUpdate` do **not** produce it (verified against OpenSSL 3.0).

### Three things follow from clearing `readpending`

It also decides which arm the timeout takes:

1. **The `!readpending` arm never called `socket_shutdown()`** — the only place `SSL_free()`/`SSL_CTX_free()` happen — so a deferred write that never completed had its fd closed with the SSL objects still allocated. Hoisted so both arms free the session. This also closes the same leak for a **handshake** that times out, which could already reach that arm.
2. **That arm marks the test a connect failure**, which is wrong for a socket that reached TCP and TLS before stalling. It now skips that when a write is still owed.
3. **Hoisting made an older hazard reachable.** `SSLSETUP_PENDING` is `-1`, so `if (item->sslrunning)` is already true from `add_tcp_test()` while `ssldata` is still `NULL` — a connection timing out before `setup_ssl()` ran would have reached `SSL_shutdown(NULL)`. `socket_shutdown()` now guards on the objects and clears them, which also makes a second call harmless.

On (3): I could **not** get that to fault in practice — a blackholed SSL port times out cleanly before and after. It is a latent hazard closed, not a crash fixed.

### Consequences differ by service

Which is why it stayed hidden:

`socket_write()` only reaches `SSL_write()` under `if (item->sslrunning)`, so the reach is the TLS-carrying entries and nothing else:

| services | effect of a dropped payload |
|---|---|
| `smtps`, `imaps`, `pop3s`, `nntps`, `ftps`, `telnets` and any entry with `options ssl` | with `banner`, the greeting arrives unprompted, so the test **reports green** with the send quietly missing |
| the same entries without `banner` | no response at all — the test fails, loudly |
| `https` | `TCP_HTTP`, already retried, unaffected |
| every plaintext entry — `smtp`, `ftp`, `ssh`, `bbd`, `cupsd`, `ajp13`, `rdp`, … | never touches this path |

### What I verified

- a real smtps peer still tests correctly after the change
- a blackholed SSL port still times out cleanly, no crash
- `./tests/testsuite`: the failing set is identical before and after this change, and none of it is a network test. (Not enumerated here — which tests fail depends on the machine, and a list in a description goes stale without telling anyone.)
- retries are bounded by the existing per-test cutoff, checked before fd readiness

### What I could not verify

I did not reach `WANT_WRITE` through a real probe. It needs a stalled peer and a multi-megabyte payload, and the shipped probes send a few bytes — which is why this is latent rather than live. It was reproduced in a standalone harness using this function's body verbatim.

### On the test

Assertions strip comments first — this function and its call site are commented with the identifiers under assertion, so prose could otherwise satisfy a claim about the code beside it. Mutation-checked; each is caught: commenting out `sendagain = 1`, the per-call reset, the shutdown condition or the header field; deleting any of them; collapsing `WANT_READ` back into the retry arm; reverting the `ssldata` guard.

### Note for the release manager

Not added to `Changes` per CONTRIBUTING. Suggested wording: *xymonnet no longer discards a service probe's payload when the SSL layer defers the write.*

## Added: a behavioural test

`tests/network/ssl-write-defer-behaviour.sh` forces `SSL_write()` to actually defer — a payload larger than the socket buffers, sent to a TLS peer that pauses before reading — and asserts every byte arrives.

This is the case the source test cannot reach: both versions "send" the data and neither reports an error, so only the peer knows how many bytes it really got.

The payload size is empirical, not arbitrary. Swept against a build without the fix: **1MB was absorbed by the buffers and never deferred at all — the test passed on the bug**. 4MB and 16MB truncated. The default is 8MB, and the reasoning is recorded in the test so the number is not magic. Verified failing without the fix and passing with it.

---
### Where this sits

`main` → #453 → **#454 (here)** → the dialogue work.

#488 builds on this. Merging #453 retargets this onto `main`.




