### PR TITLE
xymonnet: four corrections to the dialogue engine

### DIFF
--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -456,6 +456,44 @@ static void check_graph(svcinfo_t *rec)
 			 * ->next regardless would make every state reachable and
 			 * the check useless.
 			 */
+			/*
+			 * A timeout or idle edge is a way OUT of the state, not a
+			 * step the dialogue stops at: the state carries on past it
+			 * when the budget does not fire. Letting the terminal test
+			 * below claim "timeout(10) -> fail" ends the walk there, so
+			 * every state after it was reported unreachable -- which is
+			 * every state in an entry that budgets its first one.
+			 */
+			if ((st->type == STEP_TIMEOUT) || (st->type == STEP_IDLE)) {
+				if ((st->action == ACT_GOTO) && st->targetstep)
+					for (j = 0; j < nsteps; j++)
+						if ((idx[j] == st->targetstep) && !reach[j]) { reach[j] = 1; changed = 1; }
+				if (st->next)
+					for (j = 0; j < nsteps; j++)
+						if ((idx[j] == st->next) && !reach[j]) { reach[j] = 1; changed = 1; }
+				continue;
+			}
+			/*
+			 * An expect that takes an edge does not continue to whatever
+			 * follows its group -- that step is entered only when some
+			 * alternative matches and simply carries on. The next
+			 * alternative is reachable whatever this one's edge does,
+			 * because it is what gets tried when this one does not match.
+			 * That includes an edge that ends the test: handled by the
+			 * terminal case below, "expect A -> warning" written before
+			 * "expect B -> state" made B's state unreachable, so the same
+			 * two alternatives warned or not depending on their order.
+			 */
+			if (st->type == STEP_EXPECT) {
+				if ((st->action == ACT_GOTO) && st->targetstep)
+					for (j = 0; j < nsteps; j++)
+						if ((idx[j] == st->targetstep) && !reach[j]) { reach[j] = 1; changed = 1; }
+				if (st->next &&
+				    ((st->next->type == STEP_EXPECT) || (st->action == ACT_NEXT)))
+					for (j = 0; j < nsteps; j++)
+						if ((idx[j] == st->next) && !reach[j]) { reach[j] = 1; changed = 1; }
+				continue;
+			}
 			if ((st->type == STEP_JUMP) || (st->action == ACT_FAIL) ||
 			    (st->action == ACT_WARNING) || (st->action == ACT_SUCCESS)) {
 				int j;
@@ -463,24 +501,6 @@ static void check_graph(svcinfo_t *rec)
 				if ((st->action == ACT_GOTO) && st->targetstep)
 					for (j = 0; j < nsteps; j++)
 						if ((idx[j] == st->targetstep) && !reach[j]) { reach[j] = 1; changed = 1; }
-				continue;
-			}
-			/*
-			 * An expect that takes an edge does not continue to whatever
-			 * follows its group -- that step is entered only when some
-			 * alternative matches and simply carries on. The next
-			 * alternative is still reachable, because it is what gets
-			 * tried when this one does not match.
-			 */
-			if ((st->type == STEP_EXPECT) && (st->action == ACT_GOTO)) {
-				int j;
-
-				if (st->targetstep)
-					for (j = 0; j < nsteps; j++)
-						if ((idx[j] == st->targetstep) && !reach[j]) { reach[j] = 1; changed = 1; }
-				if (st->next && (st->next->type == STEP_EXPECT))
-					for (j = 0; j < nsteps; j++)
-						if ((idx[j] == st->next) && !reach[j]) { reach[j] = 1; changed = 1; }
 				continue;
 			}
 			if (st->next)

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -198,6 +198,7 @@ static void free_svcsteps(svcinfo_t *rec)
 		if (st->target)  xfree(st->target);
 		if (st->label)   xfree(st->label);
 		if (st->varname) xfree(st->varname);
+		if (st->srcname) xfree(st->srcname);
 		if (st->user) { memset(st->user, 0, strlen(st->user)); xfree(st->user); }
 		if (st->pass) { memset(st->pass, 0, strlen(st->pass)); xfree(st->pass); }
 		if (st->re)      freeregex((pcre2_code *)st->re);
@@ -236,7 +237,24 @@ static void check_undefined_vars(svcinfo_t *rec)
 			continue;
 		}
 
+		/* "expect ... as NAME" binds the reply it accepted. */
+		if ((st->type == STEP_EXPECT) && st->varname) {
+			if (nknown < 64) known[nknown++] = st->varname;
+			continue;
+		}
+
 		if (st->type == STEP_CAPTURE) {
+			/*
+			 * An extraction reads a name and binds others. Reading one
+			 * that nothing binds yields an empty value for every reply,
+			 * which is silent at run time.
+			 */
+			if (st->srcname && !name_is_known(known, nknown, st->srcname))
+				errprintf("Service %s: '%s ~ ... as %s' reads a value that is "
+					  "never bound before it - it can only bind empty\n",
+					  rec->svcname, st->srcname,
+					  (st->varname ? st->varname : "?"));
+
 			/* "as a;b;c" binds three names, not one called "a;b;c". */
 			if (st->varname) {
 				char *p = st->varname;
@@ -257,8 +275,8 @@ static void check_undefined_vars(svcinfo_t *rec)
 		if (st->type == STEP_WHEN) {
 			/* Testing a name nothing binds silently takes the else-arm. */
 			if (st->varname && !name_is_known(known, nknown, st->varname))
-				errprintf("Service %s: 'when %s ~ ...' tests a value that is never "
-					  "captured before it - the test can only fail\n",
+				errprintf("Service %s: '%s ~ ...' tests a value that is never "
+					  "bound before it - the test can only fail\n",
 					  rec->svcname, st->varname);
 			continue;
 		}
@@ -329,7 +347,7 @@ static void refuse_overlapping_groups(svcinfo_t *rec)
 					 */
 					errprintf("Service %s: 'expect \"%.30s\"' and 'expect \"%.30s\"' overlap - "
 						  "both match the same reply. Match the shared prefix in one "
-						  "state, then distinguish with 'capture as NAME' and a "
+						  "state, then distinguish with 'expect ... as NAME' and a "
 						  "'NAME ~ ...' edge in the next state\n",
 						  rec->svcname, a->text, b->text);
 					rec->flags |= TCP_DIALOGUE_BROKEN;
@@ -341,20 +359,6 @@ static void refuse_overlapping_groups(svcinfo_t *rec)
 		st = last;	/* skip past the group we just examined */
 	}
 }
-
-/* Has this entry produced an expect yet? A capture binds the reply that the
-   preceding expect accepted, so one with nothing in front of it can only ever
-   bind an empty value. */
-static int has_expect_step(svcinfo_t *rec)
-{
-	svcstep_t *st;
-
-	for (st = rec->steps; (st); st = st->next)
-		if (st->type == STEP_EXPECT) return 1;
-
-	return 0;
-}
-
 
 /*
  * Resolve "-> NAME" to the step that "state NAME" defines. Done once
@@ -609,6 +613,7 @@ static void emit_step(svclist_t *first, svcstep_t *tmpl)
 		if (tmpl->target)  st->target  = strdup(tmpl->target);
 		if (tmpl->label)   st->label   = strdup(tmpl->label);
 		if (tmpl->varname) st->varname = strdup(tmpl->varname);
+		if (tmpl->srcname) st->srcname = strdup(tmpl->srcname);
 		if (tmpl->user)    st->user    = strdup(tmpl->user);
 		if (tmpl->pass)    st->pass    = strdup(tmpl->pass);
 		if (tmpl->until) {
@@ -864,6 +869,27 @@ char *init_tcp_services(void)
 					rest = skipwhitespace(after_quoted(tp));
 				}
 
+				/*
+				 * "as NAME" binds the reply this expect accepted, and is
+				 * written here rather than on a step of its own because a
+				 * separate step has to say WHICH reply it means by its
+				 * position. One written a state too late bound the reply
+				 * from an earlier state and said nothing: the value was
+				 * wrong rather than missing, so no check could see it.
+				 */
+				if (strncmp(rest, "as ", 3) == 0) {
+					char *nm = skipwhitespace(rest + 2);
+					char *end = nm;
+
+					while (*end && (*end != ' ') && (*end != '\t')) end++;
+					if (end == nm) errprintf("'expect ... as' with no name\n");
+					else {
+						if (*end) { *end = '\0'; rest = skipwhitespace(end + 1); }
+						else rest = end;
+						tmpl.varname = nm;
+					}
+				}
+
 				/* Anything left after that is this edge's target. */
 				if (*rest) {
 					act = strtok(rest, " \t");
@@ -917,90 +943,6 @@ char *init_tcp_services(void)
 				else errprintf("'state' with no name\n");
 			}
 		}
