### PR TITLE
xymonnet: a protocols.cfg entry is a sequence, not one line each way

### DIFF
--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -66,6 +66,68 @@ static svcinfo_t default_svcinfo[] = {
 
 static svcinfo_t *svcinfo = default_svcinfo;
 
+/*
+ * Append one step to a service's dialogue, preserving file order. Every alias
+ * in an [a|b|c] header gets its own copy: the records are freed independently,
+ * so they cannot share a list.
+ */
+static svcstep_t *add_svcstep(svcinfo_t *rec, int type, unsigned char *text, int len)
+{
+	svcstep_t *step, *walk;
+
+	step = (svcstep_t *)calloc(1, sizeof(svcstep_t));
+	step->type = type;
+	step->len  = len;
+	step->text = (unsigned char *)malloc(len + 1);
+	memcpy(step->text, text, len);
+	step->text[len] = '\0';
+
+	if (rec->steps == NULL) rec->steps = step;
+	else {
+		for (walk = rec->steps; (walk->next); walk = walk->next) ;
+		walk->next = step;
+	}
+
+	return step;
+}
+
+
+/*
+ * Where a quoted string ends. Deliberately the same rule getescapestring
+ * uses -- scan to the next '"' -- so the two agree on where the value stops
+ * and any trailing keywords begin.
+ */
+static char *after_quoted(char *p)
+{
+	if (*p != '"') {
+		while (*p && !isspace((int)*p)) p++;
+		return p;
+	}
+	p = strchr(p+1, '"');
+	return (p ? p+1 : "");
+}
+
+
+/*
+ * Release one entry's step list. The reload path already promises not to
+ * leak, and a step list is more than the record it hangs off.
+ */
+static void free_svcsteps(svcinfo_t *rec)
+{
+	svcstep_t *st = rec->steps;
+
+	while (st) {
+		svcstep_t *next = st->next;
+
+		if (st->text)  xfree(st->text);
+		if (st->until) xfree(st->until);
+		xfree(st);
+		st = next;
+	}
+	rec->steps = NULL;
+}
+
+
 typedef struct svclist_t {
 	struct svcinfo_t *rec;
 	struct svclist_t *next;
@@ -152,6 +214,7 @@ char *init_tcp_services(void)
 				if (svcinfo[i].sendtxt) xfree(svcinfo[i].sendtxt);
 				if (svcinfo[i].exptext) xfree(svcinfo[i].exptext);
 				if (svcinfo[i].alpns) xfree(svcinfo[i].alpns);
+				free_svcsteps(&svcinfo[i]);
 			}
 			xfree(svcinfo);
 			svcinfo = default_svcinfo;
@@ -216,21 +279,72 @@ char *init_tcp_services(void)
 		}
 		else if (strncmp(l, "send ", 5) == 0) {
 			if (first) {
-				getescapestring(skipwhitespace(l+4), &first->rec->sendtxt, &first->rec->sendlen);
+				unsigned char *txt = NULL;
+				int txtlen = 0;
+
+				getescapestring(skipwhitespace(l+4), &txt, &txtlen);
+				/*
+				 * sendtxt keeps the FIRST send only, which is what a
+				 * single-step probe has always meant. The step list is
+				 * what a dialogue is driven from.
+				 */
+				if (first->rec->sendtxt == NULL) {
+					first->rec->sendtxt = txt;
+					first->rec->sendlen = txtlen;
+				}
+				add_svcstep(first->rec, STEP_SEND, txt, txtlen);
 				for (walk = first->next; (walk); walk = walk->next) {
-					walk->rec->sendtxt = strdup(first->rec->sendtxt);
-					walk->rec->sendlen = first->rec->sendlen;
+					if (walk->rec->sendtxt == NULL) {
+						walk->rec->sendtxt = (unsigned char *)strdup((char *)txt);
+						walk->rec->sendlen = txtlen;
+					}
+					add_svcstep(walk->rec, STEP_SEND, txt, txtlen);
 				}
 			}
 		}
 		else if (strncmp(l, "expect ", 7) == 0) {
 			if (first) {
-				getescapestring(skipwhitespace(l+6), &first->rec->exptext, &first->rec->explen);
-				for (walk = first->next; (walk); walk = walk->next) {
-					walk->rec->exptext = strdup(first->rec->exptext);
-					walk->rec->explen = first->rec->explen;
-					walk->rec->expofs = 0; /* HACK - not used right now */
+				unsigned char *txt = NULL, *untiltxt = NULL;
+				int txtlen = 0, untillen = 0;
+				char *rest;
+				svcstep_t *st;
+
+				getescapestring(skipwhitespace(l+6), &txt, &txtlen);
+
+				/*
+				 * "until" says where the reply ENDS. Without it an expect
+				 * takes a single line, which is wrong for every protocol that
+				 * answers with several: SMTP and FTP continue with "250-" and
+				 * finish with "250 ", NNTP ends a block with ".", IMAP ends
+				 * with the command tag. Naming the terminator covers all three
+				 * without teaching the parser any of them.
+				 */
+				rest = skipwhitespace(after_quoted(skipwhitespace(l+6)));
+				if (strncmp(rest, "until ", 6) == 0)
+					getescapestring(skipwhitespace(rest + 5), &untiltxt, &untillen);
+
+				if (first->rec->exptext == NULL) {
+					first->rec->exptext = txt;
+					first->rec->explen  = txtlen;
 				}
+				st = add_svcstep(first->rec, STEP_EXPECT, txt, txtlen);
+				if (untiltxt) {
+					st->until = (unsigned char *)strdup((char *)untiltxt);
+					st->untillen = untillen;
+				}
+				for (walk = first->next; (walk); walk = walk->next) {
+					if (walk->rec->exptext == NULL) {
+						walk->rec->exptext = (unsigned char *)strdup((char *)txt);
+						walk->rec->explen  = txtlen;
+						walk->rec->expofs  = 0; /* HACK - not used right now */
+					}
+					st = add_svcstep(walk->rec, STEP_EXPECT, txt, txtlen);
+					if (untiltxt) {
+						st->until = (unsigned char *)strdup((char *)untiltxt);
+						st->untillen = untillen;
+					}
+				}
+				if (untiltxt) xfree(untiltxt);
 			}
 		}
 		else if (strncmp(l, "options ", 8) == 0) {
@@ -264,6 +378,17 @@ char *init_tcp_services(void)
 				}
 			}
 		}
+		else if (*l) {
+			/*
+			 * Say so. An unrecognised line used to be a silent no-op, so
+			 * a typo simply deleted a step and the probe ran anyway --
+			 * reporting green on a conversation it never had. This is the
+			 * same treatment "options" already gives an unknown option.
+			 */
+			errprintf("Unknown protocols.cfg directive%s%s: %s\n",
+				  (first ? " in service " : ""),
+				  (first ? first->rec->svcname : ""), l);
+		}
 	}
 
 	if (fd) stackfclose(fd);
@@ -281,6 +406,22 @@ char *init_tcp_services(void)
 		svcinfo[i].flags   = walk->rec->flags;
 		svcinfo[i].port    = walk->rec->port;
 		svcinfo[i].alpns   = walk->rec->alpns;
+		svcinfo[i].steps   = walk->rec->steps;
+		/*
+		 * A dialogue is anything that is not the classic one-shot shape.
+		 * Deciding it here, once, keeps do_tcp_tests() from re-deriving it
+		 * per pass -- and means every existing entry ("send" then "expect",
+		 * or either alone) keeps the exact code path it has always used.
+		 */
+		{
+			svcstep_t *st; int nsend = 0, nexp = 0, first_is_expect = 0;
+			for (st = walk->rec->steps; (st); st = st->next) {
+				if (st == walk->rec->steps) first_is_expect = (st->type == STEP_EXPECT);
+				if (st->type == STEP_SEND) nsend++; else nexp++;
+			}
+			if (first_is_expect || nsend > 1 || nexp > 1)
+				svcinfo[i].flags |= TCP_DIALOGUE;
+		}
 	}
 	memset(&svcinfo[svccount], 0, sizeof(svcinfo_t));
 

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -19,6 +19,26 @@
 #define TCP_SSL        0x0004
 #define TCP_HTTP       0x0008
 #define TCP_ALPN       0x0010
