### PR TITLE
xymonnet: starttls as a dialogue step, and a per-step time budget

### DIFF
--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -404,7 +404,8 @@ static void emit_step(svclist_t *first, svcstep_t *tmpl)
 	for (walk = first; (walk); walk = walk->next) {
 		svcstep_t *st = add_svcstep(walk->rec, tmpl->type, tmpl->text, tmpl->len);
 
-		st->action = tmpl->action;
+		st->action  = tmpl->action;
+		st->seconds = tmpl->seconds;
 		if (tmpl->target)  st->target  = strdup(tmpl->target);
 		if (tmpl->label)   st->label   = strdup(tmpl->label);
 		if (tmpl->varname) st->varname = strdup(tmpl->varname);
@@ -876,6 +877,32 @@ char *init_tcp_services(void)
 					}
 				}
 				if (txt) xfree(txt);
+			}
+		}
+		else if (strncmp(l, "timeout ", 8) == 0) {
+			/*
+			 * How long the wait that follows may take. Without one, a
+			 * step that never matches is bounded only by --timeout, which
+			 * ends the whole test and cannot say which step stalled.
+			 *
+			 * The budget covers the write as well as the read: a peer that
+			 * will not accept the send is as stuck as one that will not
+			 * answer it, and the global ceiling still wins either way.
+			 */
+			char *arg = skipwhitespace(l + 8);
+			int secs = atoi(arg);
+
+			if (secs <= 0) {
+				errprintf("Service %s: 'timeout %s' - the budget must be a positive number of seconds\n",
+					  (first ? first->rec->svcname : "?"), arg);
+			}
+			else if (first) {
+				svcstep_t tmpl;
+
+				memset(&tmpl, 0, sizeof(tmpl));
+				tmpl.type = STEP_TIMEOUT;
+				tmpl.seconds = secs;
+				emit_step(first, &tmpl);
 			}
 		}
 		else if (strcmp(l, "starttls") == 0) {

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -878,6 +878,21 @@ char *init_tcp_services(void)
 				if (txt) xfree(txt);
 			}
 		}
+		else if (strcmp(l, "starttls") == 0) {
+			/*
+			 * Explicit TLS. Everything before this line is plaintext,
+			 * everything after it is encrypted on the same socket. The
+			 * service does NOT carry TCP_SSL -- that flag means TLS from
+			 * the first byte, which is the other thing entirely.
+			 */
+			if (first) {
+				svcstep_t tmpl;
+
+				memset(&tmpl, 0, sizeof(tmpl));
+				tmpl.type = STEP_STARTTLS;
+				emit_step(first, &tmpl);
+			}
+		}
 		else if (strncmp(l, "options ", 8) == 0) {
 			if (first) {
 				char *opt;
@@ -971,6 +986,20 @@ char *init_tcp_services(void)
 			check_undefined_vars(&svcinfo[i]);
 			mark_ambiguous_groups(&svcinfo[i]);
 
+			/*
+			 * "options ssl" is TLS from the first byte; "starttls" upgrades
+			 * a plaintext connection part-way. Asking for both would start a
+			 * second handshake inside the first, which fails in a way that
+			 * reads like a broken server rather than a broken config.
+			 */
+			if (svcinfo[i].flags & TCP_SSL) {
+				for (st = walk->rec->steps; (st); st = st->next) {
+					if (st->type != STEP_STARTTLS) continue;
+					errprintf("Service %s: 'starttls' with 'options ssl' - the connection "
+						  "is already TLS; drop one of them\n", svcinfo[i].svcname);
+					break;
+				}
+			}
 		}
 	}
 	memset(&svcinfo[svccount], 0, sizeof(svcinfo_t));

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -35,6 +35,7 @@
 #define STEP_WHEN    5	/* branch on a captured value */
 #define STEP_JUMP    6	/* unconditional; emitted to skip an else-arm */
 #define STEP_CREDS   7	/* bind ${username}/${password} from the store */
