### PR TITLE
xymonnet: the shipped SMTP entries hold the conversation, and one layout for every entry

### DIFF
--- a/docs/design/protocol-dialogues.md
+++ b/docs/design/protocol-dialogues.md
@@ -108,7 +108,8 @@ Submission on 587, upgrading to TLS and authenticating:
    state farewell
       send   "quit\r\n"
       expect "221"                -> success
-      timeout(10)                 -> fail```
+      timeout(10)                 -> fail
+```
 
 The same entry as a diagram -- generated from it rather than drawn beside it: **25 edges in the config, 25 in the diagram.**
 
@@ -172,7 +173,8 @@ stateDiagram-v2
     classDef bad  fill:#cf222e,color:#fff,stroke:#a40e26
     class success ok
     class warning warn
-    class fail bad```
+    class fail bad
+```
 
 ## Branching on a value
 
@@ -208,7 +210,8 @@ stateDiagram-v2
    state farewell
       send   "quit\r\n"
       expect "+OK"                -> success
-      timeout(5)                  -> fail```
+      timeout(5)                  -> fail
+```
 
 One entry, both server styles, no nesting. The greeting is bound where it is accepted and taken apart in the state that branches on it.
 

--- a/docs/design/protocol-dialogues.md
+++ b/docs/design/protocol-dialogues.md
@@ -40,7 +40,13 @@ condition ::= expect "…" [ until "…" ] [ as NAME ] | NAME ~ "…"
 
 **Targets** are a state, or one of `success`, `warning`, `fail` -- green, yellow, red. `warning` is the point: a server answering correctly but refusing an optional capability is not down, and calling it down teaches operators to ignore the column. An edge saying `fail` is red whatever `--checkresponse` is set to; a reply matching no alternative takes that option's colour, yellow by default.
 
-**Order is file order.** A state's lines run as written and the first edge that fires leaves, so a `~` above an `expect` decides before the socket is read at all. An earlier draft specified a fixed precedence regardless of where lines were written; the implementation does not do that and should not, because a precedence the reader cannot see is what turns a declaration back into a program.
+**Layout.** Entry attributes -- `transport`, `port`, `options`, `start` -- are written first, in any order among themselves, because they describe the definition rather than any step; then each `state` with its lines indented under it.
+
+**One action, one wait.** A state does one thing -- a `send`, a `starttls`, a `credentials` -- and waits for one answer: the clock that bounds the wait, and the `expect` lines that end the state, each naming where its answer leads. A state that acts without waiting leaves on `always`; a state that decides on a value already bound needs no action at all. Because a state holds one action and one wait, the order of its lines carries no meaning of its own: the entry is declarative down to the state, and sequence lives in the edges between states rather than in the lines within one.
+
+The parser enforces none of it: attributes are accepted anywhere, indentation is ignored, several actions and several waits in one state are accepted, and an `expect` with no `->` falls through to the line below. One ordering rule is real and unenforced: a `timeout` or `idle` arms the wait that follows it, so a clock below a state's `expect` lines bounds nothing. `protocols.cfg(5)` lists the five rules under CONVENTIONS, and `tests/buildsystem/dialogue-conventions.sh` checks every entry in the manual, in the shipped `protocols.cfg` and in the fixtures against them -- an entry that breaks one on purpose says `# conventions: permissive` and says why. Prose nothing checks is how the manual came to document a `when ... end` grammar no shipped code ever had.
+
+**Order is file order, and with one action per state that stops mattering.** The driver runs a state's lines as written and the first edge that fires leaves it, so today a `~` above an `expect` decides before the socket is read. An earlier draft specified a fixed precedence regardless of where lines were written and was rejected, because a precedence the reader cannot see is what turns a declaration back into a program. Under one action and one wait the question mostly dissolves: a state either decides on values it already holds or waits for bytes, and the two do not compete within one state. Where they still could, the honest fix is a load-time refusal rather than an invisible rule.
 
 **Values are bound where they are produced.** `expect "…" as NAME` binds the reply that expect accepted; `NAME ~ "…" as X;Y` reads a bound value and binds more out of it. No line refers to its operand by position.
 
@@ -58,15 +64,15 @@ Submission on 587, upgrading to TLS and authenticating:
    start greeting
 
    state greeting
+      timeout(5)                  -> fail
       expect "220"                -> ehlo
       expect "421"                -> warning
-      timeout(5)                  -> fail
 
    state ehlo
       send   "ehlo xymonnet\r\n"
-      expect "250" until "250 " as caps   -> offers-tls
       idle(5)                     -> warning
       timeout(30)                 -> fail
+      expect "250" until "250 " as caps   -> offers-tls
 
    state offers-tls
       caps ~ "STARTTLS"           -> upgrade
@@ -74,41 +80,41 @@ Submission on 587, upgrading to TLS and authenticating:
 
    state upgrade
       send   "starttls\r\n"
+      timeout(10)                 -> fail
       expect "220"                -> handshake
       expect "454"                -> warning
-      timeout(10)                 -> fail
 
    state handshake
       starttls
-      always                      -> ehlo-encrypted
       timeout(10)                 -> fail
+      always                      -> ehlo-encrypted
 
    state ehlo-encrypted
       send   "ehlo xymonnet\r\n"
-      expect "250" until "250 "   -> authenticate
       timeout(10)                 -> fail
+      expect "250" until "250 "   -> authenticate
 
    state authenticate
       send   "auth login\r\n"
+      timeout(10)                 -> fail
       expect "334"                -> send-user
       expect "503"                -> farewell
-      timeout(10)                 -> fail
 
    state send-user
       send   "${base64:${username}}\r\n"
-      expect "334"                -> send-pass
       timeout(10)                 -> fail
+      expect "334"                -> send-pass
 
    state send-pass
       send   "${base64:${password}}\r\n"
+      timeout(20)                 -> warning
       expect "235"                -> farewell
       expect "535"                -> fail
-      timeout(20)                 -> warning
 
    state farewell
       send   "quit\r\n"
-      expect "221"                -> success
       timeout(10)                 -> fail
+      expect "221"                -> success
 ```
 
 The same entry as a diagram -- generated from it rather than drawn beside it: **25 edges in the config, 25 in the diagram.**
@@ -180,9 +186,9 @@ stateDiagram-v2
 
 ```
    state greeting
+      timeout(5)                  -> fail
       expect "+OK" as banner      -> choose-auth
       expect "-ERR"               -> fail
-      timeout(5)                  -> fail
 
    state choose-auth
       banner ~ "\+OK (\S+) (<[^>]+>)" as server;challenge
@@ -191,26 +197,26 @@ stateDiagram-v2
 
    state apop
       send   "APOP ${username} ${md5:${challenge}${password}}\r\n"
+      timeout(5)                  -> fail
       expect "+OK"                -> farewell
       expect "-ERR"               -> fail
-      timeout(5)                  -> fail
 
    state plain
       send   "USER ${username}\r\n"
+      timeout(5)                  -> fail
       expect "+OK"                -> send-pass
       expect "-ERR"               -> fail
-      timeout(5)                  -> fail
 
    state send-pass
       send   "PASS ${password}\r\n"
