### PR TITLE
docs: the manual and the design note describe the code

### DIFF
--- a/docs/design/protocol-dialogues.md
+++ b/docs/design/protocol-dialogues.md
@@ -1,0 +1,308 @@
+# Protocol dialogues: the reasoning, and what was not built
+
+This note is for contributors. It records the designs that were tried and
+rejected for the multi-step dialogues in `protocols.cfg`, so the same ground
+is not re-explored -- which has already happened more than once here.
+
+What the grammar *is*, and every decision an operator can observe, lives in
+`xymonnet/protocols.cfg.5`, not here. The problem the feature exists to solve
+is issue #457. This file holds the reasoning behind
+that behaviour, and the counterfactuals: the alternatives, why they lost, and
+what would change each verdict.
+
+**Entries are permanent.** Anything reopened should be settled by amending its
+entry rather than deleting it.
+
+## The shape
+
+```
+[service|alias]
+   transport tcp          entry attributes. transport, port, options and
+   port N                 start set properties of the definition; the
+   options ssl,banner     order among them does not matter.
+   start NAME
+
+   state NAME             names the steps that follow, and is what an
+                          edge aims at
+
+      credentials NAME    everything from here is a STEP, and steps run
+      send "…"            in the order they are written
+      starttls
+      expect "…" [ until "…" ] [ as NAME ]
+      NAME ~ "…" as X;Y   read a bound value, bind more out of it
+      <condition> -> TARGET               an edge; the first that fires leaves
+```
+
+```
+condition ::= expect "…" [ until "…" ] [ as NAME ] | NAME ~ "…"
+            | else | always | eof | timeout(N) | idle(N)
+```
+
+**Targets** are a state, or one of `success`, `warning`, `fail` -- green, yellow, red. `warning` is the point: a server answering correctly but refusing an optional capability is not down, and calling it down teaches operators to ignore the column. An edge saying `fail` is red whatever `--checkresponse` is set to; a reply matching no alternative takes that option's colour, yellow by default.
+
+**Order is file order.** A state's lines run as written and the first edge that fires leaves, so a `~` above an `expect` decides before the socket is read at all. An earlier draft specified a fixed precedence regardless of where lines were written; the implementation does not do that and should not, because a precedence the reader cannot see is what turns a declaration back into a program.
+
+**Values are bound where they are produced.** `expect "…" as NAME` binds the reply that expect accepted; `NAME ~ "…" as X;Y` reads a bound value and binds more out of it. No line refers to its operand by position.
+
+**Regex only ever reads a value already in hand.** That is what allows it on a `~` line and not on an `expect`: it decides nothing about what arrives, so it cannot race a partial read and needs no maximum match length.
+
+## A worked example
+
+Submission on 587, upgrading to TLS and authenticating:
+
+```
+[submission]
+   port 587
+   options banner
+   credentials mysmtp
+   start greeting
+
+   state greeting
+      expect "220"                -> ehlo
+      expect "421"                -> warning
+      timeout(5)                  -> fail
+
+   state ehlo
+      send   "ehlo xymonnet\r\n"
+      expect "250" until "250 " as caps   -> offers-tls
+      idle(5)                     -> warning
+      timeout(30)                 -> fail
+
+   state offers-tls
+      caps ~ "STARTTLS"           -> upgrade
+      else                        -> warning
+
+   state upgrade
+      send   "starttls\r\n"
+      expect "220"                -> handshake
+      expect "454"                -> warning
+      timeout(10)                 -> fail
+
+   state handshake
+      starttls
+      always                      -> ehlo-encrypted
+      timeout(10)                 -> fail
+
+   state ehlo-encrypted
+      send   "ehlo xymonnet\r\n"
+      expect "250" until "250 "   -> authenticate
+      timeout(10)                 -> fail
+
+   state authenticate
+      send   "auth login\r\n"
+      expect "334"                -> send-user
+      expect "503"                -> farewell
+      timeout(10)                 -> fail
+
+   state send-user
+      send   "${base64:${username}}\r\n"
+      expect "334"                -> send-pass
+      timeout(10)                 -> fail
+
+   state send-pass
+      send   "${base64:${password}}\r\n"
+      expect "235"                -> farewell
+      expect "535"                -> fail
+      timeout(20)                 -> warning
+
+   state farewell
+      send   "quit\r\n"
+      expect "221"                -> success
+      timeout(10)                 -> fail```
+
+The same entry as a diagram -- generated from it rather than drawn beside it: **25 edges in the config, 25 in the diagram.**
+
+```mermaid
+stateDiagram-v2
+    direction TB
+    [*] --> greeting
+
+    greeting : greeting
+    ehlo : ehlo / send ehlo xymonnet
+    offers_tls : offers-tls
+    upgrade : upgrade / send starttls
+    handshake : handshake / starttls
+    ehlo_encrypted : ehlo-encrypted / send ehlo xymonnet
+    authenticate : authenticate / send auth login
+    send_user : send-user / send ${base64:${username}}
+    send_pass : send-pass / send ${base64:${password}}
+    farewell : farewell / send quit
+
+    greeting --> ehlo : expect "220"
+    greeting --> warning : expect "421"
+    greeting --> fail : timeout(5)
+
+    ehlo --> offers_tls : expect "250" until "250 " as caps
+    ehlo --> warning : idle(5)
+    ehlo --> fail : timeout(30)
+
+    offers_tls --> upgrade : caps ~ "STARTTLS"
+    offers_tls --> warning : else
+
+    upgrade --> handshake : expect "220"
+    upgrade --> warning : expect "454"
+    upgrade --> fail : timeout(10)
+
+    handshake --> ehlo_encrypted : always
+    handshake --> fail : timeout(10)
+
+    ehlo_encrypted --> authenticate : expect "250" until "250 "
+    ehlo_encrypted --> fail : timeout(10)
+
+    authenticate --> send_user : expect "334"
+    authenticate --> farewell : expect "503"
+    authenticate --> fail : timeout(10)
+
+    send_user --> send_pass : expect "334"
+    send_user --> fail : timeout(10)
+
+    send_pass --> farewell : expect "235"
+    send_pass --> fail : expect "535"
+    send_pass --> warning : timeout(20)
+
+    farewell --> success : expect "221"
+    farewell --> fail : timeout(10)
+
+    success --> [*]
+    warning --> [*]
+    fail --> [*]
+
+    classDef ok   fill:#2da44e,color:#fff,stroke:#1a7f37
+    classDef warn fill:#bf8700,color:#fff,stroke:#9a6700
+    classDef bad  fill:#cf222e,color:#fff,stroke:#a40e26
+    class success ok
+    class warning warn
+    class fail bad```
+
+## Branching on a value
+
+```
+   state greeting
+      expect "+OK" as banner      -> choose-auth
+      expect "-ERR"               -> fail
+      timeout(5)                  -> fail
+
+   state choose-auth
+      banner ~ "\+OK (\S+) (<[^>]+>)" as server;challenge
+      challenge ~ "<"             -> apop
+      else                        -> plain
+
+   state apop
+      send   "APOP ${username} ${md5:${challenge}${password}}\r\n"
+      expect "+OK"                -> farewell
+      expect "-ERR"               -> fail
+      timeout(5)                  -> fail
+
+   state plain
+      send   "USER ${username}\r\n"
+      expect "+OK"                -> send-pass
+      expect "-ERR"               -> fail
+      timeout(5)                  -> fail
+
+   state send-pass
+      send   "PASS ${password}\r\n"
+      expect "+OK"                -> farewell
+      expect "-ERR"               -> fail
+      timeout(5)                  -> fail
+
+   state farewell
+      send   "quit\r\n"
+      expect "+OK"                -> success
+      timeout(5)                  -> fail```
+
+One entry, both server styles, no nesting. The greeting is bound where it is accepted and taken apart in the state that branches on it.
+
+## The reasoning a manual has no room for
+
+The behaviour itself is documented in `protocols.cfg(5)`, which ships with the code and is where an operator will look: what a state consumes and leaves, what `as` binds, the per-step budget and the idle clock, the 32 KB cap, the STARTTLS refusal over buffered data, the certificate off the upgraded session, that entering a state re-runs its action, and every complaint the parser makes about the file. Restating it there is how the two drifted apart twice, which is why the manual is the only place the behaviour is stated. What follows is the reasoning behind it.
+
+**Why matching is literal, and nothing else is.** An unmatched reply fails at once rather than waiting out a timer, which is what makes a server that greets correctly and then rejects every command report promptly. That depends on "ruled out" being *decidably* ruled out: with alternatives `"220"` and `"221"`, a reply of `22` is unfinished rather than wrong, and both stay live until a byte decides. Prefix matching gives that at every byte. The same property makes the overlap check complete rather than heuristic -- prefix-anchored patterns collide iff one is a prefix of the other -- which is what lets the parser *refuse* an ambiguous group instead of warning about it. Both properties are lost the moment an `expect` can carry a regex, which is why one cannot.
+
+**Why the graph checks are worth having, and how they mislead.** Three mistakes are properties of the graph rather than of any line: a state with no path to a terminal, an unreachable state, and a waiting state with no timer. All three are easy to implement too permissively, so they report nothing and look like they work -- reachability cannot simply follow the step list, and on the branch a `timeout(N) -> fail` edge briefly counted as ending the flow, which called every state after it unreachable. They are topology checks and should not be oversold: the bugs that cost time here are framing, partial reads and TLS transitions, and no topology check sees those.
+
+**What is not built.** Graph export (`--graph`) is deferred. A named state improves a failure from "step 7" to `state send-pass expected "235"`, and that is not enough: the faults that cost time are *why* it did not match -- bytes retained from the previous state, a reply matched before it was complete, a name that bound empty. A transcript mode is part of the feature and is **not implemented**. Nor is the marking it would require: `${password}` is expanded into a `send`, so the sent bytes, the buffer and anything an `as` binds may contain it. A value from `credentials.cfg` would have to be marked at binding time, stay marked through `${base64:}` and `${md5:}` -- an encoded secret is still the secret, and an APOP digest only looks opaque -- and be replaced by a placeholder in every output. The code wipes secrets from memory after use and no more, which is why it has no transcript to leak them into.
+
+## Prior art
+
+| | Monit | blackbox_exporter | Expect | pexpect | here |
+|---|---|---|---|---|---|
+| form | config | config (YAML) | library | library | config |
+| matching | regex | regex + `expect_bytes` | regex + literal | regex | literal only |
+| branching | none | none | host `if` | host `if` | declarative edges |
+| capture into a send | none | `${1}` positional | match object | match object | `${name}` named |
+| per-step timeout | none | none | per `expect` | per call | `timeout(N)` |
+| idle vs total clock | no | no | `restart_timeout_upon_receive` | no | `idle(N)` / `timeout(N)` |
+| starttls | compiled | step field | host code | host code | step |
+| verdict | pass/fail | pass/fail | n/a | n/a | green / yellow / red |
+
+Literal-only matching is the one place this is *less* expressive than all four, and it is deliberate: it is what makes overlap decidable and fail-fast possible.
+
+## Explorations that were rejected
+
+Each entry says what was tried, why it lost, and where one exists, what would change it.
+
+**A regex-matching `expect`.** `expect-regex "…" -> TARGET`. Rejected because it breaks load-time decidability twice. Overlap between two literals is decidable and complete; between two PCRE2 patterns it is *undecidable* (backreferences and recursion put PCRE2 outside the regular languages), so one alternative could silently shadow another. And it reintroduces a fixed bug: alternatives used to be decided by packet boundaries, and the fix defers the decision until the buffer is as long as the longest pattern -- which needs a maximum match length that a regex has none of. Would change if restricted to a regular dialect *and* given a computable maximum match length.
+
+**A separate `capture` step.** `capture as X` / `capture-regex "…" as X;Y` as their own lines, binding out of the *preceding* expect's reply. Built, shipped in the draft, removed. It was the only line naming its operand by position, and it failed silently: the guard could only ask whether the entry had any expect at all, so a capture written one state too late bound the *earlier* state's reply -- wrong rather than missing. Two examples in this document were written that way and neither was noticed until the grammar changed.
+
+**Binding a value inside `expect`.** The regex form -- `expect /\+OK .*(<[^>]+>)/ as challenge` -- stays rejected: it puts a regex on the line that reads the socket. **Amended after building it:** the plain `expect "…" as NAME` was adopted, binding the whole consumed reply with no regex. What survives of the objection: a name bound on one alternative is not bound on another, so the check can only say a name is bound *somewhere* in the entry.
+
+**An `expect-capture` keyword.** Rejected: it multiplies with the clauses `expect` already carries -- `expect-until`, `expect-capture`, `expect-until-capture`, one per combination. A clause composes where a keyword does not, and `until` was already the precedent.
+
+**Deferring an ambiguous group instead of refusing it.** Built, tested, removed: once regex alternatives were dropped the collision check became complete, so refusing rejects nothing valid, while deferral made every *healthy* probe wait for the longest pattern's worth of bytes.
+
+**Consuming only the matched bytes rather than the whole line.** More composable, and how Expect works. Rejected: splitting an overlap across two states leaves the checker confirming each group is internally clean while missing that the pair was one ambiguous group. Would change if the checker could follow a split chain.
+
+**A catch-all `otherwise`.** Rejected: no worked example needed it; the prefix case it was for is answered by `as` plus a decision state; it is a second spelling of `else`; and fail-fast already supplies the default. Would change if a state needed a catch-all *without* binding the reply first.
+
+**Folding `until` into a line-scanning `expect`.** Rejected: it silently makes `expect` line-oriented, putting `[ajp13]`, `[rdp]` and `[amqp]` -- whose patterns contain no newline -- permanently out of reach, and it fuses *where did the reply end* with *was it good*.
+
+**A `when NAME ~ REGEX` / `else` / `end` block.** Branching as a nested block, the enclosed steps running only when the value matched. Never implemented -- the parser has only ever taken `~` and `else` as edges -- but it outlived the draft it came from and sat in `protocols.cfg(5)` describing a grammar nothing accepted, beside `goto` and a bare `fail`. Rejected on its own merits too: a block hides where a state ends, and nesting is the point at which a config becomes a program. Recorded here because a draft that survives in the manual is indistinguishable, to a reader, from a decision.
+
+**`goto TARGET` for edges.** Replaced by `->`: nothing jumps, the machine moves, and `goto` was the most program-like word in the grammar.
+
+**Terminal states named as colours.** `-> green` instead of `-> success`. Tried and reverted: the colour is how Xymon renders the outcome, not the outcome.
+
+**A default `timeout N` applying to following states.** Rejected: that is exactly the positional behaviour the shape removes.
+
+**An explicit `expect-any … end` block.** Not needed once states are named: the state *is* the group.
+
+**Reusable state blocks.** Rejected: it makes the config a macro language, and a shared destination is already reachable by an edge. Revisit if entries start repeating large blocks verbatim.
+
+**Renaming `send` and `expect`** to `say`/`on`/`read`/`bind`. Rejected: those two words are the shared vocabulary of Monit, blackbox_exporter, Expect, pexpect, telnetlib and `chat(8)`; renaming discards the field's convergence for a purity only we would notice.
+
+**Mealy: the action on the transition.** Rejected: a state reachable from several places would duplicate its action on every incoming edge -- `farewell` already has two routes in.
+
+**One thing per state.** More uniform, and makes timers structural. Rejected: with one action and one wait the sequence is forced rather than authored; the action state carries no information, its only edge being `always ->`; and it costs 17 states against 10 on the submission entry, with failures reading `state send-pass-wait expected "235"` where `-wait` is scaffolding. The split form is still correct wherever a state is the target of a cycle, since re-entry re-runs the action.
+
+**Mermaid as the config format itself.** Tested rather than assumed -- labels do preserve trailing spaces, `\r\n` and colons. Rejected: it needs a mermaid-subset parser in C, and a subset is the trap; it pins the config to someone else's release cycle; its edge list names both endpoints per line, so a state's action sits away from its edges; and `[name]`, `options`, `port` have no home in it. Generating mermaid gets the benefit with none of that.
+
+**A transport flag on a single grammar.** Superseded: a ping body has nothing in common with a dialogue body, and stretching one grammar over both is how a config language bloats. Hence `transport`, with only `tcp` implemented and anything else refused rather than silently treated as tcp.
+
+## The linear form
+
+Three independent reviews recommended a **reduced linear form** -- ordered steps
+with optional labels, no named states as edge targets -- arguing that ordering
+fixes the first problem in #457, multi-step the second and bound values the
+third, while the graph checks are only topology checks. That argument is largely
+right and deserves an answer rather than a dismissal.
+
+It stops one step short. A linear form covers all three *for a single server*,
+and `protocols.cfg` does not describe a single server: one definition is a
+column across the estate. A fleet whose servers are configured differently --
+some offering APOP, some STARTTLS -- forces a linear entry down to what they all
+do, which is the shallow check the feature exists to remove. Branching is not a
+fourth feature; it is what makes the fix hold for more than one host.
+
+What would move this: a demonstration that the shipped services are homogeneous
+enough in practice that a linear definition does not degrade.
+
+## A caution
+
+Ten bugs in the original branch were found by running probes against real
+servers, none by source-level tests. Four were invisible on plain TCP and fatal
+with `options ssl`; one broke *legacy* services the feature does not touch;
+three were state that existed in one representation and did not survive into the
+next, including an uninitialised field that aborted the probe whenever three
+dialogue services ran together; two were reports naming the wrong line. Whatever
+lands here needs behavioural tests over TLS, not assertions about the code.

