### PR TITLE
xymonnet: check the TLS certificate covers the name sent as SNI

### DIFF
--- a/docs/manpages/man1/xymonnet.1.html
+++ b/docs/manpages/man1/xymonnet.1.html
@@ -365,6 +365,17 @@ Section: User Commands (1)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="
       status.
     <p class="Pp"></p>
   </dd>
+</dl>
+<p class="Pp">When SNI is in use (see the &quot;sni&quot; option and
+    <i><a href="../man5/hosts.cfg.5.html">hosts.cfg</a>(5)</i>), xymonnet also checks whether the presented certificate
+    covers the name it was sent - matching the certificate's subjectAltName
+    entries, falling back to the common name. The result is noted on the
+    &quot;sslcert&quot; status (&quot;Certificate covers ...&quot; or
+    &quot;Certificate does NOT cover ...&quot;), so a valid but wrong-name
+    certificate is visible. This is informational and does not by itself change
+    the &quot;sslcert&quot; colour.</p>
+<p class="Pp"></p>
+<dl class="Bl-tag">
   <dt id="sni"><a class="permalink" href="#sni"><b>--sni</b>=[<b>on</b>|<b>off</b>]</a></dt>
   <dd>Sets the default for whether SSL connections use SNI (Server Name
       Indication). This can also be set with the &quot;sni&quot; or

--- a/tests/network/tls-cert-name.sh
+++ b/tests/network/tls-cert-name.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/network/tls-cert-name.sh
+#
+# xymonnet checks whether the certificate a TLS service presents actually
+# covers the name it was asked for (the SNI/host name), via X509_check_host,
+# and reports it in the sslcert status. This is informational: it does NOT
+# change the sslcert colour, which stays driven by expiry and cipher strength.
+#
+# Static assertions guard the wiring. When the built xymonnet and the openssl
+# CLI are both present, a behavioural pass drives xymonnet against a real
+# openssl s_server whose certificate names a known host, and checks both the
+# match/mismatch report and that a mismatch leaves the column colour alone.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+cc="$ROOT/xymonnet/contest.c"
+nc="$ROOT/xymonnet/xymonnet.c"
+[ -f "$cc" ] && [ -f "$nc" ] || skip "xymonnet sources not in this checkout"
+has() { grep -qE -- "$1" "$2"; }
+
+# --- static wiring guards (always run) ---
+has 'X509_check_host' "$cc" \
+	|| fail "contest.c does not call X509_check_host to match the cert name"
+has 'tt->checkname = tt->sni' "$nc" \
+	|| fail "the SNI name is not handed to the cert name check"
+has 'certnamematch = testresult->certnamematch' "$nc" \
+	|| fail "the cert name-match result is not propagated to the test item"
+has 'Certificate does NOT cover' "$nc" \
+	|| fail "a cert name mismatch is not reported"
+has 'Certificate covers' "$nc" \
+	|| fail "a cert name match is not reported"
+
+# --- behavioural pass (needs the built binary + the openssl CLI) ---
+require_bin XYMONNET xymonnet/xymonnet
+command -v openssl >/dev/null 2>&1 || skip "openssl CLI not available for the behavioural pass"
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc" "$work/tmp"
+cp "$ROOT/xymonnet/protocols.cfg" "$work/home/etc/protocols.cfg"
+
+# Long-lived cert so expiry never colours the column -- we are checking the
+# name match in isolation. CN and SAN both name good.example.com.
+openssl req -x509 -newkey rsa:2048 -keyout "$work/k.pem" -out "$work/c.pem" -days 400 -nodes \
+	-subj "/CN=good.example.com" -addext "subjectAltName=DNS:good.example.com" >/dev/null 2>&1 \
+	|| skip "openssl could not generate a test certificate"
+
+port=12744
+openssl s_server -accept "$port" -cert "$work/c.pem" -key "$work/k.pem" -quiet -naccept 8 >/dev/null 2>&1 &
+srv=$!; register_cleanup "kill $srv 2>/dev/null || :"
+i=0
+while ! (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; do
+	kill -0 "$srv" 2>/dev/null || fail "s_server exited before listening"
+	i=$((i+1)); [ "$i" -gt 50 ] && fail "s_server never started listening"
+	sleep 0.1
+done
+exec 3>&- 3<&- 2>/dev/null || :
+
+netrun() {	# NAME -> xymonnet --no-update output (status + cert detail)
+	printf '127.0.0.1 %s # imaps:%s\n' "$1" "$port" > "$work/home/etc/hosts.cfg"
+	( export XYMONHOME="$work/home" XYMONTMP="$work/tmp" HOSTSCFG="$work/home/etc/hosts.cfg" \
+	    XYMONNETSVCS="imaps" MACHINE=t CONNTEST=FALSE PINGCOLUMN=conn FPING=/x NTPDATE=/x \
+	    TRACEROUTE=/x RPCINFO=/x NONETPAGE="" NETFAILTEXT=no XYMONROUTERTEXT=r TASKSLEEP=300 \
+	    BBLOCATION="" XYMONNETWORK=""
+	  "$XYMONNET" --noping --no-update --dns=ip --timeout=6 2>/dev/null )
+}
+
+out=$(netrun good.example.com)
+grep -qF "Certificate covers 'good.example.com'" <<<"$out" \
+	|| fail "a matching cert is not reported as covering the name"
+grep -qE "sslcert green" <<<"$out" \
+	|| fail "a matching, unexpired cert should leave sslcert green"
+
+out=$(netrun wrong.example.com)
+grep -qF "Certificate does NOT cover 'wrong.example.com'" <<<"$out" \
+	|| fail "a mismatched cert is not reported"
+grep -qE "sslcert green" <<<"$out" \
+	|| fail "a name mismatch must not change the sslcert colour (it is informational)"
+
+pass "xymonnet reports whether the cert covers the SNI name, without changing the sslcert colour"

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -210,6 +210,8 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 	newtest->certinfo = NULL;
 	newtest->certissuer = NULL;
 	newtest->certexpires = 0;
+	newtest->checkname = NULL;
+	newtest->certnamematch = -1;	/* not checked */
 	/* If ALPN is configured, SSL is also necessarily enabled */
 	newtest->sslrunning = (((newtest->svcinfo->flags & TCP_SSL) || (newtest->svcinfo->flags & TCP_ALPN)) ? SSLSETUP_PENDING : 0);
 	newtest->sslagain = 0;
@@ -755,6 +757,22 @@ static void setup_ssl(tcptest_t *item)
 	}
 
 	sslinfo = newstrbuffer(0);