+/* The service is a multi-step dialogue, not a single send-then-match probe.
+   Set by the protocols.cfg parser when the steps cannot be expressed as one
+   sendtxt plus one exptext: an expect comes first, or there is more than one
+   of either. Single-step services keep the old path untouched. */
+#define TCP_DIALOGUE   0x0020
+
+/* One step of a protocol dialogue, in the order protocols.cfg lists them.
+   Kept as a list rather than an array because the parser appends while it
+   reads and every alias of a service shares the same shape. */
+#define STEP_SEND   1
+#define STEP_EXPECT 2
+
+typedef struct svcstep_t {
+	int type;
+	unsigned char *text;
+	int len;
+	unsigned char *until;		/* expect ... until "X": end-of-reply marker */
+	int untillen;
+	struct svcstep_t *next;
+} svcstep_t;
 
 typedef struct svcinfo_t {
 	char *svcname;
@@ -29,6 +49,7 @@ typedef struct svcinfo_t {
 	unsigned int flags;
 	int port;
 	char *alpns;
+	svcstep_t *steps;	/* NULL unless TCP_DIALOGUE */
 } svcinfo_t;
 
 extern char *init_tcp_services(void);

--- a/tests/lib/dialogue-peer.c
+++ b/tests/lib/dialogue-peer.c
@@ -1,0 +1,267 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later                                  */
+/*
+ * tests/lib/dialogue-peer.c
+ *
+ * A scriptable peer for the protocols.cfg dialogue tests. One program
+ * instead of one per case: the exchange is a small script, so a new test
+ * is a few lines of text rather than a new C file.
+ *
+ *   dialogue-peer SCRIPT OBSERVED [CERT KEY]
+ *
+ * Prints its port on stdout. Appends what it saw to OBSERVED, which is
+ * what the test asserts on -- the point being to check what actually
+ * went over the wire, not what the source says should have.
+ *
+ * Script commands, one per line:
+ *
+ *   send TEXT        write TEXT (\r \n \t \xNN escapes)
+ *   recv PREFIX      read one line; record it, and record MISMATCH if it
+ *                    does not begin with PREFIX
+ *   recvany          read one line and record it
+ *   replyall TEXT    answer TEXT to every further line, until EOF. Models a
+ *                    server that greets and then refuses everything.
+ *   starttls         upgrade to TLS here (needs CERT and KEY)
+ *   md5check USER SECRET
+ *                    read a line, and verify it is "APOP USER <hex>" where
+ *                    hex is md5(challenge + SECRET) for the challenge this
+ *                    script last sent in angle brackets. The peer computes
+ *                    it independently, so a wrong digest fails.
+ *   b64check PREFIX TEXT
+ *                    read a line and verify it is PREFIX + base64(TEXT).
+ *   hangup           close the connection
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <ctype.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+
+static SSL_CTX *ctx = NULL;
+static SSL *ssl = NULL;
+static int sock = -1, conn = -1;
+static FILE *obs = NULL;
+static char challenge[256] = "";
+
+static int io_write(const char *b, int n)
+{
+	return ssl ? SSL_write(ssl, b, n) : (int)send(conn, b, n, 0);
+}
+
+static int io_read(char *b, int n)
+{
+	return ssl ? SSL_read(ssl, b, n) : (int)recv(conn, b, n, 0);
+}
+
+/* One line, up to and including the newline. NULL at EOF. */
+static char *readline(char *buf, int max)
+{
+	int n = 0;
+
+	while (n < max - 1) {
+		char c;
+		if (io_read(&c, 1) != 1) return (n ? (buf[n] = '\0', buf) : NULL);
+		if (c == '\r') continue;
+		if (c == '\n') break;
+		buf[n++] = c;
+	}
+	buf[n] = '\0';
+	return buf;
+}
+
+/*
+ * Same quoting rule as protocols.cfg itself: an optional leading quote,
+ * and the value ends at the next one. Without this the quotes travel over
+ * the wire as part of the payload, and every expect in the test fails for
+ * a reason that has nothing to do with the code under test.
+ */
+static int unescape(const char *in, char *out, int max)
+{
+	int n = 0, quoted = 0;
+
+	if (*in == '"') { quoted = 1; in++; }
+
+	while (*in && (n < max - 1)) {
+		if (quoted && (*in == '"')) break;
+		if (*in != '\\') { out[n++] = *in++; continue; }
+		in++;
+		switch (*in) {
+		  case 'r': out[n++] = '\r'; in++; break;
+		  case 'n': out[n++] = '\n'; in++; break;
+		  case 't': out[n++] = '\t'; in++; break;
+		  case 'x': {
+			int v = 0;
+			in++;
+			while (isxdigit((int)*in)) {
+				v = v * 16 + (isdigit((int)*in) ? *in - '0' : (tolower(*in) - 'a' + 10));
+				in++;
+			}
+			out[n++] = (char)v;
+			break;
+		  }
+		  default: out[n++] = *in++; break;
+		}
+	}
+	out[n] = '\0';
+	return n;
+}
+
+static void tohex(const unsigned char *d, int n, char *out)
+{
+	int i;
+	for (i = 0; i < n; i++) sprintf(out + 2*i, "%02x", d[i]);
+	out[2*n] = '\0';
+}
+
+static const char b64set[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+static void b64(const char *in, char *out)
+{
+	int i = 0, o = 0, len = strlen(in);
+
+	while (i < len) {
+		unsigned long v = (unsigned char)in[i++];
+		int pad = 0;
+		v <<= 8; if (i < len) v |= (unsigned char)in[i++]; else pad++;
+		v <<= 8; if (i < len) v |= (unsigned char)in[i++]; else pad++;
+		out[o++] = b64set[(v >> 18) & 63];
+		out[o++] = b64set[(v >> 12) & 63];
+		out[o++] = (pad > 1) ? '=' : b64set[(v >> 6) & 63];
+		out[o++] = (pad > 0) ? '=' : b64set[v & 63];
+	}
+	out[o] = '\0';
+}
+
+int main(int argc, char *argv[])
+{
+	struct sockaddr_in addr;
+	socklen_t alen = sizeof(addr);
+	FILE *sc;
+	char line[4096];
+	fd_set rfds;
+	struct timeval tv;
+
+	if (argc < 3) { fprintf(stderr, "usage: %s SCRIPT OBSERVED [CERT KEY]\n", argv[0]); return 2; }
+
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) { perror("socket"); return 1; }
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) { perror("bind"); return 1; }
+	if (getsockname(sock, (struct sockaddr *)&addr, &alen) < 0) { perror("getsockname"); return 1; }
+	if (listen(sock, 4) < 0) { perror("listen"); return 1; }
+	printf("%d\n", ntohs(addr.sin_port));
+	fflush(stdout);
+
+	tv.tv_sec = 25; tv.tv_usec = 0;
+	FD_ZERO(&rfds); FD_SET(sock, &rfds);
+	if (select(sock + 1, &rfds, NULL, NULL, &tv) <= 0) return 0;
+	conn = accept(sock, NULL, NULL);
+	if (conn < 0) return 1;
+
+	obs = fopen(argv[2], "w");
+	if (!obs) { perror("fopen"); return 1; }
+
+	sc = fopen(argv[1], "r");
+	if (!sc) { fprintf(obs, "ERR no script\n"); fclose(obs); return 1; }
+
+	while (fgets(line, sizeof(line), sc)) {
+		char *cmd, *arg, buf[4096], got[4096];
+		int n;
+
+		line[strcspn(line, "\r\n")] = '\0';
+		cmd = line + strspn(line, " \t");
+		if ((*cmd == '\0') || (*cmd == '#')) continue;
+		arg = strchr(cmd, ' ');
+		if (arg) *arg++ = '\0'; else arg = "";
+
+		if (strcmp(cmd, "send") == 0) {
+			char *p;
+
+			n = unescape(arg, buf, sizeof(buf));
+			io_write(buf, n);
+			/* Remember an APOP-style challenge for md5check. */
+			p = strchr(buf, '<');
+			if (p) {
+				char *e = strchr(p, '>');
+				if (e && ((e - p + 1) < (int)sizeof(challenge))) {
+					memcpy(challenge, p, e - p + 1);
+					challenge[e - p + 1] = '\0';
+				}
+			}
+		}
+		else if ((strcmp(cmd, "recv") == 0) || (strcmp(cmd, "recvany") == 0)) {
+			if (!readline(got, sizeof(got))) { fprintf(obs, "eof\n"); break; }
+			fprintf(obs, "got %s\n", got);
+			if (*arg && strncmp(got, arg, strlen(arg)) != 0)
+				fprintf(obs, "MISMATCH want=%s got=%s\n", arg, got);
+		}
+		else if (strcmp(cmd, "replyall") == 0) {
+			n = unescape(arg, buf, sizeof(buf));
+			while (readline(got, sizeof(got))) {
+				fprintf(obs, "got %s\n", got);
+				io_write(buf, n);
+			}
+			fprintf(obs, "eof\n");
+			break;
+		}
+		else if (strcmp(cmd, "starttls") == 0) {
+			if (argc < 5) { fprintf(obs, "ERR no certificate\n"); break; }
+			SSL_library_init();
+			ctx = SSL_CTX_new(SSLv23_server_method());
+			if (!ctx ||
+			    (SSL_CTX_use_certificate_file(ctx, argv[3], SSL_FILETYPE_PEM) <= 0) ||
+			    (SSL_CTX_use_PrivateKey_file(ctx, argv[4], SSL_FILETYPE_PEM) <= 0)) {
+				fprintf(obs, "ERR bad certificate\n");
+				break;
+			}
+			ssl = SSL_new(ctx);
+			SSL_set_fd(ssl, conn);
+			if (SSL_accept(ssl) <= 0) { fprintf(obs, "ERR handshake failed\n"); ssl = NULL; break; }
+			fprintf(obs, "tls-ok\n");
+		}
+		else if (strcmp(cmd, "md5check") == 0) {
+			char user[128] = "", secret[128] = "", want[1024], hex[33], src[512];
+			unsigned char dig[EVP_MAX_MD_SIZE];
+			unsigned int diglen = 0;
+
+			sscanf(arg, "%127s %127s", user, secret);
+			if (!readline(got, sizeof(got))) { fprintf(obs, "eof\n"); break; }
+			snprintf(src, sizeof(src), "%s%s", challenge, secret);
+			EVP_Digest(src, strlen(src), dig, &diglen, EVP_md5(), NULL);
+			tohex(dig, (int)diglen, hex);
+			snprintf(want, sizeof(want), "APOP %s %s", user, hex);
+			fprintf(obs, "got %s\n", got);
+			if (strcmp(got, want) != 0) fprintf(obs, "MISMATCH want=%s got=%s\n", want, got);
+			else fprintf(obs, "md5-ok\n");
+		}
+		else if (strcmp(cmd, "b64check") == 0) {
+			char pfx[128] = "", txt[256] = "", want[1024], enc[512];
+
+			sscanf(arg, "%127s %255s", pfx, txt);
+			if (!readline(got, sizeof(got))) { fprintf(obs, "eof\n"); break; }
+			b64(txt, enc);
+			snprintf(want, sizeof(want), "%s%s", pfx, enc);
+			fprintf(obs, "got %s\n", got);
+			if (strcmp(got, want) != 0) fprintf(obs, "MISMATCH want=%s got=%s\n", want, got);
+			else fprintf(obs, "b64-ok\n");
+		}
+		else if (strcmp(cmd, "hangup") == 0) break;
+	}
+
+	fprintf(obs, "done\n");
+	fclose(obs); fclose(sc);
+	if (ssl) { SSL_shutdown(ssl); SSL_free(ssl); }
+	if (ctx) SSL_CTX_free(ctx);
+	if (conn >= 0) close(conn);
+	close(sock);
+	return 0;
+}