--- a/docs/manpages/man5/protocols.cfg.5.html
+++ b/docs/manpages/man5/protocols.cfg.5.html
@@ -96,6 +96,10 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <p class="Pp">An <b>expect</b> matches the beginning of the reply, and
         consumes one line of it. Anything the server sent beyond that line is
         kept for the next step.</p>
+    <p class="Pp">A reply that never matches is not accumulated without limit.
+        Once a conversation has buffered 32 KB with nothing matching, the test
+        fails naming the service rather than growing for as long as the server
+        cares to talk.</p>
     <p class="Pp"></p>
   </dd>
   <dt id="expect~2"><a class="permalink" href="#expect~2"><b>expect</b>
@@ -113,6 +117,18 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <p class="Pp"></p>
   </dd>
   <dt id="expect~3"><a class="permalink" href="#expect~3"><b>expect</b>
+    <i>STRING</i> <b>as</b> <i>NAME</i></a></dt>
+  <dd>Bind the reply this <b>expect</b> accepted to <i>NAME</i>, for a later
+      <b>~</b> line to read. It is written on the expect itself because that is
+      the line that produces the value: a separate step would have to say which
+      reply it meant by standing in the right place, and one standing in the
+      wrong place bound the reply of an earlier state without complaining. May
+      be combined with <b>until</b> and with an edge:
+    <p class="Pp"></p>
+    <pre>   expect &quot;250&quot; until &quot;250 &quot; as caps    -&gt; offers</pre>
+    <p class="Pp"></p>
+  </dd>
+  <dt id="expect~4"><a class="permalink" href="#expect~4"><b>expect</b>
     <i>STRING</i> <b>-&gt;</b> <i>TARGET</i></a></dt>
   <dd></dd>
   <dt id="state"><a class="permalink" href="#state"><b>state</b>
