### PR TITLE
xymonnet: add "sni=NAME" to send an explicit TLS servername

### DIFF
--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -722,6 +722,7 @@ test will go red. E.g. to check that your server only uses
 strong encryption (128 bits or better), use "sslbits=128".
 
 .IP "\fBsni\fR"
+.IP "\fBsni=\fRNAME"
 .IP "\fBnosni\fR"
 Enable or disable SNI (Server Name Indication) for SSL tests. SNI is
 on by default and sends the host name as the servername; most TLS
@@ -730,6 +731,13 @@ servers now expect it, and many pick the certificate by it. Use
 name, or set the default globally with the "--sni" option to
 .I xymonnet(1).
 A host tested by its IP address sends no SNI.
+
+Use "sni=NAME" to send a specific servername instead of the host name
+- for a host tested by IP, or whose host name is a display label
+rather than the certificate's FQDN. It also enables SNI. NAME must be
+a host name, not an IP address (RFC 6066 does not allow an address in
+SNI); an IP is logged and no SNI is sent. HTTP tests take the SNI name
+from the URL instead.
 
 
 .IP "\fBDOWNTIME\fR=\fIday\fR:\fIstarttime\fR:\fIendtime\fR[,\fIday\fR:\fIstarttime\fR:\fIendtime\fR]"

--- a/docs/manpages/man5/hosts.cfg.5.html
+++ b/docs/manpages/man5/hosts.cfg.5.html
@@ -791,6 +791,8 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
   </dd>
   <dt id="sni"><a class="permalink" href="#sni"><b>sni</b></a></dt>
   <dd></dd>
+  <dt id="sni~2"><a class="permalink" href="#sni~2"><b>sni=</b>NAME</a></dt>
+  <dd></dd>
   <dt id="nosni"><a class="permalink" href="#nosni"><b>nosni</b></a></dt>
   <dd>Enable or disable SNI (Server Name Indication) for SSL tests. SNI is on by
       default and sends the host name as the servername; most TLS servers now
@@ -798,6 +800,12 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       a server that cannot handle SNI or rejects an unknown name, or set the
       default globally with the &quot;--sni&quot; option to <i><a href="../man1/xymonnet.1.html">xymonnet</a>(1).</i>
       A host tested by its IP address sends no SNI.
+    <p class="Pp">Use &quot;sni=NAME&quot; to send a specific servername instead
+        of the host name - for a host tested by IP, or whose host name is a
+        display label rather than the certificate's FQDN. It also enables SNI.
+        NAME must be a host name, not an IP address (RFC 6066 does not allow an
+        address in SNI); an IP is logged and no SNI is sent. HTTP tests take the
+        SNI name from the URL instead.</p>
     <p class="Pp"></p>
     <p class="Pp"></p>
   </dd>

--- a/lib/loadhosts.c
+++ b/lib/loadhosts.c
@@ -180,6 +180,8 @@ static void xmh_item_list_setup(void)
 	xmh_item_name[XMH_FLAG_SNI]            = "XMH_FLAG_SNI";
 	xmh_item_key[XMH_FLAG_NOSNI]           = "nosni";		// Disable SNI (Server name Indication) for TLS requests
 	xmh_item_name[XMH_FLAG_NOSNI]          = "XMH_FLAG_NOSNI";
+	xmh_item_key[XMH_SNINAME]              = "sni=";		// Explicit SNI server name (also enables SNI); "sni" alone uses the hostname
+	xmh_item_name[XMH_SNINAME]             = "XMH_SNINAME";
 	xmh_item_key[XMH_LDAPLOGIN]            = "ldaplogin=";
 	xmh_item_name[XMH_LDAPLOGIN]           = "XMH_LDAPLOGIN";
 	xmh_item_key[XMH_CLASS]                = "CLASS:";

--- a/lib/loadhosts.h
+++ b/lib/loadhosts.h
@@ -83,6 +83,7 @@ enum xmh_item_t {
 	XMH_NOTAFTER,
 	XMH_COMPACT,
 	XMH_INTERFACES,
+	XMH_SNINAME,
 	XMH_LAST
 };
 

