### PR TITLE
xymonnet: named states, bound values and named credentials

### DIFF
--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -198,6 +198,8 @@ static void free_svcsteps(svcinfo_t *rec)
 		if (st->target)  xfree(st->target);
 		if (st->label)   xfree(st->label);
 		if (st->varname) xfree(st->varname);
+		if (st->user) { memset(st->user, 0, strlen(st->user)); xfree(st->user); }
+		if (st->pass) { memset(st->pass, 0, strlen(st->pass)); xfree(st->pass); }
 		if (st->re)      freeregex((pcre2_code *)st->re);
 		xfree(st);
 		st = next;
@@ -225,6 +227,14 @@ static void check_undefined_vars(svcinfo_t *rec)
 
 	for (st = rec->steps; (st); st = st->next) {
 		int i;
+
+		if (st->type == STEP_CREDS) {
+			if (nknown + 2 <= 64) {
+				known[nknown++] = "username";
+				known[nknown++] = "password";
+			}
+			continue;
+		}
 
 		if (st->type == STEP_CAPTURE) {
 			/* "as a;b;c" binds three names, not one called "a;b;c". */
@@ -398,6 +408,8 @@ static void emit_step(svclist_t *first, svcstep_t *tmpl)
 		if (tmpl->target)  st->target  = strdup(tmpl->target);
 		if (tmpl->label)   st->label   = strdup(tmpl->label);
 		if (tmpl->varname) st->varname = strdup(tmpl->varname);
+		if (tmpl->user)    st->user    = strdup(tmpl->user);
+		if (tmpl->pass)    st->pass    = strdup(tmpl->pass);
 		if (tmpl->until) {
 			st->until = (unsigned char *)malloc(tmpl->untillen + 1);
 			memcpy(st->until, tmpl->until, tmpl->untillen);
@@ -408,6 +420,46 @@ static void emit_step(svclist_t *first, svcstep_t *tmpl)
 		/* One compiled copy per record: records are freed independently. */
 		if (tmpl->re) st->re = (void *)compileregex_opts((char *)tmpl->text, 0);
 	}
+}
+
+
+/*
+ * Secrets do not belong in protocols.cfg -- it is world-readable and gets
+ * pasted into bug reports. "credentials NAME" names an entry in
+ * etc/credentials.cfg instead:
+ *
+ *     NAME	username	password
+ */
+static int lookup_credentials(char *name, char **user, char **pass)
+{
+	char fn[PATH_MAX];
+	FILE *fd;
+	char line[1024];
+	int found = 0;
+
+	*user = *pass = NULL;
+	snprintf(fn, sizeof(fn), "%s/etc/credentials.cfg",
+		 (xgetenv("XYMONHOME") ? xgetenv("XYMONHOME") : "."));
+	fd = fopen(fn, "r");
+	if (fd == NULL) {
+		errprintf("Cannot open %s for 'credentials %s'\n", fn, name);
+		return 0;
+	}
+
+	while (!found && fgets(line, sizeof(line), fd)) {
+		char *nam, *u, *p;
+
+		if ((line[0] == '#') || (line[0] == '\n')) continue;
+		nam = strtok(line, " \t\r\n");
+		if (!nam || strcmp(nam, name) != 0) continue;
+		u = strtok(NULL, " \t\r\n");
+		p = strtok(NULL, " \t\r\n");
+		if (u && p) { *user = strdup(u); *pass = strdup(p); found = 1; }
+	}
+	fclose(fd);
+
+	if (!found) errprintf("No credentials entry named '%s' in %s\n", name, fn);
+	return found;
 }
 
 
@@ -740,6 +792,21 @@ char *init_tcp_services(void)
 					emit_step(first, &tmpl);
 				}
 				else errprintf("Usage: capture as NAME\n");