@@ -124,12 +140,17 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       that end the test where it stands:
     <p class="Pp"></p>
     <pre>   -&gt; <i>LABEL</i>        continue in that state
-   -&gt; success      the service is up
+   -&gt; success      the service is up (green)
    -&gt; warning      answering, but not as it should (yellow)
-   -&gt; fail         the test failed (the <b>--checkresponse</b> colour)</pre>
+   -&gt; fail         the test failed (red)</pre>
     <p class="Pp"><b>warning</b> is the one worth reaching for. A server that
         answers correctly but refuses an optional capability is not down, and
         reporting it as down teaches operators to ignore the column.</p>
+    <p class="Pp">A reply that matches no alternative at all is a failure too,
+        but it takes the colour of <b>--checkresponse</b>, which is yellow
+        unless set otherwise. <b>-&gt; fail</b> is red whatever that option
+        says, so choosing it is a stronger statement than merely failing to
+        match.</p>
     <p class="Pp"><b>state</b> names the state that follows it -- the expects up
         to the next step that is not one -- and is what a <b>-&gt;</b> aims at,
         so naming a state and marking a jump target are the same act. Naming
@@ -143,16 +164,32 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <p class="Pp">A <b>-&gt;</b> may point backwards, which makes a retry loop.
         A dialogue that loops without performing any I/O is stopped rather than
         spinning.</p>