+#define STEP_STARTTLS 8	/* upgrade this connection to TLS, here */
 
 /* STEP_LABEL, STEP_CAPTURE, STEP_WHEN, STEP_JUMP and STEP_CREDS touch no
    socket. The driver runs them to completion between I/O steps, so a

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -36,13 +36,14 @@
 #define STEP_JUMP    6	/* unconditional; emitted to skip an else-arm */
 #define STEP_CREDS   7	/* bind ${username}/${password} from the store */
 #define STEP_STARTTLS 8	/* upgrade this connection to TLS, here */
+#define STEP_TIMEOUT 9	/* budget for the wait that follows */
 
 /* STEP_LABEL, STEP_CAPTURE, STEP_WHEN, STEP_JUMP and STEP_CREDS touch no
    socket. The driver runs them to completion between I/O steps, so a
    dialogue never sits in a state that has nothing to wait for. */
 #define STEP_IS_INSTANT(t) \
 	(((t) == STEP_LABEL) || ((t) == STEP_CAPTURE) || ((t) == STEP_WHEN) || \
-	 ((t) == STEP_JUMP) || ((t) == STEP_CREDS))
+	 ((t) == STEP_JUMP) || ((t) == STEP_CREDS) || ((t) == STEP_TIMEOUT))
 
 /* What an expect does once its pattern matches. Anything other than
    ACT_NEXT is an edge that leaves the straight line, which is what makes
@@ -68,6 +69,7 @@ typedef struct svcstep_t {
 	char *user, *pass;		/* STEP_CREDS: resolved at config load */
 	unsigned char *until;		/* expect ... until "X": end-of-reply marker */
 	int untillen;
+	int seconds;			/* STEP_TIMEOUT: budget for the following wait */
 	int ambiguous;			/* this alternation group has overlapping patterns */
 	int maxaltlen;			/* ... and the longest pattern in it */
 	struct svcstep_t *next;

--- a/tests/lib/dialogue-peer.c
+++ b/tests/lib/dialogue-peer.c
@@ -18,6 +18,7 @@
  *   recv PREFIX      read one line; record it, and record MISMATCH if it
  *                    does not begin with PREFIX
  *   recvany          read one line and record it
+ *   hold N           stay connected and silent for N seconds
  *   replyall TEXT    answer TEXT to every further line, until EOF. Models a
  *                    server that greets and then refuses everything.
  *   starttls         upgrade to TLS here (needs CERT and KEY)
@@ -253,6 +254,19 @@ int main(int argc, char *argv[])
 			fprintf(obs, "got %s\n", got);
 			if (strcmp(got, want) != 0) fprintf(obs, "MISMATCH want=%s got=%s\n", want, got);
 			else fprintf(obs, "b64-ok\n");
+		}
+		else if (strcmp(cmd, "hold") == 0) {
+			/*
+			 * Stay connected and say nothing. A script that simply ends
+			 * closes the socket, which the probe sees as EOF -- so without
+			 * this there is no way to test a step that runs out of time
+			 * rather than one that is refused.
+			 */
+			int secs = atoi(arg);
+
+			fprintf(obs, "holding %d\n", (secs > 0) ? secs : 1);
+			fflush(obs);
+			sleep((secs > 0) ? secs : 1);
 		}
 		else if (strcmp(cmd, "hangup") == 0) break;
 	}