-		else if (strncmp(l, "capture-regex ", 14) == 0) {
-			if (first) {
-				svcstep_t tmpl;
-				unsigned char *txt = NULL;
-				int txtlen = 0;
-				char *rest, *kw;
-
-				getrawstring(skipwhitespace(l+13), &txt, &txtlen);
-				rest = skipwhitespace(after_quoted(skipwhitespace(l+13)));
-				kw = strtok(rest, " \t");
-
-				memset(&tmpl, 0, sizeof(tmpl));
-				tmpl.type = STEP_CAPTURE; tmpl.text = txt; tmpl.len = txtlen;
-				tmpl.re = (void *)1;	/* emit_step compiles one per record */
-				if (kw && (strcmp(kw, "as") == 0)) tmpl.varname = strtok(NULL, " \t");
-
-				if (tmpl.varname) {
-					pcre2_code *probe;
-					uint32_t ngroups = 0;
-
-					if (!has_expect_step(first->rec))
-						errprintf("Service %s: 'capture-regex ... as %s' before any expect - "
-							  "there is no reply to capture from, it will bind empty\n",
-							  first->rec->svcname, tmpl.varname);
-
-					/*
-					 * The value bound is group 1, so a pattern with no
-					 * parenthesised group can never bind anything: ${name}
-					 * would expand to nothing for every reply, forever.
-					 * Unconditional, so worth saying at load time.
-					 */
-					probe = compileregex_opts((char *)txt, 0);
-					if (probe) {
-						uint32_t nnames = 1;
-						char *p;
-
-						for (p = tmpl.varname; (*p); p++) if (*p == ';') nnames++;
-
-						pcre2_pattern_info(probe, PCRE2_INFO_CAPTURECOUNT, &ngroups);
-						freeregex(probe);
-
-						/*
-						 * One name per group, in order. A mismatch means
-						 * either a group whose value is thrown away or a
-						 * name that can never be bound, and both are
-						 * silent at run time -- so say it here.
-						 */
-						if (ngroups == 0)
-							errprintf("Service %s: 'capture-regex \"%s\" as %s' has no "
-								  "capture group - it can never bind a value\n",
-								  first->rec->svcname, txt, tmpl.varname);
-						else if (ngroups != nnames)
-							errprintf("Service %s: 'capture-regex \"%s\" as %s' has %u "
-								  "capture group(s) but %u name(s)\n",
-								  first->rec->svcname, txt, tmpl.varname,
-								  ngroups, nnames);
-					}
-
-					emit_step(first, &tmpl);
-				}
-				else errprintf("Usage: capture-regex \"regex\" as NAME\n");
-				xfree(txt);
-			}
-		}
-		else if (strncmp(l, "capture ", 8) == 0) {
-			/* No regex: bind the whole reply that just matched. */
-			if (first) {
-				svcstep_t tmpl;
-				char *kw = strtok(skipwhitespace(l+7), " \t");
-
-				memset(&tmpl, 0, sizeof(tmpl));
-				tmpl.type = STEP_CAPTURE;
-				if (kw && (strcmp(kw, "as") == 0)) tmpl.varname = strtok(NULL, " \t");
-
-				if (tmpl.varname) {
-					if (!has_expect_step(first->rec))
-						errprintf("Service %s: 'capture as %s' before any expect - "
-							  "there is no reply to capture from, it will bind empty\n",
-							  first->rec->svcname, tmpl.varname);
-					emit_step(first, &tmpl);
-				}
-				else errprintf("Usage: capture as NAME\n");
-			}
-		}
 		else if (strncmp(l, "credentials ", 12) == 0) {
 			if (first) {
 				svcstep_t tmpl;
@@ -1040,18 +982,21 @@ char *init_tcp_services(void)
 				emit_step(first, &tmpl);
 			}
 		}