+    <p class="Pp">Entering a state runs its action, on re-entry as much as the
+        first time, so an edge back into a state that sends will send again.
+        That is right for a retry and wrong for &quot;ignore this and keep
+        waiting&quot;, which needs the wait as a state of its own carrying no
+        action.</p>
+    <p class="Pp">A reply that matches no alternative at all does not wait for
+        <b>timeout(</b><i>N</i><b>)</b> to expire: the test fails at once,
+        naming the state. That is what makes a server which greets correctly and
+        then rejects every command report promptly rather than as a timeout.</p>
+    <p class="Pp">The lines of a state run in the order they are written, and
+        the first edge that fires leaves it. A <b>~</b> line written above an
+        <b>expect</b> therefore decides before anything is read from the socket
+        at all, which is how a state branches on a value bound earlier without
+        waiting for input.</p>
     <p class="Pp">Avoid writing one alternative that is a prefix of another.
         Both would match the same reply, so the winner would otherwise depend on
         how much had arrived when the group was examined -- that is, on how the
         server split its reply across packets rather than on anything in this
         file.</p>
-    <p class="Pp">Such a group is reported when the file is read, and the driver
-        waits for every pattern in it to be decidable before choosing, so the
-        order written here decides the winner. The warning is still worth acting
-        on: a reader of the file cannot see which alternative wins without
-        knowing that rule.</p>
+    <p class="Pp">Such a group is refused when the file is read, and the service
+        reports that protocols.cfg would not take the definition. Matching is
+        anchored at the start of the reply, so two patterns can both match one
+        reply exactly when one is a prefix of the other -- which makes the check
+        complete rather than a guess, and means refusing rejects nothing that
+        would have worked. The fix is to match the shared prefix in one state,
+        bind it with <b>as</b>, and distinguish in the next.</p>
     <p class="Pp"></p>
   </dd>
   <dt id="start"><a class="permalink" href="#start"><b>start</b>