+
+	/*
+	 * Optional cert name check: does the presented certificate actually
+	 * cover the name we asked for (the SNI/host name)? X509_check_host
+	 * matches SAN dNSName entries, falling back to the subject CN. This is
+	 * separate from expiry: a valid but wrong-name cert -- e.g. an SNI that
+	 * fell through to a default vhost -- is otherwise reported green.
+	 */
+	if (item->checkname && *item->checkname) {
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+		int rc = X509_check_host(peercert, item->checkname, strlen(item->checkname), 0, NULL);
+		item->certnamematch = (rc == 1) ? 1 : ((rc == 0) ? 0 : -1);
+#else
+		item->certnamematch = -1;	/* X509_check_host needs OpenSSL 1.0.2+ */
+#endif
+	}
 
 	certcn = X509_NAME_oneline(X509_get_subject_name(peercert), NULL, 0);
 	certissuer = X509_NAME_oneline(X509_get_issuer_name(peercert), NULL, 0);

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -31,6 +31,7 @@
 #include <openssl/ssl.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>
+#include <openssl/x509v3.h>	/* X509_check_host() for the cert name check */
 
 #if !defined(OPENSSL_VERSION_NUMBER) || (OPENSSL_VERSION_NUMBER < 0x00905000L)
 #error SSL-protocol testing requires OpenSSL version 0.9.5 or later
@@ -115,6 +116,8 @@ typedef struct tcptest_t {
 	/* For testing SSL-wrapped services */
 	ssloptions_t *ssloptions;	/* Specific SSL options requested by user */
 	char *sni;
+	char *checkname;		/* If set, verify the peer cert matches this name (X509_check_host) */
+	int certnamematch;		/* Cert name check: 1 = matched, 0 = mismatch, -1 = not checked */
 	SSL_CTX *sslctx;		/* SSL context pointer */
 	SSL  *ssldata;			/* SSL data (socket) pointer */
 	char *certinfo;			/* Certificate info (subject+expiretime) */

--- a/xymonnet/xymonnet.1
+++ b/xymonnet/xymonnet.1
@@ -319,6 +319,16 @@ Do not show encryption cipher details on the "sslcert" status.
 .IP "\fB\-\-showallciphers\fR"
 List ALL locally available encryption ciphers on the "sslcert" status.
 
+.PP
+When SNI is in use (see the "sni" option and
+.I hosts.cfg(5)\c
+), xymonnet also checks whether the presented certificate covers the
+name it was sent - matching the certificate's subjectAltName entries,
+falling back to the common name. The result is noted on the "sslcert"
+status ("Certificate covers ..." or "Certificate does NOT cover ..."),
+so a valid but wrong-name certificate is visible. This is informational
+and does not by itself change the "sslcert" colour.
+
 .IP "\fB\-\-sni\fR=[\fBon\fR|\fBoff\fR]"
 Sets the default for whether SSL connections use SNI (Server Name
 Indication). This can also be set with the "sni" or "nosni"

--- a/xymonnet/xymonnet.c
+++ b/xymonnet/xymonnet.c
@@ -2042,6 +2042,17 @@ void send_sslcert_status(testedhost_t *host)
 					snprintf(msgline, sizeof(msgline), "&%s Certificate public key size is less than %d bits\n", colorname(keycolor), sslminkeysize);
 					addtobuffer(sslmsg, msgline);
 				}
