### PR TITLE
Stop the SMTP probes speaking before the server greets them

### DIFF
--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -38,7 +38,7 @@ static svcinfo_t default_svcinfo[] = {
 	{ "ssh1",    NULL,                0,                  "SSH",	0, 0,	(TCP_GET_BANNER), 22 },
 	{ "ssh2",    NULL,                0,                  "SSH",	0, 0,	(TCP_GET_BANNER), 22 },
 	{ "telnet",  NULL,                0,                  NULL,	0, 0,	(TCP_GET_BANNER|TCP_TELNET), 23 },
-	{ "smtp",    "mail\r\nquit\r\n",  0,                  "220",	0, 0,	(TCP_GET_BANNER), 25 }, /* Send "MAIL" to avoid sendmail NOQUEUE logs */
+	{ "smtp",    NULL,                0,                  "220",	0, 0,	(TCP_GET_BANNER), 25 }, /* No send: speaking before the 220 is an RFC 5321/2920 violation */
 	{ "pop",     "quit\r\n",          0,                  "+OK",	0, 0,	(TCP_GET_BANNER), 110 },
 	{ "pop2",    "quit\r\n",          0,                  "+OK",	0, 0,	(TCP_GET_BANNER), 109 },
 	{ "pop-2",   "quit\r\n",          0,                  "+OK",	0, 0,	(TCP_GET_BANNER), 109 },
@@ -54,7 +54,7 @@ static svcinfo_t default_svcinfo[] = {
 	{ "bbd",     "dummy",             0,                  NULL,	0, 0,	(0), 1984 },
 	{ "ftps",    "quit\r\n",          0,                  "220",	0, 0,	(TCP_GET_BANNER|TCP_SSL), 990 },
 	{ "telnets", NULL,                0,                  NULL, 	0, 0,	(TCP_GET_BANNER|TCP_TELNET|TCP_SSL), 992 },
-	{ "smtps",   "mail\r\nquit\r\n",  0,                  "220",	0, 0,	(TCP_GET_BANNER|TCP_SSL), 0 }, /* Non-standard - IANA */
+	{ "smtps",   NULL,                0,                  "220",	0, 0,	(TCP_GET_BANNER|TCP_SSL), 0 }, /* Non-standard port - IANA. No send, as for smtp */
 	{ "pop3s",   "quit\r\n",          0,                  "+OK",	0, 0,	(TCP_GET_BANNER|TCP_SSL), 995 },
 	{ "imaps",   "ABC123 LOGOUT\r\n", 0,                  "* OK",	0, 0,	(TCP_GET_BANNER|TCP_SSL), 993 },
 	{ "nntps",   "quit\r\n",          0,                  "200",	0, 0,	(TCP_GET_BANNER|TCP_SSL), 563 },

--- a/tests/lib/smtp-greet-peer.c
+++ b/tests/lib/smtp-greet-peer.c
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later                                  */
+/*
+ * tests/lib/smtp-greet-peer.c
+ *
+ * An SMTP server that records whether the client spoke before being
+ * greeted, and answers a pregreeter the way Postfix >= 3.9 does with
+ * smtpd_forbid_unauth_pipelining=yes (its default): 554, then hang up.
+ *
+ * Prints its port on stdout, then one word per line to the verdict file:
+ *
+ *   polite | PREGREET      -- did anything arrive before our 220?
+ *   PIPELINED              -- more than one command in a single write
+ *   commands=N
+ *
+ * Waiting half a second before greeting is what makes the pregreet
+ * observable: a client that writes on connect has already done so.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+static int crlfs(const char *b, int n)
+{
+	int i, c = 0;
+	for (i = 0; i + 1 < n; i++) if ((b[i] == '\r') && (b[i+1] == '\n')) c++;
+	return c;
+}
+
+int main(int argc, char *argv[])
+{
+	int sock, c, n, ncmd = 0;
+	struct sockaddr_in addr;
+	socklen_t alen = sizeof(addr);
+	char buf[2048];
+	FILE *out;
+	fd_set rfds;
+	struct timeval tv;
+
+	if (argc < 2) { fprintf(stderr, "usage: %s VERDICTFILE\n", argv[0]); return 2; }
+
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) { perror("socket"); return 1; }
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) { perror("bind"); return 1; }
+	if (getsockname(sock, (struct sockaddr *)&addr, &alen) < 0) { perror("getsockname"); return 1; }
+	if (listen(sock, 4) < 0) { perror("listen"); return 1; }
+	printf("%d\n", ntohs(addr.sin_port));
+	fflush(stdout);
+
+	tv.tv_sec = 20; tv.tv_usec = 0;
+	FD_ZERO(&rfds); FD_SET(sock, &rfds);
+	if (select(sock + 1, &rfds, NULL, NULL, &tv) <= 0) return 0;   /* nobody came */
+	c = accept(sock, NULL, NULL);
+	if (c < 0) return 1;
+
+	out = fopen(argv[1], "w");
+	if (!out) { perror("fopen"); return 1; }
+
+	/* Anything readable now arrived BEFORE our greeting. */
+	tv.tv_sec = 0; tv.tv_usec = 500000;
+	FD_ZERO(&rfds); FD_SET(c, &rfds);
+	if (select(c + 1, &rfds, NULL, NULL, &tv) > 0) {
+		n = recv(c, buf, sizeof(buf) - 1, 0);
+		if (n > 0) {
+			buf[n] = '\0';
+			fprintf(out, "PREGREET %s\n", buf);
+			send(c, "554 5.5.0 Error: SMTP protocol synchronization\r\n", 47, 0);
+			fclose(out); close(c); close(sock);
+			return 0;
+		}
+	}
+	fprintf(out, "polite\n");
+	send(c, "220 test.local ESMTP Postfix\r\n", 30, 0);
+
+	while (ncmd < 2) {
+		tv.tv_sec = 8; tv.tv_usec = 0;
+		FD_ZERO(&rfds); FD_SET(c, &rfds);
+		if (select(c + 1, &rfds, NULL, NULL, &tv) <= 0) break;
+		n = recv(c, buf, sizeof(buf) - 1, 0);
+		if (n <= 0) break;
+		buf[n] = '\0';
+		ncmd++;
+		if (crlfs(buf, n) > 1) fprintf(out, "PIPELINED %s\n", buf);
+		if (strncasecmp(buf, "ehlo", 4) == 0)
+			send(c, "250-test.local\r\n250 PIPELINING\r\n", 32, 0);
+		else if (strncasecmp(buf, "quit", 4) == 0) {
+			send(c, "221 2.0.0 Bye\r\n", 15, 0);
+			break;
+		}
+	}
+	fprintf(out, "commands=%d\n", ncmd);
+	fclose(out); close(c); close(sock);
+	return 0;
+}

--- a/tests/network/smtp-no-pregreet.sh
+++ b/tests/network/smtp-no-pregreet.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/network/smtp-no-pregreet.sh
+#
+# Guard for xymon-monitoring/xymon#450: the SMTP probes must not speak before
+# the server greets them.
+#
+# do_tcp_tests() writes before it reads -- socket_write() runs in the writable
+# branch, the banner is read on a later pass -- so any `send` in protocols.cfg
+# goes out ahead of the server's 220. The SMTP entries used to send
+# "ehlo xymonnet\r\nquit\r\n": ahead of the greeting, and two commands in one
+# write before PIPELINING was announced. Both violate RFC 5321/2920, and
+# Postfix >= 3.9 enables smtpd_forbid_unauth_pipelining by default, answering
+# with "554 5.5.0 Error: SMTP protocol synchronization".
+#
+# Nothing was lost by removing it. xymonnet reads once and compares `expect`
+# against the START of the banner (tcp_got_expected), so the EHLO's own reply
+# was never examined -- the send cost a protocol violation and bought nothing.
+#
+# This is a config assertion, not a static guard: protocols.cfg is the shipped
+# artefact, and the file itself is the thing under test. Skips only if it is
+# absent.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+CFG="$ROOT/xymonnet/protocols.cfg"
+[ -f "$CFG" ] || skip "protocols.cfg absent"
+
+# Extract one service's block: from its [header] to the next [header]. Blocks
+# are not blank-line delimited -- [smtps] is followed by a comment before the
+# next entry -- so terminating on a blank line would truncate and let a `send`
+# hide in the tail. Header names alternate ([submission|msa]), so match the
+# name as a whole alternative rather than a substring: a plain grep for "smtp"
+# would also select [smtps], and one for "[smtp]" would miss [submission|msa].
+service_block() {
+	awk -v want="$1" '
+		/^\[/ {
+			inblock = 0
+			hdr = $0
+			sub(/^\[/, "", hdr); sub(/\].*$/, "", hdr)
+			n = split(hdr, alts, "|")
+			for (i = 1; i <= n; i++) if (alts[i] == want) inblock = 1
+			if (inblock) next
+		}
+		inblock { print }
+	' "$CFG"
+}
+
+# Every SMTP-speaking probe Xymon ships. submission/msa is the same protocol on
+# 587 and was carrying the identical string, so a fix that covered only smtp
+# and smtps would leave the same violation on another port. msa is listed
+# separately from submission even though they share one [submission|msa] block
+# today: if that block is ever split, the alias must not be able to reacquire a
+# send while this test keeps passing.
+for svc in smtp smtps submission msa; do
+	block=$(service_block "$svc")
+	[ -n "$block" ] || fail "protocols.cfg no longer defines [$svc] (#450)"
+
+	if grep -Eq '^[[:space:]]*send[[:space:]]' <<<"$block"; then
+		fail "[$svc] sends before the server's greeting -- xymonnet writes before it reads, so this is a pregreet, and Postfix >= 3.9 answers 554 (#450)"
+	fi
+
+	# The probe still has to check something. Without expect, a service that
+	# accepts the connection and says nothing useful would pass, which would
+	# make removing the send a downgrade rather than a fix.
+	grep -Eq '^[[:space:]]*expect[[:space:]]+"220"' <<<"$block" || fail \
+		"[$svc] no longer expects a 220 greeting -- the probe would accept any banner (#450)"
+	# Compare option TOKENS, not substrings: "options nobanner" or
+	# "bannerless" would satisfy a substring match while meaning the opposite.
+	opts=$(sed -n 's/^[[:space:]]*options[[:space:]]*//p' <<<"$block" | tr ',' ' ')
+	has_opt() { printf '%s\n' $opts | grep -qx "$1"; }
+
+	has_opt banner || fail \
+		"[$svc] no longer asks for the banner -- with no send, the greeting is the only thing this probe can check (#450)"
+
+	# smtps is the TLS variant; losing the ssl option would silently turn it
+	# into a plaintext probe of a TLS port that still passes its 220 check.
+	if [ "$svc" = "smtps" ]; then
+		has_opt ssl || fail "[smtps] no longer requests an SSL handshake (#450)"
+	fi
+done
+
+# protocols.cfg is not the only place these probes are defined. lib/netservices.c
+# carries a compiled-in default_svcinfo[] table, used whenever protocols.cfg
+# cannot be opened (init_tcp_services() falls back to it and says so). Its smtp
+# and smtps rows had the same shape of defect -- "mail\r\nquit\r\n", a pregreet
+# and two commands in one write -- so fixing only the config would leave a
+# violating probe one unreadable file away.
+NETSVC="$ROOT/lib/netservices.c"
+if [ -f "$NETSVC" ]; then
+	for svc in smtp smtps; do
+		row=$(grep -E "^[[:space:]]*\{[[:space:]]*\"$svc\"," "$NETSVC")
+		[ -n "$row" ] || fail "lib/netservices.c no longer defines a fallback for $svc (#450)"
+		# Field 2 of the row is the data to send. Assert it is NULL rather than
+		# merely absent of a known string: any replacement literal would be a
+		# pregreet just the same.
+		grep -Eq "^[[:space:]]*\{[[:space:]]*\"$svc\",[[:space:]]*NULL," <<<"$row" || fail \
+			"lib/netservices.c fallback for $svc still sends before the greeting (#450): $row"
+		# The rest of the row still has to describe the same probe: without the
+		# 220 expectation or the banner flag, removing the send would quietly
+		# downgrade the fallback from "checks the greeting" to "connects".
+		grep -q '"220"' <<<"$row" || fail \
+			"lib/netservices.c fallback for $svc no longer expects a 220 greeting (#450): $row"
+		grep -q 'TCP_GET_BANNER' <<<"$row" || fail \
+			"lib/netservices.c fallback for $svc no longer grabs the banner (#450): $row"
+		if [ "$svc" = "smtps" ]; then
+			grep -q 'TCP_SSL' <<<"$row" || fail \
+				"lib/netservices.c fallback for smtps lost TCP_SSL (#450): $row"
+		fi
+	done
+fi
+
+pass "the SMTP probes wait for the greeting instead of pipelining into it (#450)"

--- a/tests/network/smtp-pregreet-behaviour.sh
+++ b/tests/network/smtp-pregreet-behaviour.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# The companion to smtp-no-pregreet.sh, which reads the source. This one
+# runs the probe and asks what actually went over the wire.
+#
+# Both are needed. The source test is fast and needs no build, but it can
+# only check that the code SAYS the right thing -- the ordering in
+# protocols.cfg is half of it, the driver has to honour it.
+#
+# The peer answers 554 to anything arriving before its greeting, as Postfix
+# does with smtpd_forbid_unauth_pipelining=yes (default since 3.9), so an
+# unfixed probe fails here the way it fails in the field.
+#
+# The service definition is the one the tree SHIPS: protocols.cfg is copied
+# and only the [smtp] port is redirected, so this covers the real entry
+# rather than a convenient local one.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+"$CC" -o "$work/peer" "$root/tests/lib/smtp-greet-peer.c" 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "smtp-greet-peer does not compile"; }
+
+"$work/peer" "$work/verdict.txt" > "$work/port" &
+peer=$!
+register_cleanup "kill $peer 2>/dev/null || :"
+
+i=0
+while [ "$i" -lt 50 ]; do
+	[ -s "$work/port" ] && break
+	kill -0 "$peer" 2>/dev/null || fail "the peer exited before naming its port"
+	sleep 0.1
+	i=$((i + 1))
+done
+port=$(cat "$work/port")
+[ -n "$port" ] || fail "the peer never named a port"
+
+# Copy the shipped file and redirect only the port inside [smtp].
+awk -v port="$port" '
+	/^[[:space:]]*\[/ { insmtp = ($0 ~ /^[[:space:]]*\[smtp\][[:space:]]*$/) }
+	insmtp && /^[[:space:]]*port[[:space:]]/ { print "   port " port; next }
+	{ print }
+' "$root/xymonnet/protocols.cfg" > "$work/home/etc/protocols.cfg"
+
+grep -q "port $port" "$work/home/etc/protocols.cfg" || fail "could not redirect the [smtp] port"
+printf '127.0.0.1\tpeer\t# smtp\n' > "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse \
+	--dns=ip --timeout=10 >"$work/out.txt" 2>&1 || :
+wait "$peer" 2>/dev/null || :
+
+[ -s "$work/verdict.txt" ] || fail "the peer recorded nothing -- the probe never connected"
+verdict=$(cat "$work/verdict.txt")
+
+grep -q '^polite$' <<<"$verdict" || fail \
+	"the probe spoke before the server greeted it:
+$verdict
+Postfix >= 3.9 answers that with 554 and postscreen reads it as a spambot
+signal (#450) -- the ordering in protocols.cfg is not being honoured."
+
+if grep -q PIPELINED <<<"$verdict"; then
+	fail "more than one command in a single write -- pipelining before the
+server announced PIPELINING (#450):
+$verdict"
+fi
+
+grep -q 'Service smtp on peer is OK' "$work/out.txt" || fail \
+	"the probe did not report the service up:
+$(cat "$work/out.txt")"
+
+pass "the shipped [smtp] probe waits for the greeting and sends one command at a time (#450)"

--- a/xymonnet/protocols.cfg
+++ b/xymonnet/protocols.cfg
@@ -67,19 +67,16 @@
    port 992
 
 [smtp]
-   send "ehlo xymonnet\r\nquit\r\n"
    expect "220"
    options banner
    port 25
 
 [smtps]
-   send "ehlo xymonnet\r\nquit\r\n"
    expect "220"
    options ssl,banner
 #  No default port-number assignment for smtps - nonstandard according to IANA
 
 [submission|msa]
-   send "ehlo xymonnet\r\nquit\r\n"
    expect "220"
    options banner
    port 587


### PR DESCRIPTION
Fixes #450.

`do_tcp_tests()` writes before it reads — `socket_write()` runs in the writable branch, the banner is read on a later pass — so any `send` goes out **ahead of the server's 220**. The SMTP probes sent two commands in one write, ahead of the greeting and before `PIPELINING` had been announced. That violates RFC 5321/2920.

Postfix 3.9 turned `smtpd_forbid_unauth_pipelining` on by default and answers `554 5.5.0 Error: SMTP protocol synchronization`, so **every poll of a current Postfix is rejected**.

It usually goes unnoticed: xymonnet reads one record and matches `expect` against the *start* of it, so when the 220 wins the race it reports green while the session was refused. When the write wins instead, the column goes yellow with "Unexpected service response".

### Two places define these probes

| file | entries | had |
|---|---|---|
| `xymonnet/protocols.cfg` | `smtp`, `smtps`, `submission\|msa` | `ehlo xymonnet\r\nquit\r\n` |
| `lib/netservices.c` | `smtp`, `smtps` | `mail\r\nquit\r\n` |

`lib/netservices.c` holds a compiled-in `default_svcinfo[]` used whenever `protocols.cfg` cannot be opened. Same defect, different spelling — also a pregreet, also two commands in one write. Fixing only the config would have left a violating probe one unreadable file away.

That fallback's send existed to stop sendmail logging `NOQUEUE` for a connection that greets and leaves. Removing it trades that log line for protocol correctness — the same trade the shipped config now makes, where the server logs `lost connection after CONNECT` instead. Sites with fail2ban rules counting those will want to allow their monitor.

### Nothing is lost from the verdict

`tcp_got_expected()` compares `expect` against the **start** of the banner, so the EHLO's reply was never evaluated.

Two observables do change, neither affecting pass/fail: the banner shown in the status message no longer carries EHLO/QUIT replies that happened to land in the same read, and `tcp_stats_written`/`read` shrink accordingly. Certificate collection for `smtps` is unaffected — it happens in `setup_ssl()` before any application send — and the reported `Seconds:` comes from the connection and handshake duration, not the banner exchange.

### Verified

Postfix 3.10 (Debian 13, stock config — no flags set), same build, same server either way:

| | xymonnet | Postfix log |
|---|---|---|
| before | `not OK : Unexpected service response` / `554 5.5.0 Error: SMTP protocol synchronization` | `improper command pipelining after CONNECT: ehlo xymonnet\r\nquit\r\n` |
| after | `OK (up)` / `220 test.local ESMTP Postfix (Debian)` | **no violation logged** |

`./tests/testsuite` unchanged — the two failures (`fs-sentinel-copies.sh`, `loadhosts-aliasing.sh`) are present before and after and unrelated.

### On the test

Assertions are line-anchored, so a commented-out directive cannot satisfy them. It covers both definition sites, and lists `msa` separately from `submission` even though they share one block today — if that block is ever split, the alias must not be able to reacquire a send while the test keeps passing.

Mutation-checked; each of these is caught: re-adding a send to `[smtp]`, to `[submission|msa]`, to the `smtp` fallback row, or to the `smtps` fallback row.

### Scope

This removes the violation; it does not remove the ordering that caused it. Other probes (`ftp`, `ssh`, `pop3`, `imap`, `nntp`, `clamd`, …) still write before the greeting — no mainstream server for those enforces a synchronization rule today. Making `send` safe in general means teaching `contest.c` to read the banner first: a larger behavioural change across twenty-odd services, and its own change.

Independent of #453 and #454 — different files, merges clean with either.

### Note for the release manager

Not added to `Changes` per CONTRIBUTING. Suggested wording: *the smtp, smtps and submission probes no longer violate SMTP pipelining rules, which current Postfix rejects.*

## Added: a behavioural test

`tests/network/smtp-pregreet-behaviour.sh` runs the probe against a peer that answers `554 5.5.0 Error: SMTP protocol synchronization` to anything arriving before its greeting — as Postfix does with `smtpd_forbid_unauth_pipelining=yes`, its default since 3.9 — and records whether the probe spoke first.

It copies the tree's **shipped** `protocols.cfg` and redirects only the `[smtp]` port, so it covers the real entry rather than a convenient local one. It also fails a send carrying more than one command.

Verified both ways: passes on this branch, and fails with `PREGREET b'ehlo xymonnet\r\nquit\r\n'` when the old ordering is restored.

Ordering in `protocols.cfg` is only half the fix — the driver has to honour it, and that is what this checks.