--- a/tests/network/dialogue-timeout.sh
+++ b/tests/network/dialogue-timeout.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# A step that runs out of time must say WHICH step, must not spend the
+# whole test budget doing it, and must stay silent when the service is fine.
+#
+# Without a per-step budget the only clock is --timeout, which ends the
+# entire test and reports a bare connect timeout. A conversation that was
+# nine tenths finished is then indistinguishable from a host that never
+# answered, and the operator has nothing to act on.
+#
+# Three things are checked, and the second is the one that stops this test
+# being satisfied by a timer that simply fires all the time:
+#
+#   [budgeted]  a peer that greets, takes the command, then holds the
+#               connection open saying nothing -- the budget must end it
+#   [healthy]   the same budget against a peer that answers promptly -- the
+#               budget must NOT fire, so a working service is unaffected
+#   [ceiling]   a budget far larger than --timeout -- the global cutoff must
+#               still win, since per-step budgets may never sum past it
+#
+# The peers hold rather than hang up: EOF is a different code path and a
+# different verdict, and would pass this test for the wrong reason.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+cc -o "$work/peer" "$root/tests/lib/dialogue-peer.c" $(pkg-config --cflags --libs openssl 2>/dev/null || echo -lssl -lcrypto) ||
+	skip "cannot build the dialogue peer"
+
+start_peer() {	# script obs portfile -> echoes the port
+	"$work/peer" "$1" "$2" > "$3" &
+	echo $! > "$3.pid"
+	i=0
+	while [ "$i" -lt 50 ]; do
+		[ -s "$3" ] && break
+		sleep 0.1
+		i=$((i + 1))
+	done
+	cat "$3"
+}
+
+# Greets, accepts one line, then goes quiet while staying connected.
+printf 'send 220 ready\r\n\nrecvany\nhold 30\n' > "$work/silent.script"
+# Greets, accepts one line, answers it, then quits cleanly.
+printf 'send 220 ready\r\n\nrecvany\nsend 250 ok\r\n\nhold 30\n' > "$work/quick.script"
+
+psilent=$(start_peer "$work/silent.script" "$work/silent.obs" "$work/silent.port")
+pquick=$(start_peer  "$work/quick.script"  "$work/quick.obs"  "$work/quick.port")
+pceil=$(start_peer   "$work/silent.script" "$work/ceil.obs"   "$work/ceil.port")
+register_cleanup "kill $(cat "$work/silent.port.pid") $(cat "$work/quick.port.pid") $(cat "$work/ceil.port.pid") 2>/dev/null || :"
+[ -n "$psilent" ] && [ -n "$pquick" ] && [ -n "$pceil" ] || fail "a peer never named its port"
+
+printf '127.0.0.1\tsilent\t# budgeted healthy\n' > "$work/home/etc/hosts.cfg"
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[budgeted]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   state waiting
+   timeout 2
+   expect "250"
+   options banner
+   port $psilent
+
+[healthy]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   state waiting
+   timeout 2
+   expect "250"
+   options banner
+   port $pquick
+CFG
+
+start=$(date +%s)
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse --dns=ip \
+	--timeout=25 --debug > "$work/out.txt" 2>&1 || :
+elapsed=$(( $(date +%s) - start ))
+
+grep -qi 'timed out after 2s' "$work/out.txt" || fail \
+	"the step budget did not report itself. Expected a message naming the
+state and the budget; got:
+$(grep -iE 'budgeted|timed' "$work/out.txt" | head -20)"
+
+grep -qi 'state waiting' "$work/out.txt" || fail \
+	"the timeout did not name the state it expired in, so the report cannot
+say which part of the conversation stalled:
+$(grep -i 'timed out' "$work/out.txt" | head -5)"
+
+# THE CONTROL. A timer that fires regardless would satisfy everything above.
+grep -q 'Service healthy on silent is OK' "$work/out.txt" || fail \
+	"a service that answered within its budget was still reported down, so the
+budget is firing on healthy conversations:
+$(grep -i 'healthy' "$work/out.txt" | head -10)"
+
+# 2s budget under a 25s ceiling: near 25 means the budget was ignored.
+[ "$elapsed" -lt 15 ] || fail \
+	"the run took ${elapsed}s with a 2 second step budget and a 25 second
+ceiling, so the budget is not what ended it -- the global cutoff is."
+
+# --- the global ceiling still wins -----------------------------------------
+#
+# A budget larger than --timeout must not extend the test. Asserted
+# separately because it needs a different ceiling on the command line.
+
+printf '127.0.0.1\tsilent\t# ceiling\n' > "$work/home/etc/hosts.cfg"
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[ceiling]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   state waiting
+   timeout 60
+   expect "250"
+   options banner
+   port $pceil
+CFG
+
+start=$(date +%s)
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse --dns=ip \
+	--timeout=4 --debug > "$work/ceil.txt" 2>&1 || :
+ceilelapsed=$(( $(date +%s) - start ))
+
+[ "$ceilelapsed" -lt 20 ] || fail \
+	"a 60 second step budget outlived the 4 second --timeout: the run took
+${ceilelapsed}s. Per-state budgets may never sum past the global ceiling."
+
+grep -q 'Service ceiling on silent is not OK' "$work/ceil.txt" || fail \
+	"the service was not reported down when the global cutoff ended it:
+$(grep -i 'ceiling' "$work/ceil.txt" | head -10)"
+
+pass "a step budget ends its own state (${elapsed}s), leaves a healthy service alone, and never outlives --timeout (${ceilelapsed}s)"