+				/* Cert name check (informational: reported, does not change the column colour) */
+				if (t->certnamematch == 0) {
+					snprintf(msgline, sizeof(msgline), "Certificate does NOT cover '%s' (the name sent as SNI)\n",
+						(host->sniname ? host->sniname : host->hostname));
+					addtobuffer(sslmsg, msgline);
+				}
+				else if (t->certnamematch == 1) {
+					snprintf(msgline, sizeof(msgline), "Certificate covers '%s'\n",
+						(host->sniname ? host->sniname : host->hostname));
+					addtobuffer(sslmsg, msgline);
+				}
 				addtobuffer(sslmsg, "\n");
 
 				addtobuffer(sslmsg, t->certinfo);
@@ -2457,6 +2468,8 @@ int main(int argc, char *argv[])
 										   (inet_pton(AF_INET6, name, &addr) == 1);
 								if (!isipliteral) tt->sni = name;
 							}
+							/* Always verify the peer cert covers the name we sent (informational) */
+							tt->checkname = tt->sni;
 						}
 					}
 				}
@@ -2511,6 +2524,7 @@ int main(int argc, char *argv[])
 					t->certexpires = testresult->certexpires;
 					t->certkeysz = testresult->certkeysz;
 					t->mincipherbits = testresult->mincipherbits;
+					t->certnamematch = testresult->certnamematch;
 					t->duration.tv_sec = testresult->duration.tv_sec;
 					t->duration.tv_nsec = testresult->duration.tv_nsec;
 
@@ -2531,6 +2545,7 @@ int main(int argc, char *argv[])
 			t->certexpires = testresult->tcptest->certexpires;
 			t->certkeysz = testresult->tcptest->certkeysz;
 			t->mincipherbits = testresult->tcptest->mincipherbits;
+			t->certnamematch = testresult->tcptest->certnamematch;
 		}
 	}
 

--- a/xymonnet/xymonnet.h
+++ b/xymonnet/xymonnet.h
@@ -145,6 +145,7 @@ typedef struct testitem_t {
 	char		*certinfo;
 	char		*certissuer;
 	time_t		certexpires;
+	int		certnamematch;	/* Cert name check: 1 = matched, 0 = mismatch, -1 = not checked */
 	int		mincipherbits;
 	int		certkeysz;
 	struct timespec	duration;


### PR DESCRIPTION
Stacked on #459 (base `feat/sni-name-override`). Merge #458 → #459 → this.

## What & why

The `sslcert` checks look at **expiry, cipher strength and key size** — never at whether the certificate actually **belongs to the name being tested**. On an SNI-routing server, a request that falls through to a default vhost (or a plain misconfiguration) returns a *valid but wrong-name* certificate that reads **green**. "sslcert green" has meant "not expired," not "the right cert for this name."

Now that xymonnet sends the name as SNI (#458/#459), it has exactly the name the cert should cover — so verify it.

## How

- `setup_ssl()` runs **`X509_check_host`** against the name handed to the test (the SNI / host name) — matching the certificate's `subjectAltName` entries, falling back to the common name.
- The result is carried to the `sslcert` status as a line: **`Certificate covers '<name>'`** or **`Certificate does NOT cover '<name>'`**.
- Guarded on **OpenSSL 1.0.2+** (where `X509_check_host` appeared; universal now); older builds report "not checked".

## Design (matches the discussion)

- **Automatic**, like the existing expiry/cipher checks — no flag, no config. The name is the SNI we already send. (Consistent with how `sslcert` already works.)
- **Informational only** — it does **not** by itself change the `sslcert` colour, so an upgrade adds *visibility* without turning existing hosts (whose label ≠ cert FQDN) red or yellow. Wiring a mismatch to yellow/red is a one-line follow-up if wanted later.

## Verification

`tests/network/tls-cert-name.sh` guards the wiring, and — where the built binary and the `openssl` CLI are present — drives xymonnet against a real `openssl s_server` whose cert names `good.example.com`:

| SNI sent | report | sslcert colour |
|----------|--------|----------------|
| `good.example.com` | `Certificate covers 'good.example.com'` | green |
| `wrong.example.com` | `Certificate does NOT cover 'wrong.example.com'` | **green** (unchanged) |

The green-on-mismatch assertion is the point: the check is informational.

## Docs

`xymonnet.1` documents the report; HTML regenerated from source per `CONTRIBUTING.md`.
