### PR TITLE
xymonnet: a bound value is bytes, so it keeps every one of them

### DIFF
--- a/lib/digest.c
+++ b/lib/digest.c
@@ -19,7 +19,12 @@ static char rcsid[] = "$Id$";
 
 #include "libxymon.h"
 
-char *md5hash(char *input)
+/*
+ * Hash a counted buffer. A dialogue may hash a value it read from the wire,
+ * and a framed reply is bytes rather than a string -- strlen() would digest
+ * only the part of it that precedes the first NUL.
+ */
+char *md5hash_len(char *input, int inputlen)
 {
 	/* We have a fast MD5 hash function, since that may be used a lot */
 
@@ -37,7 +42,7 @@ char *md5hash(char *input)
 	}
 
 	myMD5_Init(ctx->mdctx);
-	myMD5_Update(ctx->mdctx, input, strlen(input));
+	myMD5_Update(ctx->mdctx, input, ((inputlen > 0) ? inputlen : 0));
 	myMD5_Final(md_value, ctx->mdctx);
 
 	for(i = 0, p = md_string; (i < sizeof(md_value)); i++) 
@@ -45,6 +50,11 @@ char *md5hash(char *input)
 	*p = '\0';
 
 	return md_string;
+}
+
+char *md5hash(char *input)
+{
+	return md5hash_len(input, (input ? strlen(input) : 0));
 }
 
 

--- a/lib/digest.h
+++ b/lib/digest.h
@@ -22,6 +22,7 @@ typedef struct digestctx_t {
 } digestctx_t;
 
 extern char *md5hash(char *input);
+extern char *md5hash_len(char *input, int inputlen);
 extern digestctx_t *digest_init(char *digest);
 extern int digest_data(digestctx_t *ctx, unsigned char *buf, int buflen);
 extern char *digest_done(digestctx_t *ctx);

--- a/lib/encoding.c
+++ b/lib/encoding.c
@@ -21,17 +21,26 @@ static char rcsid[] = "$Id$";
 
 static char b64chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-char *base64encode(unsigned char *buf)