--- a/tests/network/dialogue-tls.sh
+++ b/tests/network/dialogue-tls.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# A dialogue over TLS, both ways round.
+#
+# [dlgtls] is TLS from the first byte, the "options ssl" case. It is here
+# because it broke completely and silently during development: socket_read
+# returns a NEGATIVE value with sslagain set when SSL_read wants more data,
+# the driver read that as the peer hanging up, and every TLS dialogue
+# failed the instant it waited for a greeting. Plain TCP was unaffected
+# throughout, and the source-level tests stayed green, so nothing noticed.
+#
+# [msatls] is explicit TLS: plaintext until the upgrade, encrypted after
+# it, same socket. That is submission (587), IMAP (143) and POP3 (110) --
+# none of which could be tested at all before, since "options ssl" means
+# TLS from the first byte and there was no way to say "start it here".
+#
+# The peer records the handshake and each line it receives, so the test can
+# check that the second EHLO arrived AFTER the upgrade rather than merely
+# that the probe reported success.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+command -v openssl >/dev/null 2>&1 || skip "openssl is needed to make a test certificate"
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+openssl req -x509 -newkey rsa:2048 -keyout "$work/k.pem" -out "$work/c.pem" \
+	-days 2 -nodes -subj "/CN=127.0.0.1" >"$work/ssl.log" 2>&1 \
+	|| skip "openssl could not generate a test certificate"
+
+"$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile against libssl"; }
+
+# TLS from the first byte.
+cat > "$work/imp.script" <<'EOS'
+starttls
+send "220 test.local ESMTP\r\n"
+recv ehlo
+send "250-test.local\r\n250 CHUNKING\r\n"
+recv quit
+send "221 bye\r\n"
+EOS
+
+# Plaintext, then an upgrade part-way.
+cat > "$work/exp.script" <<'EOS'
+send "220 test.local ESMTP\r\n"
+recv ehlo
+send "250-test.local\r\n250 STARTTLS\r\n"
+recv starttls
+send "220 2.0.0 Ready to start TLS\r\n"
+starttls
+recv ehlo
+send "250 OK\r\n"
+recv quit
+send "221 bye\r\n"
+EOS
+
+: > "$work/pids"
+start() {
+	"$work/peer" "$1" "$3" "$work/c.pem" "$work/k.pem" > "$2" &
+	echo $! >> "$work/pids"
+	local i=0
+	while [ "$i" -lt 50 ]; do [ -s "$2" ] && break; sleep 0.1; i=$((i + 1)); done
+	cat "$2"
+}
+pi=$(start "$work/imp.script" "$work/pi" "$work/oi")
+pe=$(start "$work/exp.script" "$work/pe" "$work/oe")
+register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
+[ -n "$pi" ] && [ -n "$pe" ] || fail "a peer never named its port"
+
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[dlgtls]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250" until "250 "
+   send "quit\r\n"
+   options ssl,banner
+   port $pi
+
+[msatls]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250" until "250 "
+   send "starttls\r\n"
+   expect "220"
+   starttls
+   send "ehlo xymonnet\r\n"
+   expect "250"
+   send "quit\r\n"
+   options banner
+   port $pe
+CFG
+printf '127.0.0.1\timplicit\t# dlgtls\n127.0.0.1\texplicit\t# msatls\n' > "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse \
+	--dns=ip --timeout=20 >"$work/out.txt" 2>&1 || :
+sleep 1
+
+# --- TLS from the first byte -------------------------------------------------
+grep -q '^tls-ok' "$work/oi" || fail "the implicit-TLS peer never completed a handshake"
+grep -q '^got ehlo' "$work/oi" || fail \
+	"over TLS the dialogue never sent its EHLO. A read that returns 'not yet'
+is being taken for end-of-file, so the dialogue gives up while waiting for
+the greeting -- plain TCP would not show this:
+$(cat "$work/oi")"
+grep -q 'Service dlgtls on implicit is OK' "$work/out.txt" || fail \
+	"the TLS dialogue did not report the service up:
+$(cat "$work/out.txt")"
+
+# --- explicit TLS ------------------------------------------------------------
+grep -q '^tls-ok' "$work/oe" || fail \
+	"the upgrade never happened: $(cat "$work/oe")"
+[ "$(grep -c '^got ehlo' "$work/oe")" -eq 2 ] || fail \
+	"expected an EHLO before the upgrade and another after it:
+$(cat "$work/oe")"
+# The second EHLO must land after the handshake, not before it.
+awk '/^tls-ok/{seen=1} /^got ehlo/{if (seen) found=1} END{exit !found}' "$work/oe" || fail \
+	"no EHLO arrived after the handshake, so nothing was actually sent over
+the upgraded connection:
+$(cat "$work/oe")"
+grep -q '^got quit' "$work/oe" || fail "the upgraded session never reached QUIT"
+grep -q 'Service msatls on explicit is OK' "$work/out.txt" || fail \
+	"the starttls dialogue did not report the service up:
+$(cat "$work/out.txt")"
+
+pass "a dialogue runs over TLS from the first byte, and over a connection upgraded part-way"