--- a/tests/lib/tls-slow-reader.c
+++ b/tests/lib/tls-slow-reader.c
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later                                  */
+/*
+ * tests/lib/tls-slow-reader.c
+ *
+ * A TLS server that completes the handshake and then does NOT read for a
+ * moment, so a client sending more than the socket buffers hold gets
+ * SSL_ERROR_WANT_WRITE part-way through. After the pause it drains
+ * everything and reports the byte count.
+ *
+ * That count is the whole point: a probe that retries the deferred write
+ * delivers all of it, one that drops the remainder delivers less, and
+ * neither reports an error -- so only the peer can tell them apart.
+ *
+ *   argv[1] certificate   argv[2] key   argv[3] output file
+ *
+ * Prints its port on stdout. Writes the byte count, or "ERR ...", to the
+ * output file.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+int main(int argc, char *argv[])
+{
+	int sock, c;
+	struct sockaddr_in addr;
+	socklen_t alen = sizeof(addr);
+	SSL_CTX *ctx;
+	SSL *ssl;
+	FILE *out;
+	char buf[65536];
+	long total = 0;
+	int rcvbuf = 8192;
+	fd_set rfds;
+	struct timeval tv;
+
+	if (argc < 4) { fprintf(stderr, "usage: %s CERT KEY OUTFILE\n", argv[0]); return 2; }
+
+	SSL_library_init();
+	SSL_load_error_strings();
+	ctx = SSL_CTX_new(SSLv23_server_method());
+	if (!ctx) { fprintf(stderr, "SSL_CTX_new failed\n"); return 1; }
+	if (SSL_CTX_use_certificate_file(ctx, argv[1], SSL_FILETYPE_PEM) <= 0 ||
+	    SSL_CTX_use_PrivateKey_file(ctx, argv[2], SSL_FILETYPE_PEM) <= 0) {
+		fprintf(stderr, "cannot load certificate/key\n");
+		return 1;
+	}
+
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) { perror("socket"); return 1; }
+	/* A small receive buffer makes the sender stall sooner and more reliably. */
+	setsockopt(sock, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) { perror("bind"); return 1; }
+	if (getsockname(sock, (struct sockaddr *)&addr, &alen) < 0) { perror("getsockname"); return 1; }
+	if (listen(sock, 4) < 0) { perror("listen"); return 1; }
+	printf("%d\n", ntohs(addr.sin_port));
+	fflush(stdout);
+
+	tv.tv_sec = 25; tv.tv_usec = 0;
+	FD_ZERO(&rfds); FD_SET(sock, &rfds);
+	if (select(sock + 1, &rfds, NULL, NULL, &tv) <= 0) return 0;
+	c = accept(sock, NULL, NULL);
+	if (c < 0) return 1;
+
+	out = fopen(argv[3], "w");
+	if (!out) { perror("fopen"); return 1; }
+
+	ssl = SSL_new(ctx);
+	SSL_set_fd(ssl, c);
+	if (SSL_accept(ssl) <= 0) {
+		fprintf(out, "ERR handshake failed\n");
+		fclose(out); return 0;
+	}
+
+	/* Do NOT read yet: let the sender fill the pipe and hit WANT_WRITE. */
+	sleep(2);
+
+	for (;;) {
+		int n;
+
+		tv.tv_sec = 8; tv.tv_usec = 0;
+		FD_ZERO(&rfds); FD_SET(c, &rfds);
+		if (!SSL_pending(ssl) && (select(c + 1, &rfds, NULL, NULL, &tv) <= 0)) break;
+		n = SSL_read(ssl, buf, sizeof(buf));
+		if (n <= 0) break;
+		total += n;
+	}
+
+	SSL_write(ssl, "OK\r\n", 4);
+	fprintf(out, "%ld\n", total);
+	fclose(out);
+	SSL_shutdown(ssl);
+	SSL_free(ssl);
+	close(c); close(sock);
+	SSL_CTX_free(ctx);
+	return 0;
+}

--- a/tests/network/dialogue-buffer-cap.sh
+++ b/tests/network/dialogue-buffer-cap.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# A reply that never matches must not be accumulated forever.
+#
+# The driver appends every read to a per-conversation buffer and keeps it
+# until an alternative matches. A server that talks without ever saying
+# anything the config waits for would otherwise grow that buffer for as
+# long as it cares to send -- and the poll loop runs hundreds of these at
+# once, so it is a memory fault on the monitor caused by a remote host.
+# MAX_DIALOGUE_BYTES bounds it; this is the test that the bound is real.
+#
+# The entry sends after its expect, which is what puts it on the dialogue
+# driver: a lone expect is the classic single-shot shape and is bounded by
+# nothing, because it accumulates nothing. The send is never reached -- the
+# reply it waits for never terminates -- it is there to choose the probe.
+#
+# It also has to fail by NAME rather than by running out of time. Both end
+# the test, so a cap that merely stopped reading would look identical from
+# the outside while telling an operator nothing about why -- and would
+# still hold the slot for the whole global timeout. The only clock here is
+# the global --timeout, deliberately set far above the bound: if the cap
+# does not fire, this test fails by taking 90 seconds rather than passing
+# because a timer rescued it.
+#
+# THE CONTROL is [bigreply]: a multi-line reply of about 20 KB that does
+# finish. It is the same shape of traffic, under the cap instead of over
+# it, and it must go green. Without it a cap set far too low -- or one
+# that fired on any large reply -- would pass the assertions below while
+# breaking every server with a long capability list.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+"$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile"; }
+
+# Each line is ~100 bytes of SMTP continuation, so it accumulates the way a
+# real capability list does rather than as one huge write.
+line='send "250-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\r\n"'
+
+# Over the cap: 500 lines, ~50 KB, and the terminator never arrives.
+{ i=0; while [ $i -lt 500 ]; do echo "$line"; i=$((i + 1)); done; echo 'hold 20'; } > "$work/over.script"
+
+# Under it: 200 lines, ~20 KB, properly terminated.
+{ i=0; while [ $i -lt 200 ]; do echo "$line"; i=$((i + 1)); done
+  printf 'send "250 done\\r\\n"\nrecvany\nhold 5\n'; } > "$work/under.script"
+
+: > "$work/pids"
+start() {	# script portfile obsfile
+	"$work/peer" "$1" "$3" > "$2" &
+	echo $! >> "$work/pids"
+	local i=0
+	while [ "$i" -lt 50 ]; do [ -s "$2" ] && break; sleep 0.1; i=$((i + 1)); done
+	cat "$2"
+}
+pover=$(start "$work/over.script"  "$work/po" "$work/oo")
+punder=$(start "$work/under.script" "$work/pu" "$work/ou")
+register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
+[ -n "$pover" ] && [ -n "$punder" ] || fail "a peer never named its port"
+
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[toobig]
+   expect "250" until "250 "
+   send "quit\r\n"
+   port $pover
+
+[bigreply]
+   expect "250" until "250 "
+   send "quit\r\n"
+   port $punder
+CFG
+printf '127.0.0.1\tover\t# toobig\n127.0.0.1\tunder\t# bigreply\n' > "$work/home/etc/hosts.cfg"
+
+started=$(date +%s)
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse \
+	--dns=ip --timeout=90 >"$work/out.txt" 2>&1 || :
+elapsed=$(( $(date +%s) - started ))
+
+grep -qi 'exceeded .* bytes with no match' "$work/out.txt" || fail \
+	"a server that sent ~50 KB without ever completing the reply was not
+stopped by the buffer cap. The buffer grows for as long as a remote host
+cares to talk, on a monitor running hundreds of these at once:
+$(grep -iE 'toobig|exceed|bytes' "$work/out.txt" | head -5)"
+
+grep -q 'Service toobig on over is not OK' "$work/out.txt" || fail \
+	"the cap fired but the service did not report a failure:
+$(grep -i toobig "$work/out.txt" | head -5)"
+
+# The cap must end it, not the clock. The global budget is far longer than
+# this bound, so finishing quickly can only mean the cap decided.
+[ "$elapsed" -lt 45 ] || fail \
+	"the run took ${elapsed}s, so the test was ended by a timer rather than
+by the cap -- which means the cap is not what stopped the reading"
+
+# THE CONTROL: the same traffic, under the cap, must still work.
+grep -q 'Service bigreply on under is OK' "$work/out.txt" || fail \
+	"a ~20 KB multi-line reply that does terminate was not accepted. The cap
+is set too low or fires on any large reply, which would break every server
+with a long capability list:
+$(grep -i bigreply "$work/out.txt" | head -5)"
+
+pass "an unmatched reply is bounded and fails by name, while a large complete one still passes"