@@ -181,47 +218,37 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
   <dd></dd>
   <dt id="idle(SECONDS"><a class="permalink" href="#idle(SECONDS"><b>idle(</b><i>SECONDS</i><b>)</b>
     <b>-&gt;</b> <i>TARGET</i></a></dt>
-  <dd>How long the state may take, and where to go when it does not finish in
-      time. <b>timeout</b> is the budget for the whole state; <b>idle</b> is how
-      long the server may say nothing at all. They differ for a long reply that
-      keeps arriving: that is not idle, but it may still be over budget. Either
-      may lead to <b>warning</b>, which is how &quot;slow&quot; is reported as
-      distinct from &quot;broken&quot;.
+  <dd>How long to wait, and where to go when the wait runs out. <b>timeout</b>
+      is armed against the step the dialogue is on and re-armed when it
+      advances, so it bounds each wait rather than the state as a whole -- the
+      same thing in a state that waits once, and not in one whose <b>send</b>
+      blocks before its <b>expect</b> begins. <b>idle</b> is how long the server
+      may say nothing at all, and restarts on any byte. They differ for a long
+      reply that keeps arriving: that is not idle, but it may still be over
+      budget. Either may lead to <b>warning</b>, which is how &quot;slow&quot;
+      is reported as distinct from &quot;broken&quot;.
     <p class="Pp"></p>
   </dd>
   <dt><i>NAME</i> <b>~</b> <i>REGEX</i> <b>-&gt;</b> <i>TARGET</i></dt>
   <dd></dd>
   <dt id="else"><a class="permalink" href="#else"><b>else</b> <b>-&gt;</b>
     <i>TARGET</i></a></dt>
-  <dd>Branch on a value bound earlier by <b>as</b>. The line begins with the
-      name being tested, so it is recognised by its shape rather than by a
-      leading keyword.
-    <p class="Pp">The regex is tested against a value already in hand, never
-        against the socket. That is why a regex is allowed here and not in an
-        <b>expect</b>: it decides nothing about what arrives, so it cannot race
-        a partial read. A name that nothing bound never matches, and so takes
-        the <b>else</b> arm.</p>
-    <p class="Pp"></p>
-  </dd>
-  <dt id="expect~4"><a class="permalink" href="#expect~4"><b>expect</b>
-    <i>STRING</i> <b>as</b> <i>NAME</i></a></dt>
-  <dd>Bind the reply this <b>expect</b> accepted to <i>NAME</i>, for a later
-      <b>~</b> line to read. It is written on the expect itself because that is
-      the line that produces the value: a separate step would have to say which
-      reply it meant by standing in the right place, and one standing in the
-      wrong place bound the reply of an earlier state without complaining. May
-      be combined with <b>until</b> and with an edge:
-    <p class="Pp"></p>
-    <pre>   expect &quot;250&quot; until &quot;250 &quot; as caps    -&gt; offers</pre>
-    <p class="Pp"></p>
-  </dd>
+  <dd></dd>
   <dt><i>NAME</i> <b>~</b> <i>REGEX</i> <b>as</b>
     <i>NAME2</i>[;<i>NAME3</i>]</dt>
-  <dd>Read the value called <i>NAME</i> and bind what the pattern's capture
-      groups found in it, one name per group, in the order the groups appear.
-      The regex is case-sensitive, and a pattern that does not match binds
-      empty. It reads a value already in hand and never the socket, which is
-      what allows a regex here and not on an <b>expect</b>.
+  <dd>Read the value called <i>NAME</i>: the first two forms branch on whether
+      it matches, the third binds what the pattern's capture groups found in it.
+      One name per group, in the order the groups appear. Each line begins with
+      the name it reads, so both are recognised by their shape rather than by a
+      leading keyword.
+    <p class="Pp">The regex reads a value already in hand, never the socket.
+        That is what allows a regex here and not in an <b>expect</b>: it decides
+        nothing about what arrives, so it cannot race a partial read and needs
+        no maximum match length. The regex is case-sensitive, and a pattern that
+        does not match binds empty.</p>
+    <p class="Pp">A name that nothing binds never matches, so a branch on one
+        can only ever take the <b>else</b> arm and an extraction from one can
+        only ever bind empty. Both are reported when the file is read.</p>
     <p class="Pp"></p>
   </dd>
   <dt id="credentials"><a class="permalink" href="#credentials"><b>credentials</b>
@@ -230,6 +257,9 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       <i>NAME</i> in <b>$XYMONHOME/etc/credentials.cfg</b>, one entry per line:
     <p class="Pp"></p>
     <pre>   NAME	username	password</pre>
+    <p class="Pp">It is a step, not a property of the entry: it takes effect
+        where it is written, like <b>send</b>, and the names it binds are
+        available to the steps after it.</p>
     <p class="Pp">Credentials are named rather than written here because
         protocols.cfg is world-readable and is the file people attach to bug
         reports.</p>
@@ -247,6 +277,10 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       plaintext and everything after it is encrypted, on the same socket. This
       is what submission (587), IMAP (143) and POP3 (110) use, and it is not the
       same as the <b>ssl</b> option, which means TLS from the first byte.
+    <p class="Pp">The certificate is read from the upgraded session, so a
+        service that begins in plaintext -- submission on 587, IMAP on 143, SMTP
+        on 25 -- reaches the <b>sslcert</b> column with its expiry checked. It
+        cannot, while <b>ssl</b> is the only way to start TLS.</p>
     <p class="Pp">If the server has sent anything that is still unread when the
         upgrade begins, the test fails rather than proceeding: the handshake has
         to start on the first byte sent after the go-ahead, and data arriving
@@ -294,6 +328,35 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
 </section>
 <section class="Sh">
 <p>&#160;</p>