--- a/tests/network/sni-tcp-tls-behaviour.sh
+++ b/tests/network/sni-tcp-tls-behaviour.sh
@@ -37,9 +37,9 @@ export XYMONNETSVCS="imaps smtps pop3s imap smtp pop3 http ssh"
 # run TAG HOSTLINE EXPECT -- start the peer, point one imaps test at it via
 # HOSTLINE (with @PORT@ replaced by the peer's port), and check the SNI it saw.
 run() {
-	local tag=$1 line=$2 expect=$3
-	local out="$work/out" port="" got pp
-	rm -f "$out"
+	local tag=$1 line=$2 expect=$3 warn=${4:-}
+	local out="$work/out" err="$work/err" port="" got pp
+	rm -f "$out" "$err"
 	"$peer" 10 > "$out" 2>/dev/null &
 	pp=$!
 	register_cleanup "kill $pp 2>/dev/null || :"
@@ -52,10 +52,13 @@ run() {
 	done
 	[ -n "$port" ] || fail "$tag: peer never named a port"
 	printf '%s\n' "${line//@PORT@/$port}" > "$work/home/etc/hosts.cfg"
-	"$XYMONNET" --noping --no-update --dns=ip --timeout=5 >/dev/null 2>&1 || :
+	"$XYMONNET" --noping --no-update --dns=ip --timeout=5 >/dev/null 2>"$err" || :
 	wait "$pp" 2>/dev/null || :
 	got=$(sed -n '2p' "$out" 2>/dev/null | sed 's/^SNI=//')
 	[ "$got" = "$expect" ] || fail "$tag: expected SNI '$expect', the peer saw '$got'"
+	if [ -n "$warn" ]; then
+		grep -qF -- "$warn" "$err" || fail "$tag: expected a log warning containing '$warn'"
+	fi
 }
 
 run "default sends the hostname"    '127.0.0.1 host.example.com # imaps:@PORT@'        'host.example.com'
@@ -63,4 +66,10 @@ run "nosni suppresses it"           '127.0.0.1 host.example.com # imaps:@PORT@ n
 run "a testip host sends no SNI"     '127.0.0.1 host.example.com # testip imaps:@PORT@' ''
 run "an IP-literal name sends none"  '127.0.0.1 127.0.0.1 # imaps:@PORT@'               ''
 
-pass "xymonnet puts the right SNI on the wire: hostname by default; none for nosni, a testip host, or an IP-literal name"
+# "sni=NAME" sends an explicit servername -- even for a testip host, since the
+# operator chose it -- but an IP literal is still refused (RFC 6066).
+run "sni=NAME sends that name"       '127.0.0.1 label # imaps:@PORT@ sni=mail.example.com'         'mail.example.com'
+run "sni=NAME works on a testip host" '127.0.0.1 label # testip imaps:@PORT@ sni=mx.example.org'   'mx.example.org'
+run "sni=<ip> sends no SNI and warns" '127.0.0.1 label # imaps:@PORT@ sni=203.0.113.9'             '' 'sni=203.0.113.9 is an IP address'
+
+pass "xymonnet puts the right SNI on the wire: hostname by default; explicit sni=NAME; none for nosni, a testip host, or any IP-literal name"

--- a/tests/network/sni-tcp-tls.sh
+++ b/tests/network/sni-tcp-tls.sh
@@ -8,7 +8,7 @@
 # or multi-tenant mail -- answers instead of failing the handshake. SNI used to
 # be wired for HTTP tests only; this guards that the plain TCP path wires it the
 # same way: on by default sending the host name, --sni to set the global
-# default, per-host nosni to disable.
+# default, per-host nosni to disable, and "sni=NAME" to send an explicit name.
 #
 # Static guard, like its siblings alpn-support.sh / tls13-support.sh: a
 # behavioural run needs a TLS peer that reports the servername it was handed,
@@ -25,7 +25,8 @@ n="$ROOT/xymonnet/xymonnet.c"
 h="$ROOT/xymonnet/xymonnet.h"
 c="$ROOT/xymonnet/contest.c"
 w="$ROOT/xymonnet/httptest.c"
-[ -f "$n" ] && [ -f "$h" ] && [ -f "$c" ] && [ -f "$w" ] || skip "xymonnet sources not in this checkout"
+l="$ROOT/lib/loadhosts.c"
+[ -f "$n" ] && [ -f "$h" ] && [ -f "$c" ] && [ -f "$w" ] && [ -f "$l" ] || skip "xymonnet sources not in this checkout"
 
 # Strip comment-only lines so the block's own comments don't satisfy the rules,
 # and capture into a variable: `... | grep -q` would let grep -q exit early and
@@ -34,6 +35,7 @@ ncode=$(grep -vE '^[[:space:]]*(\*|/\*|//)' "$n" || true)
 hcode=$(grep -vE '^[[:space:]]*(\*|/\*|//)' "$h" || true)
 ccode=$(grep -vE '^[[:space:]]*(\*|/\*|//)' "$c" || true)
 wcode=$(grep -vE '^[[:space:]]*(\*|/\*|//)' "$w" || true)
+lcode=$(grep -vE '^[[:space:]]*(\*|/\*|//)' "$l" || true)
 has() { grep -qE -- "$1" <<<"$2"; }   # here-string (no pipe -> no SIGPIPE); -- so a pattern starting with '-' is not read as options
 
 has 'int[[:space:]]+sni;' "$hcode" \
@@ -61,12 +63,14 @@ block=$(awk '
 
 has 'flags & TCP_SSL' "$block" \
 	|| fail "SNI for TCP tests is not gated on TCP_SSL"
-has '->sni = .*hostname' "$block" \
-	|| fail "the hostname is never handed to a TCP-TLS test as SNI (inside the TCP_SSL block)"
+has 'host->hostname' "$block" \
+	|| fail "the hostname is never used as the SNI servername (inside the TCP_SSL block)"
+has 'tt->sni = name' "$block" \
+	|| fail "the chosen name is never handed to the TCP-TLS test as SNI"
 has 'snienabled' "$block" \
 	|| fail "the global --sni default is not consulted inside the TCP_SSL block"
 has 'inet_pton' "$block" \
-	|| fail "an IP-literal hostname is not excluded from SNI (RFC 6066 forbids an address as servername)"
+	|| fail "an IP-literal name is not excluded from SNI (RFC 6066 forbids an address as servername)"
 has 'snienabled = 1' "$ccode" \
 	|| fail "SNI is not enabled by default (snienabled should default to 1)"
 
@@ -78,4 +82,17 @@ has 'inet_pton' "$wcode" \
 has 'tcptest->sni = host' "$wcode" \
 	|| fail "the HTTP SNI path no longer assigns the guarded URL host"
 
-pass "plain TCP-TLS tests wire SNI: host field, sni/nosni flags, in-block TCP_SSL gate + hostname + default, no IP-literal SNI (TCP and HTTP)"
+# Explicit "sni=NAME" override. The IP-literal guard above applies to it too:
+# the name feeds the same guarded assignment, so "sni=1.2.3.4" is not sent.
+has 'XMH_SNINAME\][[:space:]]*=[[:space:]]*"sni="' "$lcode" \
+	|| fail "the 'sni=' host tag (XMH_SNINAME) is not registered in loadhosts.c"
+has 'char[[:space:]]*\*sniname;' "$hcode" \
+	|| fail "testedhost_t has no sniname field for the explicit SNI name"
+has 'XMH_SNINAME' "$ncode" \
+	|| fail "the 'sni=NAME' override is not read onto the host"
+has 'host->sniname' "$block" \
+	|| fail "the explicit sniname is never used as the servername (inside the TCP_SSL block)"
+has 'sni=%s is an IP' "$ncode" \
+	|| fail "an explicit sni=<ip> is dropped silently instead of being logged"
+
+pass "plain TCP-TLS tests wire SNI: host field, sni/nosni flags, in-block TCP_SSL gate + hostname + default, no IP-literal SNI (TCP and HTTP), sni=NAME override"

--- a/xymonnet/xymonnet.c
+++ b/xymonnet/xymonnet.c
@@ -457,6 +457,18 @@ void load_tests(void)
 		if (xmh_item(hwalk, XMH_FLAG_NOSSLCERT)) h->nosslcert = 1;
 		if (xmh_item(hwalk, XMH_FLAG_SNI)) h->sni = 1;
 		else if (xmh_item(hwalk, XMH_FLAG_NOSNI)) h->sni = -1;
+		/* "sni=NAME" sets an explicit servername (and, via the "sni" prefix, also enables SNI above) */
+		p = xmh_item(hwalk, XMH_SNINAME);
+		if (p && *p) {
+			struct in6_addr addr;
+			h->sniname = strdup(p);
+			/* A bare host name that happens to be an IP silently sends no SNI;
+			 * an explicit sni=<ip> is a mistake worth naming, since the guard
+			 * then drops it (RFC 6066 forbids an address as the servername). */
+			if ((inet_pton(AF_INET, p, &addr) == 1) || (inet_pton(AF_INET6, p, &addr) == 1))
+				errprintf("Host %s: sni=%s is an IP address; SNI needs a host name, not sending it\n",
+					  h->hostname, p);
+		}
 		if (xmh_item(hwalk, XMH_FLAG_LDAPFAILYELLOW)) h->ldapsearchfailyellow = 1;
 		if (xmh_item(hwalk, XMH_FLAG_HIDEHTTP)) h->hidehttp = 1;
 
@@ -2424,18 +2436,27 @@ int main(int argc, char *argv[])
 					 * mail -- fails the handshake and the service reads as
 					 * down. Send the hostname the way the HTTP tests already
 					 * do. Per-host "sni"/"nosni" override the global default
-					 * (--sni). Skipped when the host is tested by IP, and when
-					 * the hostname is itself an IP literal: RFC 6066 forbids an
-					 * address in SNI, so a proper server ignores it anyway.
+					 * (--sni); "sni=NAME" sets an explicit servername.
+					 *
+					 * The name is the host's "sni=NAME" if given (used even for
+					 * a testip host, since the operator chose it), otherwise the
+					 * hostname (skipped for a testip host, whose name may be a
+					 * label rather than the certificate's FQDN). Either source
+					 * must be a host name: RFC 6066 forbids an address in SNI,
+					 * so a name that parses as an IP literal is not sent.
 					 */
 					{
 						tcptest_t *tt = (tcptest_t *)t->privdata;
-						if (tt && tt->svcinfo && (tt->svcinfo->flags & TCP_SSL) && !t->host->testip) {
+						if (tt && tt->svcinfo && (tt->svcinfo->flags & TCP_SSL)) {
 							int want = (t->host->sni != 0) ? (t->host->sni > 0) : snienabled;
-							struct in6_addr addr;
-							int isipliteral = (inet_pton(AF_INET,  t->host->hostname, &addr) == 1) ||
-									   (inet_pton(AF_INET6, t->host->hostname, &addr) == 1);
-							if (want && !isipliteral) tt->sni = t->host->hostname;
+							char *name = t->host->sniname ? t->host->sniname :
+								     (t->host->testip ? NULL : t->host->hostname);
+							if (want && name) {
+								struct in6_addr addr;
+								int isipliteral = (inet_pton(AF_INET,  name, &addr) == 1) ||
+										   (inet_pton(AF_INET6, name, &addr) == 1);
+								if (!isipliteral) tt->sni = name;
+							}
 						}
 					}
 				}

--- a/xymonnet/xymonnet.h
+++ b/xymonnet/xymonnet.h
@@ -89,6 +89,7 @@ typedef struct testedhost_t {
 	int testip;		/* testip flag (don't do dns lookups on hostname) */
 	int nosslcert;		/* nosslcert flag */
 	int sni;		/* TLS SNI: 0 = global default (--sni), 1 = force on (sni), -1 = force off (nosni) */
+	char *sniname;		/* explicit SNI server name from "sni=NAME"; NULL means use the hostname */
 	int hidehttp;		/* hidehttp flag */
 	int dodns;              /* set while loading tests if we need to do a DNS lookup */
 	int dnserror;		/* set internally if we cannot find the host's IP */


### PR DESCRIPTION
Stacked on #458 (base `feat/sni-tcp-tls`) — review/merge that first.

## What & why

#458 sends the **host name** as the SNI servername. That is wrong when the host name can't be the certificate's FQDN:

- a host monitored by **IP** (or `testip`) has no usable name to send (#458 deliberately sends no SNI for it);
- a host whose **identity is a friendly/business name** while the certificate uses a **technical FQDN** — you don't want to rename the host (all its history, alerts, acks are keyed on the name) just to fix SNI.

`NAME:` can't solve this: it changes the *display* name, not the *servername* (which comes from the host name). So this adds **`sni=NAME`** to send an explicit servername while the host name stays the identity.

## Behaviour

- `sni` → SNI on, servername = host name (as in #458)
- `sni=mail.example.com` → SNI on, servername = `mail.example.com` (used even on a `testip`/IP-only host — the operator vouched for it)
- `nosni` → off

`do_tcp_tests()` picks the name (explicit `sni=NAME` if set, else the hostname for a non-`testip` host) and feeds it through **one IP-literal guard**: RFC 6066 forbids an address in SNI, so `sni=1.2.3.4` sends nothing, exactly as an IP-literal hostname does. `NAME` must be a host name.

## Why it's safe

- `sni=NAME` registers as `XMH_SNINAME` with key `"sni="`, which shares the `"sni"` prefix and so also trips the on-flag. Bare `sni` does **not** match the `"sni="` lookup; `nosni` matches neither — existing behaviour is untouched.
- The only two `xmh_item_idx()` callers test solely for `== -1` (known vs unknown tag), so the shared prefix can't misroute anything.
- New enum value appended before `XMH_LAST`, so no existing item index shifts.

## Verification

Built in-tree and run against an SNI-reporting TLS peer:

| hosts.cfg | servername sent |
|-----------|-----------------|
| `… imaps sni=mail.example.com` | `mail.example.com` |
| `… testip imaps sni=mx.example.org` | `mx.example.org` |
| `… imaps sni=203.0.113.9` (IPv4) | *(none)* |
| `… imaps sni=2001:db8::1` (IPv6) | *(none)* |
| `… imaps` (name = FQDN) | the FQDN |
| `… imaps nosni` | *(none)* |

`tests/network/sni-tcp-tls.sh` (static guard) gains block-scoped checks for the tag registration, the `sniname` field, the read, and its use through the guarded assignment. `tests/network/sni-tcp-tls-behaviour.sh` (behavioural, drives the built xymonnet against a ClientHello-reading peer) gains cases that `sni=NAME` is sent — including on a `testip` host — and `sni=<ip>` is not. Both mutation-checked.

## Docs

`common/hosts.cfg.5` documents the new form (kept short) and states `NAME` must be a host name; its HTML is regenerated from source per `CONTRIBUTING.md`.



---

**Draft, and likely to be dropped.** The case this exists for is narrow: a
`testip` host whose configured name is a label rather than the certificate's
FQDN, where the hostname is the wrong servername to send and #458 therefore
sends none. A new `hosts.cfg` key is a lot of permanent surface for that, and
#458 stands on its own without it — `nosni` already covers the "do not send"
direction, which is the one operators actually reach for.

Kept open rather than closed because the need may yet show up in practice, and
because two things currently lean on it: #460 reads `host->sniname` in nine
places, and #458's description points here for the `testip` opt-in. Both want a
small adjustment if this does go.
