### PR TITLE
xymonnet: verdicts, refused ambiguity, and the checks a graph can make

### DIFF
--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -899,29 +899,46 @@ char *init_tcp_services(void)
 				if (txt) xfree(txt);
 			}
 		}
-		else if (strncmp(l, "timeout ", 8) == 0) {
+		else if (strncmp(l, "timeout(", 8) == 0) {
 			/*
-			 * How long the wait that follows may take. Without one, a
-			 * step that never matches is bounded only by --timeout, which
-			 * ends the whole test and cannot say which step stalled.
+			 * "timeout(N) -> TARGET": how long this state may take, and
+			 * where to go when it does not. Without one, a state that never
+			 * matches is bounded only by --timeout, which ends the whole
+			 * test and cannot say which state stalled.
 			 *
-			 * The budget covers the write as well as the read: a peer that
-			 * will not accept the send is as stuck as one that will not
-			 * answer it, and the global ceiling still wins either way.
+			 * The budget covers writing the action as well as reading the
+			 * reply: a peer that will not accept the send is as stuck as one
+			 * that will not answer it. --timeout still wins, so per-state
+			 * budgets can never sum past it.
 			 */
-			char *arg = skipwhitespace(l + 8);
-			int secs = atoi(arg);
+			char *close = strchr(l, ')');
+			int secs = atoi(l + 8);
 
-			if (secs <= 0) {
-				errprintf("Service %s: 'timeout %s' - the budget must be a positive number of seconds\n",
-					  (first ? first->rec->svcname : "?"), arg);
+			if (!close) errprintf("Service %s: 'timeout(' with no ')'\n",
+					      (first ? first->rec->svcname : "?"));
+			else if (secs <= 0) {
+				errprintf("Service %s: 'timeout(%d)' - the budget must be a positive "
+					  "number of seconds\n",
+					  (first ? first->rec->svcname : "?"), secs);
 			}
 			else if (first) {
 				svcstep_t tmpl;
+				char *arrow = strstr(close, "->");
 
 				memset(&tmpl, 0, sizeof(tmpl));
 				tmpl.type = STEP_TIMEOUT;
 				tmpl.seconds = secs;
+				tmpl.action = ACT_FAIL;	/* a budget with no target ends the test */
+
+				if (arrow) {
+					char *tgt = strtok(skipwhitespace(arrow + 2), " \t");
+
+					if (!tgt) errprintf("'timeout(%d) ->' with no target\n", secs);
+					else if (strcmp(tgt, "fail") == 0)    tmpl.action = ACT_FAIL;
+					else if (strcmp(tgt, "warning") == 0) tmpl.action = ACT_WARNING;
+					else if (strcmp(tgt, "success") == 0) tmpl.action = ACT_SUCCESS;
+					else { tmpl.target = tgt; tmpl.action = ACT_GOTO; }
+				}
 				emit_step(first, &tmpl);
 			}
 		}

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -304,43 +304,38 @@ static void check_undefined_vars(svcinfo_t *rec)
  * packets. Say so, and record the longest pattern so the driver can wait
  * for the group to be decidable instead of racing.
  */
-static void mark_ambiguous_groups(svcinfo_t *rec)
+static void refuse_overlapping_groups(svcinfo_t *rec)
 {
 	svcstep_t *st;
 
 	for (st = rec->steps; (st); st = st->next) {
 		svcstep_t *a, *b, *last;
-		int maxlen = 0, clash = 0;
 
 		if (st->type != STEP_EXPECT) continue;
 
 		/* the group is this step and the expects immediately after it */
 		for (last = st; (last->next && (last->next->type == STEP_EXPECT)); last = last->next) ;
-		for (a = st; ; a = a->next) {
-			if (a->len > maxlen) maxlen = a->len;
-			if (a == last) break;
-		}
 
 		for (a = st; (a != last); a = a->next) {
 			for (b = a->next; ; b = b->next) {
 				int n = (a->len < b->len) ? a->len : b->len;
 
 				if ((n > 0) && (memcmp(a->text, b->text, n) == 0)) {
-					clash = 1;
+					/*
+					 * An error that only says "these overlap" leaves the
+					 * author stuck, because what they wanted is reasonable.
+					 * Name the fix.
+					 */
 					errprintf("Service %s: 'expect \"%.30s\"' and 'expect \"%.30s\"' overlap - "
-						  "both match the same reply, and which one wins depends on how "
-						  "the server split it\n", rec->svcname, a->text, b->text);
+						  "both match the same reply. Match the shared prefix in one "
+						  "state, then distinguish with 'capture as NAME' and a "
+						  "'NAME ~ ...' edge in the next state\n",
+						  rec->svcname, a->text, b->text);
+					rec->flags |= TCP_DIALOGUE_BROKEN;
 				}
 				if (b == last) break;
 			}
 		}
-
-		if (clash)
-			for (a = st; ; a = a->next) {
-				a->ambiguous = 1;
-				a->maxaltlen = maxlen;
-				if (a == last) break;
-			}
 
 		st = last;	/* skip past the group we just examined */
 	}
@@ -1011,7 +1006,7 @@ char *init_tcp_services(void)
 				svcinfo[i].flags |= TCP_DIALOGUE;
 
 			check_undefined_vars(&svcinfo[i]);
-			mark_ambiguous_groups(&svcinfo[i]);
+			refuse_overlapping_groups(&svcinfo[i]);
 
 			/*
 			 * "options ssl" is TLS from the first byte; "starttls" upgrades

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -395,6 +395,176 @@ static void resolve_svcsteps(svcinfo_t *rec)
 }
 
 
+/*
+ * Three mistakes that are properties of the graph rather than of any one
+ * line, and so cannot be seen a line at a time:
+ *
+ *   - a state nothing can reach: dead config, usually an edge naming the
+ *     wrong existing state, which the "no matching state" check passes
+ *   - a state that waits with no timer: legal, but it can only ever fail
+ *     as an unattributed global timeout, which is the complaint this
+ *     whole feature exists to answer
+ *   - a state with no way to finish: a cycle whose every exit leads back
+ *     into itself, so the dialogue can never end except on the ceiling
+ *
+ * Run after resolve_svcsteps(), which is what turns targets into pointers.
+ */
+static void check_graph(svcinfo_t *rec)
+{
+	svcstep_t *st;
+	int nsteps = 0, nlabels = 0, i, changed;
+	svcstep_t **idx;
+	char *reach, *ends;
+
+	for (st = rec->steps; (st); st = st->next) {
+		nsteps++;
+		if (st->type == STEP_LABEL) nlabels++;
+	}
+	if (nsteps == 0) return;
+
+	/*
+	 * Only entries written as a state machine. A positional dialogue has
+	 * no states to be unreachable and no state boundary for a timer to
+	 * belong to, so every one of these would fire on it and say nothing
+	 * -- and a check that cries wolf on the shipped file gets ignored,
+	 * which costs the real warnings too.
+	 */
+	if (nlabels == 0) return;
+
+	idx   = (svcstep_t **)calloc(nsteps, sizeof(svcstep_t *));
+	reach = (char *)calloc(nsteps, 1);
+	ends  = (char *)calloc(nsteps, 1);
+	if (!idx || !reach || !ends) { if (idx) xfree(idx); if (reach) xfree(reach);
+				       if (ends) xfree(ends); return; }
+
+	for (st = rec->steps, i = 0; (st); st = st->next, i++) idx[i] = st;
+
+	/* Which steps can be entered at all, from wherever the dialogue starts. */
+	for (i = 0; i < nsteps; i++)
+		if (idx[i] == (rec->startstep ? rec->startstep : rec->steps)) reach[i] = 1;
+	do {
+		changed = 0;
+		for (i = 0; i < nsteps; i++) {
+			int j;
+
+			if (!reach[i]) continue;
+			st = idx[i];
+			/*
+			 * A step that always leaves does not fall through to the
+			 * one written after it: an unconditional jump goes to its
+			 * target, and a terminal ends the dialogue. Following
+			 * ->next regardless would make every state reachable and
+			 * the check useless.
+			 */
+			if ((st->type == STEP_JUMP) || (st->action == ACT_FAIL) ||
+			    (st->action == ACT_WARNING) || (st->action == ACT_SUCCESS)) {
+				int j;
+
+				if ((st->action == ACT_GOTO) && st->targetstep)
+					for (j = 0; j < nsteps; j++)
+						if ((idx[j] == st->targetstep) && !reach[j]) { reach[j] = 1; changed = 1; }
+				continue;
+			}
+			/*
+			 * An expect that takes an edge does not continue to whatever
+			 * follows its group -- that step is entered only when some
+			 * alternative matches and simply carries on. The next
+			 * alternative is still reachable, because it is what gets
+			 * tried when this one does not match.
+			 */
+			if ((st->type == STEP_EXPECT) && (st->action == ACT_GOTO)) {
+				int j;
+
+				if (st->targetstep)
+					for (j = 0; j < nsteps; j++)
+						if ((idx[j] == st->targetstep) && !reach[j]) { reach[j] = 1; changed = 1; }
+				if (st->next && (st->next->type == STEP_EXPECT))
+					for (j = 0; j < nsteps; j++)
+						if ((idx[j] == st->next) && !reach[j]) { reach[j] = 1; changed = 1; }
+				continue;
+			}
+			if (st->next)
+				for (j = 0; j < nsteps; j++)
+					if ((idx[j] == st->next) && !reach[j]) { reach[j] = 1; changed = 1; }
+			if ((st->action == ACT_GOTO) && st->targetstep)
+				for (j = 0; j < nsteps; j++)
+					if ((idx[j] == st->targetstep) && !reach[j]) { reach[j] = 1; changed = 1; }
+		}
+	} while (changed);
+
+	for (i = 0; i < nsteps; i++) {
+		if (reach[i] || (idx[i]->type != STEP_LABEL) || !idx[i]->label) continue;
+		errprintf("Service %s: state '%s' cannot be reached - no edge names it "
+			  "and nothing falls into it\n", rec->svcname, idx[i]->label);
+	}
+
+	/*
+	 * A state waits if it has an expect; it is timed if a timeout was set
+	 * anywhere in it. Both reset at the state boundary.
+	 */
+	{
+		char *statename = NULL;
+		int timed = 0, waits = 0, reported = 0;
+
+		for (st = rec->steps; ; st = st->next) {
+			if (!st || (st->type == STEP_LABEL)) {
+				if (waits && !timed && !reported) {
+					if (statename)
+						errprintf("Service %s: state '%s' waits for a reply with no "
+							  "timeout - it can only fail as an unattributed "
+							  "global timeout\n", rec->svcname, statename);
+					else
+						errprintf("Service %s: a state waits for a reply with no "
+							  "timeout - it can only fail as an unattributed "
+							  "global timeout\n", rec->svcname);
+				}
+				if (!st) break;
+				statename = st->label; timed = 0; waits = 0; reported = 0;
+				continue;
+			}
+			if (st->type == STEP_TIMEOUT) timed = 1;
+			if (st->type == STEP_EXPECT)  waits = 1;
+		}
+	}
+
+	/*
+	 * A state with no way out. Asked per state rather than as a global
+	 * reachability question: "can this step reach the end of the list"
+	 * is answered yes by falling through to a state nothing can enter,
+	 * which is exactly the config being complained about.
+	 *
+	 * So: if every edge in a state names that same state, and none of
+	 * them is a terminal, the dialogue can never leave it.
+	 */
+	for (i = 0; i < nsteps; i++) {
+		svcstep_t *own, *scan;
+		int edges = 0, escapes = 0;
+
+		if (!reach[i] || (idx[i]->type != STEP_LABEL) || !idx[i]->label) continue;
+		own = idx[i];
+
+		for (scan = own->next; (scan && (scan->type != STEP_LABEL)); scan = scan->next) {
+			if ((scan->action == ACT_FAIL) || (scan->action == ACT_WARNING) ||
+			    (scan->action == ACT_SUCCESS)) { edges++; escapes++; continue; }
+			if (scan->action == ACT_GOTO) {
+				edges++;
+				if (scan->targetstep != own) escapes++;
+				continue;
+			}
+			/* a step that simply continues is itself a way onward */
+			if ((scan->type == STEP_SEND) || (scan->type == STEP_STARTTLS)) continue;
+			if (scan->type == STEP_EXPECT) { edges++; escapes++; }
+		}
+
+		if (edges && !escapes)
+			errprintf("Service %s: state '%s' has no way to finish - every edge "
+				  "in it leads back to itself\n", rec->svcname, idx[i]->label);
+	}
+
+	xfree(idx); xfree(reach); xfree(ends);
+}
+
+
 typedef struct svclist_t {
 	struct svcinfo_t *rec;
 	struct svclist_t *next;
@@ -1101,7 +1271,8 @@ char *init_tcp_services(void)
 		 * the entry has a 'start' line, so it has to be cleared first.
 		 */
 		svcinfo[i].startstep = NULL;
-		resolve_svcsteps(&svcinfo[i]);	/* sets startstep from startlabel */
+		resolve_svcsteps(&svcinfo[i]);
+		check_graph(&svcinfo[i]);
 		/*
 		 * A dialogue is anything that is not the classic one-shot shape.
 		 * Deciding it here, once, keeps do_tcp_tests() from re-deriving it

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -317,8 +317,9 @@ static void refuse_overlapping_groups(svcinfo_t *rec)
 		for (last = st; (last->next && (last->next->type == STEP_EXPECT)); last = last->next) ;
 
 		for (a = st; (a != last); a = a->next) {
+			if (a->oneof) continue;		/* EOF competes with no byte pattern */
 			for (b = a->next; ; b = b->next) {
-				int n = (a->len < b->len) ? a->len : b->len;
+				int n = (b->oneof) ? 0 : ((a->len < b->len) ? a->len : b->len);
 
 				if ((n > 0) && (memcmp(a->text, b->text, n) == 0)) {
 					/*
@@ -373,9 +374,22 @@ static void resolve_svcsteps(svcinfo_t *rec)
 
 		if (lbl) st->targetstep = lbl;
 		else {
-			errprintf("Service %s: 'goto %s' has no matching state - "
+			errprintf("Service %s: '-> %s' has no matching state - "
 				  "the branch is dropped\n", rec->svcname, st->target);
 			st->action = ACT_NEXT;
+		}
+	}
+
+	if (rec->startlabel) {
+		for (lbl = rec->steps; (lbl); lbl = lbl->next)
+			if ((lbl->type == STEP_LABEL) && lbl->label &&
+			    (strcmp(lbl->label, rec->startlabel) == 0)) break;
+
+		if (lbl) rec->startstep = lbl;
+		else {
+			errprintf("Service %s: 'start %s' has no matching state\n",
+				  rec->svcname, rec->startlabel);
+			rec->flags |= TCP_DIALOGUE_BROKEN;
 		}
 	}
 }
@@ -401,6 +415,7 @@ static void emit_step(svclist_t *first, svcstep_t *tmpl)
 
 		st->action  = tmpl->action;
 		st->seconds = tmpl->seconds;
+		st->oneof   = tmpl->oneof;
 		if (tmpl->target)  st->target  = strdup(tmpl->target);
 		if (tmpl->label)   st->label   = strdup(tmpl->label);
 		if (tmpl->varname) st->varname = strdup(tmpl->varname);
@@ -910,6 +925,74 @@ char *init_tcp_services(void)
 				emit_step(first, &tmpl);
 			}
 		}
+		else if (strncmp(l, "start ", 6) == 0) {
+			/* Where the dialogue begins. Without it, the first step. */
+			char *nm = skipwhitespace(l + 6);
+
+			if (!*nm) errprintf("'start' with no state name\n");
+			else for (walk = first; (walk); walk = walk->next) {
+				if (walk->rec->startlabel) xfree(walk->rec->startlabel);
+				walk->rec->startlabel = strdup(nm);
+			}
+		}
+		else if (strncmp(l, "transport ", 10) == 0) {
+			/*
+			 * Which probe runs this entry. Only tcp is implemented; anything
+			 * else must refuse rather than be silently treated as tcp, or a
+			 * datagram entry would quietly become a stream one.
+			 */
+			char *nm = skipwhitespace(l + 10);
+
+			if (strcmp(nm, "tcp") != 0) {
+				errprintf("Service %s: transport '%s' is not implemented - "
+					  "only 'tcp' is supported\n",
+					  (first ? first->rec->svcname : "?"), nm);
+				for (walk = first; (walk); walk = walk->next)
+					walk->rec->flags |= TCP_DIALOGUE_BROKEN;
+			}
+		}
+		else if (strncmp(l, "always ", 7) == 0) {
+			/* An unconditional edge, for a state with nothing to wait for. */
+			char *rest = skipwhitespace(l + 7);
+
+			if (strncmp(rest, "->", 2) != 0) errprintf("'always' without '->'\n");
+			else if (first) {
+				svcstep_t tmpl;
+				char *tgt = strtok(skipwhitespace(rest + 2), " \t");
+
+				memset(&tmpl, 0, sizeof(tmpl));
+				tmpl.type = STEP_JUMP;
+				if (!tgt) errprintf("'always ->' with no target\n");
+				else { tmpl.target = tgt; tmpl.action = ACT_GOTO; emit_step(first, &tmpl); }
+			}
+		}
+		else if (strncmp(l, "eof ", 4) == 0) {
+			/*
+			 * The peer closing is an outcome, not automatically a fault:
+			 * after QUIT it is the correct one. Carried as an alternative
+			 * that matches EOF instead of bytes, so it sits in the same
+			 * group as the expects it competes with.
+			 */
+			char *rest = skipwhitespace(l + 4);
+
+			if (strncmp(rest, "->", 2) != 0) errprintf("'eof' without '->'\n");
+			else if (first) {
+				svcstep_t tmpl;
+				char *tgt = strtok(skipwhitespace(rest + 2), " \t");
+
+				memset(&tmpl, 0, sizeof(tmpl));
+				tmpl.type = STEP_EXPECT;
+				tmpl.oneof = 1;
+				tmpl.text = (unsigned char *)strdup("");
+				tmpl.len = 0;
+				if (!tgt) errprintf("'eof ->' with no target\n");
+				else if (strcmp(tgt, "fail") == 0)    tmpl.action = ACT_FAIL;
+				else if (strcmp(tgt, "warning") == 0) tmpl.action = ACT_WARNING;
+				else if (strcmp(tgt, "success") == 0) tmpl.action = ACT_SUCCESS;
+				else { tmpl.target = tgt; tmpl.action = ACT_GOTO; }
+				emit_step(first, &tmpl);
+			}
+		}
 		else if (strcmp(l, "starttls") == 0) {
 			/*
 			 * Explicit TLS. Everything before this line is plaintext,
@@ -929,7 +1012,15 @@ char *init_tcp_services(void)
 			if (first) {
 				char *opt;
 
-				first->rec->flags = 0;
+				/*
+				 * options REPLACES the option bits rather than adding to
+				 * them, so a later 'options' line does not inherit an
+				 * earlier one. A refusal is not an option bit and must
+				 * survive: it says the definition is unusable, and an
+				 * 'options' line below it would otherwise clear it and let
+				 * the service report green.
+				 */
+				first->rec->flags &= TCP_DIALOGUE_BROKEN;
 				l = skipwhitespace(l+7);
 				opt = strtok(l, ",");
 				while (opt) {
@@ -985,7 +1076,15 @@ char *init_tcp_services(void)
 		svcinfo[i].port    = walk->rec->port;
 		svcinfo[i].alpns   = walk->rec->alpns;
 		svcinfo[i].steps   = walk->rec->steps;
-		resolve_svcsteps(&svcinfo[i]);
+		svcinfo[i].startlabel = walk->rec->startlabel;
+		/*
+		 * The array is malloc'd, not calloc'd, and every field here is
+		 * assigned by hand -- so a field left out is not NULL, it is
+		 * whatever the heap held. startstep is only set by resolve when
+		 * the entry has a 'start' line, so it has to be cleared first.
+		 */
+		svcinfo[i].startstep = NULL;
+		resolve_svcsteps(&svcinfo[i]);	/* sets startstep from startlabel */
 		/*
 		 * A dialogue is anything that is not the classic one-shot shape.
 		 * Deciding it here, once, keeps do_tcp_tests() from re-deriving it

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -659,18 +659,24 @@ char *init_tcp_services(void)
 					rest = skipwhitespace(after_quoted(tp));
 				}
 
-				/* Anything left after that is this edge's action. */
+				/* Anything left after that is this edge's target. */
 				if (*rest) {
 					act = strtok(rest, " \t");
 					if (act && (strcmp(act, "->") == 0)) {
 						/*
-						 * Every edge is "<condition> -> TARGET". "fail" is
-						 * a reserved target: the dialogue ends there.
+						 * Every edge is "<condition> -> TARGET". Three
+						 * target names are reserved and declare the
+						 * verdict rather than naming a state, so a
+						 * dialogue says how it ended instead of leaving
+						 * the driver to infer it from running out of
+						 * steps.
 						 */
 						char *tgt = strtok(NULL, " \t");
 
 						if (!tgt) errprintf("'expect ... ->' with no target\n");
-						else if (strcmp(tgt, "fail") == 0) tmpl.action = ACT_FAIL;
+						else if (strcmp(tgt, "fail") == 0)    tmpl.action = ACT_FAIL;
+						else if (strcmp(tgt, "warning") == 0) tmpl.action = ACT_WARNING;
+						else if (strcmp(tgt, "success") == 0) tmpl.action = ACT_SUCCESS;
 						else { tmpl.target = tgt; tmpl.action = ACT_GOTO; }
 					}
 					else if (act) errprintf("Unknown expect action: %s - edges are "
@@ -822,7 +828,9 @@ char *init_tcp_services(void)
 				memset(&tmpl, 0, sizeof(tmpl));
 				tmpl.type = STEP_JUMP;
 				if (!tgt) errprintf("'else ->' with no target\n");
-				else if (strcmp(tgt, "fail") == 0) tmpl.action = ACT_FAIL;
+				else if (strcmp(tgt, "fail") == 0)    tmpl.action = ACT_FAIL;
+				else if (strcmp(tgt, "warning") == 0) tmpl.action = ACT_WARNING;
+				else if (strcmp(tgt, "success") == 0) tmpl.action = ACT_SUCCESS;
 				else { tmpl.target = tgt; tmpl.action = ACT_GOTO; }
 				emit_step(first, &tmpl);
 			}
@@ -866,7 +874,9 @@ char *init_tcp_services(void)
 						char *tgt = strtok(skipwhitespace(arrow + 2), " \t");
 
 						if (!tgt) errprintf("'%s ~ ... ->' with no target\n", var);
-						else if (strcmp(tgt, "fail") == 0) tmpl.action = ACT_FAIL;
+						else if (strcmp(tgt, "fail") == 0)    tmpl.action = ACT_FAIL;
+						else if (strcmp(tgt, "warning") == 0) tmpl.action = ACT_WARNING;
+						else if (strcmp(tgt, "success") == 0) tmpl.action = ACT_SUCCESS;
 						else { tmpl.target = tgt; tmpl.action = ACT_GOTO; }
 						emit_step(first, &tmpl);
 					}

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -522,7 +522,7 @@ static void check_graph(svcinfo_t *rec)
 				statename = st->label; timed = 0; waits = 0; reported = 0;
 				continue;
 			}
-			if (st->type == STEP_TIMEOUT) timed = 1;
+			if ((st->type == STEP_TIMEOUT) || (st->type == STEP_IDLE)) timed = 1;
 			if (st->type == STEP_EXPECT)  waits = 1;
 		}
 	}
@@ -1104,6 +1104,47 @@ char *init_tcp_services(void)
 					char *tgt = strtok(skipwhitespace(arrow + 2), " \t");
 
 					if (!tgt) errprintf("'timeout(%d) ->' with no target\n", secs);
+					else if (strcmp(tgt, "fail") == 0)    tmpl.action = ACT_FAIL;
+					else if (strcmp(tgt, "warning") == 0) tmpl.action = ACT_WARNING;
+					else if (strcmp(tgt, "success") == 0) tmpl.action = ACT_SUCCESS;
+					else { tmpl.target = tgt; tmpl.action = ACT_GOTO; }
+				}
+				emit_step(first, &tmpl);
+			}
+		}
+		else if (strncmp(l, "idle(", 5) == 0) {
+			/*
+			 * "idle(N) -> TARGET": how long this state may go with NOTHING
+			 * arriving. Unlike timeout(N) the clock restarts whenever a byte
+			 * does arrive, which is the difference between slow and stopped:
+			 * a large EHLO trickling in over thirty seconds is a working
+			 * server on a poor link, while five seconds of silence in the
+			 * middle of that reply is one that has died. One clock cannot
+			 * tell those apart, and reports the same colour for both.
+			 */
+			char *close = strchr(l, ')');
+			int secs = atoi(l + 5);
+
+			if (!close) errprintf("Service %s: 'idle(' with no ')'\n",
+					      (first ? first->rec->svcname : "?"));
+			else if (secs <= 0) {
+				errprintf("Service %s: 'idle(%d)' - the budget must be a positive "
+					  "number of seconds\n",
+					  (first ? first->rec->svcname : "?"), secs);
+			}
+			else if (first) {
+				svcstep_t tmpl;
+				char *arrow = strstr(close, "->");
+
+				memset(&tmpl, 0, sizeof(tmpl));
+				tmpl.type = STEP_IDLE;
+				tmpl.seconds = secs;
+				tmpl.action = ACT_FAIL;	/* a budget with no target ends the test */
+
+				if (arrow) {
+					char *tgt = strtok(skipwhitespace(arrow + 2), " \t");
+
+					if (!tgt) errprintf("'idle(%d) ->' with no target\n", secs);
 					else if (strcmp(tgt, "fail") == 0)    tmpl.action = ACT_FAIL;
 					else if (strcmp(tgt, "warning") == 0) tmpl.action = ACT_WARNING;
 					else if (strcmp(tgt, "success") == 0) tmpl.action = ACT_SUCCESS;

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -52,6 +52,15 @@
 #define ACT_NEXT 0
 #define ACT_GOTO 1
 #define ACT_FAIL 2
+#define ACT_SUCCESS 3	/* -> success: end the dialogue green */
+#define ACT_WARNING 4	/* -> warning: end it yellow, not red */
+
+/* Reserved edge targets. A dialogue declares its verdict by arriving at
+   one of these rather than by running out of steps. */
+#define TARGET_IS_TERMINAL(s) \
+	(((s) != NULL) && ((strcmp((s), "success") == 0) || \
+	                   (strcmp((s), "warning") == 0) || \
+	                   (strcmp((s), "fail") == 0)))
 
 /* Consecutive STEP_EXPECTs are alternatives of ONE state: the first whose
    pattern matches wins and its action fires, so a state has as many

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -80,6 +80,7 @@ typedef struct svcstep_t {
 	unsigned char *until;		/* expect ... until "X": end-of-reply marker */
 	int untillen;
 	int seconds;			/* STEP_TIMEOUT: budget for the following wait */
+	int oneof;			/* this alternative fires on EOF, not on bytes */
 	struct svcstep_t *next;
 } svcstep_t;
 
@@ -93,6 +94,8 @@ typedef struct svcinfo_t {
 	int port;
 	char *alpns;
 	svcstep_t *steps;	/* NULL unless TCP_DIALOGUE */
+	char *startlabel;	/* 'start NAME': where the dialogue begins */
+	svcstep_t *startstep;	/* ... resolved after parsing */
 } svcinfo_t;
 
 extern char *init_tcp_services(void);

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -24,6 +24,7 @@
    sendtxt plus one exptext: an expect comes first, or there is more than one
    of either. Single-step services keep the old path untouched. */
 #define TCP_DIALOGUE   0x0020
+#define TCP_DIALOGUE_BROKEN 0x0040	/* refused at load: do not report OK */
 
 /* One step of a protocol dialogue, in the order protocols.cfg lists them.
    Kept as a list rather than an array because the parser appends while it
@@ -70,8 +71,6 @@ typedef struct svcstep_t {
 	unsigned char *until;		/* expect ... until "X": end-of-reply marker */
 	int untillen;
 	int seconds;			/* STEP_TIMEOUT: budget for the following wait */
-	int ambiguous;			/* this alternation group has overlapping patterns */
-	int maxaltlen;			/* ... and the longest pattern in it */
 	struct svcstep_t *next;
 } svcstep_t;
 

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -38,13 +38,15 @@
 #define STEP_CREDS   7	/* bind ${username}/${password} from the store */
 #define STEP_STARTTLS 8	/* upgrade this connection to TLS, here */
 #define STEP_TIMEOUT 9	/* budget for the wait that follows */
+#define STEP_IDLE   10	/* ... the same, but restarted whenever data arrives */
 
 /* STEP_LABEL, STEP_CAPTURE, STEP_WHEN, STEP_JUMP and STEP_CREDS touch no
    socket. The driver runs them to completion between I/O steps, so a
    dialogue never sits in a state that has nothing to wait for. */
 #define STEP_IS_INSTANT(t) \
 	(((t) == STEP_LABEL) || ((t) == STEP_CAPTURE) || ((t) == STEP_WHEN) || \
-	 ((t) == STEP_JUMP) || ((t) == STEP_CREDS) || ((t) == STEP_TIMEOUT))
+	 ((t) == STEP_JUMP) || ((t) == STEP_CREDS) || ((t) == STEP_TIMEOUT) || \
+	 ((t) == STEP_IDLE))
 
 /* What an expect does once its pattern matches. Anything other than
    ACT_NEXT is an edge that leaves the straight line, which is what makes

--- a/tests/buildsystem/test-suite-portability.sh
+++ b/tests/buildsystem/test-suite-portability.sh
@@ -180,7 +180,23 @@ check_posix_bre() {
 	done
 }
 
+# A test that sources assert.sh must declare bash. assert.sh uses bash
+# arrays and 'local', so a "#!/bin/sh" test works on any box where /bin/sh
+# is bash and dies on any box where it is dash -- which is CI. Three tests
+# shipped that way and passed every local run before failing there.
+check_shebang() {
+	f=$1; out=$2
+
+	# an actual source line, not a mention: the runner and assert.sh
+	# itself both name the path without sourcing it
+	grep -qE '^[[:space:]]*(\.|source)[[:space:]].*lib/assert\.sh' "$f" || return 0
+	head -1 "$f" | grep -q 'env bash' && return 0
+	printf 'shebang\t%s\t%s\n' "${f#"$ROOT"/}:1" \
+		'sources assert.sh, which needs bash; declare #!/usr/bin/env bash, not #!/bin/sh' >>"$out"
+}
+
 for f in $files; do check_posix_bre "$f" "$work/violations"; done
+for f in $files; do check_shebang "$f" "$work/violations"; done
 
 if [ -s "$work/violations" ]; then
 	printf 'portability rules broken by the test suite:\n\n' >&2
@@ -243,6 +259,21 @@ undeclared="$work/undeclared.sh"
 check_uname_guard "$undeclared" "$work/uname-violations"
 assert_equal "1" "$(wc -l <"$work/uname-violations" | tr -d " ")" \
 	"the uname rule no longer reports a test that guards on uname without declaring its primitive"
+
+# the shebang rule reports a sh-declared test that sources assert.sh, and
+# stays quiet on a bash-declared one
+shb="$work/shb.sh"
+{ printf '#!/bin/sh\n'; printf '. "$(dirname "$0")/../lib/assert.sh"\n'; } >"$shb"
+: >"$work/shb-violations"
+check_shebang "$shb" "$work/shb-violations"
+assert_equal "1" "$(wc -l <"$work/shb-violations" | tr -d " ")" \
+	"the shebang rule no longer reports a #!/bin/sh test that sources assert.sh"
+
+{ printf '#!/usr/bin/env bash\n'; printf '. "$(dirname "$0")/../lib/assert.sh"\n'; } >"$shb"
+: >"$work/shb-violations"
+check_shebang "$shb" "$work/shb-violations"
+assert_equal "0" "$(wc -l <"$work/shb-violations" | tr -d " ")" \
+	"the shebang rule reports a correctly declared test"
 
 declared="$work/declared.sh"
 {

--- a/tests/lib/dialogue-peer.c
+++ b/tests/lib/dialogue-peer.c
@@ -19,6 +19,7 @@
  *                    does not begin with PREFIX
  *   recvany          read one line and record it
  *   hold N           stay connected and silent for N seconds
+ *   dribble TEXT     send TEXT one byte per second
  *   replyall TEXT    answer TEXT to every further line, until EOF. Models a
  *                    server that greets and then refuses everything.
  *   starttls         upgrade to TLS here (needs CERT and KEY)
@@ -254,6 +255,24 @@ int main(int argc, char *argv[])
 			fprintf(obs, "got %s\n", got);
 			if (strcmp(got, want) != 0) fprintf(obs, "MISMATCH want=%s got=%s\n", want, got);
 			else fprintf(obs, "b64-ok\n");
+		}
+		else if (strcmp(cmd, "dribble") == 0) {
+			/*
+			 * Send one byte per second. The connection is never idle and
+			 * the reply takes a long time -- which is what separates a slow
+			 * server from a stopped one, and what an idle timer must not
+			 * mistake for silence.
+			 */
+			char buf[512];
+			int i, len;
+
+			len = unescape(arg, buf, sizeof(buf));
+			fprintf(obs, "dribbling %d bytes\n", len);
+			fflush(obs);
+			for (i = 0; i < len; i++) {
+				io_write(buf + i, 1);
+				sleep(1);
+			}
 		}
 		else if (strcmp(cmd, "hold") == 0) {
 			/*

--- a/tests/network/dialogue-ambiguity.sh
+++ b/tests/network/dialogue-ambiguity.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Two alternatives that overlap must not be decided by the network.
+# Two alternatives that overlap must be refused, not resolved.
 #
 # Consecutive expects are alternatives and the first match wins, but an
 # alternative cannot be decided until enough of the reply has arrived.
@@ -10,13 +10,20 @@
 # in one call or two. Measured, before this was fixed: red for one write,
 # green for two.
 #
-# Both halves are checked here. The overlap is reported when the file is
-# read, because a config whose meaning depends on packet boundaries is
-# worth knowing about; and the verdict is now the same either way, so a
-# config that ignores the warning is at least deterministic.
+# That was first fixed by deferring the decision until every pattern in
+# the group was decidable. This is the stronger fix: the definition is
+# refused when the file is read, so the situation cannot arise. Two
+# patterns can both match one reply exactly when one is a prefix of the
+# other, so the check is complete rather than a guess, and refusing costs
+# nothing a deferral was buying.
 #
-# Two alternatives can both match one reply exactly when one is a prefix
-# of the other, so the parse-time check is complete rather than a guess.
+# The refused service must still report -- and report RED. Dropping it
+# would remove the column from the display, which looks like a service
+# nobody configured rather than one whose definition is wrong.
+#
+# The message is asserted too, not just the refusal. What the author
+# wanted is reasonable, so an error that only says "these overlap" leaves
+# them stuck; it has to name the fix.
 
 set -eu
 . "$(dirname "$0")/../lib/assert.sh"
@@ -82,13 +89,28 @@ comment. Which of them matches depends on how the server split its reply,
 so the config's meaning is decided by the network:
 $out"
 
-v1=$(grep -c 'Service amb1 on onewrite is OK' <<<"$out" || true)
-v2=$(grep -c 'Service amb2 on split is OK' <<<"$out" || true)
-[ "$v1" = "$v2" ] || fail \
-	"the same config against the same bytes gave different verdicts: one write
-was $([ "$v1" = 1 ] && echo up || echo down), split across two writes was
-$([ "$v2" = 1 ] && echo up || echo down). The winner is being decided by
-packet boundaries rather than by the order in protocols.cfg:
+grep -qi "capture as NAME" <<<"$out" || fail \
+	"the overlap was reported without saying what to do about it. What the
+author wanted is reasonable -- distinguishing two replies that share a
+prefix -- so the error has to name the fix, not just the fault:
 $out"
 
-pass "overlapping alternatives are reported, and the verdict no longer depends on how the reply was split"
+# THE POINT. A refused definition must not be able to report OK, however
+# the server behaves, and must not vary with how the reply was split.
+grep -q 'Service amb1 on onewrite is OK' <<<"$out" && fail \
+	"a definition refused when the file was read still reported the service up:
+$out"
+
+grep -q 'Service amb2 on split is OK' <<<"$out" && fail \
+	"a definition refused when the file was read still reported the service up
+when the reply arrived in two writes:
+$out"
+
+# And it must still be reported at all -- refusing is not the same as
+# dropping the test, which would look like a service nobody configured.
+grep -q 'Service amb1 on onewrite is not OK' <<<"$out" || fail \
+	"the refused service produced no status at all. It should report red with
+the reason, not vanish from the display:
+$out"
+
+pass "overlapping alternatives are refused, the error names the fix, and the service reports red either way"

--- a/tests/network/dialogue-buffer-cap.sh
+++ b/tests/network/dialogue-buffer-cap.sh
@@ -9,18 +9,10 @@
 # once, so it is a memory fault on the monitor caused by a remote host.
 # MAX_DIALOGUE_BYTES bounds it; this is the test that the bound is real.
 #
-# The entry sends after its expect, which is what puts it on the dialogue
-# driver: a lone expect is the classic single-shot shape and is bounded by
-# nothing, because it accumulates nothing. The send is never reached -- the
-# reply it waits for never terminates -- it is there to choose the probe.
-#
 # It also has to fail by NAME rather than by running out of time. Both end
 # the test, so a cap that merely stopped reading would look identical from
 # the outside while telling an operator nothing about why -- and would
-# still hold the slot for the whole global timeout. The only clock here is
-# the global --timeout, deliberately set far above the bound: if the cap
-# does not fire, this test fails by taking 90 seconds rather than passing
-# because a timer rescued it.
+# still hold the slot for the whole global timeout.
 #
 # THE CONTROL is [bigreply]: a multi-line reply of about 20 KB that does
 # finish. It is the same shape of traffic, under the cap instead of over
@@ -65,15 +57,24 @@ punder=$(start "$work/under.script" "$work/pu" "$work/ou")
 register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
 [ -n "$pover" ] && [ -n "$punder" ] || fail "a peer never named its port"
 
+# The per-state budget is deliberately long: if the cap does not fire, this
+# test must fail by timing out rather than pass because a timer rescued it.
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [toobig]
-   expect "250" until "250 "
-   send "quit\r\n"
+   state one
+   timeout(60)                       -> fail
+   expect "250" until "250 "         -> success
    port $pover
 
 [bigreply]
-   expect "250" until "250 "
+   state one
+   timeout(60)                       -> fail
+   expect "250" until "250 "         -> quit
+
+   state quit
+   timeout(10)                       -> fail
    send "quit\r\n"
+   eof                               -> success
    port $punder
 CFG
 printf '127.0.0.1\tover\t# toobig\n127.0.0.1\tunder\t# bigreply\n' > "$work/home/etc/hosts.cfg"
@@ -93,7 +94,7 @@ grep -q 'Service toobig on over is not OK' "$work/out.txt" || fail \
 	"the cap fired but the service did not report a failure:
 $(grep -i toobig "$work/out.txt" | head -5)"
 
-# The cap must end it, not the clock. The global budget is far longer than
+# The cap must end it, not the clock. Both budgets here are far longer than
 # this bound, so finishing quickly can only mean the cap decided.
 [ "$elapsed" -lt 45 ] || fail \
 	"the run took ${elapsed}s, so the test was ended by a timer rather than

--- a/tests/network/dialogue-eof.sh
+++ b/tests/network/dialogue-eof.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# The peer closing is an outcome, not automatically a fault.
+#
+# After QUIT a server hanging up is the correct end of the conversation,
+# and until now it was reported the same as a server that dropped the call
+# mid-command. "eof -> TARGET" lets the entry say which it meant.
+#
+# The control is the pair: the same peer and the same conversation, with
+# and without the eof edge. Without it, an eof edge that did nothing would
+# still pass, because the hangup is what ends both runs.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+cc -o "$work/peer" "$root/tests/lib/dialogue-peer.c" $(pkg-config --cflags --libs openssl 2>/dev/null || echo -lssl -lcrypto) ||
+	skip "cannot build the dialogue peer"
+
+start_peer() {
+	"$work/peer" "$1" "$2" > "$3" &
+	echo $! > "$3.pid"
+	i=0
+	while [ "$i" -lt 50 ]; do
+		[ -s "$3" ] && break
+		sleep 0.1
+		i=$((i + 1))
+	done
+	cat "$3"
+}
+
+# greets, takes QUIT, then closes without answering -- as a real server may
+printf 'send 220 ready\r\n\nrecvany\nhangup\n' > "$work/bye.script"
+# One peer per service: each serves a single connection and then exits,
+# so sharing one port between entries makes the run a race.
+p1=$(start_peer "$work/bye.script" "$work/o1" "$work/p1")
+p2=$(start_peer "$work/bye.script" "$work/o2" "$work/p2")
+p3=$(start_peer "$work/bye.script" "$work/o3" "$work/p3")
+register_cleanup "kill $(cat "$work/p1.pid") $(cat "$work/p2.pid") $(cat "$work/p3.pid") 2>/dev/null || :"
+[ -n "$p1" ] && [ -n "$p2" ] && [ -n "$p3" ] || fail "a peer never named its port"
+
+printf '127.0.0.1\thost\t# eofok eofbad\n' > "$work/home/etc/hosts.cfg"
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[eofok]
+   state greeting
+   expect "220"                -> farewell
+   state farewell
+   send "quit\r\n"
+   eof                         -> success
+   expect "221"                -> success
+   options banner
+   port $p1
+
+[eofbad]
+   expect "220"
+   send "quit\r\n"
+   expect "221"                -> success
+   options banner
+   port $p2
+
+CFG
+
+out=$(XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse \
+	--dns=ip --timeout=15 --debug 2>&1 || :)
+echo "$out" > "$work/out.txt"
+
+grep -q 'Service eofok on host is OK' "$work/out.txt" || fail \
+	"the eof edge did not fire, so the conversation that a real server
+completes was reported as a failure:
+$(grep -i eofok "$work/out.txt" | head -10)"
+
+# THE CONTROL. Same peer, same conversation, no eof edge -- must fail.
+# Without this, an eof edge that did nothing would still pass above.
+grep -q 'Service eofbad on host is not OK' "$work/out.txt" || fail \
+	"an entry with no 'eof' edge still passed when the peer hung up, so the
+edge is not what decided the verdict:
+$(grep -i eofbad "$work/out.txt" | head -10)"
+
+pass "the peer closing is an outcome when the entry says so, and a fault when it does not"

--- a/tests/network/dialogue-grammar.sh
+++ b/tests/network/dialogue-grammar.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# start and transport: where an entry begins, and which probe runs it.
+#
+# start proves the dialogue does not have to begin at the first line of
+# the entry -- which is what makes the file order-free rather than
+# positional. The entry below writes 'farewell' ABOVE 'greeting' on
+# purpose: read positionally it would send QUIT before the server had
+# greeted, which is the #450 bug reintroduced by moving two blocks.
+#
+# transport proves an unimplemented one is refused rather than silently
+# treated as tcp. A datagram entry quietly becoming a stream probe is the
+# kind of thing nobody notices until it reports green.
+#
+# eof has its own file; the edge is used here only to let the healthy
+# conversation finish.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+cc -o "$work/peer" "$root/tests/lib/dialogue-peer.c" $(pkg-config --cflags --libs openssl 2>/dev/null || echo -lssl -lcrypto) ||
+	skip "cannot build the dialogue peer"
+
+start_peer() {
+	"$work/peer" "$1" "$2" > "$3" &
+	echo $! > "$3.pid"
+	i=0
+	while [ "$i" -lt 50 ]; do
+		[ -s "$3" ] && break
+		sleep 0.1
+		i=$((i + 1))
+	done
+	cat "$3"
+}
+
+# greets, takes QUIT, then closes without answering -- as a real server may
+printf 'send 220 ready\r\n\nrecvany\nhangup\n' > "$work/bye.script"
+# One peer per service: each serves a single connection and then exits,
+# so sharing one port between entries makes the run a race.
+p1=$(start_peer "$work/bye.script" "$work/o1" "$work/p1")
+p2=$(start_peer "$work/bye.script" "$work/o2" "$work/p2")
+p3=$(start_peer "$work/bye.script" "$work/o3" "$work/p3")
+register_cleanup "kill $(cat "$work/p1.pid") $(cat "$work/p2.pid") $(cat "$work/p3.pid") 2>/dev/null || :"
+[ -n "$p1" ] && [ -n "$p2" ] && [ -n "$p3" ] || fail "a peer never named its port"
+
+printf '127.0.0.1\thost\t# eofok eofbad udpsvc\n' > "$work/home/etc/hosts.cfg"
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[eofok]
+   transport tcp
+   start greeting
+   state farewell
+   send "quit\r\n"
+   eof                         -> success
+   expect "221"                -> success
+   state greeting
+   expect "220"                -> farewell
+   options banner
+   port $p1
+
+[eofbad]
+   expect "220"
+   send "quit\r\n"
+   expect "221"                -> success
+   options banner
+   port $p2
+
+[udpsvc]
+   transport udp
+   expect "220"                -> success
+   options banner
+   port $p3
+CFG
+
+out=$(XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse \
+	--dns=ip --timeout=15 --debug 2>&1 || :)
+echo "$out" > "$work/out.txt"
+
+# start: 'farewell' is written above 'greeting', so a positional reading
+# would send QUIT before the greeting arrived.
+grep -q 'Service eofok on host is OK' "$work/out.txt" || fail \
+	"the entry did not begin at its 'start' state, so a positional reading
+sent QUIT before the greeting arrived:
+$(grep -i eofok "$work/out.txt" | head -10)"
+
+# THE CONTROL. Same peer, same conversation, no eof edge -- must fail.
+# Without this, an eof edge that did nothing would still pass above.
+grep -q 'Service eofbad on host is not OK' "$work/out.txt" || fail \
+	"an entry with no 'eof' edge still passed when the peer hung up, so the
+edge is not what decided the verdict:
+$(grep -i eofbad "$work/out.txt" | head -10)"
+
+grep -qi "transport 'udp' is not implemented" "$work/out.txt" || fail \
+	"an unimplemented transport was accepted. It must refuse, not fall back to
+tcp:
+$(grep -i udp "$work/out.txt" | head -5)"
+
+grep -q 'Service udpsvc on host is not OK' "$work/out.txt" || fail \
+	"the refused transport still reported the service up:
+$(grep -i udpsvc "$work/out.txt" | head -5)"
+
+pass "start chooses the entry state, and an unimplemented transport is refused rather than run as tcp"

--- a/tests/network/dialogue-idle.sh
+++ b/tests/network/dialogue-idle.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Slow is not stopped, and one clock cannot tell them apart.
+#
+# A large EHLO reply trickling in over half a minute is a working server
+# on a poor link. Five seconds of silence in the middle of that same
+# reply is a server that has died. With only an absolute budget both are
+# the same colour, and an operator cannot tell which they are looking at.
+#
+# idle(N) restarts whenever a byte arrives; timeout(N) does not.
+#
+# THE CONTROL IS THE SECOND SERVICE. A timer that simply fired would
+# satisfy the first assertion on its own -- the peer is silent, something
+# expires, the service goes yellow. What has to also hold is that the
+# DRIBBLING peer, whose reply takes far longer than the idle budget but
+# never pauses for it, is NOT reported idle. That is the whole
+# distinction, and it is the half a plain timeout would fail.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+cc -o "$work/peer" "$root/tests/lib/dialogue-peer.c" $(pkg-config --cflags --libs openssl 2>/dev/null || echo -lssl -lcrypto) ||
+	skip "cannot build the dialogue peer"
+
+start_peer() {
+	"$work/peer" "$1" "$2" > "$3" &
+	echo $! > "$3.pid"
+	i=0
+	while [ "$i" -lt 50 ]; do
+		[ -s "$3" ] && break
+		sleep 0.1
+		i=$((i + 1))
+	done
+	cat "$3"
+}
+
+# stops dead after taking the command
+printf 'send 220 ready\r\n\nrecvany\nhold 30\n' > "$work/stopped.script"
+# answers, but one byte per second. The reply is multi-line and the
+# expect below wants its terminator, so the match cannot complete early
+# -- the whole 14 bytes have to arrive, taking ~14s against an idle(3).
+# NB: the dribble argument keeps its backslashes -- printf would turn
+# \r\n into a real CRLF and end the script line there, so the peer would
+# dribble five bytes and the reply would never finish.
+{ printf 'send 220 ready\r\n\n'
+  printf 'recvany\n'
+  printf 'dribble 250-a\\r\\n250 b\\r\\n\n'
+  printf 'hold 20\n'; } > "$work/slow.script"
+
+pstop=$(start_peer "$work/stopped.script" "$work/o1" "$work/p1")
+pslow=$(start_peer "$work/slow.script"    "$work/o2" "$work/p2")
+register_cleanup "kill $(cat "$work/p1.pid") $(cat "$work/p2.pid") 2>/dev/null || :"
+[ -n "$pstop" ] && [ -n "$pslow" ] || fail "a peer never named its port"
+
+printf '127.0.0.1\thost\t# stopped slow\n' > "$work/home/etc/hosts.cfg"
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[stopped]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   state waiting
+   idle(3)                     -> warning
+   timeout(30)                 -> fail
+   expect "250"                -> success
+   options banner
+   port $pstop
+
+[slow]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   state waiting
+   idle(3)                     -> warning
+   timeout(30)                 -> fail
+   expect "250" until "250 "   -> success
+   options banner
+   port $pslow
+CFG
+
+start=$(date +%s)
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse --dns=ip \
+	--timeout=40 --debug > "$work/out.txt" 2>&1 || :
+elapsed=$(( $(date +%s) - start ))
+
+stopcol=$(grep -oE 'host\.stopped (green|yellow|red|clear)' "$work/out.txt" | awk '{print $2}' | head -1)
+slowcol=$(grep -oE 'host\.slow (green|yellow|red|clear)' "$work/out.txt" | awk '{print $2}' | head -1)
+
+[ "$stopcol" = "yellow" ] || fail \
+	"a server that went silent for longer than idle(3) reported ${stopcol:-nothing},
+not yellow. Silence in the middle of a reply is what the idle clock is for:
+$(grep -i stopped "$work/out.txt" | head -8)"
+
+# THE CONTROL. Its reply takes ~14s -- more than four times the idle
+# budget -- but never pauses for 3s, so the clock must have restarted on
+# every byte. A plain timeout would have fired four times over.
+[ "$slowcol" = "green" ] || fail \
+	"a server answering one byte per second reported ${slowcol:-nothing}, not
+green. Its reply takes longer than the idle budget but never pauses for
+it, so an idle clock that does not restart on arriving data is being
+used as a plain timeout:
+$(grep -i 'host\.slow' "$work/out.txt" | head -8)"
+
+# Neither should have reached the 30s absolute budget or the 40s ceiling.
+[ "$elapsed" -lt 32 ] || fail \
+	"the run took ${elapsed}s; idle(3) is not what ended the silent test."
+
+pass "silence is yellow (${stopcol}) and slowness is not (${slowcol}), in ${elapsed}s"

--- a/tests/network/dialogue-terminals.sh
+++ b/tests/network/dialogue-terminals.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# A dialogue declares its own verdict, and the three verdicts differ.
+#
+# Today a dialogue that fails gets respcheck_color -- one colour for every
+# way of failing. So a server that is BUSY and a server that is BROKEN
+# report identically, and the display cannot tell an operator which one
+# they are looking at. "expect ... -> warning" and "expect ... -> fail"
+# are the config saying which it meant.
+#
+# The control is the pair, not either half. A single red proves nothing:
+# respcheck_color would produce the same colour for both peers, and the
+# test would pass while the feature did nothing. What has to hold is that
+# the SAME probe run gives the busy peer and the broken peer DIFFERENT
+# colours.
+#
+# "-> success" is the third: reaching it ends the conversation green even
+# though the entry has no more steps to run, so the verdict comes from the
+# config rather than from running out of file.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+cc -o "$work/peer" "$root/tests/lib/dialogue-peer.c" $(pkg-config --cflags --libs openssl 2>/dev/null || echo -lssl -lcrypto) ||
+	skip "cannot build the dialogue peer"
+
+start_peer() {	# script obs portfile -> echoes the port
+	"$work/peer" "$1" "$2" > "$3" &
+	echo $! > "$3.pid"
+	i=0
+	while [ "$i" -lt 50 ]; do
+		[ -s "$3" ] && break
+		sleep 0.1
+		i=$((i + 1))
+	done
+	cat "$3"
+}
+
+# healthy: greets, answers EHLO, answers QUIT
+printf 'send 220 ready\r\n\nrecvany\nsend 250 ok\r\n\nrecvany\nsend 221 bye\r\n\nhangup\n' > "$work/ok.script"
+# busy: greets 421 and stays up. Not broken -- temporarily unavailable.
+printf 'send 421 too many connections\r\n\nhold 20\n' > "$work/busy.script"
+# broken: greets correctly, then rejects the command
+printf 'send 220 ready\r\n\nrecvany\nsend 500 command unrecognized\r\n\nhold 20\n' > "$work/bad.script"
+
+pok=$(start_peer   "$work/ok.script"   "$work/ok.obs"   "$work/ok.port")
+pbusy=$(start_peer "$work/busy.script" "$work/busy.obs" "$work/busy.port")
+pbad=$(start_peer  "$work/bad.script"  "$work/bad.obs"  "$work/bad.port")
+register_cleanup "kill $(cat "$work/ok.port.pid") $(cat "$work/busy.port.pid") $(cat "$work/bad.port.pid") 2>/dev/null || :"
+[ -n "$pok" ] && [ -n "$pbusy" ] && [ -n "$pbad" ] || fail "a peer never named its port"
+
+printf '127.0.0.1\thost\t# termok termbusy termbad\n' > "$work/home/etc/hosts.cfg"
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[termok]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250"
+   send "quit\r\n"
+   expect "221"                -> success
+   options banner
+   port $pok
+
+[termbusy]
+   expect "220"                -> proceed
+   expect "421"                -> warning
+   state proceed
+   send "quit\r\n"
+   expect "221"                -> success
+   options banner
+   port $pbusy
+
+[termbad]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250"                -> done
+   expect "5"                  -> fail
+   state done
+   send "quit\r\n"
+   expect "221"                -> success
+   options banner
+   port $pbad
+CFG
+
+out=$(XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse \
+	--dns=ip --timeout=15 --debug 2>&1 || :)
+echo "$out" > "$work/out.txt"
+
+grep -q 'Service termok on host is OK' "$work/out.txt" || fail \
+	"reaching '-> success' did not report the service up. The verdict should
+come from the edge, not from running out of steps:
+$(grep -i termok "$work/out.txt" | head -10)"
+
+grep -q 'Service termbusy on host is not OK' "$work/out.txt" || fail \
+	"the busy peer was reported up:
+$(grep -i termbusy "$work/out.txt" | head -10)"
+
+grep -q 'Service termbad on host is not OK' "$work/out.txt" || fail \
+	"the broken peer was reported up:
+$(grep -i termbad "$work/out.txt" | head -10)"
+
+# THE POINT. Both failed; they must not have failed the same way.
+busycol=$(grep -oE 'host\.termbusy (green|yellow|red|clear)' "$work/out.txt" | awk '{print $2}' | head -1)
+badcol=$(grep -oE 'host\.termbad (green|yellow|red|clear)' "$work/out.txt" | awk '{print $2}' | head -1)
+
+[ -n "$busycol" ] && [ -n "$badcol" ] || fail \
+	"could not read the colours back out of the status messages:
+$(grep -E 'host\.(termbusy|termbad)' "$work/out.txt" | head -6)"
+
+[ "$busycol" = "yellow" ] || fail \
+	"'-> warning' produced $busycol, not yellow. A busy server is not a broken
+one, and that distinction is the whole point of declaring the verdict."
+
+[ "$badcol" = "red" ] || fail \
+	"'-> fail' produced $badcol, not red."
+
+[ "$busycol" != "$badcol" ] || fail \
+	"the busy peer and the broken peer both reported $busycol, so the terminal
+edges are not deciding the colour -- one setting is."
+
+pass "a dialogue declares its verdict: success green, warning yellow ($busycol), fail red ($badcol)"

--- a/tests/network/dialogue-timeout.sh
+++ b/tests/network/dialogue-timeout.sh
@@ -8,7 +8,7 @@
 # nine tenths finished is then indistinguishable from a host that never
 # answered, and the operator has nothing to act on.
 #
-# Three things are checked, and the second is the one that stops this test
+# Four things are checked, and the second is the one that stops this test
 # being satisfied by a timer that simply fires all the time:
 #
 #   [budgeted]  a peer that greets, takes the command, then holds the
@@ -17,6 +17,10 @@
 #               budget must NOT fire, so a working service is unaffected
 #   [ceiling]   a budget far larger than --timeout -- the global cutoff must
 #               still win, since per-step budgets may never sum past it
+#   [routed]    the same silent peer with "timeout(2) -> warning" -- the
+#               budget is an EDGE, so where it leads is the config's
+#               choice. Ignore the target and expiry is a plain failure,
+#               and this comes out red instead of yellow.
 #
 # The peers hold rather than hang up: EOF is a different code path and a
 # different verdict, and would pass this test for the wrong reason.
@@ -52,18 +56,19 @@ printf 'send 220 ready\r\n\nrecvany\nhold 30\n' > "$work/silent.script"
 printf 'send 220 ready\r\n\nrecvany\nsend 250 ok\r\n\nhold 30\n' > "$work/quick.script"
 
 psilent=$(start_peer "$work/silent.script" "$work/silent.obs" "$work/silent.port")
+prouted=$(start_peer "$work/silent.script" "$work/routed.obs" "$work/routed.port")
 pquick=$(start_peer  "$work/quick.script"  "$work/quick.obs"  "$work/quick.port")
 pceil=$(start_peer   "$work/silent.script" "$work/ceil.obs"   "$work/ceil.port")
-register_cleanup "kill $(cat "$work/silent.port.pid") $(cat "$work/quick.port.pid") $(cat "$work/ceil.port.pid") 2>/dev/null || :"
+register_cleanup "kill $(cat "$work/silent.port.pid") $(cat "$work/quick.port.pid") $(cat "$work/ceil.port.pid") $(cat "$work/routed.port.pid") 2>/dev/null || :"
 [ -n "$psilent" ] && [ -n "$pquick" ] && [ -n "$pceil" ] || fail "a peer never named its port"
 
-printf '127.0.0.1\tsilent\t# budgeted healthy\n' > "$work/home/etc/hosts.cfg"
+printf '127.0.0.1\tsilent\t# budgeted healthy routed\n' > "$work/home/etc/hosts.cfg"
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [budgeted]
    expect "220"
    send "ehlo xymonnet\r\n"
    state waiting
-   timeout 2
+   timeout(2)                  -> fail
    expect "250"
    options banner
    port $psilent
@@ -72,10 +77,19 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
    expect "220"
    send "ehlo xymonnet\r\n"
    state waiting
-   timeout 2
+   timeout(2)                  -> fail
    expect "250"
    options banner
    port $pquick
+
+[routed]
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   state waiting
+   timeout(2)                  -> warning
+   expect "250"                -> success
+   options banner
+   port $prouted
 CFG
 
 start=$(date +%s)
@@ -99,6 +113,14 @@ grep -q 'Service healthy on silent is OK' "$work/out.txt" || fail \
 budget is firing on healthy conversations:
 $(grep -i 'healthy' "$work/out.txt" | head -10)"
 
+# THE EDGE. Same silent peer and same budget, routed to warning rather
+# than failing. Ignore the target and expiry is a plain failure: red.
+routedcol=$(grep -oE 'silent\.routed (green|yellow|red|clear)' "$work/out.txt" | awk '{print $2}' | head -1)
+[ "$routedcol" = "yellow" ] || fail \
+	"'timeout(2) -> warning' produced ${routedcol:-nothing}, not yellow. A
+budget is an edge -- where it leads is the config's choice, not always a
+failure."
+
 # 2s budget under a 25s ceiling: near 25 means the budget was ignored.
 [ "$elapsed" -lt 15 ] || fail \
 	"the run took ${elapsed}s with a 2 second step budget and a 25 second
@@ -115,7 +137,7 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
    expect "220"
    send "ehlo xymonnet\r\n"
    state waiting
-   timeout 60
+   timeout(60)                 -> fail
    expect "250"
    options banner
    port $pceil
@@ -134,4 +156,4 @@ grep -q 'Service ceiling on silent is not OK' "$work/ceil.txt" || fail \
 	"the service was not reported down when the global cutoff ended it:
 $(grep -i 'ceiling' "$work/ceil.txt" | head -10)"
 
-pass "a step budget ends its own state (${elapsed}s), leaves a healthy service alone, and never outlives --timeout (${ceilelapsed}s)"
+pass "a budget ends its own state (${elapsed}s), routes where the config says (${routedcol}), leaves a healthy service alone, and never outlives --timeout (${ceilelapsed}s)"

--- a/tests/network/dialogue-validation.sh
+++ b/tests/network/dialogue-validation.sh
@@ -40,7 +40,7 @@ cat > "$work/home/etc/protocols.cfg" <<'CFG'
    capture as tooearly
    expect "220"
    send "x${sha1:foo}\r\n"
-   timeout 0
+   timeout(0)                  -> fail
    starttls
    options ssl,banner
    port 9

--- a/tests/network/dialogue-validation.sh
+++ b/tests/network/dialogue-validation.sh
@@ -58,6 +58,21 @@ cat > "$work/home/etc/protocols.cfg" <<'CFG'
    send "USER ${usernam}\r\n"
    expect "+OK"
    port 9
+   port 9
+
+[graph]
+   start entry
+   state entry
+      expect "220"                -> spin
+      timeout(5)                  -> fail
+   state spin
+      send "x\r\n"
+      expect "250"                -> spin
+   state unreachable
+      send "y\r\n"
+      expect "250"                -> fail
+      timeout(5)                  -> fail
+   port 9
 CFG
 out=$(run_xymonnet)
 
@@ -69,6 +84,23 @@ $out"
 grep -qi 'before any expect' <<<"$out" || fail \
 	"'capture as' with no preceding expect was accepted; it can only bind an
 empty value:
+$out"
+
+grep -qi "state 'spin' waits for a reply with no timeout" <<<"$out" || fail \
+	"a state that waits with no timer was accepted. It can only ever fail as
+the global timeout, which cannot say which state stalled -- the complaint
+this feature exists to answer:
+$out"
+
+grep -qi "state 'spin' has no way to finish" <<<"$out" || fail \
+	"a state whose every path leads back into itself was accepted; the
+dialogue can never end except on the ceiling:
+$out"
+
+grep -qi "state 'unreachable' cannot be reached" <<<"$out" || fail \
+	"a state nothing can reach was accepted. That is dead config, and the
+'-> NAME has no matching state' check does not catch it because the name
+resolves fine -- nothing simply names it:
 $out"
 
 grep -qi 'the budget must be a positive number of seconds' <<<"$out" || fail \

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -242,6 +242,8 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 	newtest->steptimedout = 0;
 	newtest->dialogverdict = 0;
 	newtest->timeoutstep = NULL;
+	newtest->idlesecs = 0;
+	newtest->idlestep = NULL;
 	newtest->stepbuf = NULL;
 	newtest->stepbuflen = 0;
 
@@ -1250,6 +1252,17 @@ static svcstep_t *dlg_run_instant(tcptest_t *item, svcstep_t *st)
 			st = st->next;
 			break;
 
+		  case STEP_IDLE:
+			/*
+			 * Armed against lastactive, which the read and write arms
+			 * already stamp, so "restarts whenever data arrives" needs
+			 * no clock of its own.
+			 */
+			item->idlesecs = st->seconds;
+			item->idlestep = (void *)st;
+			st = st->next;
+			break;
+
 		  case STEP_TIMEOUT:
 			/*
 			 * Sets the budget for the wait that follows and re-arms it,
@@ -1622,6 +1635,44 @@ restartselect:
 				    (item->stepdeadlinefor != item->curstep)) {
 					item->stepdeadline = timestamp.tv_sec + item->stepsecs;
 					item->stepdeadlinefor = item->curstep;
+				}
+
+				if ((item->idlesecs > 0) && item->curstep && item->lastactive &&
+				    ((timestamp.tv_sec - item->lastactive) > item->idlesecs)) {
+					svcstep_t *edge = (svcstep_t *)item->idlestep;
+
+					/*
+					 * Nothing has arrived for long enough. Distinct from
+					 * the absolute budget below: this says the server has
+					 * stopped, not that the reply was long.
+					 */
+					item->steptimedout = 1;
+					if (!item->failstep) item->failstep = item->curstep;
+					item->idlesecs = 0;
+
+					if (edge && (edge->action == ACT_GOTO) && edge->targetstep) {
+						item->curstep = (void *)dlg_run_instant(item, edge->targetstep);
+						item->stepdeadlinefor = NULL;
+						continue;
+					}
+					if (edge && (edge->action == ACT_SUCCESS)) {
+						item->dialogverdict = 1;
+						item->curstep = NULL;
+					}
+					else {
+						item->dialogfail = 1;
+						item->dialogverdict = (edge && (edge->action == ACT_WARNING)) ? 2 : 3;
+						item->curstep = NULL;
+					}
+
+					socket_shutdown(item);
+					get_totaltime(item, &timestamp);
+					close(item->fd);
+					item->fd = -1;
+					activesockets--;
+					pending--;
+					if (item == firstactive) firstactive = item->next;
+					continue;
 				}
 
 				if (item->stepdeadline && (timestamp.tv_sec > item->stepdeadline)) {

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -224,7 +224,14 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 	 */
 	newtest->curstep = ((newtest->svcinfo && (newtest->svcinfo->flags & TCP_DIALOGUE))
 			    ? (void *)newtest->svcinfo->steps : NULL);
-	newtest->dialogfail = 0;
+	/*
+	 * A definition refused when the file was read must not be able to
+	 * report OK. Failing it here rather than dropping the service keeps
+	 * the column present and says why, instead of the test quietly
+	 * disappearing from the display.
+	 */
+	newtest->dialogfail = (newtest->svcinfo &&
+			       (newtest->svcinfo->flags & TCP_DIALOGUE_BROKEN)) ? 1 : 0;
 	newtest->failstep = NULL;
 	newtest->stepsecs = 0;
 	newtest->stepdeadline = 0;
@@ -2047,17 +2054,14 @@ restartselect:
 									}
 
 									/*
-									 * An ambiguous group is one where a longer
-									 * alternative could still overtake the one
-									 * that just matched. Wait until every
-									 * pattern in the group is decidable, so the
-									 * winner is the config's order rather than
-									 * the server's packet boundaries. Bounded:
-									 * maxaltlen is known at load time, and the
-									 * buffer cap and test timeout end the wait.
+									 * No deferral is needed here. A longer
+									 * alternative could once overtake the one
+									 * that just matched, so the winner depended
+									 * on how the server split its reply -- but
+									 * overlapping patterns are now refused when
+									 * the file is read, so at most one
+									 * alternative in a group can match.
 									 */