+			}
+		}
+		else if (strncmp(l, "credentials ", 12) == 0) {
+			if (first) {
+				svcstep_t tmpl;
+				char *nam = strtok(skipwhitespace(l+11), " \t");
+
+				memset(&tmpl, 0, sizeof(tmpl));
+				tmpl.type = STEP_CREDS;
+				if (nam && lookup_credentials(nam, &tmpl.user, &tmpl.pass)) {
+					tmpl.varname = nam;
+					emit_step(first, &tmpl);
+					if (tmpl.user) xfree(tmpl.user);
+					if (tmpl.pass) xfree(tmpl.pass);
+				}
 			}
 		}
 		else if (strncmp(l, "else ", 5) == 0) {

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -79,7 +79,7 @@ static svcstep_t *add_svcstep(svcinfo_t *rec, int type, unsigned char *text, int
 	step->type = type;
 	step->len  = len;
 	step->text = (unsigned char *)malloc(len + 1);
-	memcpy(step->text, text, len);
+	if (text) memcpy(step->text, text, len);
 	step->text[len] = '\0';
 
 	if (rec->steps == NULL) rec->steps = step;
@@ -93,9 +93,32 @@ static svcstep_t *add_svcstep(svcinfo_t *rec, int type, unsigned char *text, int
 
 
 /*
+ * A quoted string, verbatim. Regex arguments must NOT go through
+ * getescapestring(): it consumes the backslash, so "\\d" reaches PCRE as
+ * "d" and "\\+" as "+", quietly turning the pattern into a different one
+ * (or an invalid one). PCRE handles its own escapes.
+ */
+static void getrawstring(char *msg, unsigned char **buf, int *buflen)
+{
+	char *inp = msg, *end;
+	int len;
+
+	if (*inp == '"') inp++;
+	end = strchr(inp, '"');
+	len = (end ? (int)(end - inp) : (int)strlen(inp));
+
+	*buf = (unsigned char *)malloc(len + 1);
+	memcpy(*buf, inp, len);
+	(*buf)[len] = '\0';
+	if (buflen) *buflen = len;
+}
+
+
+/*
  * Where a quoted string ends. Deliberately the same rule getescapestring
- * uses -- scan to the next '"' -- so the two agree on where the value stops
- * and any trailing keywords begin.
+ * uses -- scan to the next '"' -- so the two agree on where the value
+ * stops and the trailing keywords begin. (Neither supports \" ; that is a
+ * pre-existing limit of the string lexer, not one introduced here.)
  */
 static char *after_quoted(char *p)
 {
@@ -109,8 +132,59 @@ static char *after_quoted(char *p)
 
 
 /*
+ * Report a mistyped expansion when the file is read, not when the step
+ * runs. ${sha1:x} is otherwise read as a variable literally named
+ * "sha1:x", found to be unset, and expanded to nothing -- and a step that
+ * is never reached would never say so at all.
+ */
+static void check_expansions(char *svcname, unsigned char *txt, int len)
+{
+	int i;
+
+	for (i = 0; (i < len - 1); i++) {
+		int depth, j, blen;
+		char *colon, body[256];
+
+		if (!((txt[i] == '$') && (txt[i+1] == '{'))) continue;
+
+		depth = 1;
+		for (j = i + 2; ((j < len) && depth); j++) {
+			if ((txt[j] == '$') && ((j+1) < len) && (txt[j+1] == '{')) { depth++; j++; }
+			else if (txt[j] == '}') depth--;
+		}
+		if (depth) continue;			/* unterminated: left alone */
+
+		blen = (j - 1) - (i + 2);
+		if ((blen <= 0) || (blen >= (int)sizeof(body))) continue;
+		memcpy(body, txt + i + 2, blen);
+		body[blen] = '\0';
+
+		colon = strchr(body, ':');
+		if (colon) {
+			*colon = '\0';
+			if ((strcmp(body, "md5") != 0) && (strcmp(body, "base64") != 0))
+				errprintf("Service %s: unknown expansion ${%s:...} - "
+					  "known functions are md5 and base64\n", svcname, body);
+		}
+	}
+}
+
+
+/*
+ * Every ${name} a send refers to must be bound by something earlier in the
+ * same entry -- a capture, or the username/password that credentials binds.
+ * An unbound one is not an error at run time: it expands to nothing, the
+ * command goes out malformed, and the server rejects it, so the test fails
+ * for a reason that has nothing to do with the mistake.
+ *
+ * Only plain ${name} references are checked. A body carrying ':' is a
+ * function call, and check_expansions() has already vetted the name.
+ */
+/*
  * Release one entry's step list. The reload path already promises not to
- * leak, and a step list is more than the record it hangs off.
+ * leak, and a step list holds more than the strings: the compiled regexes
+ * are the largest allocations here, and the credentials a step carries
+ * should not outlive the configuration that named them.
  */
 static void free_svcsteps(svcinfo_t *rec)
 {
@@ -119,8 +193,12 @@ static void free_svcsteps(svcinfo_t *rec)
 	while (st) {
 		svcstep_t *next = st->next;
 
-		if (st->text)  xfree(st->text);
-		if (st->until) xfree(st->until);
+		if (st->text)    xfree(st->text);
+		if (st->until)   xfree(st->until);
+		if (st->target)  xfree(st->target);
+		if (st->label)   xfree(st->label);
+		if (st->varname) xfree(st->varname);
+		if (st->re)      freeregex((pcre2_code *)st->re);
 		xfree(st);
 		st = next;
 	}
@@ -128,10 +206,209 @@ static void free_svcsteps(svcinfo_t *rec)
 }
 
 
+static int name_is_known(char **known, int nknown, const char *name)
+{
+	int k;
+
+	for (k = 0; (k < nknown); k++)
+		if (strcmp(known[k], name) == 0) return 1;
+
+	return 0;
+}
+
+
+static void check_undefined_vars(svcinfo_t *rec)
+{
+	svcstep_t *st;
+	char *known[64];
+	int nknown = 0;
+
+	for (st = rec->steps; (st); st = st->next) {
+		int i;
+
+		if (st->type == STEP_CAPTURE) {
+			/* "as a;b;c" binds three names, not one called "a;b;c". */
+			if (st->varname) {
+				char *p = st->varname;
+
+				while (p && *p && (nknown < 64)) {
+					char *semi = strchr(p, ';');
+					int len = (semi ? (int)(semi - p) : (int)strlen(p));
+					char *one = (char *)malloc(len + 1);
+
+					memcpy(one, p, len); one[len] = '\0';
+					known[nknown++] = one;
+					p = (semi ? semi + 1 : NULL);
+				}
+			}
+			continue;
+		}
+
+		if (st->type == STEP_WHEN) {
+			/* Testing a name nothing binds silently takes the else-arm. */
+			if (st->varname && !name_is_known(known, nknown, st->varname))
+				errprintf("Service %s: 'when %s ~ ...' tests a value that is never "
+					  "captured before it - the test can only fail\n",
+					  rec->svcname, st->varname);
+			continue;
+		}
+
+		if ((st->type != STEP_SEND) || !st->text) continue;
+
+		for (i = 0; (i < st->len - 1); i++) {
+			int j, blen;
+			char name[128];
+
+			if (!((st->text[i] == '$') && (st->text[i+1] == '{'))) continue;
+
+			/* Plain ${name} only: a '{' or ':' inside means a nested
+			   reference or a function call, and check_expansions()
+			   has already vetted the function name. */
+			for (j = i + 2; ((j < st->len) && (st->text[j] != '}')); j++)
+				if ((st->text[j] == '{') || (st->text[j] == ':')) break;
+			if ((j >= st->len) || (st->text[j] != '}')) continue;
+
+			blen = j - (i + 2);
+			if ((blen <= 0) || (blen >= (int)sizeof(name))) continue;
+			memcpy(name, st->text + i + 2, blen);
+			name[blen] = '\0';
+
+			if (!name_is_known(known, nknown, name))
+				errprintf("Service %s: ${%s} is never captured or bound before it is "
+					  "used - it will expand to nothing\n", rec->svcname, name);
+
+			i = j;
+		}
+	}
+}
+
+
+/*
+ * Two alternatives can both match the same reply exactly when one is a
+ * prefix of the other -- matching is prefix-anchored, so patterns that
+ * diverge anywhere can never both match. That makes this check complete
+ * rather than a heuristic.
+ *
+ * Such a group is ambiguous: which one wins depends on how much of the
+ * reply has arrived, and therefore on how the server split it across
+ * packets. Say so, and record the longest pattern so the driver can wait
+ * for the group to be decidable instead of racing.
+ */
+static void mark_ambiguous_groups(svcinfo_t *rec)
+{
+	svcstep_t *st;
+
+	for (st = rec->steps; (st); st = st->next) {
+		svcstep_t *a, *b, *last;
+		int maxlen = 0, clash = 0;
+
+		if (st->type != STEP_EXPECT) continue;
+
+		/* the group is this step and the expects immediately after it */
+		for (last = st; (last->next && (last->next->type == STEP_EXPECT)); last = last->next) ;
+		for (a = st; ; a = a->next) {
+			if (a->len > maxlen) maxlen = a->len;
+			if (a == last) break;
+		}
+
+		for (a = st; (a != last); a = a->next) {
+			for (b = a->next; ; b = b->next) {
+				int n = (a->len < b->len) ? a->len : b->len;
+
+				if ((n > 0) && (memcmp(a->text, b->text, n) == 0)) {
+					clash = 1;
+					errprintf("Service %s: 'expect \"%.30s\"' and 'expect \"%.30s\"' overlap - "
+						  "both match the same reply, and which one wins depends on how "
+						  "the server split it\n", rec->svcname, a->text, b->text);
+				}
+				if (b == last) break;
+			}
+		}
+
+		if (clash)
+			for (a = st; ; a = a->next) {
+				a->ambiguous = 1;
+				a->maxaltlen = maxlen;
+				if (a == last) break;
+			}
+
+		st = last;	/* skip past the group we just examined */
+	}
+}
+
+/* Has this entry produced an expect yet? A capture binds the reply that the
+   preceding expect accepted, so one with nothing in front of it can only ever
+   bind an empty value. */
+static int has_expect_step(svcinfo_t *rec)
+{
+	svcstep_t *st;
+
+	for (st = rec->steps; (st); st = st->next)
+		if (st->type == STEP_EXPECT) return 1;
+
+	return 0;
+}
+
+
+/*
+ * Resolve "goto NAME" to the step that "label NAME" defines. Done once
+ * after the whole entry is read, so a goto may point forwards -- a retry
+ * loop points backwards, and both are ordinary edges here.
+ */
+static void resolve_svcsteps(svcinfo_t *rec)
+{
+	svcstep_t *st, *lbl;
+
+	for (st = rec->steps; (st); st = st->next) {
+		if (st->action != ACT_GOTO || st->target == NULL) continue;
+
+		for (lbl = rec->steps; (lbl); lbl = lbl->next)
+			if ((lbl->type == STEP_LABEL) && lbl->label &&
+			    (strcmp(lbl->label, st->target) == 0)) break;
+
+		if (lbl) st->targetstep = lbl;
+		else {
+			errprintf("Service %s: 'goto %s' has no matching state - "
+				  "the branch is dropped\n", rec->svcname, st->target);
+			st->action = ACT_NEXT;
+		}
+	}
+}
+
+
 typedef struct svclist_t {
 	struct svcinfo_t *rec;
 	struct svclist_t *next;
 } svclist_t;
+
+
+/*
+ * Emit one step to every record in the current [a|b|c] section. `first`
+ * heads that section and the aliases follow it, so walking to the end of
+ * the list is exactly this section -- later sections have not been read.
+ */
+static void emit_step(svclist_t *first, svcstep_t *tmpl)
+{
+	svclist_t *walk;
+
+	for (walk = first; (walk); walk = walk->next) {
+		svcstep_t *st = add_svcstep(walk->rec, tmpl->type, tmpl->text, tmpl->len);
+
+		st->action = tmpl->action;
+		if (tmpl->target)  st->target  = strdup(tmpl->target);
+		if (tmpl->label)   st->label   = strdup(tmpl->label);
+		if (tmpl->varname) st->varname = strdup(tmpl->varname);
+		if (tmpl->until) {
+			st->until = (unsigned char *)malloc(tmpl->untillen + 1);
+			memcpy(st->until, tmpl->until, tmpl->untillen);
+			st->until[tmpl->untillen] = '\0';
+			st->untillen = tmpl->untillen;
+		}
+
+		/* One compiled copy per record: records are freed independently. */
+		if (tmpl->re) st->re = (void *)compileregex_opts((char *)tmpl->text, 0);
+	}
+}
 
 
 static char *binview(unsigned char *buf, int buflen)
@@ -279,6 +556,7 @@ char *init_tcp_services(void)
 		}
 		else if (strncmp(l, "send ", 5) == 0) {
 			if (first) {
+				svcstep_t tmpl;
 				unsigned char *txt = NULL;
 				int txtlen = 0;
 
@@ -288,28 +566,33 @@ char *init_tcp_services(void)
 				 * single-step probe has always meant. The step list is
 				 * what a dialogue is driven from.
 				 */
-				if (first->rec->sendtxt == NULL) {
-					first->rec->sendtxt = txt;
-					first->rec->sendlen = txtlen;
-				}
-				add_svcstep(first->rec, STEP_SEND, txt, txtlen);
-				for (walk = first->next; (walk); walk = walk->next) {
+				for (walk = first; (walk); walk = walk->next) {
 					if (walk->rec->sendtxt == NULL) {
 						walk->rec->sendtxt = (unsigned char *)strdup((char *)txt);
 						walk->rec->sendlen = txtlen;
 					}
-					add_svcstep(walk->rec, STEP_SEND, txt, txtlen);
 				}
+				check_expansions(first->rec->svcname, txt, txtlen);
+
+				memset(&tmpl, 0, sizeof(tmpl));
+				tmpl.type = STEP_SEND; tmpl.text = txt; tmpl.len = txtlen;
+				emit_step(first, &tmpl);
+				xfree(txt);
 			}
 		}
 		else if (strncmp(l, "expect ", 7) == 0) {
 			if (first) {
+				svcstep_t tmpl;
 				unsigned char *txt = NULL, *untiltxt = NULL;
 				int txtlen = 0, untillen = 0;
-				char *rest;
-				svcstep_t *st;
+				char *rest, *act;
 
 				getescapestring(skipwhitespace(l+6), &txt, &txtlen);
+
+				memset(&tmpl, 0, sizeof(tmpl));
+				tmpl.type = STEP_EXPECT; tmpl.text = txt; tmpl.len = txtlen;
+
+				rest = skipwhitespace(after_quoted(skipwhitespace(l+6)));
 
 				/*
 				 * "until" says where the reply ENDS. Without it an expect
@@ -319,32 +602,213 @@ char *init_tcp_services(void)
 				 * with the command tag. Naming the terminator covers all three
 				 * without teaching the parser any of them.
 				 */
-				rest = skipwhitespace(after_quoted(skipwhitespace(l+6)));
-				if (strncmp(rest, "until ", 6) == 0)
-					getescapestring(skipwhitespace(rest + 5), &untiltxt, &untillen);
+				if (strncmp(rest, "until ", 6) == 0) {
+					char *tp = skipwhitespace(rest + 5);
 
-				if (first->rec->exptext == NULL) {
-					first->rec->exptext = txt;
-					first->rec->explen  = txtlen;
+					getescapestring(tp, &untiltxt, &untillen);
+					tmpl.until = untiltxt;
+					tmpl.untillen = untillen;
+					rest = skipwhitespace(after_quoted(tp));
 				}
-				st = add_svcstep(first->rec, STEP_EXPECT, txt, txtlen);
-				if (untiltxt) {
-					st->until = (unsigned char *)strdup((char *)untiltxt);
-					st->untillen = untillen;
+
+				/* Anything left after that is this edge's action. */
+				if (*rest) {
+					act = strtok(rest, " \t");
+					if (act && (strcmp(act, "->") == 0)) {
+						/*
+						 * Every edge is "<condition> -> TARGET". "fail" is
+						 * a reserved target: the dialogue ends there.
+						 */
+						char *tgt = strtok(NULL, " \t");
+
+						if (!tgt) errprintf("'expect ... ->' with no target\n");
+						else if (strcmp(tgt, "fail") == 0) tmpl.action = ACT_FAIL;
+						else { tmpl.target = tgt; tmpl.action = ACT_GOTO; }
+					}
+					else if (act) errprintf("Unknown expect action: %s - edges are "
+								"'<condition> -> TARGET'\n", act);
 				}
-				for (walk = first->next; (walk); walk = walk->next) {
+
+				for (walk = first; (walk); walk = walk->next) {
 					if (walk->rec->exptext == NULL) {
 						walk->rec->exptext = (unsigned char *)strdup((char *)txt);
 						walk->rec->explen  = txtlen;
 						walk->rec->expofs  = 0; /* HACK - not used right now */
 					}
-					st = add_svcstep(walk->rec, STEP_EXPECT, txt, txtlen);
-					if (untiltxt) {
-						st->until = (unsigned char *)strdup((char *)untiltxt);
-						st->untillen = untillen;
+				}
+				emit_step(first, &tmpl);
+				xfree(txt);
+				if (untiltxt) xfree(untiltxt);
+			}
+		}
+		else if (strncmp(l, "state ", 6) == 0) {
+			/*
+			 * Names the state that follows: the expects up to the next
+			 * step that is not one. It is also what "goto" aims at, so
+			 * naming a state and marking a jump target are the same act
+			 * rather than two keywords for one idea.
+			 */
+			if (first) {
+				svcstep_t tmpl;
+
+				memset(&tmpl, 0, sizeof(tmpl));
+				tmpl.type = STEP_LABEL;
+				tmpl.label = strtok(skipwhitespace(l+5), " \t");
+				if (tmpl.label) emit_step(first, &tmpl);
+				else errprintf("'state' with no name\n");
+			}
+		}
+		else if (strncmp(l, "capture-regex ", 14) == 0) {
+			if (first) {
+				svcstep_t tmpl;
+				unsigned char *txt = NULL;
+				int txtlen = 0;
+				char *rest, *kw;
+
+				getrawstring(skipwhitespace(l+13), &txt, &txtlen);
+				rest = skipwhitespace(after_quoted(skipwhitespace(l+13)));
+				kw = strtok(rest, " \t");
+
+				memset(&tmpl, 0, sizeof(tmpl));
+				tmpl.type = STEP_CAPTURE; tmpl.text = txt; tmpl.len = txtlen;
+				tmpl.re = (void *)1;	/* emit_step compiles one per record */
+				if (kw && (strcmp(kw, "as") == 0)) tmpl.varname = strtok(NULL, " \t");
+
+				if (tmpl.varname) {
+					pcre2_code *probe;
+					uint32_t ngroups = 0;
+
+					if (!has_expect_step(first->rec))
+						errprintf("Service %s: 'capture-regex ... as %s' before any expect - "
+							  "there is no reply to capture from, it will bind empty\n",
+							  first->rec->svcname, tmpl.varname);
+
+					/*
+					 * The value bound is group 1, so a pattern with no
+					 * parenthesised group can never bind anything: ${name}
+					 * would expand to nothing for every reply, forever.
+					 * Unconditional, so worth saying at load time.
+					 */
+					probe = compileregex_opts((char *)txt, 0);
+					if (probe) {
+						uint32_t nnames = 1;
+						char *p;
+
+						for (p = tmpl.varname; (*p); p++) if (*p == ';') nnames++;
+
+						pcre2_pattern_info(probe, PCRE2_INFO_CAPTURECOUNT, &ngroups);
+						freeregex(probe);
+
+						/*
+						 * One name per group, in order. A mismatch means
+						 * either a group whose value is thrown away or a
+						 * name that can never be bound, and both are
+						 * silent at run time -- so say it here.
+						 */
+						if (ngroups == 0)
+							errprintf("Service %s: 'capture-regex \"%s\" as %s' has no "
+								  "capture group - it can never bind a value\n",
+								  first->rec->svcname, txt, tmpl.varname);
+						else if (ngroups != nnames)
+							errprintf("Service %s: 'capture-regex \"%s\" as %s' has %u "
+								  "capture group(s) but %u name(s)\n",
+								  first->rec->svcname, txt, tmpl.varname,
+								  ngroups, nnames);
+					}
+
+					emit_step(first, &tmpl);
+				}
+				else errprintf("Usage: capture-regex \"regex\" as NAME\n");
+				xfree(txt);
+			}
+		}
+		else if (strncmp(l, "capture ", 8) == 0) {
+			/* No regex: bind the whole reply that just matched. */
+			if (first) {
+				svcstep_t tmpl;
+				char *kw = strtok(skipwhitespace(l+7), " \t");
+
+				memset(&tmpl, 0, sizeof(tmpl));
+				tmpl.type = STEP_CAPTURE;
+				if (kw && (strcmp(kw, "as") == 0)) tmpl.varname = strtok(NULL, " \t");
+
+				if (tmpl.varname) {
+					if (!has_expect_step(first->rec))
+						errprintf("Service %s: 'capture as %s' before any expect - "
+							  "there is no reply to capture from, it will bind empty\n",
+							  first->rec->svcname, tmpl.varname);
+					emit_step(first, &tmpl);
+				}
+				else errprintf("Usage: capture as NAME\n");
+			}
+		}
+		else if (strncmp(l, "else ", 5) == 0) {
+			/*
+			 * The arm taken when no '~' edge in this state matched. An
+			 * unconditional edge that only makes sense after one, so it is
+			 * emitted as a jump and never reached if a '~' above it already
+			 * left the state.
+			 */
+			char *rest = skipwhitespace(l + 5);
+
+			if (strncmp(rest, "->", 2) != 0) errprintf("'else' without '->'\n");
+			else if (first) {
+				svcstep_t tmpl;
+				char *tgt = strtok(skipwhitespace(rest + 2), " \t");
+
+				memset(&tmpl, 0, sizeof(tmpl));
+				tmpl.type = STEP_JUMP;
+				if (!tgt) errprintf("'else ->' with no target\n");
+				else if (strcmp(tgt, "fail") == 0) tmpl.action = ACT_FAIL;
+				else { tmpl.target = tgt; tmpl.action = ACT_GOTO; }
+				emit_step(first, &tmpl);
+			}
+		}
+		else if (strstr(l, "~") && strstr(l, "->")) {
+			/*
+			 * "NAME ~ \"regex\" -> TARGET": branch on a value already bound.
+			 * Recognised by shape rather than by a leading keyword, because
+			 * the line begins with the name being tested. The regex tests a
+			 * captured value, never the socket, so it decides nothing about
+			 * what arrives and cannot race a partial read -- which is why a
+			 * regex is allowed here and not in an expect.
+			 */
+			if (first) {
+				svcstep_t tmpl;
+				char *var, *op, *rest;
+				unsigned char *txt = NULL;
+				int txtlen = 0;
+
+				var = strtok(l, " \t");
+				op  = (var ? strtok(NULL, " \t") : NULL);
+				rest = (op ? skipwhitespace(op + strlen(op) + 1) : NULL);
+
+				if (!var || !op || (strcmp(op, "~") != 0) || !rest || !*rest) {
+					errprintf("Usage: NAME ~ \"regex\" -> TARGET\n");
+				}
+				else {
+					char *arrow;
+
+					getrawstring(rest, &txt, &txtlen);
+					arrow = strstr(skipwhitespace(after_quoted(rest)), "->");
+
+					memset(&tmpl, 0, sizeof(tmpl));
+					tmpl.type = STEP_WHEN;
+					tmpl.varname = var;
+					tmpl.text = txt; tmpl.len = txtlen;
+					tmpl.re = (void *)1;	/* emit_step compiles a copy per record */
+
+					if (!arrow) errprintf("'%s ~ ...' with no '->'\n", var);
+					else {
+						char *tgt = strtok(skipwhitespace(arrow + 2), " \t");
+
+						if (!tgt) errprintf("'%s ~ ... ->' with no target\n", var);
+						else if (strcmp(tgt, "fail") == 0) tmpl.action = ACT_FAIL;
+						else { tmpl.target = tgt; tmpl.action = ACT_GOTO; }
+						emit_step(first, &tmpl);
 					}
 				}
-				if (untiltxt) xfree(untiltxt);
+				if (txt) xfree(txt);
 			}
 		}
 		else if (strncmp(l, "options ", 8) == 0) {
@@ -407,6 +871,7 @@ char *init_tcp_services(void)
 		svcinfo[i].port    = walk->rec->port;
 		svcinfo[i].alpns   = walk->rec->alpns;
 		svcinfo[i].steps   = walk->rec->steps;
+		resolve_svcsteps(&svcinfo[i]);
 		/*
 		 * A dialogue is anything that is not the classic one-shot shape.
 		 * Deciding it here, once, keeps do_tcp_tests() from re-deriving it
@@ -414,13 +879,31 @@ char *init_tcp_services(void)
 		 * or either alone) keeps the exact code path it has always used.
 		 */
 		{
-			svcstep_t *st; int nsend = 0, nexp = 0, first_is_expect = 0;
+			svcstep_t *st;
+			int nsend = 0, nexp = 0, nother = 0, first_is_expect = 0;
+
 			for (st = walk->rec->steps; (st); st = st->next) {
 				if (st == walk->rec->steps) first_is_expect = (st->type == STEP_EXPECT);
-				if (st->type == STEP_SEND) nsend++; else nexp++;
+				if (st->type == STEP_SEND) nsend++;
+				else if (st->type == STEP_EXPECT) {
+					nexp++;
+					if (st->action != ACT_NEXT) nother++;	/* a branch edge */
+				}
+				else nother++;					/* when/capture/label/... */
 			}
-			if (first_is_expect || nsend > 1 || nexp > 1)
+			/*
+			 * A lone "expect" with nothing to send is the classic
+			 * shape -- rsync and svn are exactly that -- so it stays
+			 * on the old path. What needs the driver is an expect that
+			 * something is sent AFTER, which is the ordering the
+			 * single-shot probe cannot express.
+			 */
+			if ((first_is_expect && (nsend > 0)) || (nsend > 1) || (nexp > 1) || nother)
 				svcinfo[i].flags |= TCP_DIALOGUE;
+
+			check_undefined_vars(&svcinfo[i]);
+			mark_ambiguous_groups(&svcinfo[i]);
+
 		}
 	}
 	memset(&svcinfo[svccount], 0, sizeof(svcinfo_t));

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -34,13 +34,14 @@
 #define STEP_CAPTURE 4	/* pull a value out of the reply just matched */
 #define STEP_WHEN    5	/* branch on a captured value */
 #define STEP_JUMP    6	/* unconditional; emitted to skip an else-arm */
+#define STEP_CREDS   7	/* bind ${username}/${password} from the store */
 
-/* STEP_LABEL, STEP_CAPTURE, STEP_WHEN and STEP_JUMP touch no
+/* STEP_LABEL, STEP_CAPTURE, STEP_WHEN, STEP_JUMP and STEP_CREDS touch no
    socket. The driver runs them to completion between I/O steps, so a
    dialogue never sits in a state that has nothing to wait for. */
 #define STEP_IS_INSTANT(t) \
 	(((t) == STEP_LABEL) || ((t) == STEP_CAPTURE) || ((t) == STEP_WHEN) || \
-	 ((t) == STEP_JUMP))
+	 ((t) == STEP_JUMP) || ((t) == STEP_CREDS))
 
 /* What an expect does once its pattern matches. Anything other than
    ACT_NEXT is an edge that leaves the straight line, which is what makes
@@ -63,6 +64,7 @@ typedef struct svcstep_t {
 	char *label;			/* STEP_LABEL: the name it defines */
 	char *varname;			/* STEP_CAPTURE/WHEN: variable name */
 	void *re;			/* compiled pcre2_code, or NULL */
+	char *user, *pass;		/* STEP_CREDS: resolved at config load */
 	unsigned char *until;		/* expect ... until "X": end-of-reply marker */
 	int untillen;
 	int ambiguous;			/* this alternation group has overlapping patterns */

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -28,15 +28,45 @@
 /* One step of a protocol dialogue, in the order protocols.cfg lists them.
    Kept as a list rather than an array because the parser appends while it
    reads and every alias of a service shares the same shape. */
-#define STEP_SEND   1
-#define STEP_EXPECT 2
+#define STEP_SEND    1
+#define STEP_EXPECT  2
+#define STEP_LABEL   3	/* a jump target; performs no I/O */
+#define STEP_CAPTURE 4	/* pull a value out of the reply just matched */
+#define STEP_WHEN    5	/* branch on a captured value */
+#define STEP_JUMP    6	/* unconditional; emitted to skip an else-arm */
 
+/* STEP_LABEL, STEP_CAPTURE, STEP_WHEN and STEP_JUMP touch no
+   socket. The driver runs them to completion between I/O steps, so a
+   dialogue never sits in a state that has nothing to wait for. */
+#define STEP_IS_INSTANT(t) \
+	(((t) == STEP_LABEL) || ((t) == STEP_CAPTURE) || ((t) == STEP_WHEN) || \
+	 ((t) == STEP_JUMP))
+
+/* What an expect does once its pattern matches. Anything other than
+   ACT_NEXT is an edge that leaves the straight line, which is what makes
+   this a graph rather than a list. */
+#define ACT_NEXT 0
+#define ACT_GOTO 1
+#define ACT_FAIL 2
+
+/* Consecutive STEP_EXPECTs are alternatives of ONE state: the first whose
+   pattern matches wins and its action fires, so a state has as many
+   outgoing edges as it has alternatives, plus the implicit failure edge
+   taken when every alternative has been ruled out. */
 typedef struct svcstep_t {
 	int type;
-	unsigned char *text;
+	unsigned char *text;		/* send/expect literal, or capture regex */
 	int len;
+	int action;			/* ACT_* -- expect steps only */
+	char *target;			/* goto label, unresolved */
+	struct svcstep_t *targetstep;	/* ... and resolved, after parsing */
+	char *label;			/* STEP_LABEL: the name it defines */
+	char *varname;			/* STEP_CAPTURE/WHEN: variable name */
+	void *re;			/* compiled pcre2_code, or NULL */
 	unsigned char *until;		/* expect ... until "X": end-of-reply marker */
 	int untillen;
+	int ambiguous;			/* this alternation group has overlapping patterns */
+	int maxaltlen;			/* ... and the longest pattern in it */
 	struct svcstep_t *next;
 } svcstep_t;
 

--- a/tests/network/dialogue-ambiguity.sh
+++ b/tests/network/dialogue-ambiguity.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Two alternatives that overlap must not be decided by the network.
+#
+# Consecutive expects are alternatives and the first match wins, but an
+# alternative cannot be decided until enough of the reply has arrived.
+# A shorter pattern that already fits therefore used to beat a longer one
+# still in flight -- so the SAME config against the SAME bytes gave
+# opposite verdicts depending only on whether the server wrote its reply
+# in one call or two. Measured, before this was fixed: red for one write,
+# green for two.
+#
+# Both halves are checked here. The overlap is reported when the file is
+# read, because a config whose meaning depends on packet boundaries is
+# worth knowing about; and the verdict is now the same either way, so a
+# config that ignores the warning is at least deterministic.
+#
+# Two alternatives can both match one reply exactly when one is a prefix
+# of the other, so the parse-time check is complete rather than a guess.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+"$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile"; }
+
+# The identical reply, written once and written in two pieces.
+cat > "$work/one.script" <<'EOS'
+send "220 ready\r\n"
+recv x
+send "250 OK\r\n"
+EOS
+cat > "$work/two.script" <<'EOS'
+send "220 ready\r\n"
+recv x
+send "250"
+send " OK\r\n"
+EOS
+
+: > "$work/pids"
+start() {
+	"$work/peer" "$1" "$3" > "$2" &
+	echo $! >> "$work/pids"
+	local i=0
+	while [ "$i" -lt 50 ]; do [ -s "$2" ] && break; sleep 0.1; i=$((i + 1)); done
+	cat "$2"
+}
+p1=$(start "$work/one.script" "$work/p1" "$work/o1")
+p2=$(start "$work/two.script" "$work/p2" "$work/o2")
+register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
+[ -n "$p1" ] && [ -n "$p2" ] || fail "a peer never named its port"
+
+# "250 OK" and "250" overlap: either could match "250 OK".
+blk() {
+cat <<CFG
+[$1]
+   expect "220"
+   send "x\r\n"
+   expect "250 OK"             -> fail
+   expect "250"
+   send "quit\r\n"
+   options banner
+   port $2
+CFG
+}
+{ blk amb1 "$p1"; echo; blk amb2 "$p2"; } > "$work/home/etc/protocols.cfg"
+printf '127.0.0.1\tonewrite\t# amb1\n127.0.0.1\tsplit\t# amb2\n' > "$work/home/etc/hosts.cfg"
+
+out=$(XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse \
+	--dns=ip --timeout=15 2>&1 || :)
+
+grep -qi 'overlap' <<<"$out" || fail \
+	"two alternatives where one is a prefix of the other were accepted without
+comment. Which of them matches depends on how the server split its reply,
+so the config's meaning is decided by the network:
+$out"
+
+v1=$(grep -c 'Service amb1 on onewrite is OK' <<<"$out" || true)
+v2=$(grep -c 'Service amb2 on split is OK' <<<"$out" || true)
+[ "$v1" = "$v2" ] || fail \
+	"the same config against the same bytes gave different verdicts: one write
+was $([ "$v1" = 1 ] && echo up || echo down), split across two writes was
+$([ "$v2" = 1 ] && echo up || echo down). The winner is being decided by
+packet boundaries rather than by the order in protocols.cfg:
+$out"
+
+pass "overlapping alternatives are reported, and the verdict no longer depends on how the reply was split"

--- a/tests/network/dialogue-validation.sh
+++ b/tests/network/dialogue-validation.sh
@@ -33,16 +33,29 @@ run_xymonnet() {
 }
 
 # --- a file with one of each mistake ----------------------------------------
+printf 'mypop\tuser\tsecret\n' > "$work/home/etc/credentials.cfg"
 cat > "$work/home/etc/protocols.cfg" <<'CFG'
 [bad]
    exepct "220"
    capture as tooearly
-   capture-regex "[0-9]+" as nogroup
    expect "220"
    send "x${sha1:foo}\r\n"
    options banner
    port 9
 
+[typo]
+   expect "+OK"
+   capture-regex "(<[^>]+>)" as challenge
+   capture-regex "[0-9]+" as nogroup
+   credentials mypop
+   challeng ~ "<"              -> apop
+   else                        -> plain
+   state apop
+   send "APOP ${username} ${md5:${challeng}${password}}\r\n"
+   state plain
+   send "USER ${usernam}\r\n"
+   expect "+OK"
+   port 9
 CFG
 out=$(run_xymonnet)
 
@@ -61,17 +74,28 @@ grep -qi 'unknown expansion' <<<"$out" || fail \
 variable of that name and expands to nothing:
 $out"
 
+
+grep -q 'never captured or bound' <<<"$out" || fail \
+	"a \${name} that nothing binds was accepted. It expands to nothing, the
+command goes out malformed, and the test then fails for a reason that has
+nothing to do with the typo:
+$out"
+
+grep -qi 'can only fail' <<<"$out" || fail \
+	"a '~' edge testing a value nothing captures was accepted; it can only
+ever fall through to the else-arm:
+$out"
+
 grep -q 'no capture group' <<<"$out" || fail \
 	"a capture-regex with no parenthesised group was accepted. The value bound
 is group 1, so that pattern can never bind anything and \${name} expands to
 nothing for every reply:
 $out"
 
-
 # --- and the shipped file must be quiet -------------------------------------
 cp "$root/xymonnet/protocols.cfg" "$work/home/etc/protocols.cfg"
 out=$(run_xymonnet)
-noise=$(grep -ciE 'unknown protocols.cfg directive|before any expect|unknown expansion|no capture group' <<<"$out" || true)
+noise=$(grep -ciE 'unknown protocols.cfg directive|before any expect|unknown expansion|never captured or bound|can only fail|no capture group' <<<"$out" || true)
 [ "$noise" -eq 0 ] || fail \
 	"the protocols.cfg this tree ships triggers $noise of its own warnings:
 $(grep -iE 'unknown|before any expect' <<<"$out")"

--- a/tests/network/dialogue-validation.sh
+++ b/tests/network/dialogue-validation.sh
@@ -2,10 +2,16 @@
 #
 # A protocols.cfg mistake should say so.
 #
-# An unrecognised directive was a silent no-op: the step simply vanished
-# and the probe reported on a conversation it never had. That is checked
-# when the file is read, not when the step executes, which is why this
-# test never connects to anything.
+# Every one of these used to be silent. A mistyped directive was a no-op,
+# so the step simply vanished and the probe reported on a conversation it
+# never had; ${sha1:...} was read as a variable named "sha1:..." and
+# expanded to nothing; a capture with no expect in front of it bound an
+# empty string; starttls on a service that is already TLS started a second
+# handshake inside the first and failed like a broken server.
+#
+# The checks run when the file is read, not when the step executes -- a
+# step that is never reached would otherwise never report its own mistake.
+# That is why this test never connects to anything.
 #
 # The second half matters as much as the first: the config the tree SHIPS
 # must produce none of these. A validator that cries wolf gets ignored,
@@ -26,13 +32,17 @@ run_xymonnet() {
 		--timeout=2 2>&1 || :
 }
 
-# --- a file with a mistyped directive --------------------------------------
+# --- a file with one of each mistake ----------------------------------------
 cat > "$work/home/etc/protocols.cfg" <<'CFG'
 [bad]
    exepct "220"
+   capture as tooearly
+   capture-regex "[0-9]+" as nogroup
    expect "220"
+   send "x${sha1:foo}\r\n"
    options banner
    port 9
+
 CFG
 out=$(run_xymonnet)
 
@@ -41,12 +51,29 @@ grep -qi 'unknown protocols.cfg directive' <<<"$out" || fail \
 probe still runs, so the test reports on a conversation it never had:
 $out"
 
+grep -qi 'before any expect' <<<"$out" || fail \
+	"'capture as' with no preceding expect was accepted; it can only bind an
+empty value:
+$out"
+
+grep -qi 'unknown expansion' <<<"$out" || fail \
+	"\${sha1:...} was accepted. It is not a function, so it is read as a
+variable of that name and expands to nothing:
+$out"
+
+grep -q 'no capture group' <<<"$out" || fail \
+	"a capture-regex with no parenthesised group was accepted. The value bound
+is group 1, so that pattern can never bind anything and \${name} expands to
+nothing for every reply:
+$out"
+
+
 # --- and the shipped file must be quiet -------------------------------------
 cp "$root/xymonnet/protocols.cfg" "$work/home/etc/protocols.cfg"
 out=$(run_xymonnet)
-noise=$(grep -ciE 'unknown protocols.cfg directive' <<<"$out" || true)
+noise=$(grep -ciE 'unknown protocols.cfg directive|before any expect|unknown expansion|no capture group' <<<"$out" || true)
 [ "$noise" -eq 0 ] || fail \
 	"the protocols.cfg this tree ships triggers $noise of its own warnings:
 $(grep -iE 'unknown|before any expect' <<<"$out")"
 
-pass "a mistyped directive is reported when the file is read, and the shipped file reports none"
+pass "protocols.cfg mistakes are reported when the file is read, and the shipped file reports none"

--- a/tests/network/dialogue-values.sh
+++ b/tests/network/dialogue-values.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Branching on what the server said, and the values carried out of it.
+#
+# The peer recomputes what it expects rather than accepting what arrives:
+# it derives md5(challenge + secret) and the base64 itself, so a probe that
+# sends a wrong digest fails here instead of being waved through. That is
+# the only way this proves anything -- a peer that just records bytes would
+# pass on any hash at all.
+#
+# The same service definition meets two servers: one greeting WITH an APOP
+# challenge and one without. The branch has to take a different arm for
+# each, which is what makes it a branch rather than a straight line.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+"$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile"; }
+
+printf 'mypop\ttestuser\ts3cret\n' > "$work/home/etc/credentials.cfg"
+chmod 600 "$work/home/etc/credentials.cfg"
+
+cat > "$work/apop.script" <<'EOS'
+send "+OK POP3 mail.example.com <1896.697@test>\r\n"
+md5check testuser s3cret
+send "+OK logged in\r\n"
+recv quit mail.example.com
+send "+OK bye\r\n"
+EOS
+cat > "$work/plain.script" <<'EOS'
+send "+OK POP3 ready\r\n"
+recv USER testuser
+send "+OK\r\n"
+recv PASS s3cret
+send "+OK\r\n"
+recv quit
+send "+OK bye\r\n"
+EOS
+cat > "$work/b64.script" <<'EOS'
+send "+OK ready\r\n"
+b64check AUTH_ testuser
+send "+OK\r\n"
+recv quit
+send "+OK bye\r\n"
+EOS
+
+: > "$work/pids"
+start() {
+	"$work/peer" "$1" "$3" > "$2" &
+	echo $! >> "$work/pids"
+	local i=0
+	while [ "$i" -lt 50 ]; do [ -s "$2" ] && break; sleep 0.1; i=$((i + 1)); done
+	cat "$2"
+}
+pa=$(start "$work/apop.script"  "$work/pa" "$work/oa")
+pp=$(start "$work/plain.script" "$work/pp" "$work/op")
+pb=$(start "$work/b64.script"   "$work/pb" "$work/ob")
+register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
+[ -n "$pa" ] && [ -n "$pp" ] && [ -n "$pb" ] || fail "a peer never named its port"
+
+# One definition, two servers: the branch decides which arm runs.
+authblock() {
+cat <<CFG
+[$1]
+   expect "+OK"
+   capture-regex "\\+OK POP3 (\\S+) (<[^>]+>)" as server;challenge
+   credentials mypop
+   challenge ~ "<"             -> apop
+   else                        -> plain
+
+   state apop
+   send "APOP \${username} \${md5:\${challenge}\${password}}\r\n"
+   expect "+OK"                -> farewell
+
+   state plain
+   send "USER \${username}\r\n"
+   expect "+OK"
+   send "PASS \${password}\r\n"
+   expect "+OK"                -> farewell
+
+   state farewell
+   send "quit \${server}\r\n"
+   options banner
+   port $2
+CFG
+}
+{
+	authblock popapop "$pa"
+	authblock popplain "$pp"
+	cat <<CFG
+
+[popb64]
+   expect "+OK"
+   credentials mypop
+   send "AUTH_\${base64:\${username}}\r\n"
+   expect "+OK"
+   send "quit\r\n"
+   options banner
+   port $pb
+CFG
+} > "$work/home/etc/protocols.cfg"
+printf '127.0.0.1\tapop\t# popapop\n127.0.0.1\tplain\t# popplain\n127.0.0.1\tb64\t# popb64\n' \
+	> "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse \
+	--dns=ip --timeout=15 >"$work/out.txt" 2>&1 || :
+sleep 1
+
+# Two names from one pattern, and a regex whose backslashes survive the
+# config reader. \S used to be eaten before PCRE saw it -- the pattern
+# became "(S+)", failed to compile, and every ${name} silently expanded to
+# nothing. A regex is not a C string; it has its own escapes.
+grep -qE 'no capture group|pcre compile' "$work/out.txt" && fail \
+	"the capture-regex did not compile. Its backslashes are being consumed
+before PCRE sees them, so the pattern is not the one that was written:
+$(grep -iE 'pcre|capture' "$work/out.txt" | head -2)"
+
+grep -q '^got quit mail.example.com' "$work/oa" || fail \
+	"group 1 did not bind: 'as server;challenge' should give one name per
+capture group, in order. The peer received:
+$(cat "$work/oa")"
+
+grep -q '^md5-ok' "$work/oa" || fail \
+	"the APOP digest the probe sent is not md5(challenge + password). The peer
+computed it independently:
+$(cat "$work/oa")"
+
+grep -q '^got USER testuser' "$work/op" || fail \
+	"against a greeting with no challenge the else-arm did not run, so the
+branch is not reacting to the captured value:
+$(cat "$work/op")"
+grep -q '^got PASS s3cret' "$work/op" || fail \
+	"the else-arm stopped after USER; \${password} did not expand:
+$(cat "$work/op")"
+
+grep -q '^b64-ok' "$work/ob" || fail \
+	"\${base64:\${username}} did not produce base64 of the username:
+$(cat "$work/ob")"
+
+for svc in "popapop on apop" "popplain on plain" "popb64 on b64"; do
+	grep -q "Service $svc is OK" "$work/out.txt" || fail \
+		"$svc did not report up:
+$(cat "$work/out.txt")"
+done
+
+pass "capture, branching, credentials and \${md5:}/\${base64:} produce the values the server itself expects"

--- a/tests/network/protocol-dialogue.sh
+++ b/tests/network/protocol-dialogue.sh
@@ -34,13 +34,13 @@ h=$(strip "$root/lib/netservices.h")
 c=$(strip "$root/lib/netservices.c")
 n=$(strip "$root/xymonnet/contest.c")
 
-for sym in STEP_SEND STEP_EXPECT STEP_WHEN STEP_JUMP \
+for sym in STEP_SEND STEP_EXPECT STEP_WHEN STEP_JUMP STEP_CREDS \
 	   ACT_GOTO ACT_FAIL svcstep_t TCP_DIALOGUE; do
 	printf '%s\n' "$h" | grep -q "$sym" ||
 		fail "lib/netservices.h does not define $sym -- the step list has no type"
 done
 
-for sym in STEP_EXPECT STEP_SEND STEP_WHEN STEP_CAPTURE; do
+for sym in STEP_EXPECT STEP_SEND STEP_WHEN STEP_CAPTURE STEP_CREDS; do
 	printf '%s\n' "$c" | grep -q "$sym" ||
 		fail "the protocols.cfg parser never records a $sym step"
 done

--- a/tests/network/protocol-dialogue.sh
+++ b/tests/network/protocol-dialogue.sh
@@ -23,22 +23,52 @@ set -eu
 . "$(dirname "$0")/../lib/assert.sh"
 root=$(find_root)
 
-strip() { sed 's://.*::' "$1" | sed 's:/\*:\n&:g' | sed '/\/\*/,/\*\//d'; }
+# Strip same-line /* ... */ FIRST. A sed range whose start line also matches
+# the end pattern runs on to the NEXT match, so leaving them in deletes real
+# code -- which silently emptied two assertions here before this was fixed.
+strip() {
+	sed -e 's://.*::' -e 's:/\*[^*]*\*/::g' "$1" | sed '/\/\*/,/\*\//d'
+}
 
 h=$(strip "$root/lib/netservices.h")
 c=$(strip "$root/lib/netservices.c")
 n=$(strip "$root/xymonnet/contest.c")
 
-for sym in STEP_SEND STEP_EXPECT svcstep_t TCP_DIALOGUE; do
+for sym in STEP_SEND STEP_EXPECT STEP_WHEN STEP_JUMP \
+	   ACT_GOTO ACT_FAIL svcstep_t TCP_DIALOGUE; do
 	printf '%s\n' "$h" | grep -q "$sym" ||
 		fail "lib/netservices.h does not define $sym -- the step list has no type"
 done
 
-printf '%s\n' "$c" | grep -q 'add_svcstep.*STEP_EXPECT' ||
-	fail "the protocols.cfg parser never records an expect step"
-printf '%s\n' "$c" | grep -q 'add_svcstep.*STEP_SEND' ||
-	fail "the protocols.cfg parser never records a send step"
+for sym in STEP_EXPECT STEP_SEND STEP_WHEN STEP_CAPTURE; do
+	printf '%s\n' "$c" | grep -q "$sym" ||
+		fail "the protocols.cfg parser never records a $sym step"
+done
 
+# An unresolved "goto" must not leave a NULL target behind: jumping to it
+# would end the dialogue early and report OK.
+printf '%s\n' "$c" | grep -q 'st->action = ACT_NEXT' ||
+	fail "resolve_svcsteps does not neutralise a goto whose label is missing --
+an unresolved branch would jump to NULL and end the dialogue as a success"
+
+# when/else may jump backwards, which is a legal retry loop. Without a cap,
+# a loop that performs no I/O spins forever inside the poll loop.
+printf '%s\n' "$n" | grep -qE '\+\+guard *>' ||
+	fail "dlg_run_instant has no runaway guard -- a backward jump that does no
+I/O would hang xymonnet rather than failing the test"
+
+# md5hash() returns a static buffer; freeing it corrupts the allocator.
+# Asserted positively -- the negative form passed for free when the grep
+# matched nothing at all.
+md5line=$(printf '%s\n' "$n" | grep 'md5hash(' | head -1)
+[ -n "$md5line" ] ||
+	fail "no md5hash() call found -- either the md5 expansion is gone, or the
+comment stripper ate it and this assertion is passing for free"
+case "$md5line" in
+	*freeval*)
+		fail "md5hash()'s result is routed through the free-list, but it is a
+static buffer -- freeing it corrupts the allocator: $md5line" ;;
+esac
 # THE ASSERTION. Both halves, on the same return.
 verdict=$(printf '%s\n' "$n" | grep -n 'dialogfail' | grep 'return' || true)
 [ -n "$verdict" ] ||
@@ -52,5 +82,6 @@ reported OK -- which is exactly the 421 bug this feature exists to catch"
 # off by the very close that the single-shot probe used to do.
 printf '%s\n' "$n" | grep -q '!item->curstep' ||
 	fail "no close guard mentions curstep -- the connection is torn down mid-dialogue"
+
 
 pass "an unfinished dialogue cannot report OK (both dialogfail and curstep are checked)"

--- a/xymonnet/Makefile
+++ b/xymonnet/Makefile
@@ -82,7 +82,7 @@ beastat.o: beastat.c
 
 
 contest: contest.c httptest.o dns.o dns2.o httpcookies.o $(XYMONCOMMLIB) $(XYMONTIMELIB)
-	$(CC) $(LDFLAGS) $(CFLAGS) -o contest -I../include $(CARESINC) -DSTANDALONE contest.c httptest.o dns.o dns2.o httpcookies.o $(CARESLIBS) $(XYMONCOMMLIBS) $(XYMONTIMELIBS)
+	$(CC) $(LDFLAGS) $(CFLAGS) -o contest -I../include $(CARESINC) -DSTANDALONE contest.c httptest.o dns.o dns2.o httpcookies.o $(CARESLIBS) $(XYMONCOMMLIBS) $(XYMONTIMELIBS) $(PCRELIBS)
 
 
 # net-snmp-config exports the distro's full build policy along with the

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -997,6 +997,268 @@ static void tcptest_setnext(void *a, void *newval)
 }
 
 
+/*
+ * ---- dialogue support: variables, expansion, and the instant steps ----
+ */
+
+/*
+ * Overwrite before releasing. ${password} lives in this list, and a plain
+ * memset on memory that is about to be freed is exactly what a compiler is
+ * entitled to delete, so the write goes through a volatile pointer.
+ */
+static void dlg_wipe(char *s)
+{
+	volatile char *p = (volatile char *)s;
+
+	while (p && *p) *p++ = '\0';
+}
+
+
+static void dlg_free(tcptest_t *item)
+{
+	dlgvar_t *v = (dlgvar_t *)item->dlgvars;
+
+	while (v) {
+		dlgvar_t *next = v->next;
+
+		if (v->value) { dlg_wipe(v->value); xfree(v->value); }
+		if (v->name) xfree(v->name);
+		xfree(v);
+		v = next;
+	}
+	item->dlgvars = NULL;
+
+	if (item->stepbuf) { xfree(item->stepbuf); item->stepbuf = NULL; }
+	item->stepbuflen = 0;
+	if (item->lastreply) { xfree(item->lastreply); item->lastreply = NULL; }
+}
+
+
+static char *dlg_get(tcptest_t *item, const char *name)
+{
+	dlgvar_t *v;
+
+	for (v = (dlgvar_t *)item->dlgvars; (v); v = v->next)
+		if (strcmp(v->name, name) == 0) return v->value;
+
+	return NULL;
+}
+
+static void dlg_set(tcptest_t *item, const char *name, const char *value)
+{
+	dlgvar_t *v;
+
+	for (v = (dlgvar_t *)item->dlgvars; (v); v = v->next) {
+		if (strcmp(v->name, name) != 0) continue;
+		if (v->value) xfree(v->value);
+		v->value = strdup(value ? value : "");
+		return;
+	}
+
+	v = (dlgvar_t *)calloc(1, sizeof(dlgvar_t));
+	v->name  = strdup(name);
+	v->value = strdup(value ? value : "");
+	v->next  = (dlgvar_t *)item->dlgvars;
+	item->dlgvars = (void *)v;
+}
+
+/*
+ * Expand ${...} in a send string. Nesting is why this recurses rather than
+ * scanning once: APOP is ${md5:${challenge}${password}}, and the digest has
+ * to be taken of the *expanded* argument.
+ *
+ * The result is NUL-terminated but the length is returned separately --
+ * a send may legitimately carry NULs.
+ */
+static char *dlg_expand(tcptest_t *item, const char *text, int len, int *outlen)
+{
+	char *out;
+	int outsz, n = 0, i;
+
+	outsz = len + 128;
+	out = (char *)malloc(outsz + 1);
+
+	for (i = 0; (i < len); i++) {
+		int depth, j, blen;
+		char *body, *inner, *val = NULL, *freeval = NULL;
+		int innerlen;
+
+		if (!((text[i] == '$') && ((i+1) < len) && (text[i+1] == '{'))) {
+			if (n >= outsz) { outsz *= 2; out = (char *)realloc(out, outsz + 1); }
+			out[n++] = text[i];
+			continue;
+		}
+
+		/* find the matching brace, counting nested ${ } */
+		depth = 1;
+		for (j = i + 2; (j < len) && depth; j++) {
+			if ((text[j] == '$') && ((j+1) < len) && (text[j+1] == '{')) { depth++; j++; }
+			else if (text[j] == '}') depth--;
+		}
+		if (depth) {			/* unterminated -- emit literally */
+			if (n >= outsz) { outsz *= 2; out = (char *)realloc(out, outsz + 1); }
+			out[n++] = text[i];
+			continue;
+		}
+
+		blen = (j - 1) - (i + 2);
+		body = (char *)malloc(blen + 1);
+		memcpy(body, text + i + 2, blen);
+		body[blen] = '\0';
+
+		if (strncmp(body, "md5:", 4) == 0) {
+			inner = dlg_expand(item, body + 4, blen - 4, &innerlen);
+			/* md5hash() hands back a static buffer -- copy, never free. */
+			val = md5hash(inner);
+			xfree(inner);
+		}
+		else if (strncmp(body, "base64:", 7) == 0) {
+			inner = dlg_expand(item, body + 7, blen - 7, &innerlen);
+			val = freeval = base64encode((unsigned char *)inner);
+			xfree(inner);
+		}
+		else {
+			/* Mistyped functions are reported when the file is read. */
+			val = dlg_get(item, body);
+			if (val == NULL) {
+				dbgprintf("dialogue: ${%s} is not set, expanding empty\n", body);
+				val = "";
+			}
+		}
+
+		{
+			int vlen = strlen(val);
+
+			while ((n + vlen) >= outsz) { outsz *= 2; out = (char *)realloc(out, outsz + 1); }
+			memcpy(out + n, val, vlen);
+			n += vlen;
+		}
+
+		if (freeval) xfree(freeval);
+		xfree(body);
+		i = j - 1;
+	}
+
+	out[n] = '\0';
+	if (outlen) *outlen = n;
+	return out;
+}
+
+/* Group 1 of the pattern, against the reply the last expect accepted. */
+static void dlg_capture(tcptest_t *item, svcstep_t *st)
+{
+	char *subject = (item->lastreply ? item->lastreply : "");
+	pcre2_match_data *md;
+	int res, n;
+	char names[256], *name, *rest;
+
+	if (st->re == NULL) {			/* plain "capture as NAME" */
+		dlg_set(item, st->varname, subject);
+		return;
+	}
+
+	md = pcre2_match_data_create(32, NULL);
+	res = pcre2_match((pcre2_code *)st->re, (PCRE2_SPTR)subject,
+			  strlen(subject), 0, 0, md, NULL);
+
+	/*
+	 * One name per capture group, in order: "as server;challenge" binds
+	 * group 1 to server and group 2 to challenge. The parser has already
+	 * refused a list whose length does not match the pattern, so a group
+	 * with no name cannot reach here.
+	 */
+	strncpy(names, st->varname, sizeof(names) - 1);
+	names[sizeof(names) - 1] = '\0';
+	rest = names;
+	n = 1;
+
+	while ((name = strtok(rest, ";")) != NULL) {
+		rest = NULL;
+
+		if (res > n) {
+			PCRE2_SIZE *ov = pcre2_get_ovector_pointer(md);
+			int b = ov[2*n], e = ov[2*n + 1];
+			char *v = (char *)malloc(e - b + 1);
+
+			memcpy(v, subject + b, e - b);
+			v[e-b] = '\0';
+			dlg_set(item, name, v);
+			xfree(v);
+		}
+		else {
+			dbgprintf("dialogue: capture-regex did not match, ${%s} left empty\n", name);
+			dlg_set(item, name, "");
+		}
+		n++;
+	}
+
+	pcre2_match_data_free(md);
+}
+
+
+/*
+ * Run every step that needs no socket, and return the next one that does
+ * (or NULL at the end of the dialogue). Bounded: a "when" that jumps
+ * backwards is a legal retry loop, but a loop that performs no I/O would
+ * spin here forever, so cap the run.
+ */
+static svcstep_t *dlg_run_instant(tcptest_t *item, svcstep_t *st)
+{
+	int guard = 0;
+
+	while (st && STEP_IS_INSTANT(st->type)) {
+		if (++guard > 1000) {
+			errprintf("Service %s: dialogue loops without doing any I/O\n",
+				  (item->svcinfo ? item->svcinfo->svcname : "?"));
+			item->dialogfail = 1;
+			if (!item->failstep) item->failstep = (void *)st;
+			return NULL;
+		}
+
+		switch (st->type) {
+		  case STEP_LABEL:
+			st = st->next;
+			break;
+
+		  case STEP_CAPTURE:
+			dlg_capture(item, st);
+			st = st->next;
+			break;
+
+		  case STEP_WHEN: {
+			char *v = dlg_get(item, st->varname);
+
+			/*
+			 * An edge: taken when the test matches, fallen through when
+			 * it does not, so the next line -- another '~' or an 'else'
+			 * -- gets its turn. The regex tests a value already bound,
+			 * never the socket, so nothing here races a partial read.
+			 */
+			if (!(v && st->re && matchregex(v, (pcre2_code *)st->re))) {
+				st = st->next;
+				break;
+			}
+		  }
+		  /* FALLTHROUGH: a matched '~' takes its edge exactly as a jump does */
+		  case STEP_JUMP:
+			if (st->action == ACT_FAIL) {
+				item->dialogfail = 1;
+				if (!item->failstep) item->failstep = (void *)st;
+				return NULL;
+			}
+			st = st->targetstep;
+			break;
+
+		  default:
+			st = st->next;
+			break;
+		}
+	}
+
+	return st;
+}
+
+
 void do_tcp_tests(int timeout, int concurrency)
 {
 	int		selres;
@@ -1386,7 +1648,12 @@ restartselect:
 							 * rule is the whole state machine -- the current
 							 * step decides which fd set the socket joins.
 							 */
-							svcstep_t *st = (svcstep_t *)item->curstep;
+							svcstep_t *st;
+
+							/* Settle onto a step that actually needs the socket. */
+							st = dlg_run_instant(item, (svcstep_t *)item->curstep);
+							item->curstep = (void *)st;
+
 
 							while (st && (st->type == STEP_SEND) && item->silenttest) {
 								/*
@@ -1395,11 +1662,15 @@ restartselect:
 								 * leaving it current would strand the dialogue
 								 * with a step it will never perform.
 								 */
-								st = st->next;
+								st = dlg_run_instant(item, st->next);
 								item->curstep = (void *)st;
 							}
 							if (st && (st->type == STEP_SEND)) {
-								res = socket_write(item, (char *)st->text, st->len);
+								int slen = 0;
+								char *sbuf = dlg_expand(item, (char *)st->text, st->len, &slen);
+
+								res = socket_write(item, sbuf, slen);
+								xfree(sbuf);
 								tcp_stats_written += res;
 								if (res == -1) {
 									dbgprintf("write failed\n");
@@ -1408,7 +1679,7 @@ restartselect:
 									st = NULL;
 								}
 								else {
-									st = st->next;
+									st = dlg_run_instant(item, st->next);
 									item->curstep = (void *)st;
 								}
 							}
@@ -1584,6 +1855,8 @@ restartselect:
 								 * or not enough yet -- and only the third is
 								 * new here.
 								 */
+								int progress = 1;
+
 								/*
 								 * Bound it. An expect that waits for a
 								 * terminator will otherwise accumulate
@@ -1617,66 +1890,113 @@ restartselect:
 								item->stepbuflen += res;
 								item->stepbuf[item->stepbuflen] = '\0';
 
-								if (item->stepbuflen >= st->len) {
-									if (memcmp(item->stepbuf, st->text, st->len) == 0) {
-										int cut = st->len, ready = 1;
+								/*
+								 * Loop, because one read can satisfy more than one
+								 * expect when the peer coalesces its replies -- and
+								 * we are only woken again by readable data.
+								 */
+								while (progress) {
+									svcstep_t *alt, *hit = NULL;
+									int undecided = 0;
 
-										if (st->until) {
+									progress = 0;
+									st = (svcstep_t *)item->curstep;
+									if (!st || (st->type != STEP_EXPECT)) break;
+
+									/* Consecutive expects are alternatives of ONE state. */
+									for (alt = st; (alt && (alt->type == STEP_EXPECT)); alt = alt->next) {
+										if (item->stepbuflen < alt->len) { undecided++; continue; }
+										if (memcmp(item->stepbuf, alt->text, alt->len) == 0) { hit = alt; break; }
+									}
+
+									/*
+									 * An ambiguous group is one where a longer
+									 * alternative could still overtake the one
+									 * that just matched. Wait until every
+									 * pattern in the group is decidable, so the
+									 * winner is the config's order rather than
+									 * the server's packet boundaries. Bounded:
+									 * maxaltlen is known at load time, and the
+									 * buffer cap and test timeout end the wait.
+									 */
+									if (hit && hit->ambiguous &&
+									    (item->stepbuflen < hit->maxaltlen)) break;
+
+									if (hit) {
+										int cut = hit->len;
+
+										if (hit->until) {
 											/*
-											 * Multi-line: consume complete lines
-											 * until one starts with the terminator.
-											 * If it has not arrived, consume NOTHING
-											 * and wait -- taking the lines we have
-											 * would strand the rest of the reply for
-											 * the next expect to trip over.
+											 * A multi-line reply: consume complete
+											 * lines until one starts with the
+											 * terminator. If it has not arrived yet
+											 * consume NOTHING and wait -- taking the
+											 * lines we have would strand the rest of
+											 * the reply for the next expect to trip
+											 * over.
 											 */
-											int pos = 0;
+											int pos = 0, done = 0;
 
-											ready = 0;
 											while (pos < item->stepbuflen) {
 												int eol = pos;
 
 												while ((eol < item->stepbuflen) &&
 												       (item->stepbuf[eol] != '\n')) eol++;
-												if (eol >= item->stepbuflen) break;
-												if (((item->stepbuflen - pos) >= st->untillen) &&
-												    (memcmp(item->stepbuf + pos, st->until, st->untillen) == 0)) {
+												if (eol >= item->stepbuflen) break;   /* partial line */
+												if (((item->stepbuflen - pos) >= hit->untillen) &&
+												    (memcmp(item->stepbuf + pos, hit->until, hit->untillen) == 0)) {
 													cut = eol + 1;
-													ready = 1;
+													done = 1;
 													break;
 												}
 												pos = eol + 1;
 											}
+											if (!done) break;	/* wait for the rest */
 										}
 										else {
 											/*
-											 * Single line. Consume through its end
-											 * and KEEP the rest: discarding it would
-											 * throw away a reply the peer had already
-											 * sent, and the next expect would wait for
-											 * data that already arrived.
+											 * Single line. Consume through its end and
+											 * KEEP the rest: discarding it would throw
+											 * away a reply the peer had already sent,
+											 * and the next expect would wait for data
+											 * that already arrived.
 											 */
-											while ((cut < item->stepbuflen) &&
-											       (item->stepbuf[cut] != '\n')) cut++;
+											while ((cut < item->stepbuflen) && (item->stepbuf[cut] != '\n')) cut++;
 											if (cut < item->stepbuflen) cut++;
 										}
 
-										if (ready) {
-											memmove(item->stepbuf, item->stepbuf + cut,
-												item->stepbuflen - cut);
-											item->stepbuflen -= cut;
-											st = st->next;
+										if (item->lastreply) xfree(item->lastreply);
+										item->lastreply = (char *)malloc(cut + 1);
+										memcpy(item->lastreply, item->stepbuf, cut);
+										item->lastreply[cut] = '\0';
+
+										memmove(item->stepbuf, item->stepbuf + cut, item->stepbuflen - cut);
+										item->stepbuflen -= cut;
+
+										if (hit->action == ACT_FAIL) {
+											item->dialogfail = 1;
+											if (!item->failstep) item->failstep = (void *)st;
+											item->curstep = NULL;
+											st = NULL;
+										}
+										else {
+											if (hit->action == ACT_GOTO) alt = hit->targetstep;
+											else for (alt = st; (alt && (alt->type == STEP_EXPECT)); alt = alt->next) ;
+
+											st = dlg_run_instant(item, alt);
 											item->curstep = (void *)st;
+											progress = 1;
 										}
 									}
-									else {
+									else if (!undecided) {
+										/* every alternative has been ruled out */
 										item->dialogfail = 1;
 										if (!item->failstep) item->failstep = (void *)st;
 										item->curstep = NULL;
 										st = NULL;
 									}
+									/* else: short of every pattern -- wait for more */
 								}
-								/* else: short of the pattern -- wait for more */
 
 								/*
 								 * The step we land on decides which fd set the socket
@@ -1766,6 +2086,13 @@ restartselect:
 		}  /* end for loop */
 	} /* end while (pending) */
 
+	/*
+	 * Release the dialogue state. Not in socket_shutdown(): a connection
+	 * that is refused, or that times out before it opens, never reaches
+	 * that. Here every test in the list is covered however it ended.
+	 */
+	for (item = thead; (item); item = item->next) dlg_free(item);
+
 	dbgprintf("TCP tests completed normally\n");
 }
 
@@ -1826,6 +2153,7 @@ char *tcp_dialogue_failure(tcptest_t *test)
 {
 	static char buf[160];
 	svcstep_t *st, *bad;
+	char *name = NULL;
 	int idx = 0, n = 0;
 
 	if (!test || !test->svcinfo || !(test->svcinfo->flags & TCP_DIALOGUE)) return NULL;
@@ -1836,18 +2164,41 @@ char *tcp_dialogue_failure(tcptest_t *test)
 		st = (svcstep_t *)test->curstep;
 		if (!st) return NULL;
 		bad = st;
-		for (st = test->svcinfo->steps; (st); st = st->next) { n++; if (st == bad) idx = n; }
-		snprintf(buf, sizeof(buf), "no reply to step %d (expecting \"%.40s\")",
-			 idx, (bad->text ? (char *)bad->text : ""));
+		for (st = test->svcinfo->steps; (st); st = st->next) {
+			n++;
+			if (st->type == STEP_LABEL) name = st->label;
+			if (st == bad) { idx = n; break; }
+		}
+		if (name)
+			snprintf(buf, sizeof(buf), "no reply in state %s (expecting \"%.40s\")",
+				 name, (bad->text ? (char *)bad->text : ""));
+		else
+			snprintf(buf, sizeof(buf), "no reply to step %d (expecting \"%.40s\")",
+				 idx, (bad->text ? (char *)bad->text : ""));
 		return buf;
 	}
 
-	for (st = test->svcinfo->steps; (st); st = st->next) { n++; if (st == bad) idx = n; }
-	if (bad->type == STEP_EXPECT)
-		snprintf(buf, sizeof(buf), "step %d expected \"%.40s\"", idx,
-			 (bad->text ? (char *)bad->text : ""));
-	else
-		snprintf(buf, sizeof(buf), "step %d failed", idx);
+	/*
+	 * Prefer the state's name. "step 7" is accurate and tells an operator
+	 * nothing; "state want-password" is what they need to read. Entries
+	 * that name no states still get the number.
+	 */
+	for (st = test->svcinfo->steps; (st); st = st->next) {
+		n++;
+		if (st->type == STEP_LABEL) name = st->label;
+		if (st == bad) { idx = n; break; }
+	}
+
+	if (bad->type == STEP_EXPECT) {
+		if (name)
+			snprintf(buf, sizeof(buf), "state %s expected \"%.40s\"", name,
+				 (bad->text ? (char *)bad->text : ""));
+		else
+			snprintf(buf, sizeof(buf), "step %d expected \"%.40s\"", idx,
+				 (bad->text ? (char *)bad->text : ""));
+	}
+	else if (name) snprintf(buf, sizeof(buf), "state %s failed", name);
+	else           snprintf(buf, sizeof(buf), "step %d failed", idx);
 
 	return buf;
 }

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -1225,6 +1225,12 @@ static svcstep_t *dlg_run_instant(tcptest_t *item, svcstep_t *st)
 			st = st->next;
 			break;
 
+		  case STEP_CREDS:
+			dlg_set(item, "username", st->user);
+			dlg_set(item, "password", st->pass);
+			st = st->next;
+			break;
+
 		  case STEP_WHEN: {
 			char *v = dlg_get(item, st->varname);
 

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -82,6 +82,13 @@ typedef void (*f_callback_final)(void *privdata);
 #define CONTEST_EIO        4
 #define CONTEST_ESSL       5
 
+/* A value captured during the dialogue, referenced later as ${name}. */
+typedef struct dlgvar_t {
+	char *name;
+	char *value;
+	struct dlgvar_t *next;
+} dlgvar_t;
+
 /* How much a single expect may accumulate before giving up. A server that
    never sends the terminator must not be able to grow this without limit. */
 #define MAX_DIALOGUE_BYTES (32 * 1024)
@@ -138,6 +145,8 @@ typedef struct tcptest_t {
 	void *failstep;			/* svcstep_t *: WHICH step, for the report */
 	unsigned char *stepbuf;		/* replies for the CURRENT expect step */
 	int stepbuflen;
+	char *lastreply;		/* the reply that satisfied the last expect */
+	void *dlgvars;			/* captured values, a dlgvar_t list */
 
 	/* For testing telnet services */
 	unsigned char *telnetbuf;	/* Buffer for telnet option negotiation */


### PR DESCRIPTION
A linear dialogue cannot see past the greeting in a useful way, and cannot use a value the server sent. This slice adds named states as edge targets, so a state's alternatives each decide where the dialogue goes next; values bound out of a reply and read by a later step; and `credentials NAME`, which names an entry in `etc/credentials.cfg` instead of writing a secret into a world-readable file.

Together these are what make APOP and AUTH expressible — a probe that shows the service *works*, not that it answers.

**Verified.** `dialogue-values.sh` and `dialogue-validation.sh` drive the peer, which recomputes the digest and the base64 itself, so a probe sending a wrong value fails there rather than passing on a string comparison.

---

**Grammar.** The manual page is added once, in #476, in the form the finished grammar takes — [`protocols.cfg(5)`](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/xymonnet/protocols.cfg.5). The slices below it change no documentation, so none of them ships a page describing steps their own code does not have.

**Design.** [A worked example with its state diagram](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/docs/design/protocol-dialogues.md#a-worked-example) · [branching on a value](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/docs/design/protocol-dialogues.md#branching-on-a-value) · [the shape](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/docs/design/protocol-dialogues.md#the-shape) · [why matching is literal, and what was rejected](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/docs/design/protocol-dialogues.md#explorations-that-were-rejected) — in the tree, added by #479, further up the stack.

---
### Stack

**4 of 15** in the dialogue stack: base #461, next #463. The full chain is listed in #457; read bottom-up.