--- a/tests/network/dialogue-multiline.sh
+++ b/tests/network/dialogue-multiline.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# A multi-line reply, which is what real SMTP sends.
+#
+# An expect consumes one line. EHLO answers with several, so without a way
+# to say where the reply ENDS the remaining lines stay in the buffer and
+# the next expect compares against "250-PIPELINING" and fails. Both
+# services here are identical apart from the "until" clause, so the test
+# carries its own control: if the second one starts passing, the
+# terminator has stopped doing anything and this test is no longer
+# checking what it claims to.
+#
+# Both end with an expect on the 221, and that matters: with nothing after
+# the multi-line reply the leftover lines have nothing to collide with and
+# even the broken entry passes. That is exactly why the shipped [smtp]
+# definition gets away without a terminator today.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+"$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile"; }
+
+cat > "$work/ml.script" <<'EOS'
+send "220 test.local ESMTP\r\n"
+recv ehlo
+send "250-test.local\r\n250-PIPELINING\r\n250 CHUNKING\r\n"
+recv quit
+send "221 bye\r\n"
+EOS
+
+start() {
+	"$work/peer" "$work/ml.script" "$2" > "$1" &
+	echo $! >> "$work/pids"
+	local i=0
+	while [ "$i" -lt 50 ]; do [ -s "$1" ] && break; sleep 0.1; i=$((i + 1)); done
+	cat "$1"
+}
+: > "$work/pids"
+p1=$(start "$work/p1" "$work/o1")
+p2=$(start "$work/p2" "$work/o2")
+register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
+[ -n "$p1" ] && [ -n "$p2" ] || fail "a peer never named its port"
+
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[mlok]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250" until "250 "
+   send "quit\r\n"
+   expect "221"
+   options banner
+   port $p1
+
+[mlbad]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250"
+   send "quit\r\n"
+   expect "221"
+   options banner
+   port $p2
+CFG
+printf '127.0.0.1\twith\t# mlok\n127.0.0.1\twithout\t# mlbad\n' > "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse \
+	--dns=ip --timeout=15 >"$work/out.txt" 2>&1 || :
+sleep 1
+
+grep -q 'Service mlok on with is OK' "$work/out.txt" || fail \
+	'expect ... until "250 " did not consume the multi-line reply:
+'"$(cat "$work/out.txt")"
+
+grep -q 'Service mlbad on without is OK' "$work/out.txt" && fail \
+	"the entry WITHOUT a terminator passed too, so the terminator is not what
+made the difference and this test proves nothing. Either an expect has
+started consuming whole replies by itself, or the peer stopped sending
+more than one line."
+
+grep -q 'got quit' "$work/o1" || fail \
+	"the dialogue never reached QUIT: $(cat "$work/o1")"
+
+pass "a multi-line reply is consumed through its terminator, and is not without one"

--- a/tests/network/dialogue-validation.sh
+++ b/tests/network/dialogue-validation.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# A protocols.cfg mistake should say so.
+#
+# An unrecognised directive was a silent no-op: the step simply vanished
+# and the probe reported on a conversation it never had. That is checked
+# when the file is read, not when the step executes, which is why this
+# test never connects to anything.
+#
+# The second half matters as much as the first: the config the tree SHIPS
+# must produce none of these. A validator that cries wolf gets ignored,
+# and then the real warnings go unread too.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+printf '127.0.0.1\tnobody\t# conn\n' > "$work/home/etc/hosts.cfg"
+
+run_xymonnet() {
+	XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --dns=ip \
+		--timeout=2 2>&1 || :
+}
+
+# --- a file with a mistyped directive --------------------------------------
+cat > "$work/home/etc/protocols.cfg" <<'CFG'
+[bad]
+   exepct "220"
+   expect "220"
+   options banner
+   port 9
+CFG
+out=$(run_xymonnet)
+
+grep -qi 'unknown protocols.cfg directive' <<<"$out" || fail \
+	"a mistyped directive was accepted in silence. The step is dropped and the
+probe still runs, so the test reports on a conversation it never had:
+$out"
+
+# --- and the shipped file must be quiet -------------------------------------
+cp "$root/xymonnet/protocols.cfg" "$work/home/etc/protocols.cfg"
+out=$(run_xymonnet)
+noise=$(grep -ciE 'unknown protocols.cfg directive' <<<"$out" || true)
+[ "$noise" -eq 0 ] || fail \
+	"the protocols.cfg this tree ships triggers $noise of its own warnings:
+$(grep -iE 'unknown|before any expect' <<<"$out")"
+
+pass "a mistyped directive is reported when the file is read, and the shipped file reports none"

--- a/tests/network/dialogue-verdict.sh
+++ b/tests/network/dialogue-verdict.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# What a dialogue REPORTS, against three servers.
+#
+# The point of the feature is the middle row: a server that greets
+# correctly and then fails every command was reported green, because the
+# probe matched the greeting and stopped looking. That claim is the whole
+# justification for the change and nothing else in the suite checks it.
+#
+# The third row is the one that actually broke during development. A
+# service that is still a plain send-and-match must behave exactly as it
+# did before -- the dialogue driver is opt-in, and a regression there
+# reaches services the feature does not touch. It went unnoticed through
+# a green suite, which is why it is pinned here.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+"$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile"; }
+
+start_peer() {	# $1 = script file -> echoes the port
+	local pf=$1 obs=$2 portf=$3
+	"$work/peer" "$pf" "$obs" > "$portf" &
+	echo $! > "$portf.pid"
+	local i=0
+	while [ "$i" -lt 50 ]; do
+		[ -s "$portf" ] && break
+		sleep 0.1
+		i=$((i + 1))
+	done
+	cat "$portf"
+}
+
+# --- healthy: greets, answers EHLO, accepts QUIT -----------------------------
+cat > "$work/ok.script" <<'EOS'
+send "220 test.local ESMTP\r\n"
+recv ehlo
+send "250 OK\r\n"
+recv quit
+send "221 bye\r\n"
+EOS
+
+# --- degraded: greets correctly, then refuses everything ---------------------
+cat > "$work/bad.script" <<'EOS'
+send "220 test.local ESMTP\r\n"
+replyall "421 4.7.0 Too many connections\r\n"
+EOS
+
+# --- legacy: a plain send-and-match service, unchanged by this feature -------
+cat > "$work/legacy.script" <<'EOS'
+recvany
+send "+OK legacy ready\r\n"
+EOS
+
+pok=$(start_peer "$work/ok.script"     "$work/ok.obs"     "$work/ok.port")
+pbad=$(start_peer "$work/bad.script"   "$work/bad.obs"    "$work/bad.port")
+pleg=$(start_peer "$work/legacy.script" "$work/leg.obs"   "$work/leg.port")
+register_cleanup "kill $(cat "$work/ok.port.pid") $(cat "$work/bad.port.pid") $(cat "$work/leg.port.pid") 2>/dev/null || :"
+[ -n "$pok" ] && [ -n "$pbad" ] && [ -n "$pleg" ] || fail "a peer never named its port"
+
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[dlg]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250"
+   send "quit\r\n"
+   options banner
+   port $pok
+
+[dlgbad]
+   state greeting
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   state capabilities
+   expect "250"
+   send "quit\r\n"
+   options banner
+   port $pbad
+
+[legacy]
+   send "probe\r\n"
+   expect "+OK"
+   options banner
+   port $pleg
+CFG
+printf '127.0.0.1\thealthy\t# dlg\n127.0.0.1\tdegraded\t# dlgbad\n127.0.0.1\tlegacy\t# legacy\n' \
+	> "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse \
+	--dns=ip --timeout=15 >"$work/out.txt" 2>&1 || :
+sleep 1
+
+grep -q 'Service dlg on healthy is OK' "$work/out.txt" || fail \
+	"the healthy dialogue did not report the service up:
+$(cat "$work/out.txt")"
+
+grep -q 'Service dlgbad on degraded is OK' "$work/out.txt" && fail \
+	"a server that greets 220 and then answers 421 to every command was
+reported UP. Matching the greeting and looking no further is exactly the
+coverage gap the dialogue exists to close:
+$(sed -n 's/^/  peer saw: /p' "$work/bad.obs" | head -4)"
+
+grep -q 'state capabilities' "$work/out.txt" || fail \
+	"the failure did not name the state it happened in. A dialogue can fail at
+any step, and 'Unexpected service response' alone leaves the reader guessing
+which one:
+$(grep -i 'dlgbad' "$work/out.txt" | head -2)"
+
+grep -q 'Service legacy on legacy is OK' "$work/out.txt" || fail \
+	"a plain send-and-match service stopped working. That path is supposed to
+be untouched by the dialogue driver -- a regression here reaches services
+this feature does not even use:
+$(cat "$work/out.txt")"
+
+grep -q '^got ehlo' "$work/ok.obs" || fail \
+	"the healthy peer never received the EHLO; the dialogue did not run:
+$(cat "$work/ok.obs")"
+
+pass "a dialogue reports up on success, names the state it failed in, and leaves plain services alone"

--- a/tests/network/protocol-dialogue.sh
+++ b/tests/network/protocol-dialogue.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# The dialogue engine must not report a service OK unless every step ran.
+#
+# This is the assertion the whole feature rests on. Before it, a server
+# that greeted "220" and then 421'd every command was reported GREEN --
+# xymonnet compared the greeting against the banner prefix and stopped
+# looking. Measured against a server that 421s everything after the
+# greeting: green before, "Unexpected service response" after.
+#
+# So the property under test is not "the steps are parsed" but "an
+# unfinished dialogue is a failure". A verdict that only checks
+# dialogfail would still pass a server that goes silent halfway through,
+# because nothing failed -- the conversation just stopped. curstep must
+# be NULL too, meaning the list was consumed to the end.
+#
+# Source assertions rather than a live server: the rest of this suite
+# runs without building, and the behaviour above is covered by hand
+# against real Postfix. Comments are stripped before matching, because
+# this file's own prose contains every identifier it asserts.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+strip() { sed 's://.*::' "$1" | sed 's:/\*:\n&:g' | sed '/\/\*/,/\*\//d'; }
+
+h=$(strip "$root/lib/netservices.h")
+c=$(strip "$root/lib/netservices.c")
+n=$(strip "$root/xymonnet/contest.c")
+
+for sym in STEP_SEND STEP_EXPECT svcstep_t TCP_DIALOGUE; do
+	printf '%s\n' "$h" | grep -q "$sym" ||
+		fail "lib/netservices.h does not define $sym -- the step list has no type"
+done
+
+printf '%s\n' "$c" | grep -q 'add_svcstep.*STEP_EXPECT' ||
+	fail "the protocols.cfg parser never records an expect step"
+printf '%s\n' "$c" | grep -q 'add_svcstep.*STEP_SEND' ||
+	fail "the protocols.cfg parser never records a send step"
+
+# THE ASSERTION. Both halves, on the same return.
+verdict=$(printf '%s\n' "$n" | grep -n 'dialogfail' | grep 'return' || true)
+[ -n "$verdict" ] ||
+	fail "no verdict consults dialogfail -- a failed dialogue would still report OK"
+printf '%s\n' "$verdict" | grep -q 'curstep' ||
+	fail "the verdict checks dialogfail but not curstep: a peer that goes silent
+mid-dialogue sets neither failure flag nor finishes the list, so it would be
+reported OK -- which is exactly the 421 bug this feature exists to catch"
+
+# The socket must stay open while steps remain, or the dialogue is cut
+# off by the very close that the single-shot probe used to do.
+printf '%s\n' "$n" | grep -q '!item->curstep' ||
+	fail "no close guard mentions curstep -- the connection is torn down mid-dialogue"
+
+pass "an unfinished dialogue cannot report OK (both dialogfail and curstep are checked)"