--- a/tests/network/dialogue-validation.sh
+++ b/tests/network/dialogue-validation.sh
@@ -40,7 +40,8 @@ cat > "$work/home/etc/protocols.cfg" <<'CFG'
    capture as tooearly
    expect "220"
    send "x${sha1:foo}\r\n"
-   options banner
+   starttls
+   options ssl,banner
    port 9
 
 [typo]
@@ -74,6 +75,10 @@ grep -qi 'unknown expansion' <<<"$out" || fail \
 variable of that name and expands to nothing:
 $out"
 
+grep -qi 'already TLS' <<<"$out" || fail \
+	"'starttls' together with 'options ssl' was accepted. That runs a second
+handshake inside the first:
+$out"
 
 grep -q 'never captured or bound' <<<"$out" || fail \
 	"a \${name} that nothing binds was accepted. It expands to nothing, the
@@ -95,9 +100,9 @@ $out"
 # --- and the shipped file must be quiet -------------------------------------
 cp "$root/xymonnet/protocols.cfg" "$work/home/etc/protocols.cfg"
 out=$(run_xymonnet)
-noise=$(grep -ciE 'unknown protocols.cfg directive|before any expect|unknown expansion|never captured or bound|can only fail|no capture group' <<<"$out" || true)
+noise=$(grep -ciE 'unknown protocols.cfg directive|before any expect|unknown expansion|already TLS|never captured or bound|can only fail|no capture group' <<<"$out" || true)
 [ "$noise" -eq 0 ] || fail \
 	"the protocols.cfg this tree ships triggers $noise of its own warnings:
-$(grep -iE 'unknown|before any expect' <<<"$out")"
+$(grep -iE 'unknown|before any expect|already TLS' <<<"$out")"
 
 pass "protocols.cfg mistakes are reported when the file is read, and the shipped file reports none"

--- a/tests/network/dialogue-validation.sh
+++ b/tests/network/dialogue-validation.sh
@@ -40,6 +40,7 @@ cat > "$work/home/etc/protocols.cfg" <<'CFG'
    capture as tooearly
    expect "220"
    send "x${sha1:foo}\r\n"
+   timeout 0
    starttls
    options ssl,banner
    port 9
@@ -68,6 +69,11 @@ $out"
 grep -qi 'before any expect' <<<"$out" || fail \
 	"'capture as' with no preceding expect was accepted; it can only bind an
 empty value:
+$out"
+
+grep -qi 'the budget must be a positive number of seconds' <<<"$out" || fail \
+	"'timeout 0' was accepted. A zero or negative budget can only expire
+immediately or never, and both are silent at run time:
 $out"
 
 grep -qi 'unknown expansion' <<<"$out" || fail \