+/*
+ * Encode a counted buffer. The caller may hold bytes rather than a string --
+ * a reply framed by a length carries NULs -- and measuring the input with
+ * strlen() would encode only what precedes the first one.
+ */
+char *base64encode_len(unsigned char *buf, int buflen)
 {
 	unsigned char c0, c1, c2;
 	unsigned int n0, n1, n2, n3;
 	unsigned char *inp, *outp;
 	unsigned char *result;
+	int left;
 
-	result = malloc(4*(strlen(buf)/3 + 1) + 1);
+	if (!buf || (buflen < 0)) buflen = 0;
+	left = buflen;
+
+	result = malloc(4*(buflen/3 + 1) + 1);
 	inp = buf; outp=result;
 
-	while (strlen(inp) >= 3) {
+	while (left >= 3) {
 		c0 = *inp; c1 = *(inp+1); c2 = *(inp+2);
 
 		n0 = (c0 >> 2);				/* 6 bits from c0 */
@@ -44,10 +53,10 @@ char *base64encode(unsigned char *buf)
 		*outp = b64chars[n2]; outp++;
 		*outp = b64chars[n3]; outp++;
 
-		inp += 3;
+		inp += 3; left -= 3;
 	}
 
-	if (strlen(inp) == 1) {
+	if (left == 1) {
 		c0 = *inp; c1 = 0;
 		n0 = (c0 >> 2);				/* 6 bits from c0 */
 		n1 = ((c0 & 3) << 4) + (c1 >> 4);	/* 2 bits from c0, 4 bits from c1 */
@@ -57,7 +66,7 @@ char *base64encode(unsigned char *buf)
 		*outp = '='; outp++;
 		*outp = '='; outp++;
 	}
-	else if (strlen(inp) == 2) {
+	else if (left == 2) {
 		c0 = *inp; c1 = *(inp+1); c2 = 0;
 
 		n0 = (c0 >> 2);				/* 6 bits from c0 */
@@ -73,6 +82,11 @@ char *base64encode(unsigned char *buf)
 	*outp = '\0';
 
 	return result;
+}
+
+char *base64encode(unsigned char *buf)
+{
+	return base64encode_len(buf, (buf ? strlen(buf) : 0));
 }
 
 char *base64decode(unsigned char *buf)

--- a/lib/encoding.h
+++ b/lib/encoding.h
@@ -12,6 +12,7 @@
 #define __ENCODING_H__
 
 extern char *base64encode(unsigned char *buf);
+extern char *base64encode_len(unsigned char *buf, int buflen);
 extern char *base64decode(unsigned char *buf);
 extern void getescapestring(char *msg, unsigned char **buf, int *buflen);
 extern unsigned char *nlencode(unsigned char *msg);

--- a/tests/lib/dialogue-peer.c
+++ b/tests/lib/dialogue-peer.c
@@ -18,6 +18,9 @@
  *   recv PREFIX      read one line; record it, and record MISMATCH if it
  *                    does not begin with PREFIX
  *   recvany          read one line and record it
+ *   recvbytes N      read exactly N bytes and record them as hex, "gotbytes HEX".
+ *                    A payload that carries a NUL is neither a line nor a C
+ *                    string, so this is the only way to assert on one.
  *   hold N           stay connected and silent for N seconds
  *   dribble TEXT     send TEXT one byte per second
  *   replyall TEXT    answer TEXT to every further line, until EOF. Models a
@@ -212,6 +215,31 @@ int main(int argc, char *argv[])
 			fprintf(obs, "got %s\n", got);
 			if (*arg && strncmp(got, arg, strlen(arg)) != 0)
 				fprintf(obs, "MISMATCH want=%s got=%s\n", arg, got);
+		}
+		else if (strcmp(cmd, "recvbytes") == 0) {
+			int want = atoi(arg), have = 0;
+			char hex[2*512 + 1];
+
+			if (want < 1) want = 1;
+			if (want > 512) want = 512;
+			while (have < want) {
+				int r = io_read(buf + have, want - have);
+
+				if (r <= 0) break;
+				have += r;
+			}
+			if (have < want) {
+				/*
+				 * Record what DID arrive. A probe that truncated its
+				 * payload at a NUL sends fewer bytes than it was told
+				 * to, and the short count is the evidence.
+				 */
+				tohex((unsigned char *)buf, have, hex);
+				fprintf(obs, "shortbytes %d %s\n", have, hex);
+				break;
+			}
+			tohex((unsigned char *)buf, have, hex);
+			fprintf(obs, "gotbytes %s\n", hex);
 		}
 		else if (strcmp(cmd, "replyall") == 0) {
 			n = unescape(arg, buf, sizeof(buf));

--- a/tests/network/dialogue-nul.sh
+++ b/tests/network/dialogue-nul.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# A value bound by "as NAME" is bytes, not a string.
+#
+# "expect bytes(N)" and length framing exist for the services whose replies
+# are binary -- DNS-over-TCP, LDAP, MySQL, AMQP -- and those put NULs in the
+# first few bytes of a message. A bound value stored with strdup() is cut at
+# the first one, so ${name} expands to the stump, and a regex tested against
+# the name sees only what precedes the NUL. Nothing reports an error: the
+# probe compares almost nothing and goes green, or takes an else-arm and goes
+# red, for a reason no message names.
+#
+# Every peer here sends the SAME twelve bytes, "AB\0CDEFGHIJK", and the NUL
+# is the third of them. The three green entries each use the bound value in a
+# different place, so a value that survives storage but not one of its uses
+# still fails here:
+#
+#   [nulecho]     sends ${reply} back, and the peer counts the bytes it got
+#   [nulwhen]     tests the value with a regex that only matches past the NUL
+#   [nulcapture]  extracts a group that lies past the NUL, and tests THAT
+#
+# THE CONTROL is [nulmiss]: the same value, and a pattern that is genuinely
+# not in it. It must NOT go green -- otherwise the three above would prove
+# only that a "~" edge is always taken, and the suite would pass with the
+# value never read at all.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+"$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile"; }
+
+# AB\0CDEFGHIJK -- twelve bytes, a NUL third, and no newline anywhere.
+payload='\x41\x42\x00\x43\x44\x45\x46\x47\x48\x49\x4a\x4b'
+wire='414200434445464748494a4b'
+
+printf 'send %s\nrecvbytes 12\nsend "+OK\\r\\n"\nhold 5\n' "$payload" > "$work/echo.script"
+printf 'send %s\nhold 5\n' "$payload"                                 > "$work/when.script"
+printf 'send %s\nhold 5\n' "$payload"                                 > "$work/capture.script"
+printf 'send %s\nhold 5\n' "$payload"                                 > "$work/miss.script"
+
+: > "$work/pids"
+start() {	# script portfile obsfile
+	"$work/peer" "$1" "$3" > "$2" &
+	echo $! >> "$work/pids"
+	local i=0
+	while [ "$i" -lt 50 ]; do [ -s "$2" ] && break; sleep 0.1; i=$((i + 1)); done
+	cat "$2"
+}
+pe=$(start "$work/echo.script"    "$work/pe" "$work/oe")
+pw=$(start "$work/when.script"    "$work/pw" "$work/ow")
+pc=$(start "$work/capture.script" "$work/pc" "$work/oc")
+pz=$(start "$work/miss.script"    "$work/pz" "$work/oz")
+register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
+[ -n "$pe" ] && [ -n "$pw" ] && [ -n "$pc" ] && [ -n "$pz" ] || fail "a peer never named its port"
+
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[nulecho]
+   options banner
+   port $pe
+
+   state read
+      timeout(10)                 -> fail
+      expect bytes(12) as reply   -> echo
+
+   state echo
+      send "\${reply}"
+      timeout(10)                 -> fail
+      expect "+OK"                -> success
+
+[nulwhen]
+   options banner
+   port $pw
+
+   state read
+      timeout(10)                 -> fail
+      expect bytes(12) as reply   -> choose
+
+   state choose
+      reply ~ "HIJK"              -> success
+      else                        -> fail
+
+[nulcapture]
+   options banner
+   port $pc
+
+   state read
+      timeout(10)                 -> fail
+      expect bytes(12) as reply   -> choose
+
+   state choose
+      reply ~ "(HIJK)" as tail
+      tail ~ "HIJK"               -> success
+      else                        -> fail
+
+[nulmiss]
+   options banner
+   port $pz
+
+   state read
+      timeout(10)                 -> fail
+      expect bytes(12) as reply   -> choose
+
+   state choose
+      reply ~ "ZZZZ"              -> success
+      else                        -> fail
+CFG
+printf '127.0.0.1\tec\t# nulecho\n127.0.0.1\twh\t# nulwhen\n127.0.0.1\tcp\t# nulcapture\n127.0.0.1\tms\t# nulmiss\n' \
+	> "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse=red \
+	--dns=ip --timeout=30 >"$work/out.txt" 2>&1 || :
+sleep 1
+
+colour_of() { grep -oE "status\+[0-9]+ $1 (green|yellow|red|clear)" "$work/out.txt" | awk '{print $3}' | head -1; }
+
+# What went over the wire, which is the only account of it that a truncating
+# ${reply} cannot flatter: the peer counted the bytes and wrote them as hex.
+grep -q "^gotbytes $wire\$" "$work/oe" || fail \
+	"\${reply} did not send back the twelve bytes that were bound to it. A value
+holding a NUL is being stored or expanded as a C string, so everything past
+the third byte is gone. The peer saw:
+$(cat "$work/oe")"
+
+[ "$(colour_of ec.nulecho)" = green ] || fail \
+	"the round trip through \${reply} did not complete:
+$(grep -i nulecho "$work/out.txt" | head -4)"
+
+[ "$(colour_of wh.nulwhen)" = green ] || fail \
+	"'reply ~ \"HIJK\"' did not match, so the edge was tested against the bytes
+before the NUL rather than against the value:
+$(grep -i nulwhen "$work/out.txt" | head -4)"
+
+[ "$(colour_of cp.nulcapture)" = green ] || fail \
+	"'reply ~ \"(HIJK)\" as tail' extracted nothing: the capture is matching over
+strlen(value), which stops at the NUL:
+$(grep -i nulcapture "$work/out.txt" | head -4)"
+
+# THE CONTROL
+[ "$(colour_of ms.nulmiss)" = green ] && fail \
+	"a pattern that is not in the value took its edge anyway. The '~' edges above
+are not deciding anything, so this suite would pass on a value never read:
+$(grep -i nulmiss "$work/out.txt" | head -4)"
+
+pass "a value bound by 'as NAME' keeps every byte, and is sent, tested and extracted whole"

--- a/tests/network/protocol-dialogue.sh
+++ b/tests/network/protocol-dialogue.sh
@@ -57,10 +57,11 @@ printf '%s\n' "$n" | grep -qE '\+\+guard *>' ||
 	fail "dlg_run_instant has no runaway guard -- a backward jump that does no
 I/O would hang xymonnet rather than failing the test"
 
-# md5hash() returns a static buffer; freeing it corrupts the allocator.
+# md5hash_len() returns a static buffer; freeing it corrupts the allocator.
 # Asserted positively -- the negative form passed for free when the grep
-# matched nothing at all.
-md5line=$(printf '%s\n' "$n" | grep 'md5hash(' | head -1)
+# matched nothing at all. Either spelling counts: the length-taking one is
+# what a dialogue calls, and md5hash() is the wrapper over it.
+md5line=$(printf '%s\n' "$n" | grep -E 'md5hash(_len)?\(' | head -1)
 [ -n "$md5line" ] ||
 	fail "no md5hash() call found -- either the md5 expansion is gone, or the
 comment stripper ate it and this assertion is passing for free"

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -1034,11 +1034,11 @@ static void tcptest_setnext(void *a, void *newval)
  * memset on memory that is about to be freed is exactly what a compiler is
  * entitled to delete, so the write goes through a volatile pointer.
  */
-static void dlg_wipe(char *s)
+static void dlg_wipe(char *s, int len)
 {
 	volatile char *p = (volatile char *)s;
 
-	while (p && *p) *p++ = '\0';
+	while (p && (len-- > 0)) *p++ = '\0';
 }
 
 
@@ -1049,7 +1049,7 @@ static void dlg_free(tcptest_t *item)
 	while (v) {
 		dlgvar_t *next = v->next;
 
-		if (v->value) { dlg_wipe(v->value); xfree(v->value); }
+		if (v->value) { dlg_wipe(v->value, v->vallen); xfree(v->value); }
 		if (v->name) xfree(v->name);
 		xfree(v);
 		v = next;
@@ -1059,6 +1059,7 @@ static void dlg_free(tcptest_t *item)
 	if (item->stepbuf) { xfree(item->stepbuf); item->stepbuf = NULL; }
 	item->stepbuflen = 0;
 	if (item->lastreply) { xfree(item->lastreply); item->lastreply = NULL; }
+	item->lastreplylen = 0;
 	/*
 	 * Only the arming is cleared here. stepsecs and steptimedout are part
 	 * of the verdict -- dlg_free() runs after the poll loop and before the
@@ -1088,32 +1089,78 @@ static int dlg_name_listed(const char *list, const char *name)
 }
 
 
-static char *dlg_get(tcptest_t *item, const char *name)
+static char *dlg_get(tcptest_t *item, const char *name, int *lenp)
 {
 	dlgvar_t *v;
 
 	for (v = (dlgvar_t *)item->dlgvars; (v); v = v->next)
-		if (strcmp(v->name, name) == 0) return v->value;
+		if (strcmp(v->name, name) == 0) {
+			if (lenp) *lenp = v->vallen;
+			return v->value;
+		}
 
+	if (lenp) *lenp = 0;
 	return NULL;
 }
 
-static void dlg_set(tcptest_t *item, const char *name, const char *value)
+/*
+ * A value is BYTES, not a string. "expect bytes(N)" and length framing exist
+ * for the services whose messages are binary -- DNS-over-TCP, LDAP, MySQL,
+ * AMQP -- and those carry NULs in the first few bytes, so storing a bound
+ * value with strdup() would cut it to nothing and every use of it would
+ * silently compare or send the stump. The copy is still NUL-terminated, so a
+ * value that IS text can be read as a C string; everything else uses vallen.
+ */
+static void dlg_set(tcptest_t *item, const char *name, const char *value, int vallen)
 {
 	dlgvar_t *v;
+	char *copy;
+
+	if (!value || (vallen < 0)) { value = ""; vallen = 0; }
+	copy = (char *)malloc(vallen + 1);
+	memcpy(copy, value, vallen);
+	copy[vallen] = '\0';
 
 	for (v = (dlgvar_t *)item->dlgvars; (v); v = v->next) {
 		if (strcmp(v->name, name) != 0) continue;
-		if (v->value) xfree(v->value);
-		v->value = strdup(value ? value : "");
+		if (v->value) { dlg_wipe(v->value, v->vallen); xfree(v->value); }
+		v->value  = copy;
+		v->vallen = vallen;
 		return;
 	}
 
 	v = (dlgvar_t *)calloc(1, sizeof(dlgvar_t));
-	v->name  = strdup(name);
-	v->value = strdup(value ? value : "");
-	v->next  = (dlgvar_t *)item->dlgvars;
+	v->name   = strdup(name);
+	v->value  = copy;
+	v->vallen = vallen;
+	v->next   = (dlgvar_t *)item->dlgvars;
 	item->dlgvars = (void *)v;
+}
+
+/* For the values that are known to be text: credentials, and an empty bind. */
+static void dlg_setstr(tcptest_t *item, const char *name, const char *value)
+{
+	dlg_set(item, name, value, (value ? strlen(value) : 0));
+}
+
+/*
+ * matchregex() measures its subject with strlen(). A value bound from a
+ * framed reply may hold a NUL, and the pattern is then tested against the
+ * bytes before it rather than against the value -- so match over the length
+ * that was stored.
+ */
+static int dlg_match(const char *subject, int len, pcre2_code *re)
+{
+	pcre2_match_data *md;
+	int res;
+
+	if (!subject || !re) return 0;
+
+	md = pcre2_match_data_create(4, NULL);
+	res = pcre2_match(re, (PCRE2_SPTR)subject, len, 0, 0, md, NULL);
+	pcre2_match_data_free(md);
+
+	return (res >= 0);
 }
 
 /*
@@ -1135,7 +1182,7 @@ static char *dlg_expand(tcptest_t *item, const char *text, int len, int *outlen)
 	for (i = 0; (i < len); i++) {
 		int depth, j, blen;
 		char *body, *inner, *val = NULL, *freeval = NULL;
-		int innerlen;
+		int innerlen, vallen = 0;
 
 		if (!((text[i] == '$') && ((i+1) < len) && (text[i+1] == '{'))) {
 			if (n >= outsz) { outsz *= 2; out = (char *)realloc(out, outsz + 1); }
@@ -1160,33 +1207,37 @@ static char *dlg_expand(tcptest_t *item, const char *text, int len, int *outlen)
 		memcpy(body, text + i + 2, blen);
 		body[blen] = '\0';
 
+		/*
+		 * The argument is passed by length: ${md5:${salt}} over a binary
+		 * salt is the whole point of these on a framed protocol, and
+		 * measuring the expansion with strlen() would hash or encode the
+		 * bytes up to the first NUL instead of the value.
+		 */
 		if (strncmp(body, "md5:", 4) == 0) {
 			inner = dlg_expand(item, body + 4, blen - 4, &innerlen);
-			/* md5hash() hands back a static buffer -- copy, never free. */
-			val = md5hash(inner);
+			/* md5hash_len() hands back a static buffer -- copy, never free. */
+			val = md5hash_len(inner, innerlen);
+			vallen = strlen(val);
 			xfree(inner);
 		}
 		else if (strncmp(body, "base64:", 7) == 0) {
 			inner = dlg_expand(item, body + 7, blen - 7, &innerlen);
-			val = freeval = base64encode((unsigned char *)inner);
+			val = freeval = base64encode_len((unsigned char *)inner, innerlen);
+			vallen = strlen(val);
 			xfree(inner);
 		}
 		else {
 			/* Mistyped functions are reported when the file is read. */
-			val = dlg_get(item, body);
+			val = dlg_get(item, body, &vallen);
 			if (val == NULL) {
 				dbgprintf("dialogue: ${%s} is not set, expanding empty\n", body);
-				val = "";
+				val = ""; vallen = 0;
 			}
 		}
 
-		{
-			int vlen = strlen(val);
-
-			while ((n + vlen) >= outsz) { outsz *= 2; out = (char *)realloc(out, outsz + 1); }
-			memcpy(out + n, val, vlen);
-			n += vlen;
-		}
+		while ((n + vallen) >= outsz) { outsz *= 2; out = (char *)realloc(out, outsz + 1); }
+		memcpy(out + n, val, vallen);
+		n += vallen;
 
 		if (freeval) xfree(freeval);
 		xfree(body);
@@ -1201,9 +1252,9 @@ static char *dlg_expand(tcptest_t *item, const char *text, int len, int *outlen)
 /* Group 1 of the pattern, against the reply the last expect accepted. */
 static void dlg_capture(tcptest_t *item, svcstep_t *st)
 {
-	char *subject;
+	char *subject, *src;
 	pcre2_match_data *md;
-	int res, n;
+	int res, n, subjectlen = 0;
 	char names[256], *name, *rest;
 
 	/*
@@ -1213,18 +1264,20 @@ static void dlg_capture(tcptest_t *item, svcstep_t *st)
 	 * already complained about when the file was read.
 	 */
 	/*
-	 * Work on a COPY. dlg_set() frees the old value of a name before
-	 * storing the new one, so binding a name that is also the source --
+	 * Work on a COPY. dlg_set() releases the old value of a name once it
+	 * has stored the new one, so binding a name that is also the source --
 	 * "banner ~ ... as banner", or any list that reuses it -- would free
-	 * the very bytes this match is reading, and the ovector offsets would
-	 * then index freed memory.
+	 * the very bytes this match is reading, and the ovector offsets of
+	 * every name after it would then index freed memory.
 	 */
-	subject = dlg_get(item, st->srcname);
-	subject = strdup(subject ? subject : "");
+	src = dlg_get(item, st->srcname, &subjectlen);
+	subject = (char *)malloc(subjectlen + 1);
+	if (src) memcpy(subject, src, subjectlen);
+	subject[subjectlen] = '\0';
 
 	md = pcre2_match_data_create(32, NULL);
 	res = pcre2_match((pcre2_code *)st->re, (PCRE2_SPTR)subject,
-			  strlen(subject), 0, 0, md, NULL);
+			  subjectlen, 0, 0, md, NULL);
 
 	/*
 	 * One name per capture group, in order: "as server;challenge" binds
@@ -1247,12 +1300,12 @@ static void dlg_capture(tcptest_t *item, svcstep_t *st)
 
 			memcpy(v, subject + b, e - b);
 			v[e-b] = '\0';
-			dlg_set(item, name, v);
+			dlg_set(item, name, v, e - b);
 			xfree(v);
 		}
 		else {
 			dbgprintf("dialogue: an extraction did not match, ${%s} left empty\n", name);
-			dlg_set(item, name, "");
+			dlg_setstr(item, name, "");
 		}
 		n++;
 	}
@@ -1337,21 +1390,22 @@ static svcstep_t *dlg_run_instant(tcptest_t *item, svcstep_t *st)
 				char *u = NULL, *p = NULL;
 
 				if (lookup_credentials(item->credname, &u, &p)) {
-					dlg_set(item, "username", u);
-					dlg_set(item, "password", p);
-					if (u) { dlg_wipe(u); xfree(u); }
-					if (p) { dlg_wipe(p); xfree(p); }
+					dlg_setstr(item, "username", u);
+					dlg_setstr(item, "password", p);
+					if (u) { dlg_wipe(u, strlen(u)); xfree(u); }
+					if (p) { dlg_wipe(p, strlen(p)); xfree(p); }
 					st = st->next;
 					break;
 				}
 			}
-			dlg_set(item, "username", st->user);
-			dlg_set(item, "password", st->pass);
+			dlg_setstr(item, "username", st->user);
+			dlg_setstr(item, "password", st->pass);
 			st = st->next;
 			break;
 
 		  case STEP_WHEN: {
-			char *v = dlg_get(item, st->varname);
+			int vlen = 0;
+			char *v = dlg_get(item, st->varname, &vlen);
 
 			/*
 			 * An edge: taken when the test matches, fallen through when
@@ -1359,7 +1413,7 @@ static svcstep_t *dlg_run_instant(tcptest_t *item, svcstep_t *st)
 			 * -- gets its turn. The regex tests a value already bound,
 			 * never the socket, so nothing here races a partial read.
 			 */
-			if (!(v && st->re && matchregex(v, (pcre2_code *)st->re))) {
+			if (!(v && st->re && dlg_match(v, vlen, (pcre2_code *)st->re))) {
 				st = st->next;
 				break;
 			}
@@ -2426,6 +2480,7 @@ restartselect:
 											item->lastreply = (char *)malloc(rlen + 1);
 											memcpy(item->lastreply, item->stepbuf + rbase, rlen);
 											item->lastreply[rlen] = '\0';
+											item->lastreplylen = rlen;
 										}
 
 										/*
@@ -2435,7 +2490,8 @@ restartselect:
 										 * of some earlier state.
 										 */
 										if (hit->varname)
-											dlg_set(item, hit->varname, item->lastreply);
+											dlg_set(item, hit->varname, item->lastreply,
+												item->lastreplylen);
 
 										memmove(item->stepbuf, item->stepbuf + cut, item->stepbuflen - cut);
 										item->stepbuflen -= cut;

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -86,6 +86,7 @@ typedef void (*f_callback_final)(void *privdata);
 typedef struct dlgvar_t {
 	char *name;
 	char *value;
+	int vallen;			/* value bytes: a reply is not always a string */
 	struct dlgvar_t *next;
 } dlgvar_t;
 
@@ -143,6 +144,7 @@ typedef struct tcptest_t {
 	unsigned char *stepbuf;		/* replies for the CURRENT expect step */
 	int stepbuflen;
 	char *lastreply;		/* the reply that satisfied the last expect */
+	int lastreplylen;		/* ... and its length: it may hold NULs */
 	void *dlgvars;			/* captured values, a dlgvar_t list */
 	int stepsecs;			/* 'timeout(N)': budget for this state, 0 = none */
 	time_t stepdeadline;		/* ... armed against the poll clock, 0 = unarmed */


### PR DESCRIPTION
`expect bytes(N)` and length framing exist for the services whose replies are binary — DNS-over-TCP, LDAP, MySQL, AMQP — and those carry NULs in the first few bytes. `dlg_set()` stored a bound value with `strdup()`, so it was cut at the first one: `${name}` expanded to the stump, and a regex tested against the name saw only what preceded the NUL.

Nothing reported an error. The probe compared almost nothing and reported **green** — the feature added for framed protocols did not work on them.

The length is carried with the value now, through storage, expansion, regex matching, capture, and the wipe that clears a password.

`dialogue-nul.sh` drives four peers with the same twelve bytes `AB\0CDEFGHIJK`, each green entry spending the value somewhere different. Reverted, the peer records `shortbytes 2 4142` and all three go red.
---
Part of the dialogue stack, sliced out of #456 and #465 so each PR is one subject. Reviewed bottom-up: this one is based on `dialogue-20-ignore`.