--- a/tests/network/smtp-no-pregreet.sh
+++ b/tests/network/smtp-no-pregreet.sh
@@ -60,9 +60,27 @@ for svc in smtp smtps submission msa; do
 	block=$(service_block "$svc")
 	[ -n "$block" ] || fail "protocols.cfg no longer defines [$svc] (#450)"
 
-	if grep -Eq '^[[:space:]]*send[[:space:]]' <<<"$block"; then
-		fail "[$svc] sends before the server's greeting -- xymonnet writes before it reads, so this is a pregreet, and Postfix >= 3.9 answers 554 (#450)"
+	# The invariant is ordering, not abstinence: a send is fine, a send BEFORE
+	# the first expect is the pregreet. Compare line positions rather than
+	# looking for the absence of a send, so a legal dialogue passes and the old
+	# shape still fails.
+	first_send=$(grep -nE '^[[:space:]]*send[[:space:]]' <<<"$block" | head -1 | cut -d: -f1)
+	first_expect=$(grep -nE '^[[:space:]]*expect[[:space:]]' <<<"$block" | head -1 | cut -d: -f1)
+	[ -n "$first_expect" ] || fail "[$svc] has no expect step at all (#450)"
+	if [ -n "$first_send" ] && [ "$first_send" -lt "$first_expect" ]; then
+		fail "[$svc] sends before its first expect -- that is a pregreet, and Postfix >= 3.9 answers 554 (#450)"
 	fi
+
+	# One command per send. "ehlo x\r\nquit\r\n" in a single write is
+	# unauthorized pipelining even after the greeting -- measured: Postfix
+	# rejects it 5/5 with "improper command pipelining after EHLO".
+	while IFS= read -r sline; do
+		[ -n "$sline" ] || continue
+		body=${sline#*send }
+		crlfs=$(grep -o '\\r\\n' <<<"$body" | wc -l | tr -d ' ')
+		[ "$crlfs" -le 1 ] || fail \
+			"[$svc] packs $crlfs commands into one send -- pipelining before PIPELINING is announced (#450): $sline"
+	done <<<"$(grep -E '^[[:space:]]*send[[:space:]]' <<<"$block")"
 
 	# The probe still has to check something. Without expect, a service that
 	# accepts the connection and says nothing useful would pass, which would

--- a/tests/network/smtp-no-pregreet.sh
+++ b/tests/network/smtp-no-pregreet.sh
@@ -64,7 +64,10 @@ for svc in smtp smtps submission msa; do
 	# the first expect is the pregreet. Compare line positions rather than
 	# looking for the absence of a send, so a legal dialogue passes and the old
 	# shape still fails.
-	first_send=$(grep -nE '^[[:space:]]*send[[:space:]]' <<<"$block" | head -1 | cut -d: -f1)
+	# An entry with nothing to send cannot pregreet, and grep exiting 1 on it
+	# must not end the test: every test runs under `set -o pipefail`, so an
+	# unguarded no-match here would abort before a single assertion ran.
+	first_send=$({ grep -nE '^[[:space:]]*send[[:space:]]' <<<"$block" || :; } | head -1 | cut -d: -f1)
 	first_expect=$(grep -nE '^[[:space:]]*expect[[:space:]]' <<<"$block" | head -1 | cut -d: -f1)
 	[ -n "$first_expect" ] || fail "[$svc] has no expect step at all (#450)"
 	if [ -n "$first_send" ] && [ "$first_send" -lt "$first_expect" ]; then

--- a/tests/network/ssl-write-defer-behaviour.sh
+++ b/tests/network/ssl-write-defer-behaviour.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# The companion to ssl-write-retry.sh, which reads the source. This one
+# makes SSL_write() actually defer and checks whether the bytes arrive.
+#
+# Forcing the condition needs two things at once: a payload larger than the
+# socket buffers, and a peer that does not read for a moment. Then
+# SSL_write() takes part of it and returns WANT_WRITE for the rest. What
+# happens next is the point -- the remainder is either retried or silently
+# dropped -- and it is invisible in the source: both versions "send" the
+# data and neither reports an error. Only the peer knows what it got.
+#
+# The probe's real sends are a few dozen bytes and would never trigger
+# this, which is why the bug survived: it needs a slow reader on the far
+# side, which is what a loaded mail server looks like.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+command -v openssl >/dev/null 2>&1 || skip "openssl is needed to make a test certificate"
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+openssl req -x509 -newkey rsa:2048 -keyout "$work/k.pem" -out "$work/c.pem" \
+	-days 2 -nodes -subj "/CN=127.0.0.1" >"$work/ssl.log" 2>&1 \
+	|| skip "openssl could not generate a test certificate"
+
+"$CC" -o "$work/peer" "$root/tests/lib/tls-slow-reader.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "tls-slow-reader does not compile against libssl"; }
+
+# Size matters and is not arbitrary. Swept against a build WITHOUT the fix:
+# 1MB was absorbed by the socket buffers and never deferred at all -- the
+# test passed on the bug, a false green. 4MB and 16MB both truncated. 8MB is
+# the smallest round size with margin either side. If this ever stops
+# failing on an unfixed build, the payload has become too small for the
+# host's buffers rather than the bug having gone away.
+payload=${XYMON_TEST_SSLWRITE_BYTES:-8000000}
+
+"$work/peer" "$work/c.pem" "$work/k.pem" "$work/got.txt" > "$work/port" &
+peer=$!
+register_cleanup "kill $peer 2>/dev/null || :"
+
+i=0
+while [ "$i" -lt 50 ]; do
+	[ -s "$work/port" ] && break
+	kill -0 "$peer" 2>/dev/null || fail "the peer exited before naming its port"
+	sleep 0.1
+	i=$((i + 1))
+done
+port=$(cat "$work/port")
+[ -n "$port" ] || fail "the peer never named a port"
+
+# One send far larger than any socket buffer, so SSL_write cannot take it in
+# a single call while the peer is not reading.
+{
+	printf '[bigsend]\n   send "'
+	# dd and tr, not awk. BSD awk's gsub() is quadratic in the length of the
+	# subject: building this string took 5s at 800KB and minutes at 8MB, so
+	# the test hung on macOS long before it reached a socket. gawk's gsub is
+	# linear, which kept CI green and hid it. Same bytes, a fraction of a
+	# second, and no assumption about which awk is installed.
+	dd if=/dev/zero bs="$payload" count=1 2>/dev/null | tr '\0' 'A'
+	printf '"\n   expect "OK"\n   options ssl,banner\n   port %s\n' "$port"
+} > "$work/home/etc/protocols.cfg"
+printf '127.0.0.1\tpeer\t# bigsend\n' > "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --dns=ip \
+	--timeout=25 >"$work/out.txt" 2>&1 || :
+wait "$peer" 2>/dev/null || :
+
+[ -s "$work/got.txt" ] || fail "the peer recorded nothing -- it never completed a TLS handshake"
+got=$(cat "$work/got.txt")
+case $got in
+	ERR*) skip "the peer could not run the TLS exchange: $got" ;;
+esac
+
+[ "$got" -eq "$payload" ] || fail \
+	"the peer received $got of $payload bytes. SSL_write() could not take the
+whole buffer while the peer was not reading, and the remainder was dropped
+instead of retried. The probe reports no error, so this is silent data loss
+against any slow reader (#451)."
+
+pass "a deferred SSL_write is retried, not dropped: all $payload bytes arrived (#451)"

--- a/tests/network/ssl-write-retry.sh
+++ b/tests/network/ssl-write-retry.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/network/ssl-write-retry.sh
+#
+# Guard for xymon-monitoring/xymon#451: when SSL_write() accepts nothing,
+# xymonnet must retry the same buffer rather than drop the payload.
+#
+# socket_write() used to translate SSL_ERROR_WANT_READ/WANT_WRITE into a bare
+# `res = 0` return. At the call site 0 is neither the -1 error case nor the
+# TCP_HTTP short-write case, so for every non-HTTP service the bytes were
+# silently discarded -- and because readpending had already been set, the test
+# then sat waiting for a reply to a command that was never transmitted. HTTP
+# escaped only by accident: sendlen never decreased, so its own branch retried.
+#
+# Four things have to hold together, and each is a separate way to reintroduce
+# the bug, so each is asserted separately:
+#   1. the flag exists,
+#   2. socket_write() sets it on WANT_READ/WANT_WRITE,
+#   3. the call site acts on it *before* the TCP_HTTP branch,
+#   4. the shutdown leaves a socket that still owes a write open -- without
+#      this the retry can never happen, and (1)-(3) are decoration.
+#
+# Static guard: reaching WANT_WRITE through a real probe needs a stalled peer
+# and a multi-megabyte payload, while the shipped probes send a few bytes --
+# which is exactly why the bug was latent. Skips only if the source is absent.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+SRC="$ROOT/xymonnet/contest.c"
+HDR="$ROOT/xymonnet/contest.h"
+
+for f in "$SRC" "$HDR"; do
+	[ -f "$f" ] || skip "$(basename "$f") absent"
+done
+
+grep -Eq '^[[:space:]]*int[[:space:]]+sendagain;' "$HDR" || fail \
+	"contest.h lost the sendagain flag -- a dropped write cannot be signalled (#451)"
+
+# contest.c defines socket_write() twice: once for builds without OpenSSL and
+# once for builds with it. Only the second has anything to retry, so select the
+# body by content rather than by position -- picking the first would assert
+# against the plain-write stub and pass no matter what the SSL one does.
+# Strip comments before asserting. Every check below is a string-presence
+# check, and this function and its call site are heavily commented with the
+# very identifiers under assertion -- so a commented-out `item->sendagain = 1`,
+# or prose mentioning sendagain, would satisfy a claim about the code beside
+# it. Deleting a line and leaving the comment that explains it is the realistic
+# edit, and it is exactly the one a token grep cannot see.
+strip_comments() { sed -e 's,/\*.*\*/,,' -e '/^[[:space:]]*\/\*/d' -e '/^[[:space:]]*\*/d'; }
+
+ssl_write_fn=$(awk '
+	/^static int socket_write/ { buf = ""; inbody = 1 }
+	inbody                     { buf = buf $0 "\n" }
+	inbody && /^}/             { if (buf ~ /SSL_write/) { printf "%s", buf; exit } inbody = 0 }
+' "$SRC" | strip_comments)
+[ -n "$ssl_write_fn" ] || fail \
+	"contest.c has no socket_write() that calls SSL_write() (#451)"
+
+grep -q 'sendagain = 1' <<<"$ssl_write_fn" || fail \
+	"socket_write() no longer flags a write that sent nothing -- the payload is dropped silently (#451)"
+
+# Scoped to WANT_WRITE on purpose. Clearing readpending puts the fd in writefds,
+# which is what WANT_WRITE waits for; retrying a WANT_READ there would select on
+# a set that is always ready and busy-wait. If the two labels are ever collapsed
+# back together, that is the bug this pins.
+want_write_arm=$(awk '/case SSL_ERROR_WANT_WRITE:/{c=1} c{print} c&&/break;/{exit}' <<<"$ssl_write_fn")
+grep -q 'sendagain = 1' <<<"$want_write_arm" || fail \
+	"socket_write() no longer sets sendagain under SSL_ERROR_WANT_WRITE (#451)"
+# ...and must return 0, not the negative SSL_write() gave back: the call site
+# tests res == -1 first, so a deferred write left negative is treated as a hard
+# I/O error and the sendagain branch is never reached.
+grep -qE '\bres = 0;' <<<"$want_write_arm" || fail \
+	"socket_write() no longer normalises a deferred write to 0 -- res == -1 is handled first, so the retry branch is unreachable (#451)"
+want_read_arm=$(awk '/case SSL_ERROR_WANT_READ:/{c=1} c{print} c&&/break;/{exit}' <<<"$ssl_write_fn")
+grep -q 'sendagain = 1' <<<"$want_read_arm" && fail \
+	"socket_write() retries a WANT_READ on the write set -- that fd is always ready, so it busy-waits (#451)"
+
+# Reset per call. A flag that is only ever set latches on: the first deferred
+# write would leave every later socket looking like it still owed bytes.
+grep -q 'sendagain = 0' <<<"$ssl_write_fn" || fail \
+	"socket_write() never clears sendagain -- the flag latches after the first deferred write (#451)"
+
+# The call site must consult it BEFORE the TCP_HTTP branch. Ordered after, the
+# HTTP branch would claim res==0 first and advance nothing, leaving non-HTTP
+# services exactly as broken as before.
+call_site=$(awk '/res = socket_write\(item, outbuf, outlen\)/{c=1} c{print} c&&/TCP_HTTP/{exit}' "$SRC" | strip_comments)
+[ -n "$call_site" ] || fail "contest.c no longer has the socket_write() call site (#451)"
+grep -q 'sendagain' <<<"$call_site" || fail \
+	"the socket_write() call site ignores sendagain -- a deferred write is still indistinguishable from nothing to send (#451)"
+# The branch has to clear readpending, which is what returns the socket to
+# writefds. An empty sendagain branch keeps the token and retries nothing.
+sendagain_branch=$(awk '/else if \(item->sendagain\)/{c=1} c{print} c&&/^[[:space:]]*}/{exit}' <<<"$call_site")
+grep -qE 'readpending[[:space:]]*=[[:space:]]*0' <<<"$sendagain_branch" || fail \
+	"the sendagain branch no longer clears readpending -- the socket never goes back into writefds, so the retry never happens (#451)"
+
+# And the socket must survive to be retried. This is the assertion that matters
+# most: with the shutdown untouched, clearing readpending closes the connection
+# on the same pass and the retry never comes.
+shutdown_cond=$(awk '/If closed and\/or no bannergrabbing/{c=1} c{print} c&&/socket_shutdown\(item\)/{exit}' "$SRC" | strip_comments)
+[ -n "$shutdown_cond" ] || fail "contest.c no longer has the post-write shutdown block (#451)"
+grep -Eq '!item->readpending && !item->sendagain' <<<"$shutdown_cond" || fail \
+	"contest.c closes a socket that still owes a write -- the retry can never happen (#451)"
+
+# Hoisting socket_shutdown() into the timeout path made an old latent hazard
+# reachable: SSLSETUP_PENDING is -1, so `if (item->sslrunning)` is already true
+# from add_tcp_test() while ssldata is still NULL, and a connection that times
+# out before setup_ssl() runs would reach SSL_shutdown(NULL). Guard on the
+# objects instead. Same block selection trick as above -- the non-OpenSSL build
+# has its own socket_shutdown() with nothing to free.
+sd=$(awk '
+	/^static void socket_shutdown/ { buf = ""; inbody = 1 }
+	inbody                        { buf = buf $0 "\n" }
+	inbody && /^}/                { if (buf ~ /SSL_shutdown/) { printf "%s", buf; exit } inbody = 0 }
+' "$SRC" | strip_comments)
+[ -n "$sd" ] || fail "contest.c has no socket_shutdown() that frees an SSL session (#451)"
+grep -q 'if (item->ssldata)' <<<"$sd" || fail \
+	"socket_shutdown() no longer guards on ssldata -- a timeout before setup_ssl() reaches SSL_shutdown(NULL) (#451)"
+# The sslrunning guard must stay OUTSIDE it. setup_ssl()'s failure paths free
+# ssldata/sslctx without clearing them and set sslrunning to 0, so a
+# pointer-only guard frees dangling pointers.
+grep -q 'if (item->sslrunning) {' <<<"$sd" || fail \
+	"socket_shutdown() dropped the sslrunning guard -- setup_ssl()'s failure paths free without clearing, so a pointer-only test double-frees (#451)"
+
+pass "xymonnet retries a write that SSL_write() did not accept (#451)"

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -1601,7 +1601,15 @@ restartselect:
 									if (!item->failstep) item->failstep = (void *)st;
 									item->curstep = NULL;
 									st = NULL;
-									break;
+									/*
+									 * This test is finished; the others are not.
+									 * A break here leaves the for() over active
+									 * sockets, so one capped reply would abandon
+									 * every remaining test in the pass -- the
+									 * same fault the pending-handshake arm was
+									 * fixed for.
+									 */
+									continue;
 								}
 
 								item->stepbuf = (unsigned char *)realloc(item->stepbuf, item->stepbuflen + res + 1);

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -214,6 +214,7 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 	newtest->sslrunning = (((newtest->svcinfo->flags & TCP_SSL) || (newtest->svcinfo->flags & TCP_ALPN)) ? SSLSETUP_PENDING : 0);
 	newtest->sslagain = 0;
 	newtest->sslwantwrite = 0;