-									if (hit && hit->ambiguous &&
-									    (item->stepbuflen < hit->maxaltlen)) break;
 
 									if (hit) {
 										int cut = hit->len;
@@ -2294,6 +2298,9 @@ char *tcp_dialogue_failure(tcptest_t *test)
 	int idx = 0, n = 0;
 
 	if (!test || !test->svcinfo || !(test->svcinfo->flags & TCP_DIALOGUE)) return NULL;
+
+	if (test->svcinfo->flags & TCP_DIALOGUE_BROKEN)
+		return "protocols.cfg refused this definition - see the xymonnet log";
 
 	bad = (svcstep_t *)test->failstep;
 

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -223,7 +223,10 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 	 * sockets were never closed and every legacy TLS test timed out.
 	 */
 	newtest->curstep = ((newtest->svcinfo && (newtest->svcinfo->flags & TCP_DIALOGUE))
-			    ? (void *)newtest->svcinfo->steps : NULL);
+			    ? (void *)(newtest->svcinfo->startstep
+				       ? newtest->svcinfo->startstep
+				       : newtest->svcinfo->steps)
+			    : NULL);
 	/*
 	 * A definition refused when the file was read must not be able to
 	 * report OK. Failing it here rather than dropping the service keeps
@@ -1983,7 +1986,45 @@ restartselect:
 								 * greeting was read as the peer hanging up,
 								 * and every TLS dialogue failed instantly.
 								 */