--- a/tests/network/protocol-dialogue.sh
+++ b/tests/network/protocol-dialogue.sh
@@ -83,5 +83,14 @@ reported OK -- which is exactly the 421 bug this feature exists to catch"
 printf '%s\n' "$n" | grep -q '!item->curstep' ||
 	fail "no close guard mentions curstep -- the connection is torn down mid-dialogue"
 
+# starttls upgrades a live connection, so reading must follow the SESSION
+# and not the service definition -- keying it off TCP_SSL hands back raw
+# TLS records once a plaintext connection has been upgraded.
+printf '%s\n' "$n" | grep -q 'STEP_STARTTLS' ||
+	fail "no starttls step in the driver"
+readfn=$(printf '%s\n' "$n" | awk '/^static int socket_read\(tcptest_t \*item, char \*inbuf/{c=1} c{print} c&&/^}/{exit}')
+printf '%s\n' "$readfn" | grep -qE 'if \(item->sslrunning\)' ||
+	fail "socket_read() does not dispatch on the live session: an upgraded
+connection would keep calling read() and return ciphertext as the reply"
 
 pass "an unfinished dialogue cannot report OK (both dialogfail and curstep are checked)"

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -909,8 +909,15 @@ static int socket_read(tcptest_t *item, char *inbuf, int inbufsize)
 	int res = 0;
 	char errtxt[1024];
 
-	if (item->svcinfo->flags & TCP_SSL) {
-		if (item->sslrunning) {
+	/*
+	 * Dispatch on the LIVE session, not on the service definition.
+	 * socket_write() already does. Keying the read off TCP_SSL means a
+	 * connection that became TLS part-way -- starttls -- keeps calling
+	 * read() and hands back raw TLS records as if they were the server's
+	 * reply.
+	 */
+	if (item->sslrunning) {
+		{
 			item->sslagain = 0;
 			res = SSL_read(item->ssldata, inbuf, inbufsize);
 			if (res < 0) {
@@ -926,10 +933,10 @@ static int socket_read(tcptest_t *item, char *inbuf, int inbufsize)
 				}
 			}
 		}
-		else {
-			/* SSL setup failed - flag 0 bytes read. */
-			res = 0;
-		}
+	}
+	else if (item->svcinfo->flags & TCP_SSL) {
+		/* SSL was wanted but setup failed - flag 0 bytes read. */
+		res = 0;
 	}
 	else {
 		res = read(item->fd, inbuf, inbufsize);
@@ -1660,6 +1667,50 @@ restartselect:
 							st = dlg_run_instant(item, (svcstep_t *)item->curstep);
 							item->curstep = (void *)st;
 
+							if (st && (st->type == STEP_STARTTLS)) {
+								if (item->sslrunning == 0) {
+									/*
+									 * The handshake must start on the first byte
+									 * the server sends AFTER its go-ahead. Anything
+									 * still buffered was sent before TLS began and
+									 * would be read as ciphertext -- and a server
+									 * that pipelines into its own STARTTLS reply is
+									 * the plaintext-injection flaw (CVE-2011-0411
+									 * and relatives), so refuse rather than paper
+									 * over it.
+									 */
+									if (item->stepbuflen > 0) {
+										errprintf("%s: data buffered across a starttls - refusing the upgrade\n",
+											  item->svcinfo->svcname);
+										item->dialogfail = 1;
+										if (!item->failstep) item->failstep = (void *)st;
+										item->curstep = NULL;
+										st = NULL;
+									}
+									else {
+										item->sslrunning = SSLSETUP_PENDING;
+										setup_ssl(item);
+									}
+								}
+								/*
+								 * setup_ssl() wants another pass whenever it
+								 * leaves sslrunning at SSLSETUP_PENDING. It
+								 * records the direction OpenSSL asked for in
+								 * sslwantwrite, and the fd registration reads
+								 * that while a handshake is pending -- so this
+								 * sleeps on the right event instead of
+								 * re-asking a socket that is always writable.
+								 */
+								if (st && (item->sslrunning == SSLSETUP_PENDING)) setup_ssl(item);
+
+								if (st && (item->sslrunning == 1)) {
+									st = dlg_run_instant(item, st->next);
+									item->curstep = (void *)st;
+								}
+								else if (st) {
+									st = NULL;	/* mid-handshake; registration picks the fd set */
+								}
+							}
 
 							while (st && (st->type == STEP_SEND) && item->silenttest) {
 								/*
@@ -1810,6 +1861,23 @@ restartselect:
 							 * write arm picks it up on the next pass exactly as
 							 * it did when the handshake completed there.
 							 */
+							continue;
+						}
+
+						/*
+						 * A dialogue that asked for STARTTLS parks on the step
+						 * while the handshake runs. It is finished now, so step
+						 * past it and hand the socket back to the write arm --
+						 * there is no application data to read yet, and waiting
+						 * for some would stall until the timeout.
+						 */
+						if ((item->svcinfo->flags & TCP_DIALOGUE) && item->curstep &&
+						    (((svcstep_t *)item->curstep)->type == STEP_STARTTLS) &&
+						    (item->sslrunning == 1)) {
+							svcstep_t *nx = dlg_run_instant(item, ((svcstep_t *)item->curstep)->next);
+
+							item->curstep = (void *)nx;
+							item->readpending = (nx && (nx->type == STEP_EXPECT));
 							continue;
 						}
 

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -226,6 +226,10 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 			    ? (void *)newtest->svcinfo->steps : NULL);
 	newtest->dialogfail = 0;
 	newtest->failstep = NULL;
+	newtest->stepsecs = 0;
+	newtest->stepdeadline = 0;
+	newtest->stepdeadlinefor = NULL;
+	newtest->steptimedout = 0;
 	newtest->stepbuf = NULL;
 	newtest->stepbuflen = 0;
 
@@ -1038,6 +1042,13 @@ static void dlg_free(tcptest_t *item)
 	if (item->stepbuf) { xfree(item->stepbuf); item->stepbuf = NULL; }
 	item->stepbuflen = 0;
 	if (item->lastreply) { xfree(item->lastreply); item->lastreply = NULL; }
+	/*
+	 * Only the arming is cleared here. stepsecs and steptimedout are part
+	 * of the verdict -- dlg_free() runs after the poll loop and before the
+	 * results are reported, so zeroing them here erased the reason a step
+	 * failed and the report fell back to a generic mismatch.
+	 */
+	item->stepdeadline = 0; item->stepdeadlinefor = NULL;
 }
 
 