-		else if (strstr(l, "~") && strstr(l, "->")) {
+		else if (strstr(l, "~")) {
 			/*
-			 * "NAME ~ \"regex\" -> TARGET": branch on a value already bound.
-			 * Recognised by shape rather than by a leading keyword, because
-			 * the line begins with the name being tested. The regex tests a
-			 * captured value, never the socket, so it decides nothing about
-			 * what arrives and cannot race a partial read -- which is why a
-			 * regex is allowed here and not in an expect.
+			 * "NAME ~ \"regex\" -> TARGET" branches on a value already
+			 * bound; "NAME ~ \"regex\" as N1;N2" binds new ones out of it.
+			 * Both are recognised by shape rather than by a leading
+			 * keyword, because the line begins with the name it reads.
+			 *
+			 * The regex reads a value already in hand, never the socket.
+			 * That is what allows a regex here and not in an expect: it
+			 * decides nothing about what arrives, so it cannot race a
+			 * partial read, and it needs no maximum match length.
 			 */
 			if (first) {
 				svcstep_t tmpl;
-				char *var, *op, *rest;
+				char *var, *op, *rest, *after;
 				unsigned char *txt = NULL;
 				int txtlen = 0;
 
@@ -1060,31 +1005,76 @@ char *init_tcp_services(void)
 				rest = (op ? skipwhitespace(op + strlen(op) + 1) : NULL);
 
 				if (!var || !op || (strcmp(op, "~") != 0) || !rest || !*rest) {
-					errprintf("Usage: NAME ~ \"regex\" -> TARGET\n");
+					errprintf("Usage: NAME ~ \"regex\" -> TARGET, or "
+						  "NAME ~ \"regex\" as NAME[;NAME]\n");
 				}
 				else {
-					char *arrow;
-
 					getrawstring(rest, &txt, &txtlen);
-					arrow = strstr(skipwhitespace(after_quoted(rest)), "->");
+					after = skipwhitespace(after_quoted(rest));
 
 					memset(&tmpl, 0, sizeof(tmpl));
-					tmpl.type = STEP_WHEN;
-					tmpl.varname = var;
 					tmpl.text = txt; tmpl.len = txtlen;
-					tmpl.re = (void *)1;	/* emit_step compiles a copy per record */
+					tmpl.re = (void *)1;	/* emit_step compiles one per record */
 
-					if (!arrow) errprintf("'%s ~ ...' with no '->'\n", var);
-					else {
-						char *tgt = strtok(skipwhitespace(arrow + 2), " \t");
+					if (strncmp(after, "as ", 3) == 0) {
+						tmpl.type = STEP_CAPTURE;
+						tmpl.srcname = var;
+						tmpl.varname = strtok(skipwhitespace(after + 2), " \t");
+
+						if (!tmpl.varname)
+							errprintf("'%s ~ ... as' with no name\n", var);
+						else {
+							pcre2_code *probe = compileregex_opts((char *)txt, 0);
+
+							if (probe) {
+								uint32_t ngroups = 0, nnames = 1;
+								char *q;
+
+								for (q = tmpl.varname; (*q); q++)
+									if (*q == ';') nnames++;
+
+								pcre2_pattern_info(probe, PCRE2_INFO_CAPTURECOUNT,
+										   &ngroups);
+								freeregex(probe);
+
+								/*
+								 * One name per group, in order. A group
+								 * with no name throws its value away and a
+								 * name with no group can never be bound;
+								 * both are silent at run time.
+								 */
+								if (ngroups == 0)
+									errprintf("Service %s: '%s ~ \"%s\" as %s' has "
+										  "no capture group - it can never "
+										  "bind a value\n",
+										  first->rec->svcname, var, txt,
+										  tmpl.varname);
+								else if (ngroups != nnames)
+									errprintf("Service %s: '%s ~ \"%s\" as %s' has "
+										  "%u capture group(s) but %u name(s)\n",
+										  first->rec->svcname, var, txt,
+										  tmpl.varname, ngroups, nnames);
+							}
+							emit_step(first, &tmpl);
+						}
+					}
+					else if (strncmp(after, "->", 2) == 0) {
+						char *tgt = strtok(skipwhitespace(after + 2), " \t");
+
+						tmpl.type = STEP_WHEN;
+						tmpl.varname = var;
 
 						if (!tgt) errprintf("'%s ~ ... ->' with no target\n", var);
-						else if (strcmp(tgt, "fail") == 0)    tmpl.action = ACT_FAIL;
-						else if (strcmp(tgt, "warning") == 0) tmpl.action = ACT_WARNING;
-						else if (strcmp(tgt, "success") == 0) tmpl.action = ACT_SUCCESS;
-						else { tmpl.target = tgt; tmpl.action = ACT_GOTO; }
-						emit_step(first, &tmpl);
+						else {
+							if (strcmp(tgt, "fail") == 0)         tmpl.action = ACT_FAIL;
+							else if (strcmp(tgt, "warning") == 0) tmpl.action = ACT_WARNING;
+							else if (strcmp(tgt, "success") == 0) tmpl.action = ACT_SUCCESS;
+							else { tmpl.target = tgt; tmpl.action = ACT_GOTO; }
+							emit_step(first, &tmpl);
+						}
 					}
+					else errprintf("'%s ~ \"...\"' is followed by neither "
+						       "'-> TARGET' nor 'as NAME'\n", var);
 				}
 				if (txt) xfree(txt);
 			}

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -297,12 +297,12 @@ static void check_undefined_vars(svcinfo_t *rec)
  * Two alternatives can both match the same reply exactly when one is a
  * prefix of the other -- matching is prefix-anchored, so patterns that
  * diverge anywhere can never both match. That makes this check complete
- * rather than a heuristic.
+ * rather than a heuristic, which is what lets it refuse rather than warn.
  *
- * Such a group is ambiguous: which one wins depends on how much of the
- * reply has arrived, and therefore on how the server split it across
- * packets. Say so, and record the longest pattern so the driver can wait
- * for the group to be decidable instead of racing.
+ * Which one would win depends on how much of the reply has arrived, and
+ * so on how the server split it across packets. Refuse the definition and
+ * name the fix: match the shared prefix in one state, distinguish in the
+ * next.
  */
 static void refuse_overlapping_groups(svcinfo_t *rec)
 {
@@ -357,8 +357,8 @@ static int has_expect_step(svcinfo_t *rec)
 
 
 /*
- * Resolve "goto NAME" to the step that "label NAME" defines. Done once
- * after the whole entry is read, so a goto may point forwards -- a retry
+ * Resolve "-> NAME" to the step that "state NAME" defines. Done once
+ * after the whole entry is read, so an edge may point forwards -- a retry
  * loop points backwards, and both are ordinary edges here.
  */
 static void resolve_svcsteps(svcinfo_t *rec)
@@ -883,7 +883,7 @@ char *init_tcp_services(void)
 		else if (strncmp(l, "state ", 6) == 0) {
 			/*
 			 * Names the state that follows: the expects up to the next
-			 * step that is not one. It is also what "goto" aims at, so
+			 * step that is not one. It is also what an edge aims at, so
 			 * naming a state and marking a jump target are the same act
 			 * rather than two keywords for one idea.
 			 */

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -73,9 +73,9 @@ typedef struct svcstep_t {
 	unsigned char *text;		/* send/expect literal, or capture regex */
 	int len;
 	int action;			/* ACT_* -- expect steps only */
-	char *target;			/* goto label, unresolved */
+	char *target;			/* '-> NAME', unresolved */
 	struct svcstep_t *targetstep;	/* ... and resolved, after parsing */
-	char *label;			/* STEP_LABEL: the name it defines */
+	char *label;			/* STEP_LABEL: the state name it defines */
 	char *varname;			/* STEP_CAPTURE/WHEN: variable name */
 	void *re;			/* compiled pcre2_code, or NULL */
 	char *user, *pass;		/* STEP_CREDS: resolved at config load */

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -33,7 +33,7 @@
 #define STEP_EXPECT  2
 #define STEP_LABEL   3	/* a jump target; performs no I/O */
 #define STEP_CAPTURE 4	/* pull a value out of the reply just matched */
-#define STEP_WHEN    5	/* branch on a captured value */
+#define STEP_WHEN    5	/* branch on a bound value */
 #define STEP_JUMP    6	/* unconditional; emitted to skip an else-arm */
 #define STEP_CREDS   7	/* bind ${username}/${password} from the store */
 #define STEP_STARTTLS 8	/* upgrade this connection to TLS, here */
@@ -70,7 +70,8 @@
    taken when every alternative has been ruled out. */
 typedef struct svcstep_t {
 	int type;
-	unsigned char *text;		/* send/expect literal, or capture regex */
+	unsigned char *text;		/* send/expect literal, or extraction regex */
+	char *srcname;			/* STEP_CAPTURE: the named value it reads from */
 	int len;
 	int action;			/* ACT_* -- expect steps only */
 	char *target;			/* '-> NAME', unresolved */

--- a/tests/network/dialogue-ambiguity.sh
+++ b/tests/network/dialogue-ambiguity.sh
@@ -89,7 +89,7 @@ comment. Which of them matches depends on how the server split its reply,
 so the config's meaning is decided by the network:
 $out"
 
-grep -qi "capture as NAME" <<<"$out" || fail \
+grep -qi "expect ... as NAME" <<<"$out" || fail \
 	"the overlap was reported without saying what to do about it. What the
 author wanted is reasonable -- distinguishing two replies that share a
 prefix -- so the error has to name the fix, not just the fault:

--- a/tests/network/dialogue-starttls-negotiation.sh
+++ b/tests/network/dialogue-starttls-negotiation.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+#
+# What happens when the upgrade does NOT succeed.
+#
+# dialogue-tls.sh covers a STARTTLS that works, and dialogue-terminals.sh
+# covers "-> warning" on its own. Neither covers the two together, which
+# is the combination an operator actually deploys: a mail server that
+# stopped offering STARTTLS, or that answers 454 because its certificate
+# file went missing, is not down. It answers every command correctly. A
+# probe that calls that red gets switched off; a probe that calls it green
+# never noticed. Yellow is the whole point of the feature, so it is worth
+# a test that it is really yellow and not merely "not green".
+#
+# THE CONTROL is --checkresponse=red: with a plain dialogue failure
+# reporting red, a yellow result can only have come from an edge that says
+# "-> warning". Without it these assertions would also pass on a probe
+# that failed for an unrelated reason, since yellow is the default colour
+# for a response mismatch.
+#
+# The last two entries are the same conversation with the two expect lines
+# written in the opposite order. They must produce the SAME message. They
+# did not: the report blamed the head of the alternatives group rather than
+# the alternative that matched, so a server answering "454" was reported
+# as 'expected "220"' -- and swapping two lines that changed nothing about
+# the test changed what an operator was told to go and look at.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+command -v openssl >/dev/null 2>&1 || skip "openssl is needed to make a test certificate"
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+# A name nothing else in this run uses, so finding it proves the
+# certificate came off the session that started in plaintext.
+openssl req -x509 -newkey rsa:2048 -keyout "$work/k.pem" -out "$work/c.pem" \
+	-days 2 -nodes -subj "/CN=negotiated.example" >"$work/ssl.log" 2>&1 \
+	|| skip "openssl could not generate a test certificate"
+
+"$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile against libssl"; }
+
+# Offers STARTTLS and completes the upgrade.
+cat > "$work/up.script" <<'EOS'
+send "220 test.local ESMTP\r\n"
+recv ehlo
+send "250-test.local\r\n250 STARTTLS\r\n"
+recv starttls
+send "220 2.0.0 Ready to start TLS\r\n"
+starttls
+recv ehlo
+send "250-test.local\r\n250 OK\r\n"
+recv quit
+send "221 bye\r\n"
+EOS
+
+# Answers everything correctly, but never advertises STARTTLS.
+cat > "$work/none.script" <<'EOS'
+send "220 test.local ESMTP\r\n"
+recv ehlo
+send "250-test.local\r\n250 SIZE 10240000\r\n"
+hold 20
+EOS
+
+# Advertises STARTTLS and then declines it -- what a server with an
+# unreadable certificate file does.
+cat > "$work/refuse.script" <<'EOS'
+send "220 test.local ESMTP\r\n"
+recv ehlo
+send "250-test.local\r\n250 STARTTLS\r\n"
+recv starttls
+send "454 4.7.0 TLS not available due to local problem\r\n"
+hold 20
+EOS
+
+: > "$work/pids"
+start() {	# script portfile obsfile
+	"$work/peer" "$1" "$3" "$work/c.pem" "$work/k.pem" > "$2" &
+	echo $! >> "$work/pids"
+	local i=0
+	while [ "$i" -lt 50 ]; do [ -s "$2" ] && break; sleep 0.1; i=$((i + 1)); done
+	cat "$2"
+}
+pup=$(start "$work/up.script"     "$work/pup" "$work/oup")
+pno=$(start "$work/none.script"   "$work/pno" "$work/ono")
+pra=$(start "$work/refuse.script" "$work/pra" "$work/ora")
+prb=$(start "$work/refuse.script" "$work/prb" "$work/orb")
+register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
+for p in "$pup" "$pno" "$pra" "$prb"; do
+	[ -n "$p" ] || fail "a peer never named its port"
+done
+
+# tlsup is the worked example from protocols.cfg(5), verbatim. If this
+# entry stops working the manual is wrong, which is worse than a bug.
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[tlsup]
+   state greeting
+   timeout(10)         -> fail
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250" until "250 "
+   capture as caps
+   caps ~ "STARTTLS"   -> upgrade
+   else                -> warning
+
+   state upgrade
+   timeout(10)         -> fail
+   send "starttls\r\n"
+   expect "220"        -> secure
+   expect "454"        -> warning
+
+   state secure
+   timeout(10)         -> fail
+   starttls
+   send "ehlo xymonnet\r\n"
+   expect "250" until "250 "
+   send "quit\r\n"
+   expect "221"        -> success
+   options banner
+   port $pup
+
+[tlsnone]
+   state greeting
+   timeout(10)         -> fail
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250" until "250 "
+   capture as caps
+   caps ~ "STARTTLS"   -> upgrade
+   else                -> warning
+
+   state upgrade
+   timeout(10)         -> fail
+   send "starttls\r\n"
+   expect "220"        -> secure
+   expect "454"        -> warning
+
+   state secure
+   timeout(10)         -> fail
+   starttls
+   send "quit\r\n"
+   expect "221"        -> success
+   options banner
+   port $pno
+
+[tls454a]
+   state greeting
+   timeout(10)         -> fail
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250" until "250 "
+
+   state upgrade
+   timeout(10)         -> fail
+   send "starttls\r\n"
+   expect "220"        -> secure
+   expect "454"        -> warning
+
+   state secure
+   timeout(10)         -> fail
+   starttls
+   send "quit\r\n"
+   expect "221"        -> success
+   options banner
+   port $pra
+
+[tls454b]
+   state greeting
+   timeout(10)         -> fail
+   expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250" until "250 "
+
+   state upgrade
+   timeout(10)         -> fail
+   send "starttls\r\n"
+   expect "454"        -> warning
+   expect "220"        -> secure
+
+   state secure
+   timeout(10)         -> fail
+   starttls
+   send "quit\r\n"
+   expect "221"        -> success
+   options banner
+   port $prb
+CFG
+
+printf '127.0.0.1\tup\t# tlsup\n127.0.0.1\tnone\t# tlsnone\n' > "$work/home/etc/hosts.cfg"
+printf '127.0.0.1\trefa\t# tls454a\n127.0.0.1\trefb\t# tls454b\n' >> "$work/home/etc/hosts.cfg"
+
+# --checkresponse=red is the control: see the header.
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse=red \
+	--dns=ip --timeout=20 >"$work/out.txt" 2>&1 || :
+sleep 1
+
+colour_of() {	# host.service -> the colour xymonnet reported
+	grep -oE "status\+[0-9]+ $1 (green|yellow|red|clear)" "$work/out.txt" |
+		awk '{print $3}' | head -1
+}
+message_of() {	# service host -> the failure text
+	sed -n "s/^Service $1 on $2 is not OK : //p" "$work/out.txt" | head -1
+}
+
+# A state named only by a "~" edge, in an entry whose states budget their
+# waits, must not be reported unreachable: a timeout edge leaves the state
+# but the state continues past it, so the walk must not stop there. Every
+# entry below is shaped that way, and the manual's example is too.
+grep -q 'cannot be reached' "$work/out.txt" && fail \
+	"a state that an edge plainly names was reported unreachable, so the
+config checker is contradicting a working entry:
+$(grep 'cannot be reached' "$work/out.txt")"
+
+# --- the upgrade succeeds ----------------------------------------------------
+grep -q '^tls-ok' "$work/oup" || fail \
+	"the offered upgrade never completed: $(cat "$work/oup")"
+[ "$(colour_of up.tlsup)" = green ] || fail \
+	"a server that offers STARTTLS and completes it should be green, got '$(colour_of up.tlsup)':
+$(grep -i tlsup "$work/out.txt" | head -4)"
+grep -q 'CN=negotiated.example' "$work/out.txt" || fail \
+	"no certificate was read off the upgraded session, so the probe reported
+an upgraded service while knowing nothing about the certificate protecting it:
+$(grep -iE 'certinfo|CN=' "$work/out.txt" | head -4)"
+
+# --- STARTTLS is not offered -------------------------------------------------
+grep -q '^got starttls' "$work/ono" && fail \
+	"the probe sent STARTTLS to a server that never advertised it. The
+capability test is not reading the EHLO reply:
+$(cat "$work/ono")"
+[ "$(colour_of none.tlsnone)" = yellow ] || fail \
+	"a server that answers correctly but offers no STARTTLS should be yellow
+via 'else -> warning'. With --checkresponse=red a plain failure would be red,
+so '$(colour_of none.tlsnone)' means the else-arm did not decide this:
+$(grep -i tlsnone "$work/out.txt" | head -4)"
+
+# --- STARTTLS is refused -----------------------------------------------------
+for h in refa refb; do
+	svc=tls454a; [ "$h" = refb ] && svc=tls454b
+	[ "$(colour_of $h.$svc)" = yellow ] || fail \
+		"a 454 answer to STARTTLS should be yellow via 'expect \"454\" -> warning',
+got '$(colour_of $h.$svc)' with plain failures set to red:
+$(grep -i "$svc" "$work/out.txt" | head -4)"
+done
+
+# The message must name the alternative that MATCHED, not whichever one
+# happens to be written first.
+ma=$(message_of tls454a refa)
+mb=$(message_of tls454b refb)
+case "$ma" in
+	*454*) : ;;
+	*) fail "the report does not mention the 454 the server actually sent: '$ma'" ;;
+esac
+case "$ma" in
+	*'"220"'*) fail \
+		"the server answered 454 and the report blames the 220 alternative
+instead: '$ma'. An operator reading this goes looking for a broken
+greeting on a server whose greeting was fine." ;;
+esac
+[ "$ma" = "$mb" ] || fail \
+	"writing the two alternatives in the opposite order changed the report,
+though it changed nothing about the test:
+   220 first: '$ma'
+   454 first: '$mb'"
+
+pass "a STARTTLS that is not offered or is refused reports yellow, and names the answer that decided it"

--- a/tests/network/dialogue-starttls-negotiation.sh
+++ b/tests/network/dialogue-starttls-negotiation.sh
@@ -102,8 +102,7 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
    timeout(10)         -> fail
    expect "220"
    send "ehlo xymonnet\r\n"
-   expect "250" until "250 "
-   capture as caps
+   expect "250" until "250 " as caps
    caps ~ "STARTTLS"   -> upgrade
    else                -> warning
 
@@ -128,8 +127,7 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
    timeout(10)         -> fail
    expect "220"
    send "ehlo xymonnet\r\n"
-   expect "250" until "250 "
-   capture as caps
+   expect "250" until "250 " as caps
    caps ~ "STARTTLS"   -> upgrade
    else                -> warning
 

--- a/tests/network/dialogue-tls.sh
+++ b/tests/network/dialogue-tls.sh
@@ -17,6 +17,13 @@
 # The peer records the handshake and each line it receives, so the test can
 # check that the second EHLO arrived AFTER the upgrade rather than merely
 # that the probe reported success.
+#
+# And the certificate is read off the UPGRADED session. That is the half
+# people actually ask for: you can monitor SMTP on port 25 today, but you
+# cannot check that its TLS works or when its certificate expires, because
+# the certificate only exists after a STARTTLS. Asserted for [msatls] --
+# not [dlgtls], where it would pass on the implicit handshake and prove
+# nothing about the upgrade.
 
 set -eu
 . "$(dirname "$0")/../lib/assert.sh"
@@ -32,6 +39,14 @@ mkdir -p "$work/home/etc"
 openssl req -x509 -newkey rsa:2048 -keyout "$work/k.pem" -out "$work/c.pem" \
 	-days 2 -nodes -subj "/CN=127.0.0.1" >"$work/ssl.log" 2>&1 \
 	|| skip "openssl could not generate a test certificate"
+
+# A SECOND certificate, for the peer that upgrades part-way, with a name
+# nothing else uses. Both peers presenting the same certificate would let
+# the assertion below pass on the implicit handshake and say nothing
+# about the upgraded one.
+openssl req -x509 -newkey rsa:2048 -keyout "$work/k2.pem" -out "$work/c2.pem" \
+	-days 2 -nodes -subj "/CN=upgraded.example" >>"$work/ssl.log" 2>&1 \
+	|| skip "openssl could not generate the second test certificate"
 
 "$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
 	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile against libssl"; }
@@ -61,15 +76,15 @@ send "221 bye\r\n"
 EOS
 
 : > "$work/pids"
-start() {
-	"$work/peer" "$1" "$3" "$work/c.pem" "$work/k.pem" > "$2" &
+start() {	# script portfile obsfile [cert key]
+	"$work/peer" "$1" "$3" "${4:-$work/c.pem}" "${5:-$work/k.pem}" > "$2" &
 	echo $! >> "$work/pids"
 	local i=0
 	while [ "$i" -lt 50 ]; do [ -s "$2" ] && break; sleep 0.1; i=$((i + 1)); done
 	cat "$2"
 }
 pi=$(start "$work/imp.script" "$work/pi" "$work/oi")
-pe=$(start "$work/exp.script" "$work/pe" "$work/oe")
+pe=$(start "$work/exp.script" "$work/pe" "$work/oe" "$work/c2.pem" "$work/k2.pem")
 register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
 [ -n "$pi" ] && [ -n "$pe" ] || fail "a peer never named its port"
 
@@ -97,7 +112,7 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
 CFG
 printf '127.0.0.1\timplicit\t# dlgtls\n127.0.0.1\texplicit\t# msatls\n' > "$work/home/etc/hosts.cfg"
 
-XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse \
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse --sslcert-valid-by=1 \
 	--dns=ip --timeout=20 >"$work/out.txt" 2>&1 || :
 sleep 1
 
@@ -127,5 +142,22 @@ grep -q '^got quit' "$work/oe" || fail "the upgraded session never reached QUIT"
 grep -q 'Service msatls on explicit is OK' "$work/out.txt" || fail \
 	"the starttls dialogue did not report the service up:
 $(cat "$work/out.txt")"
+
+# THE CERTIFICATE, on the connection that was upgraded part-way. Without
+# this the probe can report an upgraded session healthy while knowing
+# nothing about the certificate it is protected by -- which is the state
+# xymon is in today for every service that starts in plaintext.
+# The name belongs to the upgrading peer and to nothing else in this run,
+# so finding it proves the certificate came from the session that started
+# in plaintext -- not from the implicit handshake next door.
+grep -q 'CN=upgraded.example' "$work/out.txt" || fail \
+	"no certificate was read from the STARTTLS session. The upgrade happened
+and the conversation completed, so the probe reported an upgraded service
+while knowing nothing about the certificate protecting it:
+$(grep -iE 'certinfo|certificate|CN=' "$work/out.txt" | head -6)"
+
+grep -q 'Service msatls on explicit is OK' "$work/out.txt" || fail \
+	"the explicit-TLS service did not pass:
+$(grep -i msatls "$work/out.txt" | head -6)"
 
 pass "a dialogue runs over TLS from the first byte, and over a connection upgraded part-way"

--- a/tests/network/dialogue-validation.sh
+++ b/tests/network/dialogue-validation.sh
@@ -5,8 +5,8 @@
 # Every one of these used to be silent. A mistyped directive was a no-op,
 # so the step simply vanished and the probe reported on a conversation it
 # never had; ${sha1:...} was read as a variable named "sha1:..." and
-# expanded to nothing; a capture with no expect in front of it bound an
-# empty string; starttls on a service that is already TLS started a second
+# expanded to nothing; an extraction naming a value that nothing
+# binds read an empty string; starttls on a service that is already TLS started a second
 # handshake inside the first and failed like a broken server.
 #
 # The checks run when the file is read, not when the step executes -- a
@@ -37,8 +37,8 @@ printf 'mypop\tuser\tsecret\n' > "$work/home/etc/credentials.cfg"
 cat > "$work/home/etc/protocols.cfg" <<'CFG'
 [bad]
    exepct "220"
-   capture as tooearly
    expect "220"
+   nosuch ~ "(x)"              as tooearly
    send "x${sha1:foo}\r\n"
    timeout(0)                  -> fail
    starttls
@@ -46,9 +46,9 @@ cat > "$work/home/etc/protocols.cfg" <<'CFG'
    port 9
 
 [typo]
-   expect "+OK"
-   capture-regex "(<[^>]+>)" as challenge
-   capture-regex "[0-9]+" as nogroup
+   expect "+OK" as greeting
+   greeting ~ "(<[^>]+>)" as challenge
+   greeting ~ "[0-9]+" as nogroup
    credentials mypop
    challeng ~ "<"              -> apop
    else                        -> plain
@@ -81,9 +81,9 @@ grep -qi 'unknown protocols.cfg directive' <<<"$out" || fail \
 probe still runs, so the test reports on a conversation it never had:
 $out"
 
-grep -qi 'before any expect' <<<"$out" || fail \
-	"'capture as' with no preceding expect was accepted; it can only bind an
-empty value:
+grep -qi 'never bound before it' <<<"$out" || fail \
+	"an extraction reading a name that nothing binds was accepted; it can only
+ever bind an empty value:
 $out"
 
 grep -qi "state 'spin' waits for a reply with no timeout" <<<"$out" || fail \
@@ -130,7 +130,7 @@ ever fall through to the else-arm:
 $out"
 
 grep -q 'no capture group' <<<"$out" || fail \
-	"a capture-regex with no parenthesised group was accepted. The value bound
+	"an extraction with no parenthesised group was accepted. The value bound
 is group 1, so that pattern can never bind anything and \${name} expands to
 nothing for every reply:
 $out"
@@ -138,7 +138,7 @@ $out"
 # --- and the shipped file must be quiet -------------------------------------
 cp "$root/xymonnet/protocols.cfg" "$work/home/etc/protocols.cfg"
 out=$(run_xymonnet)
-noise=$(grep -ciE 'unknown protocols.cfg directive|before any expect|unknown expansion|already TLS|never captured or bound|can only fail|no capture group' <<<"$out" || true)
+noise=$(grep -ciE 'unknown protocols.cfg directive|never bound before it|unknown expansion|already TLS|never captured or bound|can only fail|no capture group' <<<"$out" || true)
 [ "$noise" -eq 0 ] || fail \
 	"the protocols.cfg this tree ships triggers $noise of its own warnings:
 $(grep -iE 'unknown|before any expect|already TLS' <<<"$out")"

--- a/tests/network/dialogue-values.sh
+++ b/tests/network/dialogue-values.sh
@@ -70,8 +70,8 @@ register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
 authblock() {
 cat <<CFG
 [$1]
-   expect "+OK"
-   capture-regex "\\+OK POP3 (\\S+) (<[^>]+>)" as server;challenge
+   expect "+OK" as greeting
+   greeting ~ "\\+OK POP3 (\\S+) (<[^>]+>)" as server;challenge
    credentials mypop
    challenge ~ "<"             -> apop
    else                        -> plain

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -1201,15 +1201,18 @@ static char *dlg_expand(tcptest_t *item, const char *text, int len, int *outlen)
 /* Group 1 of the pattern, against the reply the last expect accepted. */
 static void dlg_capture(tcptest_t *item, svcstep_t *st)
 {
-	char *subject = (item->lastreply ? item->lastreply : "");
+	char *subject = dlg_get(item, st->srcname);
 	pcre2_match_data *md;
 	int res, n;
 	char names[256], *name, *rest;
 
-	if (st->re == NULL) {			/* plain "capture as NAME" */
-		dlg_set(item, st->varname, subject);
-		return;
-	}
+	/*
+	 * The input is named, so this reads the value the config asked for
+	 * rather than whichever reply happened to be the most recent one.
+	 * An unbound name binds empty, which check_undefined_vars() has
+	 * already complained about when the file was read.
+	 */
+	if (subject == NULL) subject = "";
 
 	md = pcre2_match_data_create(32, NULL);
 	res = pcre2_match((pcre2_code *)st->re, (PCRE2_SPTR)subject,
@@ -1240,7 +1243,7 @@ static void dlg_capture(tcptest_t *item, svcstep_t *st)
 			xfree(v);
 		}
 		else {
-			dbgprintf("dialogue: capture-regex did not match, ${%s} left empty\n", name);
+			dbgprintf("dialogue: an extraction did not match, ${%s} left empty\n", name);
 			dlg_set(item, name, "");
 		}
 		n++;
@@ -2274,6 +2277,15 @@ restartselect:
 										item->lastreply = (char *)malloc(cut + 1);
 										memcpy(item->lastreply, item->stepbuf, cut);
 										item->lastreply[cut] = '\0';
+
+										/*
+										 * "expect ... as NAME" binds the reply THIS
+										 * alternative accepted, on the line that
+										 * produced it -- so it cannot name the reply
+										 * of some earlier state.
+										 */
+										if (hit->varname)
+											dlg_set(item, hit->varname, item->lastreply);
 
 										memmove(item->stepbuf, item->stepbuf + cut, item->stepbuflen - cut);
 										item->stepbuflen -= cut;

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -236,6 +236,7 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 	newtest->dialogfail = (newtest->svcinfo &&
 			       (newtest->svcinfo->flags & TCP_DIALOGUE_BROKEN)) ? 1 : 0;
 	newtest->failstep = NULL;
+	newtest->failmatched = 0;
 	newtest->stepsecs = 0;
 	newtest->stepdeadline = 0;
 	newtest->stepdeadlinefor = NULL;
@@ -2281,7 +2282,19 @@ restartselect:
 										    (hit->action == ACT_WARNING)) {
 											item->dialogfail = 1;
 											item->dialogverdict = (hit->action == ACT_WARNING) ? 2 : 3;
-											if (!item->failstep) item->failstep = (void *)st;
+											/*
+											 * Blame the alternative that matched, not
+											 * the head of its group. Naming st reports
+											 * whichever expect is written first: a
+											 * server answering "454" to a STARTTLS was
+											 * reported as 'expected "220"', and the
+											 * text changed when the two edges were
+											 * swapped though nothing else did.
+											 */
+											if (!item->failstep) {
+												item->failstep = (void *)hit;
+												item->failmatched = 1;
+											}
 											item->curstep = NULL;
 											st = NULL;
 										}
@@ -2530,11 +2543,20 @@ char *tcp_dialogue_failure(tcptest_t *test)
 	}
 
 	if (bad->type == STEP_EXPECT) {
+		/*
+		 * "expected" is for an alternative that never matched. When the
+		 * step being reported is the one that DID match -- an edge whose
+		 * target is "warning" or "fail" -- saying the probe expected the
+		 * thing it just received reads as a fault in the config. Name it
+		 * as what arrived instead.
+		 */
+		char *verb = (test->failmatched ? "got" : "expected");
+
 		if (name)
-			snprintf(buf, sizeof(buf), "state %s expected \"%.40s\"", name,
+			snprintf(buf, sizeof(buf), "state %s %s \"%.40s\"", name, verb,
 				 (bad->text ? (char *)bad->text : ""));
 		else
-			snprintf(buf, sizeof(buf), "step %d expected \"%.40s\"", idx,
+			snprintf(buf, sizeof(buf), "step %d %s \"%.40s\"", idx, verb,
 				 (bad->text ? (char *)bad->text : ""));
 	}
 	else if (name) snprintf(buf, sizeof(buf), "state %s failed", name);

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -1672,7 +1672,7 @@ restartselect:
 		for (item=firstactive; (item != nextinqueue); item=item->next) {
 			if (item->fd > -1) {		/* Only active sockets have this */
 				/*
-				 * A per-step budget from "timeout N". Armed here, against
+				 * A per-state budget from "timeout(N)". Armed here, against
 				 * the same clock the comparison below uses: arming it from
 				 * gettimer() while comparing against getntimer()'s reading
 				 * mixes a monotonic source with a wall-clock one, and the

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -143,6 +143,7 @@ typedef struct tcptest_t {
 	void *curstep;			/* svcstep_t *: position in the dialogue */
 	int dialogfail;			/* an expect step did not match */
 	void *failstep;			/* svcstep_t *: WHICH step, for the report */
+	int failmatched;		/* that step MATCHED and ended it, not missed */
 	unsigned char *stepbuf;		/* replies for the CURRENT expect step */
 	int stepbuflen;
 	char *lastreply;		/* the reply that satisfied the last expect */

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -147,7 +147,7 @@ typedef struct tcptest_t {
 	int stepbuflen;
 	char *lastreply;		/* the reply that satisfied the last expect */
 	void *dlgvars;			/* captured values, a dlgvar_t list */
-	int stepsecs;			/* 'timeout N': budget for the current wait, 0 = none */
+	int stepsecs;			/* 'timeout(N)': budget for this state, 0 = none */
 	time_t stepdeadline;		/* ... armed against the poll clock, 0 = unarmed */
 	void *stepdeadlinefor;		/* svcstep_t *: which step it was armed for */
 	int steptimedout;		/* that budget expired, rather than a mismatch */

--- a/xymonnet/protocols.cfg.5
+++ b/xymonnet/protocols.cfg.5
@@ -95,30 +95,42 @@ covers them without special-casing any:
 \&   expect "*"   until "A01 "     (IMAP: the command tag ends it)
 .fi
 
-.IP "\fBexpect\fR \fISTRING\fR \fBgoto\fR \fILABEL\fR"
-.IP "\fBexpect\fR \fISTRING\fR \fBfail\fR"
+.IP "\fBexpect\fR \fISTRING\fR \fB\->\fR \fITARGET\fR"
 .IP "\fBstate\fR \fINAME\fR"
 Consecutive \fBexpect\fR lines are alternatives: the first whose pattern
-matches wins, and its action decides what happens next. Without an
-action the dialogue continues after the whole group; \fBgoto\fR jumps to
-the matching \fBstate\fR, and \fBfail\fR ends the test as a failure.
+matches wins, and its \fB\->\fR decides what happens next. Without one the
+dialogue simply continues after the whole group. A target is either the
+name of a \fBstate\fR, which is jumped to, or one of three outcomes that
+end the test where it stands:
+.br
+.sp
+.nf
+\&   \-> \fILABEL\fR        continue in that state
+\&   \-> success      the service is up
+\&   \-> warning      answering, but not as it should (yellow)
+\&   \-> fail         the test failed (the \fB\-\-checkresponse\fR colour)
+.fi
+.sp
+\fBwarning\fR is the one worth reaching for. A server that answers
+correctly but refuses an optional capability is not down, and reporting
+it as down teaches operators to ignore the column.
 .sp
 \fBstate\fR names the state that follows it -- the expects up to the next
-step that is not one -- and is what \fBgoto\fR aims at, so naming a state
+step that is not one -- and is what a \fB\->\fR aims at, so naming a state
 and marking a jump target are the same act. Naming them is optional, but
 worth doing: a dialogue that fails reports the state it failed in, and
-"state want-password expected \"334\"" tells an operator what "step 7"
+"state want-password expected 334" tells an operator what "step 7"
 does not.
 This is how a soft error is told apart from a hard one instead of both
 timing out:
 .br
 .sp
 .nf
-\&   expect "250" goto ready
-\&   expect "421" fail
+\&   expect "250" \-> ready
+\&   expect "421" \-> fail
 .fi
 .sp
-A \fBgoto\fR may point backwards, which makes a retry loop. A dialogue
+A \fB\->\fR may point backwards, which makes a retry loop. A dialogue
 that loops without performing any I/O is stopped rather than spinning.
 .sp
 Avoid writing one alternative that is a prefix of another. Both would
@@ -131,17 +143,53 @@ every pattern in it to be decidable before choosing, so the order written
 here decides the winner. The warning is still worth acting on: a reader
 of the file cannot see which alternative wins without knowing that rule.
 
-.IP "\fBwhen\fR \fINAME\fR ~ \fIREGEX\fR"
-.IP "\fBelse\fR"
-.IP "\fBend\fR"
-Run the enclosed steps only when the captured value \fINAME\fR matches
-\fIREGEX\fR. An unset value never matches. Blocks may be nested.
+.IP "\fBstart\fR \fINAME\fR"
+Begin the dialogue in the state called \fINAME\fR rather than at the
+first step. Useful when the states read better in an order other than
+the one they run in.
+
+.IP "\fBalways\fR \fB\->\fR \fITARGET\fR"
+An unconditional edge, for a state that has nothing to wait for -- after
+a \fBstarttls\fR, for instance.
+
+.IP "\fBeof\fR \fB\->\fR \fITARGET\fR"
+The server closing the connection is an outcome, not automatically a
+fault: after QUIT it is the correct one. This is an alternative like an
+\fBexpect\fR, competing in the same group, but it matches the close
+rather than any bytes.
+
+.IP "\fBtimeout(\fR\fISECONDS\fR\fB)\fR \fB\->\fR \fITARGET\fR"
+.IP "\fBidle(\fR\fISECONDS\fR\fB)\fR \fB\->\fR \fITARGET\fR"
+How long the state may take, and where to go when it does not finish in
+time. \fBtimeout\fR is the budget for the whole state; \fBidle\fR is how
+long the server may say nothing at all. They differ for a long reply
+that keeps arriving: that is not idle, but it may still be over budget.
+Either may lead to \fBwarning\fR, which is how "slow" is reported as
+distinct from "broken".
+
+.IP "\fINAME\fR \fB~\fR \fIREGEX\fR \fB\->\fR \fITARGET\fR"
+.IP "\fBelse\fR \fB\->\fR \fITARGET\fR"
+Branch on a value bound earlier by \fBcapture\fR. The line begins with
+the name being tested, so it is recognised by its shape rather than by a
+leading keyword.
+.sp
+The regex is tested against a value already in hand, never against the
+socket. That is why a regex is allowed here and not in an \fBexpect\fR:
+it decides nothing about what arrives, so it cannot race a partial read.
+A name that nothing bound never matches, and so takes the \fBelse\fR arm.
 
 .IP "\fBcapture as\fR \fINAME\fR"
 .IP "\fBcapture-regex\fR \fIREGEX\fR \fBas\fR \fINAME\fR"
 Bind a value out of the reply that the preceding \fBexpect\fR accepted:
 the whole reply, or the first capture group of \fIREGEX\fR. The regex is
 case-sensitive. A pattern that does not match binds an empty value.
+Several names may be given as \fIN1\fR;\fIN2\fR, one per capture group,
+in the order the groups appear.
+.sp
+The word "preceding" is load-bearing: \fBcapture\fR must come AFTER the
+\fBexpect\fR whose reply it binds. Written before it there is nothing
+bound yet, so the name takes an empty value, every branch that tests it
+falls to its \fBelse\fR arm, and nothing reports an error.
 
 .IP "\fBcredentials\fR \fINAME\fR"
 Bind \fB${username}\fR and \fB${password}\fR from the entry called
@@ -189,6 +237,10 @@ Expansion is recursive, so a digest may be taken of other values -- APOP
 is \fB${md5:${challenge}${password}}\fR. An unset name expands to
 nothing.
 
+.IP "\fBtransport\fR \fBtcp\fR"
+Which probe runs this entry. Only \fBtcp\fR is implemented; naming
+anything else refuses the entry rather than silently running it as tcp.
+
 .IP "\fBport\fR \fINUMBER\fR"
 Define the default TCP port-number for this service. If no portnumber
 is defined,
@@ -206,6 +258,51 @@ Defines test options. The possible options are
 \&   alpn=protocol1,protocol2 - specify ALPN protocols to negotiate during SSL handshake
 .fi
 
+
+.SH EXAMPLES
+An SMTP service that upgrades to TLS when the server offers it, reports
+a server that does not offer it as yellow rather than down, and reads the
+certificate off the upgraded session:
+.br
+.sp
+.nf
+\&   [smtp\-tls]
+\&      state greeting
+\&      timeout(10)         \-> fail
+\&      expect "220"
+\&      send "ehlo xymonnet\er\en"
+\&      expect "250" until "250 "
+\&      capture as caps
+\&      caps ~ "STARTTLS"   \-> upgrade
+\&      else                \-> warning
+\&
+\&      state upgrade
+\&      timeout(10)         \-> fail
+\&      send "starttls\er\en"
+\&      expect "220"        \-> secure
+\&      expect "454"        \-> warning
+\&
+\&      state secure
+\&      timeout(10)         \-> fail
+\&      starttls
+\&      send "ehlo xymonnet\er\en"
+\&      expect "250" until "250 "
+\&      send "quit\er\en"
+\&      expect "221"        \-> success
+\&      options banner
+\&      port 25
+.fi
+.sp
+Note where \fBcapture\fR sits: after the \fBexpect\fR whose reply it
+binds, not before it.
+.sp
+Note also that this is deliberately NOT what the shipped \fB[smtp]\fR
+entry does. protocols.cfg is one file for the whole installation, so an
+entry that expects STARTTLS would change what every existing host
+reports the moment the file is installed -- a site whose mail server
+offers no STARTTLS would turn yellow because it upgraded, not because
+anything changed at the site. Copy this under a new name and point the
+hosts that should use it at that name instead.
 
 .SH FILES
 .IP "\fB$XYMONHOME/etc/protocols.cfg\fR"


### PR DESCRIPTION
Four fixes and the tests that catch them, none of them user-visible syntax:

- the certificate must come off the **upgraded** session, not the plaintext one
- a failure names the alternative that **matched**, not the first one written
- a `timeout` edge does not end the reachability walk — it briefly made every state after one look unreachable
- `expect ... as NAME` binds the reply on the line that **produces** it, so it cannot name an earlier state's reply
---
Part of the dialogue stack, sliced out of #456 and #465 so each PR is one subject. Reviewed bottom-up: this one is based on `dialogue-06-perhost`.