+<h1 class="Sh" id="PER-HOST_DEPTH_AND_CREDENTIALS"><a class="permalink" href="#PER-HOST_DEPTH_AND_CREDENTIALS">PER-HOST
+  DEPTH AND CREDENTIALS</a></h1>
+<p class="Pp">protocols.cfg is one file for the whole installation: a
+    <b>[pop3]</b> definition applies to every host carrying the test. Deepening
+    a shipped entry therefore changes what every site is alerted on. Two tags in
+    hosts.cfg let a host differ from the definition without copying it:</p>
+<p class="Pp"></p>
+<pre>   smtp:ok=greeting        check only as far as that state
+   smtp:ok=greeting,ehlo   ... or any one of several
+   smtp:cred=acctb         bind this credentials.cfg entry</pre>
+<p class="Pp"><b>ok=</b> names one or more states at which this host's test
+    stops and reports success. The steps after it are not run and their absence
+    is not a failure, so a definition can become the full conversation while a
+    site keeps banner depth host by host.</p>
+<p class="Pp"><b>cred=</b> names the entry in credentials.cfg that this host's
+    <b>credentials</b> step binds, in place of the one the definition names --
+    one definition, a different account per host. The value is a key, never a
+    secret: hosts.cfg is world-readable for the same reasons protocols.cfg
+  is.</p>
+<p class="Pp">Neither tag derives a column, unlike a port. A site running mixed
+    depths would otherwise get one column per depth and no comparable
+  history.</p>
+<p class="Pp">The checks in DIAGNOSTICS below are made against the entry as
+    written, not against any host's depth. Under <b>ok=greeting</b> everything
+    downstream is legitimately unreachable, and the checks do not know that.</p>
+<p class="Pp"></p>
+</section>
+<section class="Sh">
+<p>&#160;</p>
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
 <p class="Pp">An SMTP service that upgrades to TLS when the server offers it,
     reports a server that does not offer it as yellow rather than down, and
@@ -332,6 +395,30 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
 </section>
 <section class="Sh">
 <p>&#160;</p>
+<h1 class="Sh" id="DIAGNOSTICS"><a class="permalink" href="#DIAGNOSTICS">DIAGNOSTICS</a></h1>
+<p class="Pp">This file is checked when it is read rather than when a step runs,
+    so a step that is never reached still reports its own mistake. Every message
+    names the service. The ones worth knowing:</p>
+<p class="Pp"></p>
+<pre>   Unknown protocols.cfg directive     a mistyped keyword; step dropped
+   '-&gt; NAME' has no matching state     the edge is dropped
+   'start NAME' has no matching state  the entry is refused
+   state 'NAME' cannot be reached      no edge names it
+   state 'NAME' has no way to finish   no path from it to a terminal
+   state 'NAME' waits for a reply with no timeout
+   'expect &quot;A&quot;' and 'expect &quot;B&quot;' overlap - both match the same reply
+   ${NAME} is never captured or bound before it is used
+   'NAME ~ ...' tests a value that is never bound before it
+   'NAME ~ &quot;...&quot; as X' has no capture group
+   transport 'X' is not implemented    only tcp is supported</pre>
+<p class="Pp">An overlap and an unimplemented transport refuse the definition
+    outright: the service reports that protocols.cfg would not take it, rather
+    than running a test whose result would depend on which pattern arrived
+    first.</p>
+<p class="Pp"></p>
+</section>
+<section class="Sh">
+<p>&#160;</p>
 <h1 class="Sh" id="FILES"><a class="permalink" href="#FILES">FILES</a></h1>
 <dl class="Bl-tag">
   <dt><b>$XYMONHOME/etc/protocols.cfg</b></dt>
@@ -352,7 +439,9 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
 <dt><a href="#SYNOPSIS">SYNOPSIS</a></dt>
 <dt><a href="#DESCRIPTION">DESCRIPTION</a></dt>
 <dt><a href="#FILE_FORMAT">FILE FORMAT</a></dt>
+<dt><a href="#PER-HOST_DEPTH_AND_CREDENTIALS">PER-HOST DEPTH AND CREDENTIALS</a></dt>
 <dt><a href="#EXAMPLES">EXAMPLES</a></dt>
+<dt><a href="#DIAGNOSTICS">DIAGNOSTICS</a></dt>
 <dt><a href="#FILES">FILES</a></dt>
 <dt><a href="#SEE_ALSO">SEE ALSO</a></dt>
 </dl>

--- a/xymonnet/protocols.cfg.5
+++ b/xymonnet/protocols.cfg.5
@@ -78,6 +78,11 @@ of the byte.
 An \fBexpect\fR matches the beginning of the reply, and consumes one
 line of it. Anything the server sent beyond that line is kept for the
 next step.
+.sp
+A reply that never matches is not accumulated without limit. Once a
+conversation has buffered 32 KB with nothing matching, the test fails
+naming the service rather than growing for as long as the server cares
+to talk.
 
 .IP "\fBexpect\fR \fISTRING\fR \fBuntil\fR \fITERMINATOR\fR"
 Consume a multi-line reply. Lines are consumed until one begins with
@@ -95,6 +100,19 @@ covers them without special-casing any:
 \&   expect "*"   until "A01 "     (IMAP: the command tag ends it)
 .fi
 
+.IP "\fBexpect\fR \fISTRING\fR \fBas\fR \fINAME\fR"
+Bind the reply this \fBexpect\fR accepted to \fINAME\fR, for a later
+\fB~\fR line to read. It is written on the expect itself because that is
+the line that produces the value: a separate step would have to say
+which reply it meant by standing in the right place, and one standing in
+the wrong place bound the reply of an earlier state without complaining.
+May be combined with \fBuntil\fR and with an edge:
+.br
+.sp
+.nf
+\&   expect "250" until "250 " as caps    \-> offers
+.fi
+
 .IP "\fBexpect\fR \fISTRING\fR \fB\->\fR \fITARGET\fR"
 .IP "\fBstate\fR \fINAME\fR"
 Consecutive \fBexpect\fR lines are alternatives: the first whose pattern