-								if ((res <= 0) && !item->sslagain && st) {
+								if ((res <= 0) && !item->sslagain && st &&
+								    (st->type == STEP_EXPECT)) {
+									svcstep_t *alt, *eofhit = NULL;
+
+									for (alt = st; (alt && (alt->type == STEP_EXPECT)); alt = alt->next)
+										if (alt->oneof) { eofhit = alt; break; }
+
+									if (eofhit) {
+										/*
+										 * The peer closing is what this state
+										 * was waiting for. After QUIT that is
+										 * the correct outcome, not a fault.
+										 */
+										if (eofhit->action == ACT_SUCCESS) {
+											item->dialogverdict = 1;
+											item->curstep = NULL;
+										}
+										else if ((eofhit->action == ACT_FAIL) ||
+											 (eofhit->action == ACT_WARNING)) {
+											item->dialogfail = 1;
+											item->dialogverdict = (eofhit->action == ACT_WARNING) ? 2 : 3;
+											if (!item->failstep) item->failstep = (void *)eofhit;
+											item->curstep = NULL;
+										}
+										else {
+											item->curstep = (void *)dlg_run_instant(item,
+													  (eofhit->action == ACT_GOTO)
+													  ? eofhit->targetstep : eofhit->next);
+										}
+										st = (svcstep_t *)item->curstep;
+									}
+									else {
+										item->dialogfail = 1;
+										if (!item->failstep) item->failstep = (void *)st;
+										item->curstep = NULL;
+										st = NULL;
+									}
+								}
+								else if ((res <= 0) && !item->sslagain && st) {
 								/*
 								 * The peer went away with steps still to run.
 								 * Fail here rather than leaving the socket to
@@ -2055,6 +2096,7 @@ restartselect:
 
 									/* Consecutive expects are alternatives of ONE state. */
 									for (alt = st; (alt && (alt->type == STEP_EXPECT)); alt = alt->next) {
+										if (alt->oneof) continue;	/* only fires on EOF */
 										if (item->stepbuflen < alt->len) { undecided++; continue; }
 										if (memcmp(item->stepbuf, alt->text, alt->len) == 0) { hit = alt; break; }
 									}
@@ -2317,10 +2359,12 @@ char *tcp_dialogue_failure(tcptest_t *test)
 	char *name = NULL;
 	int idx = 0, n = 0;
 
-	if (!test || !test->svcinfo || !(test->svcinfo->flags & TCP_DIALOGUE)) return NULL;
+	if (!test || !test->svcinfo) return NULL;
 
 	if (test->svcinfo->flags & TCP_DIALOGUE_BROKEN)
 		return "protocols.cfg refused this definition - see the xymonnet log";
+
+	if (!(test->svcinfo->flags & TCP_DIALOGUE)) return NULL;
 
 	bad = (svcstep_t *)test->failstep;
 
@@ -2393,6 +2437,14 @@ int tcp_got_expected(tcptest_t *test)
 	 * arrived. Re-matching exptext against the banner here would compare the
 	 * first step's pattern against whatever the last read happened to leave.
 	 */
+	/*
+	 * A refused definition can never be OK, and the refusal has to be
+	 * checked before the dialogue test: an entry that is one expect is
+	 * not a dialogue, so a bad 'transport' on it would otherwise fall
+	 * through to the legacy comparison and report green.
+	 */
+	if (test->svcinfo && (test->svcinfo->flags & TCP_DIALOGUE_BROKEN)) return 0;
+
 	if (test->svcinfo && (test->svcinfo->flags & TCP_DIALOGUE))
 		return (test->dialogfail == 0) && (test->curstep == NULL);
 		/* dialogverdict 1 ("-> success") also leaves curstep NULL and

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -237,6 +237,7 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 	newtest->stepdeadline = 0;
 	newtest->stepdeadlinefor = NULL;
 	newtest->steptimedout = 0;
+	newtest->dialogverdict = 0;
 	newtest->stepbuf = NULL;
 	newtest->stepbuflen = 0;
 
@@ -1284,8 +1285,13 @@ static svcstep_t *dlg_run_instant(tcptest_t *item, svcstep_t *st)
 		  }
 		  /* FALLTHROUGH: a matched '~' takes its edge exactly as a jump does */
 		  case STEP_JUMP:
-			if (st->action == ACT_FAIL) {
+			if (st->action == ACT_SUCCESS) {
+				item->dialogverdict = 1;
+				return NULL;
+			}
+			if ((st->action == ACT_FAIL) || (st->action == ACT_WARNING)) {
 				item->dialogfail = 1;
+				item->dialogverdict = (st->action == ACT_WARNING) ? 2 : 3;
 				if (!item->failstep) item->failstep = (void *)st;
 				return NULL;
 			}
@@ -2114,9 +2120,23 @@ restartselect:
 										memmove(item->stepbuf, item->stepbuf + cut, item->stepbuflen - cut);
 										item->stepbuflen -= cut;
 
-										if (hit->action == ACT_FAIL) {
+										if ((hit->action == ACT_FAIL) ||
+										    (hit->action == ACT_WARNING)) {
 											item->dialogfail = 1;
+											item->dialogverdict = (hit->action == ACT_WARNING) ? 2 : 3;
 											if (!item->failstep) item->failstep = (void *)st;
+											item->curstep = NULL;
+											st = NULL;
+										}
+										else if (hit->action == ACT_SUCCESS) {
+											/*
+											 * Arriving at "success" ends the
+											 * dialogue here. The remaining steps
+											 * are not run and are not a failure:
+											 * the config said this is where a
+											 * healthy conversation stops.
+											 */
+											item->dialogverdict = 1;
 											item->curstep = NULL;
 											st = NULL;
 										}
@@ -2375,6 +2395,8 @@ int tcp_got_expected(tcptest_t *test)
 	 */
 	if (test->svcinfo && (test->svcinfo->flags & TCP_DIALOGUE))
 		return (test->dialogfail == 0) && (test->curstep == NULL);
+		/* dialogverdict 1 ("-> success") also leaves curstep NULL and
+		   dialogfail clear, so it is covered by the same test. */
 
 	if (test->svcinfo && test->svcinfo->exptext) {
 		int compbytes; /* Number of bytes to compare */

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -241,6 +241,7 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 	newtest->stepdeadlinefor = NULL;
 	newtest->steptimedout = 0;
 	newtest->dialogverdict = 0;
+	newtest->timeoutstep = NULL;
 	newtest->stepbuf = NULL;
 	newtest->stepbuflen = 0;
 
@@ -1256,6 +1257,7 @@ static svcstep_t *dlg_run_instant(tcptest_t *item, svcstep_t *st)
 			 * inheriting whatever was left of the previous visit.
 			 */
 			item->stepsecs = st->seconds;
+			item->timeoutstep = (void *)st;
 			item->stepdeadline = 0;
 			item->stepdeadlinefor = NULL;
 			st = st->next;
@@ -1630,11 +1632,31 @@ restartselect:
 					 * name it. The connection was established, so this is a
 					 * dialogue failure and not a connect timeout.
 					 */
+					svcstep_t *edge = (svcstep_t *)item->timeoutstep;
+
 					item->steptimedout = 1;
-					item->dialogfail = 1;
-					if (!item->failstep) item->failstep = item->curstep;
-					item->curstep = NULL;
 					item->stepdeadline = 0;
+					if (!item->failstep) item->failstep = item->curstep;
+
+					/*
+					 * The budget is an edge like any other: it says where
+					 * to go, not just that the wait was too long. Only a
+					 * target of "fail" or none at all ends the test here.
+					 */
+					if (edge && (edge->action == ACT_GOTO) && edge->targetstep) {
+						item->curstep = (void *)dlg_run_instant(item, edge->targetstep);
+						item->stepdeadlinefor = NULL;
+						continue;
+					}
+					if (edge && (edge->action == ACT_SUCCESS)) {
+						item->dialogverdict = 1;
+						item->curstep = NULL;
+					}
+					else {
+						item->dialogfail = 1;
+						item->dialogverdict = (edge && (edge->action == ACT_WARNING)) ? 2 : 3;
+						item->curstep = NULL;
+					}
 
 					socket_shutdown(item);
 					get_totaltime(item, &timestamp);

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -153,6 +153,8 @@ typedef struct tcptest_t {
 	int steptimedout;		/* that budget expired, rather than a mismatch */
 	int dialogverdict;		/* 0 = infer, 1 = success, 2 = warning, 3 = fail */
 	void *timeoutstep;		/* svcstep_t *: the timeout edge that armed the clock */
+	int idlesecs;			/* 'idle(N)': silence budget, 0 = none */
+	void *idlestep;			/* svcstep_t *: the idle edge that armed it */
 
 	/* For testing telnet services */
 	unsigned char *telnetbuf;	/* Buffer for telnet option negotiation */

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -152,6 +152,7 @@ typedef struct tcptest_t {
 	void *stepdeadlinefor;		/* svcstep_t *: which step it was armed for */
 	int steptimedout;		/* that budget expired, rather than a mismatch */
 	int dialogverdict;		/* 0 = infer, 1 = success, 2 = warning, 3 = fail */
+	void *timeoutstep;		/* svcstep_t *: the timeout edge that armed the clock */
 
 	/* For testing telnet services */
 	unsigned char *telnetbuf;	/* Buffer for telnet option negotiation */

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -151,6 +151,7 @@ typedef struct tcptest_t {
 	time_t stepdeadline;		/* ... armed against the poll clock, 0 = unarmed */
 	void *stepdeadlinefor;		/* svcstep_t *: which step it was armed for */
 	int steptimedout;		/* that budget expired, rather than a mismatch */
+	int dialogverdict;		/* 0 = infer, 1 = success, 2 = warning, 3 = fail */
 
 	/* For testing telnet services */
 	unsigned char *telnetbuf;	/* Buffer for telnet option negotiation */

--- a/xymonnet/xymonnet.c
+++ b/xymonnet/xymonnet.c
@@ -1611,7 +1611,16 @@ int decide_color(service_t *service, char *svcname, testitem_t *test, int failgo
 							snprintf(cause, MAX_CAUSE, "Unexpected service response: %s", whichstep);
 						else
 							strcpy(cause, "Unexpected service response");
-						color = respcheck_color; countasdown = 1;
+						/*
+						 * A dialogue that declared its own verdict says which
+						 * colour it meant: "-> warning" is a busy server, "->
+						 * fail" a broken one, where respcheck_color has to be
+						 * one answer for both.
+						 */
+						if (tcptest && (tcptest->dialogverdict == 2))      color = COL_YELLOW;
+						else if (tcptest && (tcptest->dialogverdict == 3)) color = COL_RED;
+						else color = respcheck_color;
+						countasdown = 1;
 					}
 
 					/* Check that other transport issues didn't occur (like SSL) */


### PR DESCRIPTION
What a dialogue reports, and what the parser refuses to accept.

- **Three verdicts.** `-> success|warning|fail`. A failure took `respcheck_color` — one colour for every way of failing — so a *busy* server and a *broken* one reported identically. `warning` is the point: a server refusing an optional capability is not down, and calling it down teaches operators to ignore the column.
- **Overlapping alternatives are refused when the file is read.** Matching is prefix-anchored, so two patterns collide iff one is a prefix of the other — the check is complete rather than heuristic, which is what lets it refuse instead of warn.
- **Three checks only a graph can make**: a dead end that reaches no verdict, a state nothing jumps to, and a wait no clock bounds. `docs/design/protocol-dialogues.md` says why they are worth having and where they mislead.
- `eof`, `start`, `transport`, `always`, and `idle(N)` — the clock that restarts when data arrives, as distinct from the total budget.

**Two changes the title does not cover.** `timeout N` from #463 becomes `timeout(N) -> TARGET`: a budget is a condition like any other and now says where expiry leads, so an entry written against #463 needs updating. And `tests/buildsystem/test-suite-portability.sh` gains a rule that a test sourcing `assert.sh` must declare `#!/usr/bin/env bash` rather than `#!/bin/sh` — unrelated to verdicts, and here only because the suites this slice adds are what tripped it.

**Verified.** `dialogue-terminals.sh`, `dialogue-ambiguity.sh`, `dialogue-eof.sh`, `dialogue-grammar.sh`, `dialogue-idle.sh`, `dialogue-timeout.sh`. The busy and broken peers must come out of one run with different colours; a peer answering one byte per second, never pausing long enough to be idle, must stay green.

`dialogue-buffer-cap.sh` is rewritten here against the grammar this slice adds — a named state, a per-step budget, `-> success`/`-> fail` and `eof` — so the bound is checked the way an entry will actually be written. It arrived with the driver in #461, in the only grammar that existed then.

---

**Grammar.** The manual page is added once, in #476, in the form the finished grammar takes — [`protocols.cfg(5)`](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/xymonnet/protocols.cfg.5). The slices below it change no documentation, so none of them ships a page describing steps their own code does not have.

**Design.** [Why matching is literal, and how the graph checks mislead](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/docs/design/protocol-dialogues.md#the-reasoning-a-manual-has-no-room-for) · [deferring an ambiguous group, and other rejected designs](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/docs/design/protocol-dialogues.md#explorations-that-were-rejected) · [prior art](https://github.com/xymon-monitoring/xymon/blob/dialogue-09-framedsend/docs/design/protocol-dialogues.md#prior-art) — in the tree, added by #479, further up the stack.

---
### Stack

**6 of 15** in the dialogue stack: base #463, next #476. The full chain is listed in #457; read bottom-up.