@@ -1224,6 +1235,18 @@ static svcstep_t *dlg_run_instant(tcptest_t *item, svcstep_t *st)
 
 		switch (st->type) {
 		  case STEP_LABEL:
+			st = st->next;
+			break;
+
+		  case STEP_TIMEOUT:
+			/*
+			 * Sets the budget for the wait that follows and re-arms it,
+			 * so a jump back into a state gets a fresh clock rather than
+			 * inheriting whatever was left of the previous visit.
+			 */
+			item->stepsecs = st->seconds;
+			item->stepdeadline = 0;
+			item->stepdeadlinefor = NULL;
 			st = st->next;
 			break;
 
@@ -1567,6 +1590,46 @@ restartselect:
 		/* Now find out which connections had something happen to them */
 		for (item=firstactive; (item != nextinqueue); item=item->next) {
 			if (item->fd > -1) {		/* Only active sockets have this */
+				/*
+				 * A per-step budget from "timeout N". Armed here, against
+				 * the same clock the comparison below uses: arming it from
+				 * gettimer() while comparing against getntimer()'s reading
+				 * mixes a monotonic source with a wall-clock one, and the
+				 * deadline fires almost immediately.
+				 *
+				 * Keyed on the step it belongs to, so advancing to the next
+				 * step re-arms it without every advance having to remember.
+				 */
+				if ((item->stepsecs > 0) && item->curstep &&
+				    (item->stepdeadlinefor != item->curstep)) {
+					item->stepdeadline = timestamp.tv_sec + item->stepsecs;
+					item->stepdeadlinefor = item->curstep;
+				}
+
+				if (item->stepdeadline && (timestamp.tv_sec > item->stepdeadline)) {
+					/*
+					 * This step ran out of time. Distinct from the cutoff
+					 * below, which ends the whole test and cannot say where
+					 * it stopped: here the step is known, so the report can
+					 * name it. The connection was established, so this is a
+					 * dialogue failure and not a connect timeout.
+					 */
+					item->steptimedout = 1;
+					item->dialogfail = 1;
+					if (!item->failstep) item->failstep = item->curstep;
+					item->curstep = NULL;
+					item->stepdeadline = 0;
+
+					socket_shutdown(item);
+					get_totaltime(item, &timestamp);
+					close(item->fd);
+					item->fd = -1;
+					activesockets--;
+					pending--;
+					if (item == firstactive) firstactive = item->next;
+					continue;
+				}
+
 				if (timestamp.tv_sec > item->cutoff) {
 					/* 
 					 * Request timed out.
@@ -2233,6 +2296,23 @@ char *tcp_dialogue_failure(tcptest_t *test)
 	if (!test || !test->svcinfo || !(test->svcinfo->flags & TCP_DIALOGUE)) return NULL;
 
 	bad = (svcstep_t *)test->failstep;
+
+	if (bad && test->steptimedout) {
+		/* Name the state if there is one: "step 7" is not actionable. */
+		for (st = test->svcinfo->steps; (st); st = st->next) {
+			n++;
+			if (st->type == STEP_LABEL) name = st->label;
+			if (st == bad) { idx = n; break; }
+		}
+		if (name)
+			snprintf(buf, sizeof(buf), "state %s timed out after %ds (expecting \"%.30s\")",
+				 name, test->stepsecs, (bad->text ? (char *)bad->text : ""));
+		else
+			snprintf(buf, sizeof(buf), "step %d timed out after %ds (expecting \"%.30s\")",
+				 idx, test->stepsecs, (bad->text ? (char *)bad->text : ""));
+		return buf;
+	}
+
 	if (!bad) {
 		/* No step blamed itself: the conversation simply stopped short. */
 		st = (svcstep_t *)test->curstep;

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -147,6 +147,10 @@ typedef struct tcptest_t {
 	int stepbuflen;
 	char *lastreply;		/* the reply that satisfied the last expect */
 	void *dlgvars;			/* captured values, a dlgvar_t list */
+	int stepsecs;			/* 'timeout N': budget for the current wait, 0 = none */
+	time_t stepdeadline;		/* ... armed against the poll clock, 0 = unarmed */
+	void *stepdeadlinefor;		/* svcstep_t *: which step it was armed for */
+	int steptimedout;		/* that budget expired, rather than a mismatch */
 
 	/* For testing telnet services */
 	unsigned char *telnetbuf;	/* Buffer for telnet option negotiation */


### PR DESCRIPTION
`options ssl` means TLS from the first byte, which is not what submission (587), IMAP (143) or SMTP (25) do. `starttls` upgrades in place: everything before the step is plaintext, everything after is encrypted, on the same socket. Reading the certificate off the upgraded session — so 587/143/25 reach the `sslcert` column — comes with the assertions in #478; this slice does the handshake.

If the server has sent anything still unread when the upgrade begins, the test fails rather than proceeding — the handshake has to start on the first byte after the go-ahead, and data arriving before it is the STARTTLS plaintext-injection flaw.

Also here: `timeout N` as a per-step budget, armed against the step the dialogue is on and re-armed when it advances, rather than one deadline for the whole test. It becomes `timeout(N) -> TARGET` in #464, where a budget gains an edge like every other condition.

**Verified.** `dialogue-tls.sh`. Four bugs on this branch were invisible on plain TCP and fatal with `options ssl`, so the TLS suites are the ones that matter.

---

**Grammar.** The manual page is added once, in #476, in the form the finished grammar takes — [`protocols.cfg(5)`](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/xymonnet/protocols.cfg.5). The slices below it change no documentation, so none of them ships a page describing steps their own code does not have.

**Design.** [A worked example with its state diagram](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/docs/design/protocol-dialogues.md#a-worked-example), which upgrades on 587 · [the reasoning](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/docs/design/protocol-dialogues.md#the-reasoning-a-manual-has-no-room-for) — in the tree, added by #479, further up the stack.

---
### Stack

**5 of 15** in the dialogue stack: base #462, next #464. The full chain is listed in #457; read bottom-up.