@@ -106,14 +124,19 @@ end the test where it stands:
 .sp
 .nf
 \&   \-> \fILABEL\fR        continue in that state
-\&   \-> success      the service is up
+\&   \-> success      the service is up (green)
 \&   \-> warning      answering, but not as it should (yellow)
-\&   \-> fail         the test failed (the \fB\-\-checkresponse\fR colour)
+\&   \-> fail         the test failed (red)
 .fi
 .sp
 \fBwarning\fR is the one worth reaching for. A server that answers
 correctly but refuses an optional capability is not down, and reporting
 it as down teaches operators to ignore the column.
+.sp
+A reply that matches no alternative at all is a failure too, but it takes
+the colour of \fB\-\-checkresponse\fR, which is yellow unless set
+otherwise. \fB\-> fail\fR is red whatever that option says, so choosing
+it is a stronger statement than merely failing to match.
 .sp
 \fBstate\fR names the state that follows it -- the expects up to the next
 step that is not one -- and is what a \fB\->\fR aims at, so naming a state
@@ -133,15 +156,34 @@ timing out:
 A \fB\->\fR may point backwards, which makes a retry loop. A dialogue
 that loops without performing any I/O is stopped rather than spinning.
 .sp
+Entering a state runs its action, on re-entry as much as the first time,
+so an edge back into a state that sends will send again. That is right
+for a retry and wrong for "ignore this and keep waiting", which needs
+the wait as a state of its own carrying no action.
+.sp
+A reply that matches no alternative at all does not wait for
+\fBtimeout(\fR\fIN\fR\fB)\fR to expire: the test fails at once, naming
+the state. That is what makes a server which greets correctly and then
+rejects every command report promptly rather than as a timeout.
+.sp
+The lines of a state run in the order they are written, and the first
+edge that fires leaves it. A \fB~\fR line written above an \fBexpect\fR
+therefore decides before anything is read from the socket at all, which
+is how a state branches on a value bound earlier without waiting for
+input.
+.sp
 Avoid writing one alternative that is a prefix of another. Both would
 match the same reply, so the winner would otherwise depend on how much
 had arrived when the group was examined -- that is, on how the server
 split its reply across packets rather than on anything in this file.
 .sp
-Such a group is reported when the file is read, and the driver waits for
-every pattern in it to be decidable before choosing, so the order written
-here decides the winner. The warning is still worth acting on: a reader
-of the file cannot see which alternative wins without knowing that rule.
+Such a group is refused when the file is read, and the service reports
+that protocols.cfg would not take the definition. Matching is anchored at
+the start of the reply, so two patterns can both match one reply exactly
+when one is a prefix of the other -- which makes the check complete rather
+than a guess, and means refusing rejects nothing that would have worked.
+The fix is to match the shared prefix in one state, bind it with
+\fBas\fR, and distinguish in the next.
 
 .IP "\fBstart\fR \fINAME\fR"
 Begin the dialogue in the state called \fINAME\fR rather than at the
@@ -160,43 +202,35 @@ rather than any bytes.
 
 .IP "\fBtimeout(\fR\fISECONDS\fR\fB)\fR \fB\->\fR \fITARGET\fR"
 .IP "\fBidle(\fR\fISECONDS\fR\fB)\fR \fB\->\fR \fITARGET\fR"
-How long the state may take, and where to go when it does not finish in
-time. \fBtimeout\fR is the budget for the whole state; \fBidle\fR is how
-long the server may say nothing at all. They differ for a long reply
-that keeps arriving: that is not idle, but it may still be over budget.
+How long to wait, and where to go when the wait runs out. \fBtimeout\fR
+is armed against the step the dialogue is on and re-armed when it
+advances, so it bounds each wait rather than the state as a whole -- the
+same thing in a state that waits once, and not in one whose \fBsend\fR
+blocks before its \fBexpect\fR begins. \fBidle\fR is how long the server
+may say nothing at all, and restarts on any byte. They differ for a long
+reply that keeps arriving: that is not idle, but it may still be over
+budget.
 Either may lead to \fBwarning\fR, which is how "slow" is reported as
 distinct from "broken".
 
 .IP "\fINAME\fR \fB~\fR \fIREGEX\fR \fB\->\fR \fITARGET\fR"
 .IP "\fBelse\fR \fB\->\fR \fITARGET\fR"
-Branch on a value bound earlier by \fBas\fR. The line begins with
-the name being tested, so it is recognised by its shape rather than by a
-leading keyword.
-.sp
-The regex is tested against a value already in hand, never against the
-socket. That is why a regex is allowed here and not in an \fBexpect\fR:
-it decides nothing about what arrives, so it cannot race a partial read.
-A name that nothing bound never matches, and so takes the \fBelse\fR arm.
-
-.IP "\fBexpect\fR \fISTRING\fR \fBas\fR \fINAME\fR"
-Bind the reply this \fBexpect\fR accepted to \fINAME\fR, for a later
-\fB~\fR line to read. It is written on the expect itself because that is
-the line that produces the value: a separate step would have to say which
-reply it meant by standing in the right place, and one standing in the
-wrong place bound the reply of an earlier state without complaining.
-May be combined with \fBuntil\fR and with an edge:
-.br
-.sp
-.nf
-\&   expect "250" until "250 " as caps    \-> offers
-.fi
-
 .IP "\fINAME\fR \fB~\fR \fIREGEX\fR \fBas\fR \fINAME2\fR[;\fINAME3\fR]"