+      timeout(5)                  -> fail
       expect "+OK"                -> farewell
       expect "-ERR"               -> fail
-      timeout(5)                  -> fail
 
    state farewell
       send   "quit\r\n"
-      expect "+OK"                -> success
       timeout(5)                  -> fail
+      expect "+OK"                -> success
 ```
 
 One entry, both server styles, no nesting. The greeting is bound where it is accepted and taken apart in the state that branches on it.
@@ -274,7 +280,7 @@ Each entry says what was tried, why it lost, and where one exists, what would ch
 
 **Mealy: the action on the transition.** Rejected: a state reachable from several places would duplicate its action on every incoming edge -- `farewell` already has two routes in.
 
-**One thing per state.** More uniform, and makes timers structural. Rejected: with one action and one wait the sequence is forced rather than authored; the action state carries no information, its only edge being `always ->`; and it costs 17 states against 10 on the submission entry, with failures reading `state send-pass-wait expected "235"` where `-wait` is scaffolding. The split form is still correct wherever a state is the target of a cycle, since re-entry re-runs the action.
+**One thing per state.** More uniform, and makes timers structural. *Rejected, then adopted.* The objection was that with one action and one wait the sequence is forced rather than authored, that an action-only state carries no information when its single edge is `always ->`, and that it cost 17 states against 10 on the submission entry, with failures reading `state send-pass-wait expected "235"` where `-wait` is scaffolding. What overturned it: a state holding several actions and several waits makes line order significant *inside* a state, and that is what stops the file being declarative -- a clock written below an expect bounds nothing, a `~` above one decides before the socket is read. One action and one wait moves all sequence into the edges, where it is visible and checkable, and makes "this state waits twice" and "this clock bounds nothing" load-time questions. The cost is the extra states, which is a cost in reading, not in meaning.
 
 **Mermaid as the config format itself.** Tested rather than assumed -- labels do preserve trailing spaces, `\r\n` and colons. Rejected: it needs a mermaid-subset parser in C, and a subset is the trap; it pins the config to someone else's release cycle; its edge list names both endpoints per line, so a state's action sits away from its edges; and `[name]`, `options`, `port` have no home in it. Generating mermaid gets the benefit with none of that.
 

--- a/docs/manpages/man5/protocols.cfg.5.html
+++ b/docs/manpages/man5/protocols.cfg.5.html
@@ -93,13 +93,21 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
         (ASCII 13), &quot;\n&quot; represents a line-feed (ASCII 10),
         &quot;\t&quot; represents a TAB (ASCII 8). Binary data is input as
         &quot;\xNN&quot; with NN being the hexadecimal value of the byte.</p>
-    <p class="Pp">An <b>expect</b> matches the beginning of the reply, and
-        consumes one line of it. Anything the server sent beyond that line is
-        kept for the next step.</p>
-    <p class="Pp">A reply that never matches is not accumulated without limit.
-        Once a conversation has buffered 32 KB with nothing matching, the test
-        fails naming the service rather than growing for as long as the server
-        cares to talk.</p>
+    <p class="Pp">Three shapes are the classic single-shot probe, and keep the
+        code path they have always used: a lone <b>send</b>, a lone
+        <b>expect</b>, and a <b>send</b> followed by an <b>expect</b>. That
+        probe writes immediately on connect, reads once, and compares the start
+        of what came back. Everything else -- an <b>expect</b> with something
+        sent after it, more than one of either, or any of the steps below --
+        runs the dialogue driver, and only there do the rest of these pages
+        apply.</p>
+    <p class="Pp">Under the driver, an <b>expect</b> matches the beginning of
+        the reply and consumes one line of it; anything the server sent beyond
+        that line is kept for the next step. A reply that never matches is not
+        accumulated without limit: once a conversation has buffered 32 KB with
+        nothing matching, the test fails naming the service rather than growing
+        for as long as the server cares to talk. The single-shot probe
+        accumulates nothing and so has no such bound.</p>
     <p class="Pp"></p>
   </dd>
   <dt id="expect~2"><a class="permalink" href="#expect~2"><b>expect</b>
@@ -108,6 +116,11 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       <i>TERMINATOR</i>, which is consumed as well. Nothing is consumed until
       that line arrives, so a reply that is still in flight is waited for rather
       than half-read.
+    <p class="Pp">This needs the driver, and a definition that is one
+        <b>expect</b> and nothing else is a classic shape that does not use it:
+        there, <b>until</b> has no effect and the first line decides the test.
+        Adding the step that follows -- the <b>send</b> that ends the session,
+        say -- is what makes it a dialogue.</p>
     <p class="Pp">Protocols end a multi-line reply differently, and naming the
         terminator covers them without special-casing any:</p>
     <p class="Pp"></p>

--- a/docs/manpages/man5/protocols.cfg.5.html
+++ b/docs/manpages/man5/protocols.cfg.5.html
@@ -166,11 +166,34 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
         match.</p>
     <p class="Pp"><b>state</b> names the state that follows it -- the expects up
         to the next step that is not one -- and is what a <b>-&gt;</b> aims at,
-        so naming a state and marking a jump target are the same act. Naming
-        them is optional, but worth doing: a dialogue that fails reports the
-        state it failed in, and &quot;state want-password expected 334&quot;
-        tells an operator what &quot;step 7&quot; does not. This is how a soft
-        error is told apart from a hard one instead of both timing out:</p>
+        so naming a state and marking a jump target are the same act.</p>
+    <p class="Pp">Naming them is optional, but worth doing: a dialogue that
+        fails reports the state it failed in, and &quot;state want-password
+        expected 334&quot; tells an operator what &quot;step 7&quot; does
+      not.</p>
+    <p class="Pp"><b>Layout.</b> An entry that uses states is written the same
+        way throughout this page: the entry attributes -- <b>options</b>,
+        <b>port</b>, <b>transport</b>, <b>start</b> -- first, in any order among
+        themselves, because they describe the definition rather than any step;
+        then the states, each with its lines indented under it.</p>
+    <p class="Pp">A state does one thing and waits for one answer: at most one
+        action -- a <b>send</b>, a <b>starttls</b>, a <b>credentials</b> -- the
+        clock that bounds the wait, and the <b>expect</b> lines that end the
+        state, each naming where its answer leads. A state that acts without
+        waiting leaves on <b>always</b>; a state that only decides on a value
+        already bound needs no action at all. Written that way an entry is the
+        machine it describes, and the order of the lines within a state carries
+        no meaning of its own.</p>
+    <p class="Pp">The parser enforces none of this. It takes an attribute
+        anywhere in the block, ignores indentation, accepts several actions and
+        several waits in one state, and accepts an <b>expect</b> with no
+        <b>-&gt;</b>, which continues with the step below it -- the shape the
+        classic entries at the top of this page use. One ordering rule survives
+        and is real: a <b>timeout</b> or <b>idle</b> arms the wait that follows
+        it, so a clock written below a state's <b>expect</b> lines bounds
+        nothing.</p>
+    <p class="Pp">This is how a soft error is told apart from a hard one instead
+        of both timing out:</p>
     <p class="Pp"></p>
     <pre>   expect &quot;250&quot; -&gt; ready
    expect &quot;421&quot; -&gt; fail</pre>
@@ -370,40 +393,94 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
 </section>
 <section class="Sh">
 <p>&#160;</p>
+<h1 class="Sh" id="CONVENTIONS"><a class="permalink" href="#CONVENTIONS">CONVENTIONS</a></h1>
+<p class="Pp">The parser accepts an attribute anywhere in a block, ignores
+    indentation, takes several actions and several waits in one state, and
+    accepts an <b>expect</b> that names no target. None of what follows is
+    enforced by it; it is how every entry in this page and in the shipped
+    protocols.cfg is written, and what a reader is entitled to assume:</p>
+<p class="Pp"></p>
+<pre>   1  entry attributes -- options, port, transport, start -- come
+      before the first state, in any order among themselves
+   2  a state's lines are indented under it
+   3  a state holds at most one action: send, starttls, credentials
+   4  every expect names where it goes: &quot;-&gt; TARGET&quot;
+   5  a clock -- timeout or idle -- is written above the expects it
+      bounds, because it arms the wait that FOLLOWS it</pre>
+<p class="Pp">Rule 5 is the one that bites: a clock written below a state's
+    <b>expect</b> lines bounds nothing, and nothing says so. The others are
+    legibility -- an entry written this way reads as the machine it describes,
+    and one that is not still runs.</p>
+<p class="Pp">A definition that means to break a rule says so, with a comment
+    the parser ignores and a reader does not:</p>
+<p class="Pp"></p>
+<pre>   [legacy]
+      # conventions: permissive -- one expect, no state to move to</pre>
+<p class="Pp">The regression suite checks every entry in this page, in the
+    shipped protocols.cfg and in the test fixtures against these five rules, so
+    the page and the files cannot drift apart unnoticed.</p>
+<p class="Pp"></p>
+</section>
+<section class="Sh">
+<p>&#160;</p>
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
 <p class="Pp">An SMTP service that upgrades to TLS when the server offers it,
     reports a server that does not offer it as yellow rather than down, and
     reads the certificate off the upgraded session:</p>
 <p class="Pp"></p>
 <pre>   [smtp-tls]
-      state greeting
-      timeout(10)         -&gt; fail
-      expect &quot;220&quot;
-      send &quot;ehlo xymonnet\r\n&quot;
-      expect &quot;250&quot; until &quot;250 &quot; as caps
-      caps ~ &quot;STARTTLS&quot;   -&gt; upgrade
-      else                -&gt; warning
-      state upgrade
-      timeout(10)         -&gt; fail
-      send &quot;starttls\r\n&quot;
-      expect &quot;220&quot;        -&gt; secure
-      expect &quot;454&quot;        -&gt; warning
-      state secure
-      timeout(10)         -&gt; fail
-      starttls
-      send &quot;ehlo xymonnet\r\n&quot;
-      expect &quot;250&quot; until &quot;250 &quot;
-      send &quot;quit\r\n&quot;
-      expect &quot;221&quot;        -&gt; success
       options banner
-      port 25</pre>
-<p class="Pp">Note also that this is deliberately NOT what the shipped
-    <b>[smtp]</b> entry does. protocols.cfg is one file for the whole
-    installation, so an entry that expects STARTTLS would change what every
-    existing host reports the moment the file is installed -- a site whose mail
-    server offers no STARTTLS would turn yellow because it upgraded, not because
-    anything changed at the site. Copy this under a new name and point the hosts
-    that should use it at that name instead.</p>
+      port 25
+      start greeting
+      state greeting
+         timeout(10)                        -&gt; fail
+         expect &quot;220&quot;                       -&gt; ehlo
+      state ehlo
+         send &quot;ehlo xymonnet\r\n&quot;
+         timeout(30)                        -&gt; fail
+         expect &quot;250&quot; until &quot;250 &quot; as caps  -&gt; offers
+      state offers
+         caps ~ &quot;STARTTLS&quot;                  -&gt; upgrade
+         else                               -&gt; warning
+      state upgrade
+         send &quot;starttls\r\n&quot;
+         timeout(10)                        -&gt; fail
+         expect &quot;220&quot;                       -&gt; secure
+         expect &quot;454&quot;                       -&gt; warning
+      state secure
+         starttls
+         always                             -&gt; ehlo-tls
+      state ehlo-tls
+         send &quot;ehlo xymonnet\r\n&quot;
+         timeout(10)                        -&gt; fail
+         expect &quot;250&quot; until &quot;250 &quot;          -&gt; farewell
+      state farewell
+         send &quot;quit\r\n&quot;
+         timeout(10)                        -&gt; fail
+         expect &quot;221&quot;                       -&gt; success</pre>
+<p class="Pp">A state does one thing and then waits for one answer: at most one
+    action -- a <b>send</b>, a <b>starttls</b>, a <b>credentials</b> -- the
+    clock that bounds the wait, and the <b>expect</b> lines that end the state
+    by naming where each answer leads. <b>secure</b> upgrades and does nothing
+    else, so it leaves on <b>always</b>; <b>offers</b> waits for nothing at all
+    and decides on a value it already holds.</p>
+<p class="Pp">Because a state holds one action and one wait, the order of its
+    lines carries no meaning of its own -- with one exception the parser has not
+    been taught: a <b>timeout</b> or <b>idle</b> arms the wait that follows it,
+    so a clock written below the <b>expect</b> lines bounds nothing. Keep it
+    above them, as every example here does.</p>
+<p class="Pp">The entry attributes -- <b>options</b>, <b>port</b>,
+    <b>transport</b>, <b>start</b> -- describe the definition rather than any
+    step, so they are written together at the top, in any order among
+    themselves.</p>
+<p class="Pp">This is deliberately a service of its own rather than a deeper
+    <b>[smtp]</b>. protocols.cfg is one file for the whole installation, so
+    teaching <b>[smtp]</b> to expect STARTTLS would change what every existing
+    host reports the moment the file is installed -- a site whose mail server
+    offers none would turn yellow because it upgraded, not because anything
+    changed at the site. Point the hosts that should have the deeper check at
+    <b>smtp-tls</b>, or keep <b>[smtp]</b> and give those hosts
+    <b>smtp:ok=</b><i>STATE</i> instead.</p>
 <p class="Pp"></p>
 </section>
 <section class="Sh">
@@ -453,6 +530,7 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
 <dt><a href="#DESCRIPTION">DESCRIPTION</a></dt>
 <dt><a href="#FILE_FORMAT">FILE FORMAT</a></dt>
 <dt><a href="#PER-HOST_DEPTH_AND_CREDENTIALS">PER-HOST DEPTH AND CREDENTIALS</a></dt>
+<dt><a href="#CONVENTIONS">CONVENTIONS</a></dt>
 <dt><a href="#EXAMPLES">EXAMPLES</a></dt>
 <dt><a href="#DIAGNOSTICS">DIAGNOSTICS</a></dt>
 <dt><a href="#FILES">FILES</a></dt>

--- a/tests/buildsystem/dialogue-conventions.sh
+++ b/tests/buildsystem/dialogue-conventions.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/buildsystem/dialogue-conventions.sh
+#
+# protocols.cfg(5) states how a dialogue entry is written, and the parser
+# enforces none of it: an attribute is accepted anywhere in the block,
+# indentation is ignored, and several actions or several waits in one state
+# parse fine. The conventions are what make an entry readable as the machine
+# it describes, so nothing but a test keeps them true -- and prose that
+# nothing checks drifts, which is how the manual came to document a "when ...
+# end" grammar that no shipped code ever had.
+#
+# This checks every entry we publish or test against the rules the manual
+# lists under CONVENTIONS:
+#
+#   R1  entry attributes (options, port, transport, start) come before the
+#       first state, since they describe the definition and not a step
+#   R2  a state's lines are indented under it
+#   R3  a state holds at most one action (send, starttls, credentials)
+#   R4  every expect in a state names where it goes: "-> TARGET"
+#   R5  a clock (timeout, idle) is written above the expects it bounds,
+#       because it arms the wait that FOLLOWS it and bounds nothing below them
+#   R6  no directive that was tried and dropped: when/end, capture,
+#       capture-regex, expect-regex, goto, "-> green"
+#
+# Sources: the shipped protocols.cfg, the examples in protocols.cfg.5 and in
+# docs/design/protocol-dialogues.md, and the protocols.cfg written by every
+# dialogue test. An entry that means to break a rule says so in the file with
+#
+#   # conventions: permissive
+#
+# which is how the suite keeps covering the spellings the parser accepts but
+# the manual does not recommend.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+cd "$ROOT"
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+stream="$work/entries.txt"        # FILE<TAB>LINENO<TAB>TEXT
+: > "$stream"
+
+# --- extract config text from each kind of source ----------------------------
+extract_roff() {	# man page: literal lines start with "\&"
+	awk -v F="$1" 'substr($0,1,2)=="\\&" {
+		t=substr($0,3)
+		gsub(/\\-/,"-",t); gsub(/\\er/,"\\r",t); gsub(/\\en/,"\\n",t)
+		gsub(/\\e/,"\\",t); gsub(/\\f[BIRP]/,"",t)
+		print F "\t" NR "\t" t
+	}' "$1" >> "$stream"
+}
+extract_fenced() {	# markdown: inside ``` fences
+	awk -v F="$1" '
+		/^```[a-z]/ { skip=1; next }		# ```mermaid and friends: not config
+		/^```/      { if (skip) { skip=0; next } inb = !inb; next }
+		inb && $0 !~ /…|::=/ { print F "\t" NR "\t" $0 }
+	' "$1" >> "$stream"
+}
+extract_heredoc() {	# tests: inside the protocols.cfg heredoc
+	awk -v F="$1" '/protocols\.cfg" <<CFG/ { inb=1; next } inb && /^CFG$/ { inb=0; next }
+		       inb { print F "\t" NR "\t" $0 }' "$1" >> "$stream"
+}
+extract_plain() { awk -v F="$1" '{ print F "\t" NR "\t" $0 }' "$1" >> "$stream"; }
+
+extract_plain   xymonnet/protocols.cfg
+extract_roff    xymonnet/protocols.cfg.5
+[ -f docs/design/protocol-dialogues.md ] && extract_fenced docs/design/protocol-dialogues.md
+for t in tests/network/dialogue-*.sh tests/network/protocol-dialogue.sh; do
+	[ -f "$t" ] && extract_heredoc "$t"
+done
+[ -s "$stream" ] || fail "no protocols.cfg text was found to check -- the extractors match nothing, so this suite would pass on anything"
+
+# --- apply the rules ---------------------------------------------------------
+awk -F'\t' '
+function flush_state(   i) {
+	# R3/R5 are per state, and are decided when the state ends
+	if (statename != "" && actions > 1 && !permissive)
+		bad[++n] = sprintf("%s:%d  R3  state \"%s\" holds %d actions; a state does one thing and waits for one answer",
+				   sfile, sline, statename, actions)
+	if (statename != "" && clock_after_expect && !permissive)
+		bad[++n] = sprintf("%s:%d  R5  state \"%s\" writes a clock below its expects, where it bounds nothing",
+				   sfile, sline, statename)
+	statename=""; actions=0; expects=0; clock_after_expect=0
+}
+{
+	file=$1; lineno=$2; raw=$3
+	sub(/[[:space:]]+$/,"",raw)
+	text=raw; sub(/^[[:space:]]+/,"",text)
+	indent=length(raw)-length(text)
+
+	if (text ~ /^#/) { if (text ~ /conventions:[[:space:]]*permissive/) permissive=1; next }
+	if (text == "") next
+
+	if (text ~ /^\[[^]]+\]$/) {			# a new entry
+		flush_state()
+		entry=text; efile=file; seen_state=0; permissive=0
+		# "[service|alias]" heads the grammar summary, not an entry
+		if (entry ~ /service\|alias/) entry=""
+		next
+	}
+	if (entry == "") next
+
+	# A block of literal text in a manual is not always an entry: the
+	# DIAGNOSTICS table is set the same way. Anything that is not a
+	# directive ends the entry rather than being judged as part of it.
+	if (text !~ /^(state|send|expect|starttls|credentials|options|port|transport|start|always|eof|else)([[:space:]]|$)/ &&
+	    text !~ /^(timeout|idle)\(/ &&
+	    text !~ /^[A-Za-z_][A-Za-z0-9_-]*[[:space:]]+~[[:space:]]/) {
+		flush_state(); entry=""; next
+	}
+
+	# R6 -- syntax that was tried and dropped
+	if (text ~ /^(when|end|capture|capture-regex|expect-regex|expect-capture|goto)([[:space:]]|$)/ ||
+	    text ~ /->[[:space:]]*green([[:space:]]|$)/)
+		bad[++n] = sprintf("%s:%d  R6  %s uses a directive that was tried and dropped: %s", file, lineno, entry, text)
+
+	if (text ~ /^state[[:space:]]/) {
+		flush_state()
+		statename=text; sub(/^state[[:space:]]+/,"",statename)
+		sfile=file; sline=lineno; sindent=indent; seen_state=1
+		next
+	}
+
+	if (text ~ /^(options|port|transport|start)[[:space:]]/) {
+		if (seen_state && !permissive)
+			bad[++n] = sprintf("%s:%d  R1  %s writes \"%s\" after a state; attributes describe the definition and come first",
+					   file, lineno, entry, text)
+		next
+	}
+
+	if (!seen_state) next				# classic single-shot entry: R2-R5 do not apply
+
+	if (indent <= sindent && !permissive)
+		bad[++n] = sprintf("%s:%d  R2  %s: \"%s\" is not indented under state \"%s\"",
+				   file, lineno, entry, text, statename)
+
+	if (text ~ /^(send|starttls|credentials)([[:space:]]|$)/) actions++
+	else if (text ~ /^(timeout|idle)\(/) { if (expects > 0) clock_after_expect=1 }
+	else if (text ~ /^expect[[:space:]]/) {
+		expects++
+		if (text !~ /->[[:space:]]*[A-Za-z_]/ && !permissive)
+			bad[++n] = sprintf("%s:%d  R4  %s: \"%s\" names no state to move to",
+					   file, lineno, entry, text)
+	}
+}
+END {
+	flush_state()
+	for (i=1; i<=n; i++) print bad[i]
+	exit (n > 0)
+}' "$stream" > "$work/problems.txt" || :
+
+if [ -s "$work/problems.txt" ]; then
+	fail "protocols.cfg entries break the conventions protocols.cfg(5) states under CONVENTIONS.
+The parser accepts all of these; a reader cannot. Either write the entry the
+documented way, or mark it '# conventions: permissive' if it exists to cover a
+spelling the parser allows:
+
+$(cat "$work/problems.txt")"
+fi
+
+pass "every published and tested dialogue entry follows the conventions the manual states"

--- a/tests/network/dialogue-buffer-cap.sh
+++ b/tests/network/dialogue-buffer-cap.sh
@@ -61,21 +61,24 @@ register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
 # test must fail by timing out rather than pass because a timer rescued it.
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [toobig]
-   state one
-   timeout(60)                       -> fail
-   expect "250" until "250 "         -> success
    port $pover
 
-[bigreply]
    state one
-   timeout(60)                       -> fail
-   expect "250" until "250 "         -> quit
+      timeout(60)                       -> fail
+      expect "250" until "250 "         -> success
+
+[bigreply]
+   port $punder
+
+   state one
+      timeout(60)                       -> fail
+      expect "250" until "250 "         -> quit
 
    state quit
-   timeout(10)                       -> fail
-   send "quit\r\n"
-   eof                               -> success
-   port $punder
+      timeout(10)                       -> fail
+      send "quit\r\n"
+      eof                               -> success
+
 CFG
 printf '127.0.0.1\tover\t# toobig\n127.0.0.1\tunder\t# bigreply\n' > "$work/home/etc/hosts.cfg"
 

--- a/tests/network/dialogue-depth.sh
+++ b/tests/network/dialogue-depth.sh
@@ -76,15 +76,17 @@ printf 'accta\tuser-a\tsecret-a\nacctb\tuser-b\tsecret-b\n' > "$work/home/etc/cr
   printf '127.0.0.1\thostb\t# loginsvc:%s:cred=acctb\n' "$p4"; } > "$work/home/etc/hosts.cfg"
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [depthsvc]
-   start greeting
-   state greeting
-   expect "220"                -> ehlo
-   timeout(5)                  -> fail
-   state ehlo
-   send "ehlo xymonnet\r\n"
-   expect "250"                -> success
-   timeout(5)                  -> fail
    options banner
+   start greeting
+
+   state greeting
+      timeout(5)                  -> fail
+      expect "220"                -> ehlo
+
+   state ehlo
+      send "ehlo xymonnet\r\n"
+      timeout(5)                  -> fail
+      expect "250"                -> success
 
 [loginsvc]
    expect "220"

--- a/tests/network/dialogue-eof.sh
+++ b/tests/network/dialogue-eof.sh
@@ -48,14 +48,16 @@ register_cleanup "kill $(cat "$work/p1.pid") $(cat "$work/p2.pid") $(cat "$work/
 printf '127.0.0.1\thost\t# eofok eofbad\n' > "$work/home/etc/hosts.cfg"
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [eofok]
-   state greeting
-   expect "220"                -> farewell
-   state farewell
-   send "quit\r\n"
-   eof                         -> success
-   expect "221"                -> success
    options banner
    port $p1
+
+   state greeting
+      expect "220"                -> farewell
+
+   state farewell
+      send "quit\r\n"
+      eof                         -> success
+      expect "221"                -> success
 
 [eofbad]
    expect "220"

--- a/tests/network/dialogue-grammar.sh
+++ b/tests/network/dialogue-grammar.sh
@@ -54,15 +54,17 @@ printf '127.0.0.1\thost\t# eofok eofbad udpsvc\n' > "$work/home/etc/hosts.cfg"
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [eofok]
    transport tcp
-   start greeting
-   state farewell
-   send "quit\r\n"
-   eof                         -> success
-   expect "221"                -> success
-   state greeting
-   expect "220"                -> farewell
    options banner
    port $p1
+   start greeting
+
+   state farewell
+      send "quit\r\n"
+      eof                         -> success
+      expect "221"                -> success
+
+   state greeting
+      expect "220"                -> farewell
 
 [eofbad]
    expect "220"

--- a/tests/network/dialogue-idle.sh
+++ b/tests/network/dialogue-idle.sh
@@ -62,24 +62,27 @@ register_cleanup "kill $(cat "$work/p1.pid") $(cat "$work/p2.pid") 2>/dev/null |
 printf '127.0.0.1\thost\t# stopped slow\n' > "$work/home/etc/hosts.cfg"
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [stopped]
-   expect "220"
-   send "ehlo xymonnet\r\n"
-   state waiting
-   idle(3)                     -> warning
-   timeout(30)                 -> fail
-   expect "250"                -> success
    options banner
    port $pstop
-
-[slow]
    expect "220"
    send "ehlo xymonnet\r\n"
+
    state waiting
-   idle(3)                     -> warning
-   timeout(30)                 -> fail
-   expect "250" until "250 "   -> success
+      idle(3)                     -> warning
+      timeout(30)                 -> fail
+      expect "250"                -> success
+
+[slow]
    options banner
    port $pslow
+   expect "220"
+   send "ehlo xymonnet\r\n"
+
+   state waiting
+      idle(3)                     -> warning
+      timeout(30)                 -> fail
+      expect "250" until "250 "   -> success
+
 CFG
 
 start=$(date +%s)

--- a/tests/network/dialogue-starttls-negotiation.sh
+++ b/tests/network/dialogue-starttls-negotiation.sh
@@ -100,100 +100,120 @@ done
 # The two entries spell the same step differently on purpose. [tlsup] writes
 # all four clauses on one line -- expect, until, as, and the edge -- which is
 # the form the manual prints under "expect ... as NAME" and which nothing else
-# in the suite covers. [tlsnone] leaves the edge off and falls through to the
-# '~' below it. Both must reach the same state, or one of the two spellings is
-# documented and not implemented.
+# in the suite covers, and every expect in it ends its state by naming the
+# next. [tlsnone] uses the permissive spelling the parser also accepts, where
+# an expect names no target and falls through to the step below it. Both must
+# reach the same verdicts, or one of the two is documented and not
+# implemented.
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [tlsup]
-   state greeting
-   timeout(10)         -> fail
-   expect "220"
-   send "ehlo xymonnet\r\n"
-   expect "250" until "250 " as caps   -> offers
-   state offers
-   caps ~ "STARTTLS"   -> upgrade
-   else                -> warning
-
-   state upgrade
-   timeout(10)         -> fail
-   send "starttls\r\n"
-   expect "220"        -> secure
-   expect "454"        -> warning
-
-   state secure
-   timeout(10)         -> fail
-   starttls
-   send "ehlo xymonnet\r\n"
-   expect "250" until "250 "
-   send "quit\r\n"
-   expect "221"        -> success
    options banner
    port $pup
 
-[tlsnone]
    state greeting
-   timeout(10)         -> fail
-   expect "220"
-   send "ehlo xymonnet\r\n"
-   expect "250" until "250 " as caps
-   caps ~ "STARTTLS"   -> upgrade
-   else                -> warning
+      timeout(10)                        -> fail
+      expect "220"                       -> ehlo
+
+   state ehlo
+      send "ehlo xymonnet\r\n"
+      timeout(10)                        -> fail
+      expect "250" until "250 " as caps  -> offers
+
+   state offers
+      caps ~ "STARTTLS"                  -> upgrade
+      else                               -> warning
 
    state upgrade
-   timeout(10)         -> fail
-   send "starttls\r\n"
-   expect "220"        -> secure
-   expect "454"        -> warning
+      send "starttls\r\n"
+      timeout(10)                        -> fail
+      expect "220"                       -> secure
+      expect "454"                       -> warning
 
    state secure
-   timeout(10)         -> fail
-   starttls
-   send "quit\r\n"
-   expect "221"        -> success
+      starttls
+      always                             -> ehlo-tls
+
+   state ehlo-tls
+      send "ehlo xymonnet\r\n"
+      timeout(10)                        -> fail
+      expect "250" until "250 "          -> farewell
+
+   state farewell
+      send "quit\r\n"
+      timeout(10)                        -> fail
+      expect "221"                       -> success
+
+[tlsnone]
+   # conventions: permissive -- the fall-through spelling, kept covered on purpose
    options banner
    port $pno
 
-[tls454a]
    state greeting
-   timeout(10)         -> fail
-   expect "220"
-   send "ehlo xymonnet\r\n"
-   expect "250" until "250 "
+      timeout(10)         -> fail
+      expect "220"
+      send "ehlo xymonnet\r\n"
+      expect "250" until "250 " as caps
+      caps ~ "STARTTLS"   -> upgrade
+      else                -> warning
 
    state upgrade
-   timeout(10)         -> fail
-   send "starttls\r\n"
-   expect "220"        -> secure
-   expect "454"        -> warning
+      timeout(10)         -> fail
+      send "starttls\r\n"
+      expect "220"        -> secure
+      expect "454"        -> warning
 
    state secure
-   timeout(10)         -> fail
-   starttls
-   send "quit\r\n"
-   expect "221"        -> success
+      timeout(10)         -> fail
+      starttls
+      send "quit\r\n"
+      expect "221"        -> success
+
+[tls454a]
+   # conventions: permissive -- alternatives in both orders, the point of this pair
    options banner
    port $pra
 
-[tls454b]
    state greeting
-   timeout(10)         -> fail
-   expect "220"
-   send "ehlo xymonnet\r\n"
-   expect "250" until "250 "
+      timeout(10)         -> fail
+      expect "220"
+      send "ehlo xymonnet\r\n"
+      expect "250" until "250 "
 
    state upgrade
-   timeout(10)         -> fail
-   send "starttls\r\n"
-   expect "454"        -> warning
-   expect "220"        -> secure
+      timeout(10)         -> fail
+      send "starttls\r\n"
+      expect "220"        -> secure
+      expect "454"        -> warning
 
    state secure
-   timeout(10)         -> fail
-   starttls
-   send "quit\r\n"
-   expect "221"        -> success
+      timeout(10)         -> fail
+      starttls
+      send "quit\r\n"
+      expect "221"        -> success
+
+[tls454b]
+   # conventions: permissive -- alternatives in both orders, the point of this pair
    options banner
    port $prb
+
+   state greeting
+      timeout(10)         -> fail
+      expect "220"
+      send "ehlo xymonnet\r\n"
+      expect "250" until "250 "
+
+   state upgrade
+      timeout(10)         -> fail
+      send "starttls\r\n"
+      expect "454"        -> warning
+      expect "220"        -> secure
+
+   state secure
+      timeout(10)         -> fail
+      starttls
+      send "quit\r\n"
+      expect "221"        -> success
+
 CFG
 
 printf '127.0.0.1\tup\t# tlsup\n127.0.0.1\tnone\t# tlsnone\n' > "$work/home/etc/hosts.cfg"

--- a/tests/network/dialogue-starttls-negotiation.sh
+++ b/tests/network/dialogue-starttls-negotiation.sh
@@ -96,13 +96,21 @@ done
 
 # tlsup is the worked example from protocols.cfg(5), verbatim. If this
 # entry stops working the manual is wrong, which is worse than a bug.
+#
+# The two entries spell the same step differently on purpose. [tlsup] writes
+# all four clauses on one line -- expect, until, as, and the edge -- which is
+# the form the manual prints under "expect ... as NAME" and which nothing else
+# in the suite covers. [tlsnone] leaves the edge off and falls through to the
+# '~' below it. Both must reach the same state, or one of the two spellings is
+# documented and not implemented.
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [tlsup]
    state greeting
    timeout(10)         -> fail
    expect "220"
    send "ehlo xymonnet\r\n"
-   expect "250" until "250 " as caps
+   expect "250" until "250 " as caps   -> offers
+   state offers
    caps ~ "STARTTLS"   -> upgrade
    else                -> warning
 

--- a/tests/network/dialogue-terminals.sh
+++ b/tests/network/dialogue-terminals.sh
@@ -68,24 +68,27 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
    port $pok
 
 [termbusy]
-   expect "220"                -> proceed
-   expect "421"                -> warning
-   state proceed
-   send "quit\r\n"
-   expect "221"                -> success
    options banner
    port $pbusy
+   expect "220"                -> proceed
+   expect "421"                -> warning
+
+   state proceed
+      send "quit\r\n"
+      expect "221"                -> success
 
 [termbad]
+   options banner
+   port $pbad
    expect "220"
    send "ehlo xymonnet\r\n"
    expect "250"                -> done
    expect "5"                  -> fail
+
    state done
-   send "quit\r\n"
-   expect "221"                -> success
-   options banner
-   port $pbad
+      send "quit\r\n"
+      expect "221"                -> success
+
 CFG
 
 out=$(XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse \

--- a/tests/network/dialogue-timeout.sh
+++ b/tests/network/dialogue-timeout.sh
@@ -65,31 +65,37 @@ register_cleanup "kill $(cat "$work/silent.port.pid") $(cat "$work/quick.port.pi
 printf '127.0.0.1\tsilent\t# budgeted healthy routed\n' > "$work/home/etc/hosts.cfg"
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [budgeted]
-   expect "220"
-   send "ehlo xymonnet\r\n"
-   state waiting
-   timeout(2)                  -> fail
-   expect "250"
+   # conventions: permissive -- the clock, not the shape, is what this measures
    options banner
    port $psilent
+   expect "220"
+   send "ehlo xymonnet\r\n"
+
+   state waiting
+      timeout(2)                  -> fail
+      expect "250"
 
 [healthy]
-   expect "220"
-   send "ehlo xymonnet\r\n"
-   state waiting
-   timeout(2)                  -> fail
-   expect "250"
+   # conventions: permissive -- the clock, not the shape, is what this measures
    options banner
    port $pquick
-
-[routed]
    expect "220"
    send "ehlo xymonnet\r\n"
+
    state waiting
-   timeout(2)                  -> warning
-   expect "250"                -> success
+      timeout(2)                  -> fail
+      expect "250"
+
+[routed]
    options banner
    port $prouted
+   expect "220"
+   send "ehlo xymonnet\r\n"
+
+   state waiting
+      timeout(2)                  -> warning
+      expect "250"                -> success
+
 CFG
 
 start=$(date +%s)
@@ -134,13 +140,16 @@ ceiling, so the budget is not what ended it -- the global cutoff is."
 printf '127.0.0.1\tsilent\t# ceiling\n' > "$work/home/etc/hosts.cfg"
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [ceiling]
-   expect "220"
-   send "ehlo xymonnet\r\n"
-   state waiting
-   timeout(60)                 -> fail
-   expect "250"
+   # conventions: permissive -- the clock, not the shape, is what this measures
    options banner
    port $pceil
+   expect "220"
+   send "ehlo xymonnet\r\n"
+
+   state waiting
+      timeout(60)                 -> fail
+      expect "250"
+
 CFG
 
 start=$(date +%s)

--- a/tests/network/dialogue-validation.sh
+++ b/tests/network/dialogue-validation.sh
@@ -46,33 +46,39 @@ cat > "$work/home/etc/protocols.cfg" <<'CFG'
    port 9
 
 [typo]
+   port 9
+   port 9
    expect "+OK" as greeting
    greeting ~ "(<[^>]+>)" as challenge
    greeting ~ "[0-9]+" as nogroup
    credentials mypop
    challeng ~ "<"              -> apop
    else                        -> plain
+
    state apop
-   send "APOP ${username} ${md5:${challeng}${password}}\r\n"
+      send "APOP ${username} ${md5:${challeng}${password}}\r\n"
+
    state plain
-   send "USER ${usernam}\r\n"
-   expect "+OK"
-   port 9
-   port 9
+      send "USER ${usernam}\r\n"
+      expect "+OK"
 
 [graph]
+   port 9
    start entry
+
    state entry
       expect "220"                -> spin
       timeout(5)                  -> fail
+
    state spin
       send "x\r\n"
       expect "250"                -> spin
+
    state unreachable
       send "y\r\n"
       expect "250"                -> fail
       timeout(5)                  -> fail
-   port 9
+
 CFG
 out=$(run_xymonnet)
 

--- a/tests/network/dialogue-verdict.sh
+++ b/tests/network/dialogue-verdict.sh
@@ -76,14 +76,17 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
    port $pok
 
 [dlgbad]
-   state greeting
-   expect "220"
-   send "ehlo xymonnet\r\n"
-   state capabilities
-   expect "250"
-   send "quit\r\n"
+   # conventions: permissive -- a dialogue that stops mid-way, written the old way
    options banner
    port $pbad
+
+   state greeting
+      expect "220"
+      send "ehlo xymonnet\r\n"
+
+   state capabilities
+      expect "250"
+      send "quit\r\n"
 
 [legacy]
    send "probe\r\n"

--- a/xymonnet/protocols.cfg
+++ b/xymonnet/protocols.cfg
@@ -68,16 +68,25 @@
 
 [smtp]
    expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250" until "250 "
+   send "quit\r\n"
    options banner
    port 25
 
 [smtps]
    expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250" until "250 "
+   send "quit\r\n"
    options ssl,banner
 #  No default port-number assignment for smtps - nonstandard according to IANA
 
 [submission|msa]
    expect "220"
+   send "ehlo xymonnet\r\n"
+   expect "250" until "250 "
+   send "quit\r\n"
    options banner
    port 587
 

--- a/xymonnet/protocols.cfg.5
+++ b/xymonnet/protocols.cfg.5
@@ -153,10 +153,36 @@ it is a stronger statement than merely failing to match.
 .sp
 \fBstate\fR names the state that follows it -- the expects up to the next
 step that is not one -- and is what a \fB\->\fR aims at, so naming a state
-and marking a jump target are the same act. Naming them is optional, but
-worth doing: a dialogue that fails reports the state it failed in, and
+and marking a jump target are the same act.
+.sp
+Naming them is optional, but worth doing: a dialogue that fails reports
+the state it failed in, and
 "state want-password expected 334" tells an operator what "step 7"
 does not.
+.sp
+\fBLayout.\fR An entry that uses states is written the same way
+throughout this page: the entry attributes -- \fBoptions\fR,
+\fBport\fR, \fBtransport\fR, \fBstart\fR -- first, in any order
+among themselves, because they describe the definition rather than any
+step; then the states, each with its lines indented under it.
+.sp
+A state does one thing and waits for one answer: at most one action --
+a \fBsend\fR, a \fBstarttls\fR, a \fBcredentials\fR -- the clock
+that bounds the wait, and the \fBexpect\fR lines that end the state,
+each naming where its answer leads. A state that acts without waiting
+leaves on \fBalways\fR; a state that only decides on a value already
+bound needs no action at all. Written that way an entry is the machine
+it describes, and the order of the lines within a state carries no
+meaning of its own.
+.sp
+The parser enforces none of this. It takes an attribute anywhere in the
+block, ignores indentation, accepts several actions and several waits in
+one state, and accepts an \fBexpect\fR with no \fB\->\fR, which
+continues with the step below it -- the shape the classic entries at the
+top of this page use. One ordering rule survives and is real: a
+\fBtimeout\fR or \fBidle\fR arms the wait that follows it, so a clock
+written below a state's \fBexpect\fR lines bounds nothing.
+.sp
 This is how a soft error is told apart from a hard one instead of both
 timing out:
 .br
@@ -352,6 +378,42 @@ The checks in DIAGNOSTICS below are made against the entry as written,
 not against any host's depth. Under \fBok=greeting\fR everything
 downstream is legitimately unreachable, and the checks do not know that.
 
+.SH CONVENTIONS
+The parser accepts an attribute anywhere in a block, ignores indentation,
+takes several actions and several waits in one state, and accepts an
+\fBexpect\fR that names no target. None of what follows is enforced by
+it; it is how every entry in this page and in the shipped protocols.cfg
+is written, and what a reader is entitled to assume:
+.br
+.sp
+.nf
+\&   1  entry attributes -- options, port, transport, start -- come
+\&      before the first state, in any order among themselves
+\&   2  a state's lines are indented under it
+\&   3  a state holds at most one action: send, starttls, credentials
+\&   4  every expect names where it goes: "\-> TARGET"
+\&   5  a clock -- timeout or idle -- is written above the expects it
+\&      bounds, because it arms the wait that FOLLOWS it
+.fi
+.sp
+Rule 5 is the one that bites: a clock written below a state's
+\fBexpect\fR lines bounds nothing, and nothing says so. The others are
+legibility -- an entry written this way reads as the machine it
+describes, and one that is not still runs.
+.sp
+A definition that means to break a rule says so, with a comment the
+parser ignores and a reader does not:
+.br
+.sp
+.nf
+\&   [legacy]
+\&      # conventions: permissive -- one expect, no state to move to
+.fi
+.sp
+The regression suite checks every entry in this page, in the shipped
+protocols.cfg and in the test fixtures against these five rules, so the
+page and the files cannot drift apart unnoticed.
+
 .SH EXAMPLES
 An SMTP service that upgrades to TLS when the server offers it, reports
 a server that does not offer it as yellow rather than down, and reads the
@@ -360,38 +422,69 @@ certificate off the upgraded session:
 .sp
 .nf
 \&   [smtp\-tls]
-\&      state greeting
-\&      timeout(10)         \-> fail
-\&      expect "220"
-\&      send "ehlo xymonnet\er\en"
-\&      expect "250" until "250 " as caps
-\&      caps ~ "STARTTLS"   \-> upgrade
-\&      else                \-> warning
-\&
-\&      state upgrade
-\&      timeout(10)         \-> fail
-\&      send "starttls\er\en"
-\&      expect "220"        \-> secure
-\&      expect "454"        \-> warning
-\&
-\&      state secure
-\&      timeout(10)         \-> fail
-\&      starttls
-\&      send "ehlo xymonnet\er\en"
-\&      expect "250" until "250 "
-\&      send "quit\er\en"
-\&      expect "221"        \-> success
 \&      options banner
 \&      port 25
+\&      start greeting
+\&
+\&      state greeting
+\&         timeout(10)                        \-> fail
+\&         expect "220"                       \-> ehlo
+\&
+\&      state ehlo
+\&         send "ehlo xymonnet\er\en"
+\&         timeout(30)                        \-> fail
+\&         expect "250" until "250 " as caps  \-> offers
+\&
+\&      state offers
+\&         caps ~ "STARTTLS"                  \-> upgrade
+\&         else                               \-> warning
+\&
+\&      state upgrade
+\&         send "starttls\er\en"
+\&         timeout(10)                        \-> fail
+\&         expect "220"                       \-> secure
+\&         expect "454"                       \-> warning
+\&
+\&      state secure
+\&         starttls
+\&         always                             \-> ehlo\-tls
+\&
+\&      state ehlo\-tls
+\&         send "ehlo xymonnet\er\en"
+\&         timeout(10)                        \-> fail
+\&         expect "250" until "250 "          \-> farewell
+\&
+\&      state farewell
+\&         send "quit\er\en"
+\&         timeout(10)                        \-> fail
+\&         expect "221"                       \-> success
 .fi
 .sp
-Note also that this is deliberately NOT what the shipped \fB[smtp]\fR
-entry does. protocols.cfg is one file for the whole installation, so an
-entry that expects STARTTLS would change what every existing host
-reports the moment the file is installed -- a site whose mail server
-offers no STARTTLS would turn yellow because it upgraded, not because
-anything changed at the site. Copy this under a new name and point the
-hosts that should use it at that name instead.
+A state does one thing and then waits for one answer: at most one
+action -- a \fBsend\fR, a \fBstarttls\fR, a \fBcredentials\fR -- the
+clock that bounds the wait, and the \fBexpect\fR lines that end the
+state by naming where each answer leads. \fBsecure\fR upgrades and does
+nothing else, so it leaves on \fBalways\fR; \fBoffers\fR waits for
+nothing at all and decides on a value it already holds.
+.sp
+Because a state holds one action and one wait, the order of its lines
+carries no meaning of its own -- with one exception the parser has not
+been taught: a \fBtimeout\fR or \fBidle\fR arms the wait that follows
+it, so a clock written below the \fBexpect\fR lines bounds nothing.
+Keep it above them, as every example here does.
+.sp
+The entry attributes -- \fBoptions\fR, \fBport\fR, \fBtransport\fR,
+\fBstart\fR -- describe the definition rather than any step, so they
+are written together at the top, in any order among themselves.
+.sp
+This is deliberately a service of its own rather than a deeper
+\fB[smtp]\fR. protocols.cfg is one file for the whole installation, so
+teaching \fB[smtp]\fR to expect STARTTLS would change what every
+existing host reports the moment the file is installed -- a site whose
+mail server offers none would turn yellow because it upgraded, not
+because anything changed at the site. Point the hosts that should have
+the deeper check at \fBsmtp\-tls\fR, or keep \fB[smtp]\fR and give
+those hosts \fBsmtp:ok=\fR\fISTATE\fR instead.
 
 .SH DIAGNOSTICS
 This file is checked when it is read rather than when a step runs, so a

--- a/xymonnet/protocols.cfg.5
+++ b/xymonnet/protocols.cfg.5
@@ -75,20 +75,33 @@ represents a line-feed (ASCII 10), "\et" represents a TAB (ASCII 8).
 Binary data is input as "\exNN" with NN being the hexadecimal value
 of the byte.
 .sp
-An \fBexpect\fR matches the beginning of the reply, and consumes one
-line of it. Anything the server sent beyond that line is kept for the
-next step.
+Three shapes are the classic single-shot probe, and keep the code path
+they have always used: a lone \fBsend\fR, a lone \fBexpect\fR, and a
+\fBsend\fR followed by an \fBexpect\fR. That probe writes immediately
+on connect, reads once, and compares the start of what came back.
+Everything else -- an \fBexpect\fR with something sent after it, more
+than one of either, or any of the steps below -- runs the dialogue
+driver, and only there do the rest of these pages apply.
 .sp
-A reply that never matches is not accumulated without limit. Once a
-conversation has buffered 32 KB with nothing matching, the test fails
-naming the service rather than growing for as long as the server cares
-to talk.
+Under the driver, an \fBexpect\fR matches the beginning of the reply and
+consumes one line of it; anything the server sent beyond that line is
+kept for the next step. A reply that never matches is not accumulated
+without limit: once a conversation has buffered 32 KB with nothing
+matching, the test fails naming the service rather than growing for as
+long as the server cares to talk. The single-shot probe accumulates
+nothing and so has no such bound.
 
 .IP "\fBexpect\fR \fISTRING\fR \fBuntil\fR \fITERMINATOR\fR"
 Consume a multi-line reply. Lines are consumed until one begins with
 \fITERMINATOR\fR, which is consumed as well. Nothing is consumed until
 that line arrives, so a reply that is still in flight is waited for
 rather than half-read.
+.sp
+This needs the driver, and a definition that is one \fBexpect\fR and
+nothing else is a classic shape that does not use it: there,
+\fBuntil\fR has no effect and the first line decides the test. Adding
+the step that follows -- the \fBsend\fR that ends the session, say --
+is what makes it a dialogue.
 .sp
 Protocols end a multi-line reply differently, and naming the terminator
 covers them without special-casing any:


### PR DESCRIPTION
The shipped `[smtp]`/`[smtps]`/`[submission|msa]` entries carry the conversation through EHLO rather than stopping at the greeting.

Then the CONVENTIONS the manual states — attributes before states, one action and one wait per state, every expect naming where it goes, clocks above the waits they bound — and `tests/buildsystem/dialogue-conventions.sh`, which checks every entry the project publishes or tests against them. The parser enforces none of it, so prose that nothing checks drifts.
---
Part of the dialogue stack, sliced out of #456 and #465 so each PR is one subject. Reviewed bottom-up: this one is based on `dialogue-11-manual`.