### PR TITLE
xymonnet: choose depth and credentials per host, not per definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 .*.swp
 .DS_store
 # Simulated Subversion default ignores end here
+
+# Written by build/genconfig.sh from this machine probes; committing it
+# pins one host answers on everybody else build.
+include/config.h

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -611,7 +611,7 @@ static void emit_step(svclist_t *first, svcstep_t *tmpl)
  *
  *     NAME	username	password
  */
-static int lookup_credentials(char *name, char **user, char **pass)
+int lookup_credentials(char *name, char **user, char **pass)
 {
 	char fn[PATH_MAX];
 	FILE *fd;

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -86,6 +86,8 @@ typedef struct svcstep_t {
 	struct svcstep_t *next;
 } svcstep_t;
 
+extern int lookup_credentials(char *name, char **user, char **pass);
+
 typedef struct svcinfo_t {
 	char *svcname;
 	unsigned char *sendtxt;

--- a/tests/network/dialogue-depth.sh
+++ b/tests/network/dialogue-depth.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# One definition, several depths, chosen per host.
+#
+# This is the capability the whole shape is argued on. protocols.cfg is
+# one file per installation: a [smtp] definition applies to every host
+# carrying the smtp test. So deepening the shipped entries changes what
+# every site is alerted on, all at once -- which is why they have stayed
+# shallow, and why "the daemon greeted me" is still what smtp means.
+#
+# "smtp:ok=greeting" asks for THIS host to be checked only as far as that
+# state. The definition can then be the full conversation while a site
+# that wants banner depth asks for it host by host, and nobody's alerting
+# moves without consent.
+#
+# THE CONTROL IS THE SECOND HOST. The same definition, same peer, no
+# depth: it must go RED, because the conversation it describes does not
+# complete against this server. Without that, "ok= made it green" would
+# be indistinguishable from "the entry passes anyway".
+#
+# TWO MORE CONTROLS, which is what a depth is actually worth. "Check as
+# far as greeting" has to mean the greeting was CHECKED, and the first
+# spelling of it did not: the verdict was taken on entering the state,
+# before its own expect had run, so any server that completed a TCP
+# connect reported up. [badgreet] answers the wrong code and [silent]
+# answers nothing, and both must go RED even though both are tagged
+# ok=greeting. A depth that checks nothing is worse than no depth,
+# because it looks like a check.
+#
+# "cred=" is the same idea for credentials: one definition, and which
+# account it uses chosen per host. The value is a NAME -- hosts.cfg is
+# world-readable for the same reasons protocols.cfg is, so a password
+# must no more appear there than in the definition.
+#
+# A depth is not a different service, so both report in the same column.
+# A port is -- smtp:2525 derives smtp_2525 -- but a site running mixed
+# depths must not get a column per depth and no comparable history.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+cc -o "$work/peer" "$root/tests/lib/dialogue-peer.c" $(pkg-config --cflags --libs openssl 2>/dev/null || echo -lssl -lcrypto) ||
+	skip "cannot build the dialogue peer"
+
+start_peer() {
+	"$work/peer" "$1" "$2" > "$3" &
+	echo $! > "$3.pid"
+	i=0
+	while [ "$i" -lt 50 ]; do
+		[ -s "$3" ] && break
+		sleep 0.1
+		i=$((i + 1))
+	done
+	cat "$3"
+}
+
+# Greets correctly and then rejects the command -- the server this whole
+# feature exists to catch.
+printf 'send 220 ready\r\n\nrecvany\nsend 421 too many connections\r\n\nhold 20\n' > "$work/half.script"
+
+# Records the username it is offered, so the test can see WHICH account
+# each host used rather than only that some login happened.
+printf 'send 220 ready\r\n\nrecvany\nsend 250 ok\r\n\nhold 20\n' > "$work/login.script"
+
+# Greets with the WRONG code, and says nothing at all, respectively.
+printf 'send 599 broken\r\n\nhold 20\n' > "$work/badgreet.script"
+printf 'hold 20\n'                        > "$work/silent.script"
+
+p1=$(start_peer "$work/half.script"  "$work/o1" "$work/p1")
+p2=$(start_peer "$work/half.script"  "$work/o2" "$work/p2")
+p3=$(start_peer "$work/login.script" "$work/o3" "$work/p3")
+p4=$(start_peer "$work/login.script" "$work/o4" "$work/p4")
+p5=$(start_peer "$work/badgreet.script" "$work/o5" "$work/p5")
+p6=$(start_peer "$work/silent.script"   "$work/o6" "$work/p6")
+register_cleanup "kill $(cat "$work/p1.pid") $(cat "$work/p2.pid") $(cat "$work/p3.pid") $(cat "$work/p4.pid") $(cat "$work/p5.pid") $(cat "$work/p6.pid") 2>/dev/null || :"
+[ -n "$p1" ] && [ -n "$p2" ] && [ -n "$p3" ] && [ -n "$p4" ] && [ -n "$p5" ] && [ -n "$p6" ] \
+	|| fail "a peer never named its port"
+
+printf 'accta\tuser-a\tsecret-a\nacctb\tuser-b\tsecret-b\n' > "$work/home/etc/credentials.cfg"
+
+# Two hosts, ONE definition. shallow asks for banner depth; deep does not.
+{ printf '127.0.0.1\tshallow\t# depthsvc:%s:ok=greeting\n' "$p1"
+  printf '127.0.0.1\tdeep\t# depthsvc:%s\n' "$p2"
+  printf '127.0.0.1\thosta\t# loginsvc:%s:cred=accta\n' "$p3"
+  printf '127.0.0.1\thostb\t# loginsvc:%s:cred=acctb\n' "$p4"
+  printf '127.0.0.1\tbadgreet\t# depthsvc:%s:ok=greeting\n' "$p5"
+  printf '127.0.0.1\tsilent\t# depthsvc:%s:ok=greeting\n' "$p6"; } > "$work/home/etc/hosts.cfg"
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[depthsvc]
+   start greeting
+   state greeting
+   expect "220"                -> ehlo
+   timeout(5)                  -> fail
+   state ehlo
+   send "ehlo xymonnet\r\n"
+   expect "250"                -> success
+   timeout(5)                  -> fail
+   options banner
+
+[loginsvc]
+   expect "220"
+   credentials accta
+   send "user \${username}\r\n"
+   expect "250"                -> success
+   timeout(5)                  -> fail
+   options banner
+CFG
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse --dns=ip \
+	--timeout=20 --debug > "$work/out.txt" 2>&1 || :
+
+grep -q 'Service depthsvc on shallow is OK' "$work/out.txt" || fail \
+	"'ok=greeting' did not stop the dialogue at that state, so a site cannot
+ask for the shallow check it has today against a definition that is now
+the full conversation:
+$(grep -i shallow "$work/out.txt" | head -8)"
+
+# THE CONTROL. Same definition, same peer, no depth -- must fail.
+grep -q 'Service depthsvc on deep is not OK' "$work/out.txt" || fail \
+	"the same definition without a depth still passed against a server that
+greets and then rejects everything. Then 'ok=' proves nothing, because
+the entry passes either way:
+$(grep -i 'on deep' "$work/out.txt" | head -8)"
+
+# THE POINT OF THE DEPTH. Both are tagged ok=greeting, and neither gave a
+# greeting the state accepts -- one answered 599, the other said nothing.
+# Green here means the verdict was taken before the state's own expect
+# ran, which is a bare TCP connect wearing the name of a protocol check.
+grep -q 'Service depthsvc on badgreet is not OK' "$work/out.txt" || fail \
+	"a server answering '599 broken' was reported UP under ok=greeting. The
+depth is being taken on ENTERING the state, before its expect has run, so
+'check as far as the greeting' never checks the greeting:
+$(grep -i badgreet "$work/out.txt" | head -8)"
+
+grep -q 'Service depthsvc on silent is not OK' "$work/out.txt" || fail \
+	"a server that accepted the connection and then said NOTHING was reported
+UP under ok=greeting. That is a TCP connect reported as a protocol check,
+and it is the shape this whole feature exists to stop:
+$(grep -i 'on silent' "$work/out.txt" | head -8)"
+
+# A depth is not a different service.
+grep -qE 'shallow\.depthsvc ' "$work/out.txt" || fail \
+	"the shallow host did not report in the 'depthsvc' column. A depth must
+not derive a column of its own, or a site running mixed depths gets one
+column per depth and no comparable history:
+$(grep -oE '[a-z]+\.depthsvc[a-z_0-9]*' "$work/out.txt" | sort -u | head)"
+
+# cred=: the same definition, a different account per host. The
+# definition names 'accta'; hostb asks for 'acctb' and must get it.
+grep -q '^got user user-a' "$work/o3" || fail \
+	"the host asking for cred=accta did not send that account's username. The
+peer saw:
+$(cat "$work/o3")"
+
+grep -q '^got user user-b' "$work/o4" || fail \
+	"the host asking for cred=acctb sent the definition's account instead of
+its own, so credentials cannot be chosen per host. The peer saw:
+$(cat "$work/o4")"
+
+pass "a depth stops after the state it names has been checked, not before it runs, and one definition serves two depths and two accounts in one column"

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -242,6 +242,9 @@ tcptest_t *add_tcp_test(char *ip, int port, char *service, ssloptions_t *sslopt,
 	newtest->steptimedout = 0;
 	newtest->dialogverdict = 0;
 	newtest->timeoutstep = NULL;
+	newtest->okstates = NULL;
+	newtest->curlabel = NULL;
+	newtest->credname = NULL;
 	newtest->idlesecs = 0;
 	newtest->idlestep = NULL;
 	newtest->stepbuf = NULL;
@@ -1066,6 +1069,25 @@ static void dlg_free(tcptest_t *item)
 }
 
 
+/* Is NAME one of the comma-separated names in LIST? */
+static int dlg_name_listed(const char *list, const char *name)
+{
+	const char *p = list;
+	int n = strlen(name);
+
+	while (p && *p) {
+		const char *e = strchr(p, ',');
+		int len = (e ? (int)(e - p) : (int)strlen(p));
+
+		while ((len > 0) && ((*p == ' ') || (*p == '\t'))) { p++; len--; }
+		while ((len > 0) && ((p[len-1] == ' ') || (p[len-1] == '\t'))) len--;
+		if ((len == n) && (strncmp(p, name, n) == 0)) return 1;
+		p = (e ? e + 1 : NULL);
+	}
+	return 0;
+}
+
+
 static char *dlg_get(tcptest_t *item, const char *name)
 {
 	dlgvar_t *v;
@@ -1249,6 +1271,33 @@ static svcstep_t *dlg_run_instant(tcptest_t *item, svcstep_t *st)
 
 		switch (st->type) {
 		  case STEP_LABEL:
+			/*
+			 * Per-test depth. "smtp:ok=greeting" asks for this host to be
+			 * checked only as far as that state, so one definition serves
+			 * several depths and the shipped entries can be deepened
+			 * without moving anybody's alerting. The remaining steps are
+			 * not run and are not a failure.
+			 *
+			 * The verdict is taken when the named state has ENDED, which is
+			 * when the next one begins -- not when it is entered. Entering
+			 * is too early by exactly the thing being asked about: the
+			 * state's own wait has not run yet, so "ok=<start state>" said
+			 * green after the connect and before the banner, and a server
+			 * that accepted the connection and then sent nothing, or sent
+			 * garbage, was reported up. A depth that checks nothing is
+			 * worse than no depth at all, because it looks like a check.
+			 *
+			 * Every edge resolves to the target's STEP_LABEL and every
+			 * transition runs through here, so this is the one place a
+			 * state ends. A state that fails does not reach it: the verdict
+			 * for that is already set and the dialogue has stopped.
+			 */
+			if (item->okstates && item->curlabel &&
+			    dlg_name_listed(item->okstates, item->curlabel)) {
+				item->dialogverdict = 1;
+				return NULL;
+			}
+			item->curlabel = st->label;
 			st = st->next;
 			break;
 
@@ -1282,6 +1331,24 @@ static svcstep_t *dlg_run_instant(tcptest_t *item, svcstep_t *st)
 			break;
 
 		  case STEP_CREDS:
+			if (item->credname) {
+				/*
+				 * "smtp:cred=NAME" names the entry for THIS host. The
+				 * value is a key into credentials.cfg and never a secret:
+				 * hosts.cfg is world-readable for the same reasons
+				 * protocols.cfg is.
+				 */
+				char *u = NULL, *p = NULL;
+
+				if (lookup_credentials(item->credname, &u, &p)) {
+					dlg_set(item, "username", u);
+					dlg_set(item, "password", p);
+					if (u) { dlg_wipe(u); xfree(u); }
+					if (p) { dlg_wipe(p); xfree(p); }
+					st = st->next;
+					break;
+				}
+			}
 			dlg_set(item, "username", st->user);
 			dlg_set(item, "password", st->pass);
 			st = st->next;

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -153,6 +153,9 @@ typedef struct tcptest_t {
 	int steptimedout;		/* that budget expired, rather than a mismatch */
 	int dialogverdict;		/* 0 = infer, 1 = success, 2 = warning, 3 = fail */
 	void *timeoutstep;		/* svcstep_t *: the timeout edge that armed the clock */
+	char *okstates;			/* per-test depth: states that end the dialogue green */
+	char *curlabel;			/* ... and the state being run, to know when one ends */
+	char *credname;			/* per-test credentials entry, overriding the definition */
 	int idlesecs;			/* 'idle(N)': silence budget, 0 = none */
 	void *idlestep;			/* svcstep_t *: the idle edge that armed it */
 

--- a/xymonnet/xymonnet.c
+++ b/xymonnet/xymonnet.c
@@ -345,6 +345,8 @@ testitem_t *init_testitem(testedhost_t *host, service_t *service, char *srcip, c
 	newtest->reverse = reversetest;
 	newtest->alwaystrue = alwaystruetest;
 	newtest->silenttest = silenttest;
+	newtest->okstates = NULL;
+	newtest->credname = NULL;
 	newtest->senddata = sendasdata;
 	newtest->testspec = (testspec ? strdup(testspec) : NULL);
 	if (srcip)
@@ -486,6 +488,7 @@ void load_tests(void)
 		while (testspec) {
 			service_t *s = NULL;
 			int dialuptest = 0, reversetest = 0, silenttest = 0, sendasdata = 0;
+			char *okstates = NULL, *credname = NULL;
 			char *srcip = NULL;
 			int alwaystruetest = (xmh_item(hwalk, XMH_FLAG_NOCLEAR) != NULL);
 
@@ -675,25 +678,34 @@ void load_tests(void)
 						 */
 						int specialport = 0;
 						SBUF_DEFINE(specialname);
-						char *opt2 = strrchr(option, ':');
+						char *o = option, *nexto;
 
-						if (opt2) {
-							if (strcmp(opt2, ":s") == 0) {
-								/* option = "portnumber:s" */
-								silenttest = 1;
-								*opt2 = '\0';
-								specialport = atoi(option);
-								*opt2 = ':';
-							}
-						}
-						else if (strcmp(option, "s") == 0) {
-							/* option = "s" */
-							silenttest = 1;
-							specialport = 0;
-						}
-						else {
-							/* option = "portnumber" */
-							specialport = atoi(option);
+						/*
+						 * The options after a test name, in any order:
+						 *
+						 *   NNNN       a port -- a different port is a different
+						 *              service, so it derives its own column
+						 *   s          silent
+						 *   ok=a,b     check only as far as one of these states
+						 *   cred=NAME  which credentials.cfg entry to bind
+						 *
+						 * ok= and cred= describe how deeply to test THIS host and
+						 * with whose credentials. They are not a different service
+						 * and must not derive a column: a site running mixed depths
+						 * would get one per depth and no comparable history.
+						 */
+						while (o && *o) {
+							nexto = strchr(o, ':');
+							if (nexto) *nexto = '\0';
+
+							if (strcmp(o, "s") == 0)              silenttest = 1;
+							else if (strncmp(o, "ok=", 3) == 0)   okstates = strdup(o + 3);
+							else if (strncmp(o, "cred=", 5) == 0) credname = strdup(o + 5);
+							else if (atoi(o) > 0)                 specialport = atoi(o);
+							else if (*o)
+								errprintf("Unknown option '%s' on test '%s' for host %s\n",
+									  o, testspec, h->hostname);
+							if (nexto) { *nexto = ':'; o = nexto + 1; } else o = NULL;
 						}
 
 						if (specialport) {
@@ -713,6 +725,9 @@ void load_tests(void)
 
 					anytests = 1;
 					newtest = init_testitem(h, s, srcip, testspec, dialuptest, reversetest, alwaystruetest, silenttest, sendasdata);
+					newtest->okstates = okstates;
+					newtest->credname = credname;
+					okstates = credname = NULL;	/* owned by the test now */
 					newtest->next = s->items;
 					s->items = newtest;
 
@@ -2433,10 +2448,18 @@ int main(int argc, char *argv[])
 				if (!t->host->dnserror) {
 					snprintf(tname, sizeof(tname), "%s", s->testname);
 					if (s->namelen) tname[s->namelen] = '\0';
-					t->privdata = (void *)add_tcp_test(ip_to_test(t->host), s->portnum, tname, NULL,
-									   t->srcip,
-									   NULL, t->silenttest, NULL, 
-									   NULL, NULL, NULL);
+					{
+						tcptest_t *tt = add_tcp_test(ip_to_test(t->host), s->portnum, tname, NULL,
+									     t->srcip,
+									     NULL, t->silenttest, NULL,
+									     NULL, NULL, NULL);
+
+						if (tt) {
+							tt->okstates = t->okstates;
+							tt->credname = t->credname;
+						}
+						t->privdata = (void *)tt;
+					}
 				}
 			}
 		}

--- a/xymonnet/xymonnet.h
+++ b/xymonnet/xymonnet.h
@@ -134,6 +134,8 @@ typedef struct testitem_t {
 	int		dialup;		/* "?testname" flag */
 	int		alwaystrue;	/* "~testname" flag */
 	int		silenttest;	/* "testname:s" flag */
+	char		*okstates;	/* "testname:ok=a,b": states that end it green */
+	char		*credname;	/* "testname:cred=NAME": credentials for this host */
 	int             senddata;       /* For tests that merely generate a "data" report */
 	char		*srcip;
 


### PR DESCRIPTION
`svc:ok=STATE` ends a dialogue green at a named state and `svc:cred=NAME` picks the credentials entry, both as hosts.cfg tags — so one definition serves hosts checked to different depths and under different accounts, instead of a copy of the entry per depth.

---
### Stack

**8 of 15** in the dialogue stack: base #476, next #478. The full chain is listed in #457; read bottom-up.