-Read the value called \fINAME\fR and bind what the pattern's capture
-groups found in it, one name per group, in the order the groups appear.
-The regex is case-sensitive, and a pattern that does not match binds
-empty. It reads a value already in hand and never the socket, which is
-what allows a regex here and not on an \fBexpect\fR.
+Read the value called \fINAME\fR: the first two forms branch on whether
+it matches, the third binds what the pattern's capture groups found in
+it. One name per group, in the order the groups appear. Each line begins
+with the name it reads, so both are recognised by their shape rather than
+by a leading keyword.
+.sp
+The regex reads a value already in hand, never the socket. That is what
+allows a regex here and not in an \fBexpect\fR: it decides nothing about
+what arrives, so it cannot race a partial read and needs no maximum match
+length. The regex is case-sensitive, and a pattern that does not match
+binds empty.
+.sp
+A name that nothing binds never matches, so a branch on one can only ever
+take the \fBelse\fR arm and an extraction from one can only ever bind
+empty. Both are reported when the file is read.
 
 .IP "\fBcredentials\fR \fINAME\fR"
 Bind \fB${username}\fR and \fB${password}\fR from the entry called
@@ -206,6 +240,10 @@ Bind \fB${username}\fR and \fB${password}\fR from the entry called
 .nf
 \&   NAME	username	password
 .fi
+.sp
+It is a step, not a property of the entry: it takes effect where it is
+written, like \fBsend\fR, and the names it binds are available to the
+steps after it.
 .sp
 Credentials are named rather than written here because protocols.cfg is
 world-readable and is the file people attach to bug reports.
@@ -223,6 +261,11 @@ is plaintext and everything after it is encrypted, on the same socket.
 This is what submission (587), IMAP (143) and POP3 (110) use, and it is
 not the same as the \fBssl\fR option, which means TLS from the first
 byte.
+.sp
+The certificate is read from the upgraded session, so a service that
+begins in plaintext -- submission on 587, IMAP on 143, SMTP on 25 --
+reaches the \fBsslcert\fR column with its expiry checked. It cannot,
+while \fBssl\fR is the only way to start TLS.
 .sp
 If the server has sent anything that is still unread when the upgrade
 begins, the test fails rather than proceeding: the handshake has to
@@ -266,6 +309,36 @@ Defines test options. The possible options are
 .fi
 
 
+.SH PER-HOST DEPTH AND CREDENTIALS
+protocols.cfg is one file for the whole installation: a \fB[pop3]\fR
+definition applies to every host carrying the test. Deepening a shipped
+entry therefore changes what every site is alerted on. Two tags in
+hosts.cfg let a host differ from the definition without copying it:
+.br
+.sp
+.nf
+\&   smtp:ok=greeting        check only as far as that state
+\&   smtp:ok=greeting,ehlo   ... or any one of several
+\&   smtp:cred=acctb         bind this credentials.cfg entry
+.fi
+.sp
+\fBok=\fR names one or more states at which this host's test stops and
+reports success. The steps after it are not run and their absence is not
+a failure, so a definition can become the full conversation while a site
+keeps banner depth host by host.
+.sp
+\fBcred=\fR names the entry in credentials.cfg that this host's
+\fBcredentials\fR step binds, in place of the one the definition names --
+one definition, a different account per host. The value is a key, never a
+secret: hosts.cfg is world-readable for the same reasons protocols.cfg is.
+.sp
+Neither tag derives a column, unlike a port. A site running mixed depths
+would otherwise get one column per depth and no comparable history.
+.sp
+The checks in DIAGNOSTICS below are made against the entry as written,
+not against any host's depth. Under \fBok=greeting\fR everything
+downstream is legitimately unreachable, and the checks do not know that.
+
 .SH EXAMPLES
 An SMTP service that upgrades to TLS when the server offers it, reports
 a server that does not offer it as yellow rather than down, and reads the
@@ -306,6 +379,30 @@ reports the moment the file is installed -- a site whose mail server
 offers no STARTTLS would turn yellow because it upgraded, not because
 anything changed at the site. Copy this under a new name and point the
 hosts that should use it at that name instead.
+
+.SH DIAGNOSTICS
+This file is checked when it is read rather than when a step runs, so a
+step that is never reached still reports its own mistake. Every message
+names the service. The ones worth knowing:
+.br
+.sp
+.nf
+\&   Unknown protocols.cfg directive     a mistyped keyword; step dropped
+\&   '\-> NAME' has no matching state     the edge is dropped
+\&   'start NAME' has no matching state  the entry is refused
+\&   state 'NAME' cannot be reached      no edge names it
+\&   state 'NAME' has no way to finish   no path from it to a terminal
+\&   state 'NAME' waits for a reply with no timeout
+\&   'expect "A"' and 'expect "B"' overlap - both match the same reply
+\&   ${NAME} is never captured or bound before it is used
+\&   'NAME ~ ...' tests a value that is never bound before it
+\&   'NAME ~ "..." as X' has no capture group
+\&   transport 'X' is not implemented    only tcp is supported
+.fi
+.sp
+An overlap and an unimplemented transport refuse the definition outright:
+the service reports that protocols.cfg would not take it, rather than
+running a test whose result would depend on which pattern arrived first.
 
 .SH FILES
 .IP "\fB$XYMONHOME/etc/protocols.cfg\fR"


### PR DESCRIPTION
Nine documentation commits: what protocols.cfg.5 got wrong about the code, DIAGNOSTICS, the certificate, `-> fail` being red regardless of `--checkresponse`, and the design note kept as a description of the code rather than of a pull request. Documentation only.

---
### Stack

**10 of 15** in the dialogue stack: base #478, next #480. The full chain is listed in #457; read bottom-up.