+	newtest->sendagain = 0;
 
 	newtest->banner = NULL;
 	newtest->bannerbytes = 0;
@@ -846,12 +847,37 @@ static int socket_write(tcptest_t *item, char *outbuf, int outlen)
 {
 	int res = 0;
 
+	item->sendagain = 0;
 	if (item->sslrunning) {
 		res = SSL_write(item->ssldata, outbuf, outlen);
 		if (res < 0) {
 			switch (SSL_get_error (item->ssldata, res)) {
-			  case SSL_ERROR_WANT_READ:
 			  case SSL_ERROR_WANT_WRITE:
+				  /*
+				   * Nothing was sent. Returning 0 alone is
+				   * indistinguishable from "there was nothing to
+				   * send", so flag it: the caller must come back
+				   * and retry with the SAME buffer. socket_read()
+				   * uses sslagain for the same purpose.
+				   *
+				   * Only WANT_WRITE is retried. Clearing
+				   * readpending puts the socket back in writefds,
+				   * which is exactly what WANT_WRITE waits for.
+				   */
+				  item->sendagain = 1;
+				  res = 0;
+				  break;
+			  case SSL_ERROR_WANT_READ:
+				  /*
+				   * WANT_READ would need the fd in readfds, and the
+				   * read branch there would consume application data
+				   * rather than retry this write. Left as it behaves
+				   * today -- the payload is not sent and the test
+				   * waits out its timeout -- rather than retried on a
+				   * fd set that is always ready, which would busy-wait.
+				   * Reachable only via renegotiation; TLS 1.3 session
+				   * tickets and KeyUpdate do not produce it.
+				   */
 				  res = 0;
 				  break;
 			}
@@ -905,10 +931,26 @@ static int socket_read(tcptest_t *item, char *inbuf, int inbufsize)
 
 static void socket_shutdown(tcptest_t *item)
 {
+	/*
+	 * Both guards are load-bearing. sslrunning must stay the outer test:
+	 * setup_ssl()'s failure paths free ssldata/sslctx without clearing them
+	 * and set sslrunning to 0, so a pointer-only guard would free dangling
+	 * pointers here. And the inner NULL checks are needed because
+	 * SSLSETUP_PENDING is -1, so sslrunning is already true from
+	 * add_tcp_test() while ssldata is still NULL -- a connection that times
+	 * out before setup_ssl() runs would otherwise reach SSL_shutdown(NULL).
+	 * Clearing them makes a second call harmless either way.
+	 */
 	if (item->sslrunning) {
-		SSL_shutdown(item->ssldata);
-		SSL_free(item->ssldata);
-		SSL_CTX_free(item->sslctx);
+		if (item->ssldata) {
+			SSL_shutdown(item->ssldata);
+			SSL_free(item->ssldata);
+			item->ssldata = NULL;
+		}
+		if (item->sslctx) {
+			SSL_CTX_free(item->sslctx);
+			item->sslctx = NULL;
+		}
 	}
 	shutdown(item->fd, SHUT_RDWR);
 
@@ -1241,16 +1283,22 @@ restartselect:
 					/* 
 					 * Request timed out.
 					 */
-					if (item->readpending) {
-						/* Final read timeout - just shut this socket */
-						socket_shutdown(item);
-						item->errcode = CONTEST_ETIMEOUT;
-					}
-					else {
+					if (!item->readpending && !item->sendagain) {
 						/* Connection timeout */
 						item->open = 0;
-						item->errcode = CONTEST_ETIMEOUT;
 					}
+					/*
+					 * Either way, hand the socket to socket_shutdown():
+					 * it is the only place SSL_free()/SSL_CTX_free()
+					 * happen, and it no-ops on a session that was never
+					 * running. The !readpending arm used to skip it, so
+					 * an SSL session that timed out with nothing pending
+					 * to read -- a handshake that never finished, and now
+					 * also a write still waiting to be retried -- had its
+					 * fd closed with the SSL objects still allocated.
+					 */
+					socket_shutdown(item);
+					item->errcode = CONTEST_ETIMEOUT;
 					get_totaltime(item, &timestamp);
 					close(item->fd);
 					item->fd = -1;
@@ -1343,6 +1391,19 @@ restartselect:
 									item->readpending = 0;
 									item->errcode = CONTEST_EIO;
 								}
+								else if (item->sendagain) {
+									/*
+									 * The SSL layer accepted nothing and wants
+									 * another pass. Leave sendtxt/sendlen alone
+									 * so the retry sends the same bytes, and do
+									 * not wait for a reply to a command that was
+									 * never transmitted -- clearing readpending
+									 * is also what puts this socket back in the
+									 * write set. The shutdown below is taught to
+									 * leave it open.
+									 */
+									item->readpending = 0;
+								}
 								else if (item->svcinfo->flags & TCP_HTTP) {
 									/*
 									 * HTTP tests require us to send the full buffer.
@@ -1358,7 +1419,7 @@ restartselect:
 
 						/* If closed and/or no bannergrabbing, shut down socket */
 						if (item->sslrunning != SSLSETUP_PENDING) {
-							if (!item->open || !item->readpending) {
+							if (!item->open || (!item->readpending && !item->sendagain)) {
 								if (item->open) {
 									socket_shutdown(item);
 								}

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -215,6 +215,19 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 	newtest->sslagain = 0;
 	newtest->sslwantwrite = 0;
 	newtest->sendagain = 0;
+	/*
+	 * ONLY for a dialogue. The parser builds a step list for every service,
+	 * including the plain send-and-match ones, so keying off steps alone
+	 * gave legacy services a non-NULL cursor -- and the close guards below
+	 * treat a live cursor as "the conversation is still going", so those
+	 * sockets were never closed and every legacy TLS test timed out.
+	 */
+	newtest->curstep = ((newtest->svcinfo && (newtest->svcinfo->flags & TCP_DIALOGUE))
+			    ? (void *)newtest->svcinfo->steps : NULL);
+	newtest->dialogfail = 0;
+	newtest->failstep = NULL;
+	newtest->stepbuf = NULL;
+	newtest->stepbuflen = 0;
 
 	newtest->banner = NULL;
 	newtest->bannerbytes = 0;
@@ -1365,7 +1378,43 @@ restartselect:
 
 						item->readpending = (do_talk && !item->silenttest && 
 							( (item->svcinfo->flags & TCP_GET_BANNER) || item->svcinfo->exptext ));
-						if (do_talk) {
+						if (do_talk && (item->svcinfo->flags & TCP_DIALOGUE)) {
+							/*
+							 * A dialogue drives itself from where it stands:
+							 * a SEND step is written here, an EXPECT step is
+							 * waited for by leaving readpending set. That one
+							 * rule is the whole state machine -- the current
+							 * step decides which fd set the socket joins.
+							 */
+							svcstep_t *st = (svcstep_t *)item->curstep;
+
+							while (st && (st->type == STEP_SEND) && item->silenttest) {
+								/*
+								 * A silent test says nothing on the wire. Step
+								 * over the sends rather than sitting on one:
+								 * leaving it current would strand the dialogue
+								 * with a step it will never perform.
+								 */
+								st = st->next;
+								item->curstep = (void *)st;
+							}
+							if (st && (st->type == STEP_SEND)) {
+								res = socket_write(item, (char *)st->text, st->len);
+								tcp_stats_written += res;
+								if (res == -1) {
+									dbgprintf("write failed\n");
+									item->errcode = CONTEST_EIO;
+									item->curstep = NULL;
+									st = NULL;
+								}
+								else {
+									st = st->next;
+									item->curstep = (void *)st;
+								}
+							}
+							item->readpending = (st && (st->type == STEP_EXPECT));
+						}
+						else if (do_talk) {
 							if (item->telnetnegotiate && item->telnetbuflen) {
 								/*
 								 * Return the telnet negotiate data response
@@ -1419,7 +1468,12 @@ restartselect:
 
 						/* If closed and/or no bannergrabbing, shut down socket */
 						if (item->sslrunning != SSLSETUP_PENDING) {
-							if (!item->open || (!item->readpending && !item->sendagain)) {
+							/*
+							 * Three independent reasons to keep it open: a
+							 * reply still expected, a write waiting to be
+							 * retried, or a dialogue step still to run.
+							 */
+							if (!item->open || (!item->readpending && !item->sendagain && !item->curstep)) {
 								if (item->open) {
 									socket_shutdown(item);
 								}
@@ -1489,6 +1543,155 @@ restartselect:
 						tcp_stats_read += res;
 						dbgprintf("read %d bytes from socket\n", res);
 
+						if (item->svcinfo->flags & TCP_DIALOGUE) {
+							/*
+							 * An EXPECT step is matched against what THIS read
+							 * returned, not against the accumulated banner: in
+							 * a conversation the same socket carries several
+							 * replies, and only the one for this step counts.
+							 * Compare the start, which is what a status line
+							 * is -- "250-" and "250 " both satisfy "250".
+							 */
+							svcstep_t *st = (svcstep_t *)item->curstep;
+
+							/*
+								 * res <= 0 is EOF on a plain socket, but over
+								 * TLS it is also how "no data yet" arrives:
+								 * socket_read() sets sslagain for WANT_READ.
+								 * Without that guard the first wait for a
+								 * greeting was read as the peer hanging up,
+								 * and every TLS dialogue failed instantly.
+								 */
+								if ((res <= 0) && !item->sslagain && st) {
+								/*
+								 * The peer went away with steps still to run.
+								 * Fail here rather than leaving the socket to
+								 * time out: "hung up mid-conversation" is a
+								 * different fault from "never answered", and
+								 * waiting out the timeout reports the wrong one.
+								 */
+								item->dialogfail = 1;
+								if (!item->failstep) item->failstep = (void *)st;
+								item->curstep = NULL;
+								st = NULL;
+							}
+							else if ((res > 0) && st && (st->type == STEP_EXPECT)) {
+								/*
+								 * Accumulate: one read is not one reply. TLS
+								 * hands back a record at a time and SMTP's
+								 * multi-line replies span several, so a step
+								 * has three outcomes -- matched, mismatched,
+								 * or not enough yet -- and only the third is
+								 * new here.
+								 */
+								/*
+								 * Bound it. An expect that waits for a
+								 * terminator will otherwise accumulate
+								 * whatever a server cares to send, for as
+								 * long as it cares to send it -- and the
+								 * poll loop runs hundreds of these at once.
+								 * Monit caps the same buffer at 255 bytes;
+								 * this is roomier because a real EHLO reply
+								 * is several hundred, but it is a cap.
+								 */
+								if ((item->stepbuflen + res) > MAX_DIALOGUE_BYTES) {
+									errprintf("%s: reply exceeded %d bytes with no match - giving up\n",
+										  item->svcinfo->svcname, MAX_DIALOGUE_BYTES);
+									item->dialogfail = 1;
+									if (!item->failstep) item->failstep = (void *)st;
+									item->curstep = NULL;
+									st = NULL;
+									break;
+								}
+
+								item->stepbuf = (unsigned char *)realloc(item->stepbuf, item->stepbuflen + res + 1);
+								memcpy(item->stepbuf + item->stepbuflen, msgbuf, res);
+								item->stepbuflen += res;
+								item->stepbuf[item->stepbuflen] = '\0';
+
+								if (item->stepbuflen >= st->len) {
+									if (memcmp(item->stepbuf, st->text, st->len) == 0) {
+										int cut = st->len, ready = 1;
+
+										if (st->until) {
+											/*
+											 * Multi-line: consume complete lines
+											 * until one starts with the terminator.
+											 * If it has not arrived, consume NOTHING
+											 * and wait -- taking the lines we have
+											 * would strand the rest of the reply for
+											 * the next expect to trip over.
+											 */
+											int pos = 0;
+
+											ready = 0;
+											while (pos < item->stepbuflen) {
+												int eol = pos;
+
+												while ((eol < item->stepbuflen) &&
+												       (item->stepbuf[eol] != '\n')) eol++;
+												if (eol >= item->stepbuflen) break;
+												if (((item->stepbuflen - pos) >= st->untillen) &&
+												    (memcmp(item->stepbuf + pos, st->until, st->untillen) == 0)) {
+													cut = eol + 1;
+													ready = 1;
+													break;
+												}
+												pos = eol + 1;
+											}
+										}
+										else {
+											/*
+											 * Single line. Consume through its end
+											 * and KEEP the rest: discarding it would
+											 * throw away a reply the peer had already
+											 * sent, and the next expect would wait for
+											 * data that already arrived.
+											 */
+											while ((cut < item->stepbuflen) &&
+											       (item->stepbuf[cut] != '\n')) cut++;
+											if (cut < item->stepbuflen) cut++;
+										}
+
+										if (ready) {
+											memmove(item->stepbuf, item->stepbuf + cut,
+												item->stepbuflen - cut);
+											item->stepbuflen -= cut;
+											st = st->next;
+											item->curstep = (void *)st;
+										}
+									}
+									else {
+										item->dialogfail = 1;
+										if (!item->failstep) item->failstep = (void *)st;
+										item->curstep = NULL;
+										st = NULL;
+									}
+								}
+								/* else: short of the pattern -- wait for more */
+
+								/*
+								 * The step we land on decides which fd set the socket
+								 * joins next. Without this the flag keeps whatever the
+								 * write arm last set, so a dialogue that advances to a
+								 * SEND while reading stays parked in readfds and the
+								 * send is never written -- which over TLS meant the peer
+								 * saw the greeting answered by nothing at all.
+								 */
+								item->readpending = (item->curstep &&
+										      (((svcstep_t *)item->curstep)->type == STEP_EXPECT));
+							}
+							/*
+							 * Hand the socket back to the write side when the
+							 * next step is a SEND: clearing readpending is what
+							 * puts it in writefds, and the close below is
+							 * already taught to spare a socket with steps left.
+							 */
+							st = (svcstep_t *)item->curstep;
+							item->readpending = (st && (st->type == STEP_EXPECT));
+							if (st) wantmoredata = 1;
+						}
+
 						if ((res > 0) && item->datacallback) {
 							datadone = item->datacallback(msgbuf, res, item->priv);
 						}
@@ -1536,7 +1739,7 @@ restartselect:
 							wantmoredata = !datadone;
 						}
 
-						if (!wantmoredata) {
+						if (!wantmoredata && !item->curstep) {
 							if (item->open) {
 								socket_shutdown(item);
 							}
@@ -1605,9 +1808,53 @@ void show_tcp_test_results(void)
 	}
 }
 
+/*
+ * Which step gave up. A dialogue can fail at any of them, and
+ * "Unexpected service response" on its own leaves the reader guessing
+ * whether it was the greeting, a reply mid-conversation, or a peer that
+ * went quiet -- so name it.
+ */
+char *tcp_dialogue_failure(tcptest_t *test)
+{
+	static char buf[160];
+	svcstep_t *st, *bad;
+	int idx = 0, n = 0;
+
+	if (!test || !test->svcinfo || !(test->svcinfo->flags & TCP_DIALOGUE)) return NULL;
+
+	bad = (svcstep_t *)test->failstep;
+	if (!bad) {
+		/* No step blamed itself: the conversation simply stopped short. */
+		st = (svcstep_t *)test->curstep;
+		if (!st) return NULL;
+		bad = st;
+		for (st = test->svcinfo->steps; (st); st = st->next) { n++; if (st == bad) idx = n; }
+		snprintf(buf, sizeof(buf), "no reply to step %d (expecting \"%.40s\")",
+			 idx, (bad->text ? (char *)bad->text : ""));
+		return buf;
+	}
+
+	for (st = test->svcinfo->steps; (st); st = st->next) { n++; if (st == bad) idx = n; }
+	if (bad->type == STEP_EXPECT)
+		snprintf(buf, sizeof(buf), "step %d expected \"%.40s\"", idx,
+			 (bad->text ? (char *)bad->text : ""));
+	else
+		snprintf(buf, sizeof(buf), "step %d failed", idx);
+
+	return buf;
+}
+
 int tcp_got_expected(tcptest_t *test)
 {
 	if (test == NULL) return 1;
+
+	/*
+	 * A dialogue has already judged itself, step by step, as the replies
+	 * arrived. Re-matching exptext against the banner here would compare the
+	 * first step's pattern against whatever the last read happened to leave.
+	 */
+	if (test->svcinfo && (test->svcinfo->flags & TCP_DIALOGUE))
+		return (test->dialogfail == 0) && (test->curstep == NULL);
 
 	if (test->svcinfo && test->svcinfo->exptext) {
 		int compbytes; /* Number of bytes to compare */

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -126,6 +126,7 @@ typedef struct tcptest_t {
 	int sslrunning;			/* Track state of an SSL session */
 	int sslagain;			/* SSL read/write needs more data */
 	int sslwantwrite;		/* Handshake blocked on writability, not readability */
+	int sendagain;			/* Last write sent nothing; retry the same buffer */
 
 	/* For testing telnet services */
 	unsigned char *telnetbuf;	/* Buffer for telnet option negotiation */

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -82,6 +82,10 @@ typedef void (*f_callback_final)(void *privdata);
 #define CONTEST_EIO        4
 #define CONTEST_ESSL       5
 
+/* How much a single expect may accumulate before giving up. A server that
+   never sends the terminator must not be able to grow this without limit. */
+#define MAX_DIALOGUE_BYTES (32 * 1024)
+
 typedef struct tcptest_t {
 	struct sockaddr_in addr;        /* Address (IP+port) to test */
 	char *srcaddr;
@@ -127,6 +131,13 @@ typedef struct tcptest_t {
 	int sslagain;			/* SSL read/write needs more data */
 	int sslwantwrite;		/* Handshake blocked on writability, not readability */
 	int sendagain;			/* Last write sent nothing; retry the same buffer */
+
+	/* Dialogue state */
+	void *curstep;			/* svcstep_t *: position in the dialogue */
+	int dialogfail;			/* an expect step did not match */
+	void *failstep;			/* svcstep_t *: WHICH step, for the report */
+	unsigned char *stepbuf;		/* replies for the CURRENT expect step */
+	int stepbuflen;
 
 	/* For testing telnet services */
 	unsigned char *telnetbuf;	/* Buffer for telnet option negotiation */
@@ -202,6 +213,7 @@ extern unsigned int tcp_stats_connects;
 extern char *init_tcp_services(void);
 extern int default_tcp_port(char *svcname);
 extern void dump_tcp_services(void);
+extern char *tcp_dialogue_failure(tcptest_t *test);
 extern tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt, char *srcip,
 			    char *tspec, int silent, unsigned char *reqmsg, 
 			    void *priv, f_callback_data datacallback, f_callback_final finalcallback);

--- a/xymonnet/xymonnet.c
+++ b/xymonnet/xymonnet.c
@@ -1428,6 +1428,10 @@ int finish_ping_service(service_t *service)
 }
 
 
+/* The buffer every caller passes as `cause`; it is a pointer here, so its
+   size cannot be recovered with sizeof(). */
+#define MAX_CAUSE 1024
+
 int decide_color(service_t *service, char *svcname, testitem_t *test, int failgoesclear, char *cause)
 {
 	int color = COL_GREEN;
@@ -1595,7 +1599,18 @@ int decide_color(service_t *service, char *svcname, testitem_t *test, int failgo
 
 					/* Check if we got the expected data */
 					if (checktcpresponse && (service->toolid == TOOL_CONTEST) && !tcp_got_expected((tcptest_t *)test->privdata)) {
-						strcpy(cause, "Unexpected service response");
+						char *whichstep = tcp_dialogue_failure((tcptest_t *)test->privdata);
+
+						/*
+						 * Name the step. A dialogue can fail at any of
+						 * them, and the bare phrase leaves the reader
+						 * guessing whether it was the greeting, a reply
+						 * mid-conversation, or a peer that went quiet.
+						 */
+						if (whichstep)
+							snprintf(cause, MAX_CAUSE, "Unexpected service response: %s", whichstep);
+						else
+							strcpy(cause, "Unexpected service response");
 						color = respcheck_color; countasdown = 1;
 					}
 


### PR DESCRIPTION
A `protocols.cfg` entry could express one string out and one prefix match back, and it sent that string before the server had greeted. SMTP, IMAP, POP3, FTP and NNTP all transmit before the client may speak, and Postfix ≥ 3.9 answers a client that speaks first with `554 5.5.0 Error: SMTP protocol synchronization`.

This slice makes an entry a sequence: `send` and `expect` run in the order they are written, `expect … until …` consumes a multi-line reply through its terminator, and a conversation that buffers 32 KB with nothing matching fails naming the service rather than growing for as long as the server cares to talk. An entry that is a single `send` followed by a single `expect` keeps the old write-on-connect behaviour, so nothing shipped changes.

It fixes the first of the three problems in #457 on its own, and is the part none of the reviews disputed.

**`xymonnet/protocols.cfg` is untouched here** — the shipped entries are deepened in #480, and #477 adds `smtp:ok=greeting` as the per-host way to decline that. But five of them do change code path: the classifier sets `TCP_DIALOGUE` when `first_is_expect || nsend > 1 || nexp > 1`, and `[smtp]`, `[smtps]`, `[submission|msa]`, `[rsync]` and `[svn]` are expect-only, so they run the driver from this slice on. What they send and match is identical; what executes is not. A service that is one `send` followed by one `expect` does keep the old path.

**Verified.** `tests/lib/dialogue-peer.c` is a scriptable peer the suites drive a real probe against.

- `dialogue-verdict.sh` carries the headline: a server that greets `220` and then fails every command was **green before, red after**. Its third row pins the other direction -- a plain send-and-match service must behave exactly as it did, since the driver is opt-in and a regression there reaches services this does not touch.
- `protocol-dialogue.sh` and `dialogue-multiline.sh` cover ordering and `until`; `smtp-no-pregreet.sh` covers the shipped SMTP entries.
- `dialogue-buffer-cap.sh` checks that `MAX_DIALOGUE_BYTES` is real: a peer sending ~50 KB that never terminates its reply must fail **by name** rather than by running out of time, with a ~20 KB reply that does terminate as the control.

---

**Grammar.** The manual page is added once, in #476, in the form the finished grammar takes — [`protocols.cfg(5)`](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/xymonnet/protocols.cfg.5). The slices below it change no documentation, so none of them ships a page describing steps their own code does not have.

**Design.** [The shape](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/docs/design/protocol-dialogues.md#the-shape) · [the reasoning behind it](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/docs/design/protocol-dialogues.md#the-reasoning-a-manual-has-no-room-for) · [what was tried and rejected](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/docs/design/protocol-dialogues.md#explorations-that-were-rejected) — in the tree, added by #479, further up the stack.

---
### Stack

**3 of 15** in the dialogue stack: base #454, next #462. The full chain is listed in #457; read bottom-up.




