### PR TITLE
xymonnet: how a message ends, what a value keeps, what a state may be

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,6 @@
 .DS_store
 # Simulated Subversion default ignores end here
 
-# Written by build/genconfig.sh from this machine probes; committing it
-# pins one host answers on everybody else build.
+# Written by build/genconfig.sh from this machine's probes; committing it
+# pins one host's answers on everybody else's build.
 include/config.h

--- a/docs/design/protocol-dialogues.md
+++ b/docs/design/protocol-dialogues.md
@@ -17,34 +17,34 @@ entry rather than deleting it.
 
 ```
 [service|alias]
-   transport tcp          entry attributes. transport, port, options and
-   port N                 start set properties of the definition; the
-   options ssl,banner     order among them does not matter.
+   transport tcp          entry attributes: transport, port, options, framing and start
+   port N                 set properties of the definition, in any order
+   options ssl,banner     among themselves
+   framing line           how a message ends on this connection
    start NAME
 
-   state NAME             names the steps that follow, and is what an
+   state NAME             names the state that follows, and is what an
                           edge aims at
 
-      credentials NAME    everything from here is a STEP, and steps run
-      send "…"            in the order they are written
-      starttls
-      expect "…" [ until "…" ] [ as NAME ]
-      NAME ~ "…" as X;Y   read a bound value, bind more out of it
-      <condition> -> TARGET               an edge; the first that fires leaves
+      send "…"            ONE action -- send, starttls or credentials
+      timeout(N) -> fail  the clock that bounds the wait
+      expect "…" [ until "…" ] [ as NAME ]  -> TARGET
+                          the alternatives that end the state, each
+                          naming where its answer leads
 ```
 
 ```
-condition ::= expect "…" [ until "…" ] [ as NAME ] | NAME ~ "…"
+condition ::= expect "…" [ until "…" ] [ as NAME ] | expect bytes(N) | NAME ~ "…"
             | else | always | eof | timeout(N) | idle(N)
 ```
 
 **Targets** are a state, or one of `success`, `warning`, `fail` -- green, yellow, red. `warning` is the point: a server answering correctly but refusing an optional capability is not down, and calling it down teaches operators to ignore the column. An edge saying `fail` is red whatever `--checkresponse` is set to; a reply matching no alternative takes that option's colour, yellow by default.
 
-**Layout.** Entry attributes -- `transport`, `port`, `options`, `start` -- are written first, in any order among themselves, because they describe the definition rather than any step; then each `state` with its lines indented under it.
+**Layout.** Entry attributes -- `transport`, `port`, `options`, `framing`, `start` -- are written first, in any order among themselves, because they describe the definition rather than any step; then each `state` with its lines indented under it.
 
 **One action, one wait.** A state does one thing -- a `send`, a `starttls`, a `credentials` -- and waits for one answer: the clock that bounds the wait, and the `expect` lines that end the state, each naming where its answer leads. A state that acts without waiting leaves on `always`; a state that decides on a value already bound needs no action at all. Because a state holds one action and one wait, the order of its lines carries no meaning of its own: the entry is declarative down to the state, and sequence lives in the edges between states rather than in the lines within one.
 
-The parser enforces none of it: attributes are accepted anywhere, indentation is ignored, several actions and several waits in one state are accepted, and an `expect` with no `->` falls through to the line below. One ordering rule is real and unenforced: a `timeout` or `idle` arms the wait that follows it, so a clock below a state's `expect` lines bounds nothing. `protocols.cfg(5)` lists the five rules under CONVENTIONS, and `tests/buildsystem/dialogue-conventions.sh` checks every entry in the manual, in the shipped `protocols.cfg` and in the fixtures against them -- an entry that breaks one on purpose says `# conventions: permissive` and says why. Prose nothing checks is how the manual came to document a `when ... end` grammar no shipped code ever had.
+Most of this is now refused when the file is read: a state with two actions, a state that acts again after it has waited, a clock below the expects it should bound, an expect with no `-> TARGET`, a state named `success`/`warning`/`fail`, a second `options` line, and `until`/`as` on an entry the driver does not run. Each was decidable there all along, which is the standard this grammar set for itself when it gave up regex on `expect`. What is left unenforced is attribute placement and indentation -- both cosmetic, both checked by `tests/buildsystem/dialogue-conventions.sh` against every entry we ship or test. The classic shapes keep the old probe and none of this applies to them.
 
 **Order is file order, and with one action per state that stops mattering.** The driver runs a state's lines as written and the first edge that fires leaves it, so today a `~` above an `expect` decides before the socket is read. An earlier draft specified a fixed precedence regardless of where lines were written and was rejected, because a precedence the reader cannot see is what turns a declaration back into a program. Under one action and one wait the question mostly dissolves: a state either decides on values it already holds or waits for bytes, and the two do not compete within one state. Where they still could, the honest fix is a load-time refusal rather than an invisible rule.
 
@@ -230,6 +230,12 @@ The behaviour itself is documented in `protocols.cfg(5)`, which ships with the c
 **Why the graph checks are worth having, and how they mislead.** Three mistakes are properties of the graph rather than of any line: a state with no path to a terminal, an unreachable state, and a waiting state with no timer. All three are easy to implement too permissively, so they report nothing and look like they work -- reachability cannot simply follow the step list, and on the branch a `timeout(N) -> fail` edge briefly counted as ending the flow, which called every state after it unreachable. They are topology checks and should not be oversold: the bugs that cost time here are framing, partial reads and TLS transitions, and no topology check sees those.
 
 **What is not built.** Graph export (`--graph`) is deferred. A named state improves a failure from "step 7" to `state send-pass expected "235"`, and that is not enough: the faults that cost time are *why* it did not match -- bytes retained from the previous state, a reply matched before it was complete, a name that bound empty. A transcript mode is part of the feature and is **not implemented**. Nor is the marking it would require: `${password}` is expanded into a `send`, so the sent bytes, the buffer and anything an `as` binds may contain it. A value from `credentials.cfg` would have to be marked at binding time, stay marked through `${base64:}` and `${md5:}` -- an encoded secret is still the secret, and an APOP digest only looks opaque -- and be replaced by a placeholder in every output. The code wipes secrets from memory after use and no more, which is why it has no transcript to leak them into.
+
+**Three framings, because there are three ways a message ends.** `line` is the greeting protocols and `until` says where a multi-line *reply* stops within them. `length(W, endian)` is the protocols that count. `terminator "SEQ"` is everything else, and the one that makes a protocol of your own expressible: a message ends at a byte sequence wherever it falls, which `until` cannot say because it compares the start of a line. A custom protocol that ends records with a NUL, or with a blank line, or with a sentinel, needs no code -- it needs one attribute. What is deliberately absent is a read-granularity switch: how much the driver reads in one go changes no verdict, because matching is prefix-anchored and re-evaluated at every arrival, and consuming only the matched bytes is in the rejected list for breaking the ambiguity check.
+
+**Framing is a property of the connection, not of a reply.** TCP has no message boundary; the protocol supplies one, and there are only three ways it ever does: a terminator (`until`), a count, or the close (`eof`). Where the count is how the protocol always works -- DNS-over-TCP, MySQL, LDAP, AMQP -- saying so on every `expect` would repeat one fact and would need arithmetic on a captured value, since the count is data the peer sends. `framing length(W, big|little)` states it once on the entry; the driver assembles each message and every rule already in the grammar keeps working on the message instead of on the byte stream. That also fixes the thing that makes binary protocols unreadable line-by-line: a `0x0A` inside a payload is data, and nothing scans for it. `until` and `bytes(N)` are refused under any framing but `line` -- length or terminator, the framing has spoken, and a second answer could only agree or contradict.
+
+**A frame, not a line.** `expect bytes(N)` waits for N bytes and consumes exactly those. It is the one condition that is not decided by content, which is why it may not share a state with a literal: `expect bytes(3)` and `expect "220"` both accept the same three bytes and nothing in the file says which wins, so the group is refused. Two frames are worse -- the shorter always wins and the longer is dead. It exists because LDAP, MySQL, DNS-over-TCP and AMQP frame messages by length, and before it those services could be probed no further than their banner. It costs nothing the literal-only rule was buying: a length is decidable at every byte, exactly like a prefix.
 
 ## Prior art
 

--- a/docs/manpages/man5/protocols.cfg.5.html
+++ b/docs/manpages/man5/protocols.cfg.5.html
@@ -130,6 +130,23 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <p class="Pp"></p>
   </dd>
   <dt id="expect~3"><a class="permalink" href="#expect~3"><b>expect</b>
+    <b>bytes(</b><i>N</i><b>)</b></a></dt>
+  <dd>Wait for a frame of <i>N</i> bytes and consume exactly that many. LDAP,
+      MySQL, DNS over TCP and AMQP put a length in front of a message instead of
+      ending it with a line, so neither a literal nor <b>until</b> can say where
+      such a reply stops. Anything beyond the frame is kept for the next step,
+      as with any other <b>expect</b>.
+    <p class="Pp">A frame is decided by length and a literal by content, so the
+        two cannot share a state: which of them took the reply would be
+        unsayable. A state whose <b>expect</b> is a frame holds that one
+        alternative, and the clocks. <b>until</b> is refused on it, and <i>N</i>
+        must be between 1 and 32768 -- the same ceiling a conversation may
+        buffer.</p>
+    <p class="Pp"><b>as</b> works as it does elsewhere, binding the frame that
+        was consumed.</p>
+    <p class="Pp"></p>
+  </dd>
+  <dt id="expect~4"><a class="permalink" href="#expect~4"><b>expect</b>
     <i>STRING</i> <b>as</b> <i>NAME</i></a></dt>
   <dd>Bind the reply this <b>expect</b> accepted to <i>NAME</i>, for a later
       <b>~</b> line to read. It is written on the expect itself because that is
@@ -141,7 +158,7 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <pre>   expect &quot;250&quot; until &quot;250 &quot; as caps    -&gt; offers</pre>
     <p class="Pp"></p>
   </dd>
-  <dt id="expect~4"><a class="permalink" href="#expect~4"><b>expect</b>
+  <dt id="expect~5"><a class="permalink" href="#expect~5"><b>expect</b>
     <i>STRING</i> <b>-&gt;</b> <i>TARGET</i></a></dt>
   <dd></dd>
   <dt id="state"><a class="permalink" href="#state"><b>state</b>
@@ -173,9 +190,10 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
       not.</p>
     <p class="Pp"><b>Layout.</b> An entry that uses states is written the same
         way throughout this page: the entry attributes -- <b>options</b>,
-        <b>port</b>, <b>transport</b>, <b>start</b> -- first, in any order among
-        themselves, because they describe the definition rather than any step;
-        then the states, each with its lines indented under it.</p>
+        <b>port</b>, <b>transport</b>, <b>framing</b>, <b>start</b> -- first, in
+        any order among themselves, because they describe the definition rather
+        than any step; then the states, each with its lines indented under
+      it.</p>
     <p class="Pp">A state does one thing and waits for one answer: at most one
         action -- a <b>send</b>, a <b>starttls</b>, a <b>credentials</b> -- the
         clock that bounds the wait, and the <b>expect</b> lines that end the
@@ -336,6 +354,46 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
         expands to nothing.</p>
     <p class="Pp"></p>
   </dd>
+  <dt id="framing"><a class="permalink" href="#framing"><b>framing</b>
+    <b>line</b></a></dt>
+  <dd></dd>
+  <dt id="framing~2"><a class="permalink" href="#framing~2"><b>framing</b>
+    <b>length(</b><i>WIDTH</i><b>,</b> <b>big</b>|<b>little</b><b>)</b></a></dt>
+  <dd></dd>
+  <dt id="framing~3"><a class="permalink" href="#framing~3"><b>framing</b>
+    <b>terminator</b> <i>SEQUENCE</i></a></dt>
+  <dd>How a message ends on this connection. TCP says nothing about it: a
+      message boundary is always something the protocol states, and it states it
+      in one of three ways -- a terminator, a count, or the close.
+    <p class="Pp"><b>line</b> is the default and is what the greeting protocols
+        do: an <b>expect</b> consumes one line, and <b>until</b> says where a
+        reply of several lines ends. <b>length</b> is what the binary protocols
+        do -- DNS over TCP, MySQL, LDAP, AMQP -- where each message is preceded
+        by a count of <i>WIDTH</i> bytes, 1 to 4, most significant first with
+        <b>big</b> and last with <b>little</b>.</p>
+    <p class="Pp">Under <b>length</b> the driver assembles a whole message
+        before anything looks at it: an <b>expect</b> matches the start of the
+        MESSAGE rather than of whatever has arrived so far, a match consumes the
+        message and its count together, and a payload containing a newline is
+        data like any other byte. A message longer than 32 KB fails by name
+        rather than being buffered.</p>
+    <p class="Pp"><b>terminator</b> is for everything else, and for protocols of
+        your own: a message ends at <i>SEQUENCE</i> wherever that falls -- a
+        NUL, a blank line, a sentinel you chose. It is not <b>until</b>:
+        <b>until</b> compares the start of a LINE, so a terminator that does not
+        fall on a line boundary is invisible to it, and a payload with newlines
+        inside is not line-shaped at all.</p>
+    <p class="Pp"></p>
+    <pre>   framing terminator &quot;\x00&quot;        NUL-terminated records
+   framing terminator &quot;\r\n\r\n&quot;    a blank line ends the message
+   framing terminator &quot;&lt;END&gt;&quot;       a sentinel of your own</pre>
+    <p class="Pp">It describes the connection, not one reply, so it is written
+        once as an entry attribute. <b>until</b> and <b>expect
+        bytes(</b><i>N</i><b>)</b> are refused under it: the count has already
+        said where the message ends, and a second answer could only agree or
+        contradict.</p>
+    <p class="Pp"></p>
+  </dd>
   <dt id="transport"><a class="permalink" href="#transport"><b>transport</b>
     <b>tcp</b></a></dt>
   <dd>Which probe runs this entry. Only <b>tcp</b> is implemented; naming
@@ -394,31 +452,34 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
 <section class="Sh">
 <p>&#160;</p>
 <h1 class="Sh" id="CONVENTIONS"><a class="permalink" href="#CONVENTIONS">CONVENTIONS</a></h1>
-<p class="Pp">The parser accepts an attribute anywhere in a block, ignores
-    indentation, takes several actions and several waits in one state, and
-    accepts an <b>expect</b> that names no target. None of what follows is
-    enforced by it; it is how every entry in this page and in the shipped
-    protocols.cfg is written, and what a reader is entitled to assume:</p>
+<p class="Pp">An entry that uses states is written one way, and most of it is
+    now refused when the file is read rather than left to surprise somebody:</p>
 <p class="Pp"></p>
-<pre>   1  entry attributes -- options, port, transport, start -- come
-      before the first state, in any order among themselves
+<pre>   1  entry attributes -- options, port, transport, framing, start --
+      come before the first state, in any order among themselves
    2  a state's lines are indented under it
    3  a state holds at most one action: send, starttls, credentials
    4  every expect names where it goes: &quot;-&gt; TARGET&quot;
    5  a clock -- timeout or idle -- is written above the expects it
-      bounds, because it arms the wait that FOLLOWS it</pre>
-<p class="Pp">Rule 5 is the one that bites: a clock written below a state's
-    <b>expect</b> lines bounds nothing, and nothing says so. The others are
-    legibility -- an entry written this way reads as the machine it describes,
-    and one that is not still runs.</p>
-<p class="Pp">A definition that means to break a rule says so, with a comment
-    the parser ignores and a reader does not:</p>
-<p class="Pp"></p>
-<pre>   [legacy]
-      # conventions: permissive -- one expect, no state to move to</pre>
-<p class="Pp">The regression suite checks every entry in this page, in the
-    shipped protocols.cfg and in the test fixtures against these five rules, so
-    the page and the files cannot drift apart unnoticed.</p>
+      bounds, because it arms the wait that FOLLOWS it
+   6  a message boundary is stated, never guessed: a terminator with
+      &quot;until&quot;, a count with &quot;framing length&quot;, or the close with &quot;eof&quot;</pre>
+<p class="Pp">Rules 3, 4 and 5 are refusals, and so is a state that acts again
+    after it has waited -- that is a second wait in one state, and nothing could
+    name the state it failed in. So is a state named <b>success</b>,
+    <b>warning</b> or <b>fail</b>: an edge naming one of those declares a
+    verdict rather than jumping, so such a state could never be reached. So is a
+    second <b>options</b> line, which replaces the first rather than adding to
+    it, and <b>until</b> or <b>as</b> on an entry the driver does not run, where
+    they would do nothing at all.</p>
+<p class="Pp">Rules 1 and 2 are not enforced: the parser takes an attribute
+    anywhere in the block and ignores indentation entirely. They are how every
+    entry in this page and in the shipped protocols.cfg is written, and the
+    regression suite checks them, so the page and the files cannot drift apart
+    unnoticed.</p>
+<p class="Pp">None of this applies to the classic shapes -- a lone <b>send</b>,
+    a lone <b>expect</b>, or a <b>send</b> followed by an <b>expect</b> -- which
+    have no states and keep the probe they have always used.</p>
 <p class="Pp"></p>
 </section>
 <section class="Sh">
@@ -470,9 +531,9 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     so a clock written below the <b>expect</b> lines bounds nothing. Keep it
     above them, as every example here does.</p>
 <p class="Pp">The entry attributes -- <b>options</b>, <b>port</b>,
-    <b>transport</b>, <b>start</b> -- describe the definition rather than any
-    step, so they are written together at the top, in any order among
-    themselves.</p>
+    <b>transport</b>, <b>framing</b>, <b>start</b> -- describe the definition
+    rather than any step, so they are written together at the top, in any order
+    among themselves.</p>
 <p class="Pp">This is deliberately a service of its own rather than a deeper
     <b>[smtp]</b>. protocols.cfg is one file for the whole installation, so
     teaching <b>[smtp]</b> to expect STARTTLS would change what every existing
@@ -497,6 +558,22 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
    state 'NAME' has no way to finish   no path from it to a terminal
    state 'NAME' waits for a reply with no timeout
    'expect &quot;A&quot;' and 'expect &quot;B&quot;' overlap - both match the same reply
+   'expect bytes(N)' shares a state with another expect
+   'expect bytes(N) until ...' - a frame already ends the reply
+   'expect bytes(N)' is outside 1..32768
+   'until' under framing length/terminator
+   'expect bytes(N)' under framing length/terminator
+   'framing terminator' needs a quoted sequence
+   framing length width is 1..4 bytes
+   framing length endianness is 'big' or 'little'
+   framed message of N bytes is over the 32768 a conversation may hold
+   state 'NAME' has more than one action
+   state 'NAME' acts again after it has waited
+   state 'NAME' sets a clock below its expects, where it bounds nothing
+   state 'NAME' has an expect with no '-&gt; TARGET'
+   state 'NAME' takes a name reserved for a verdict
+   a second 'options' line - options replaces rather than adds
+   'until'/'as' on an entry the dialogue driver does not run
    ${NAME} is never captured or bound before it is used
    'NAME ~ ...' tests a value that is never bound before it
    'NAME ~ &quot;...&quot; as X' has no capture group

--- a/lib/digest.c
+++ b/lib/digest.c
@@ -19,7 +19,12 @@ static char rcsid[] = "$Id$";
 
 #include "libxymon.h"
 
-char *md5hash(char *input)
+/*
+ * Hash a counted buffer. A dialogue may hash a value it read from the wire,
+ * and a framed reply is bytes rather than a string -- strlen() would digest
+ * only the part of it that precedes the first NUL.
+ */
+char *md5hash_len(char *input, int inputlen)
 {
 	/* We have a fast MD5 hash function, since that may be used a lot */
 
@@ -37,7 +42,7 @@ char *md5hash(char *input)
 	}
 
 	myMD5_Init(ctx->mdctx);
-	myMD5_Update(ctx->mdctx, input, strlen(input));
+	myMD5_Update(ctx->mdctx, input, ((inputlen > 0) ? inputlen : 0));
 	myMD5_Final(md_value, ctx->mdctx);
 
 	for(i = 0, p = md_string; (i < sizeof(md_value)); i++) 
@@ -45,6 +50,11 @@ char *md5hash(char *input)
 	*p = '\0';
 
 	return md_string;
+}
+
+char *md5hash(char *input)
+{
+	return md5hash_len(input, (input ? strlen(input) : 0));
 }
 
 

--- a/lib/digest.h
+++ b/lib/digest.h
@@ -22,6 +22,7 @@ typedef struct digestctx_t {
 } digestctx_t;
 
 extern char *md5hash(char *input);
+extern char *md5hash_len(char *input, int inputlen);
 extern digestctx_t *digest_init(char *digest);
 extern int digest_data(digestctx_t *ctx, unsigned char *buf, int buflen);
 extern char *digest_done(digestctx_t *ctx);

--- a/lib/encoding.c
+++ b/lib/encoding.c
@@ -21,17 +21,26 @@ static char rcsid[] = "$Id$";
 
 static char b64chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-char *base64encode(unsigned char *buf)
+/*
+ * Encode a counted buffer. The caller may hold bytes rather than a string --
+ * a reply framed by a length carries NULs -- and measuring the input with
+ * strlen() would encode only what precedes the first one.
+ */
+char *base64encode_len(unsigned char *buf, int buflen)
 {
 	unsigned char c0, c1, c2;
 	unsigned int n0, n1, n2, n3;
 	unsigned char *inp, *outp;
 	unsigned char *result;
+	int left;
 
-	result = malloc(4*(strlen(buf)/3 + 1) + 1);
+	if (!buf || (buflen < 0)) buflen = 0;
+	left = buflen;
+
+	result = malloc(4*(buflen/3 + 1) + 1);
 	inp = buf; outp=result;
 
-	while (strlen(inp) >= 3) {
+	while (left >= 3) {
 		c0 = *inp; c1 = *(inp+1); c2 = *(inp+2);
 
 		n0 = (c0 >> 2);				/* 6 bits from c0 */
@@ -44,10 +53,10 @@ char *base64encode(unsigned char *buf)
 		*outp = b64chars[n2]; outp++;
 		*outp = b64chars[n3]; outp++;
 
-		inp += 3;
+		inp += 3; left -= 3;
 	}
 
-	if (strlen(inp) == 1) {
+	if (left == 1) {
 		c0 = *inp; c1 = 0;
 		n0 = (c0 >> 2);				/* 6 bits from c0 */
 		n1 = ((c0 & 3) << 4) + (c1 >> 4);	/* 2 bits from c0, 4 bits from c1 */
@@ -57,7 +66,7 @@ char *base64encode(unsigned char *buf)
 		*outp = '='; outp++;
 		*outp = '='; outp++;
 	}
-	else if (strlen(inp) == 2) {
+	else if (left == 2) {
 		c0 = *inp; c1 = *(inp+1); c2 = 0;
 
 		n0 = (c0 >> 2);				/* 6 bits from c0 */
@@ -73,6 +82,11 @@ char *base64encode(unsigned char *buf)
 	*outp = '\0';
 
 	return result;
+}
+
+char *base64encode(unsigned char *buf)
+{
+	return base64encode_len(buf, (buf ? strlen(buf) : 0));
 }
 
 char *base64decode(unsigned char *buf)

--- a/lib/encoding.h
+++ b/lib/encoding.h
@@ -12,6 +12,7 @@
 #define __ENCODING_H__
 
 extern char *base64encode(unsigned char *buf);
+extern char *base64encode_len(unsigned char *buf, int buflen);
 extern char *base64decode(unsigned char *buf);
 extern void getescapestring(char *msg, unsigned char **buf, int *buflen);
 extern unsigned char *nlencode(unsigned char *msg);

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -322,6 +322,111 @@ static void check_undefined_vars(svcinfo_t *rec)
  * name the fix: match the shared prefix in one state, distinguish in the
  * next.
  */
+/* The three names an edge may use instead of a state. */
+#define IS_TERMINAL_NAME(s) \
+	(((s) != NULL) && ((strcmp((s), "success") == 0) || \
+	                   (strcmp((s), "warning") == 0) || \
+	                   (strcmp((s), "fail") == 0)))
+
+/*
+ * The shape of a state, checked when the file is read.
+ *
+ * protocols.cfg(5) says a state does one thing and waits for one answer: at
+ * most one action, the clock that bounds the wait, and the expects that end
+ * the state by naming where each answer leads. Those were conventions that
+ * the parser accepted any violation of, so a file could read as one machine
+ * and run as another -- a clock below the expects bounds nothing, a second
+ * wait in a state has no name to fail under, and an expect with no target
+ * leaves the file silent about where the dialogue went.
+ *
+ * Every one of them is decidable here, which is where this grammar has
+ * decided such things belong.
+ */
+static void refuse_misshapen_states(svcinfo_t *rec)
+{
+	svcstep_t *st;
+	char *statename = NULL;
+	int actions = 0, sawexpect = 0;
+
+	/* Only entries that use states promise this shape. */
+	for (st = rec->steps; (st); st = st->next) if (st->type == STEP_LABEL) break;
+	if (!st) return;
+
+	statename = NULL;
+	for (st = rec->steps; (st); st = st->next) {
+		switch (st->type) {
+		  case STEP_LABEL:
+			statename = st->label;
+			actions = sawexpect = 0;
+			/*
+			 * success, warning and fail are answers, not places. An edge
+			 * naming one of them declares the verdict before any label is
+			 * looked up, so a state called success can be written, parsed,
+			 * and never reached -- and the reachability check cannot see
+			 * it, because the edge did resolve.
+			 */
+			if (statename && (IS_TERMINAL_NAME(statename))) {
+				errprintf("Service %s: state '%s' takes a name reserved for a verdict - "
+					  "'-> %s' ends the test rather than jumping, so this state can "
+					  "never be reached\n", rec->svcname, statename, statename);
+				rec->flags |= TCP_DIALOGUE_BROKEN;
+			}
+			break;
+
+		  case STEP_SEND:
+		  case STEP_STARTTLS:
+		  case STEP_CREDS:
+			if (!statename) break;
+			if (++actions > 1) {
+				errprintf("Service %s: state '%s' has more than one action - a state "
+					  "does one thing and waits for one answer, so give the second "
+					  "action a state of its own and reach it with an edge\n",
+					  rec->svcname, statename);
+				rec->flags |= TCP_DIALOGUE_BROKEN;
+			}
+			if (sawexpect) {
+				errprintf("Service %s: state '%s' acts again after it has waited - that "
+					  "is a second wait in one state, and nothing can name the "
+					  "state it failed in\n", rec->svcname, statename);
+				rec->flags |= TCP_DIALOGUE_BROKEN;
+			}
+			break;
+
+		  case STEP_TIMEOUT:
+		  case STEP_IDLE:
+			if (!statename) break;
+			if (sawexpect) {
+				errprintf("Service %s: state '%s' sets a clock below its expects, where it "
+					  "bounds nothing - a clock arms the wait that FOLLOWS it\n",
+					  rec->svcname, statename);
+				rec->flags |= TCP_DIALOGUE_BROKEN;
+			}
+			break;
+
+		  case STEP_EXPECT:
+			if (!statename) break;
+			/*
+			 * Consecutive expects are ONE wait. A second wait would need a
+			 * step between the groups, and every such step -- an action or
+			 * a clock -- is already refused above, so there is nothing left
+			 * to count here.
+			 */
+			sawexpect = 1;
+			if (st->action == ACT_NEXT) {
+				errprintf("Service %s: state '%s' has an expect with no '-> TARGET' - an "
+					  "expect ends its state, so the file has to say where the "
+					  "dialogue goes next\n", rec->svcname, statename);
+				rec->flags |= TCP_DIALOGUE_BROKEN;
+			}
+			break;
+
+		  default:
+			break;
+		}
+	}
+}
+
+
 static void refuse_overlapping_groups(svcinfo_t *rec)
 {
 	svcstep_t *st;
@@ -337,7 +442,30 @@ static void refuse_overlapping_groups(svcinfo_t *rec)
 		for (a = st; (a != last); a = a->next) {
 			if (a->oneof) continue;		/* EOF competes with no byte pattern */
 			for (b = a->next; ; b = b->next) {
-				int n = (b->oneof) ? 0 : ((a->len < b->len) ? a->len : b->len);
+				int n;
+
+				/*
+				 * A frame competes with everything: "expect bytes(3)" and
+				 * "expect \"220\"" both accept the same three bytes, and
+				 * which one won would depend on nothing the file says. Two
+				 * frames are worse -- the shorter always wins, so the longer
+				 * is dead. Neither is decidable by looking at the bytes, so
+				 * refuse the group rather than pick.
+				 */
+				if (a->wantbytes || b->wantbytes) {
+					if (!b->oneof) {
+						errprintf("Service %s: 'expect bytes(%d)' shares a state with another "
+							  "expect - a frame is decided by length and a literal by "
+							  "content, so which one takes the reply is unsayable. Give "
+							  "the frame a state of its own\n",
+							  rec->svcname, a->wantbytes ? a->wantbytes : b->wantbytes);
+						rec->flags |= TCP_DIALOGUE_BROKEN;
+					}
+					if (b == last) break;
+					continue;
+				}
+
+				n = (b->oneof) ? 0 : ((a->len < b->len) ? a->len : b->len);
 
 				if ((n > 0) && (memcmp(a->text, b->text, n) == 0)) {
 					/*
@@ -607,9 +735,10 @@ static void emit_step(svclist_t *first, svcstep_t *tmpl)
 	for (walk = first; (walk); walk = walk->next) {
 		svcstep_t *st = add_svcstep(walk->rec, tmpl->type, tmpl->text, tmpl->len);
 
-		st->action  = tmpl->action;
-		st->seconds = tmpl->seconds;
-		st->oneof   = tmpl->oneof;
+		st->action    = tmpl->action;
+		st->seconds   = tmpl->seconds;
+		st->oneof     = tmpl->oneof;
+		st->wantbytes = tmpl->wantbytes;
 		if (tmpl->target)  st->target  = strdup(tmpl->target);
 		if (tmpl->label)   st->label   = strdup(tmpl->label);
 		if (tmpl->varname) st->varname = strdup(tmpl->varname);
@@ -845,12 +974,41 @@ char *init_tcp_services(void)
 				int txtlen = 0, untillen = 0;
 				char *rest, *act;
 
-				getescapestring(skipwhitespace(l+6), &txt, &txtlen);
-
 				memset(&tmpl, 0, sizeof(tmpl));
-				tmpl.type = STEP_EXPECT; tmpl.text = txt; tmpl.len = txtlen;
+				tmpl.type = STEP_EXPECT;
 
-				rest = skipwhitespace(after_quoted(skipwhitespace(l+6)));
+				/*
+				 * "expect bytes(N)" waits for a frame of N bytes rather
+				 * than for text. LDAP, MySQL, DNS-over-TCP and AMQP put a
+				 * length in front of a message instead of ending it with a
+				 * line, so neither a literal nor "until" can say where the
+				 * reply stops. It consumes exactly N and keeps the rest,
+				 * like every other expect.
+				 */
+				rest = skipwhitespace(l+6);
+				if (strncmp(rest, "bytes(", 6) == 0) {
+					int n = atoi(rest + 6);
+					char *close = strchr(rest, ')');
+
+					if (!close) {
+						errprintf("Service %s: 'expect bytes(' without ')'\n", first->rec->svcname);
+						first->rec->flags |= TCP_DIALOGUE_BROKEN;
+						continue;
+					}
+					if ((n <= 0) || (n > MAX_DIALOGUE_BYTES)) {
+						errprintf("Service %s: 'expect bytes(%d)' is outside 1..%d\n",
+							  first->rec->svcname, n, MAX_DIALOGUE_BYTES);
+						first->rec->flags |= TCP_DIALOGUE_BROKEN;
+						continue;
+					}
+					tmpl.wantbytes = n;
+					rest = skipwhitespace(close + 1);
+				}
+				else {
+					getescapestring(rest, &txt, &txtlen);
+					tmpl.text = txt; tmpl.len = txtlen;
+					rest = skipwhitespace(after_quoted(rest));
+				}
 
 				/*
 				 * "until" says where the reply ENDS. Without it an expect
@@ -862,6 +1020,13 @@ char *init_tcp_services(void)
 				 */
 				if (strncmp(rest, "until ", 6) == 0) {
 					char *tp = skipwhitespace(rest + 5);
+
+					if (tmpl.wantbytes) {
+						errprintf("Service %s: 'expect bytes(%d) until ...' - a frame of "
+							  "N bytes already says where the reply ends\n",
+							  first->rec->svcname, tmpl.wantbytes);
+						first->rec->flags |= TCP_DIALOGUE_BROKEN;
+					}
 
 					getescapestring(tp, &untiltxt, &untillen);
 					tmpl.until = untiltxt;
@@ -914,15 +1079,23 @@ char *init_tcp_services(void)
 								"'<condition> -> TARGET'\n", act);
 				}
 
-				for (walk = first; (walk); walk = walk->next) {
-					if (walk->rec->exptext == NULL) {
-						walk->rec->exptext = (unsigned char *)strdup((char *)txt);
-						walk->rec->explen  = txtlen;
-						walk->rec->expofs  = 0; /* HACK - not used right now */
+				/*
+				 * exptext is what the single-shot probe matches. A frame
+				 * has no literal to put there, and it never runs on that
+				 * path anyway -- and xfree() aborts on NULL, so both of
+				 * these have to know that txt may be absent.
+				 */
+				if (txt) {
+					for (walk = first; (walk); walk = walk->next) {
+						if (walk->rec->exptext == NULL) {
+							walk->rec->exptext = (unsigned char *)strdup((char *)txt);
+							walk->rec->explen  = txtlen;
+							walk->rec->expofs  = 0; /* HACK - not used right now */
+						}
 					}
 				}
 				emit_step(first, &tmpl);
-				xfree(txt);
+				if (txt) xfree(txt);
 				if (untiltxt) xfree(untiltxt);
 			}
 		}
@@ -1173,6 +1346,87 @@ char *init_tcp_services(void)
 				walk->rec->startlabel = strdup(nm);
 			}
 		}
+		else if (strncmp(l, "framing ", 8) == 0) {
+			/*
+			 * How a message ends on this connection, which the socket
+			 * never says: "line" is the greeting protocols, and
+			 * "length(W, big|little)" is the binary ones that send a
+			 * count first -- DNS over TCP, MySQL, LDAP, AMQP. It is a
+			 * property of the protocol rather than of one reply, so it
+			 * belongs on the entry and not on every expect.
+			 */
+			if (first) {
+				char *nm = skipwhitespace(l + 8);
+				svclist_t *w;
+
+				if (strncmp(nm, "line", 4) == 0) {
+					for (w = first; (w); w = w->next) w->rec->framing = FRAMING_LINE;
+				}
+				else if (strncmp(nm, "terminator ", 11) == 0) {
+					/*
+					 * A sequence that ends a message wherever it falls --
+					 * a NUL, a blank line, a sentinel a custom protocol
+					 * chose. "until" cannot say this: it compares the
+					 * start of a LINE, so a terminator that is not at a
+					 * line boundary is invisible to it.
+					 */
+					unsigned char *t = NULL;
+					int tlen = 0;
+
+					getescapestring(skipwhitespace(nm + 10), &t, &tlen);
+					if (!t || (tlen < 1)) {
+						errprintf("Service %s: 'framing terminator' needs a quoted "
+							  "sequence\n", first->rec->svcname);
+						first->rec->flags |= TCP_DIALOGUE_BROKEN;
+						if (t) xfree(t);
+					}
+					else {
+						for (w = first; (w); w = w->next) {
+							w->rec->framing      = FRAMING_TERM;
+							w->rec->frameterm    = (unsigned char *)malloc(tlen + 1);
+							memcpy(w->rec->frameterm, t, tlen);
+							w->rec->frameterm[tlen] = '\0';
+							w->rec->frametermlen = tlen;
+						}
+						xfree(t);
+					}
+				}
+				else if (strncmp(nm, "length(", 7) == 0) {
+					int width = atoi(nm + 7);
+					char *comma = strchr(nm, ',');
+					int big = 1;
+
+					if (comma) {
+						char *e = skipwhitespace(comma + 1);
+
+						if (strncmp(e, "little", 6) == 0) big = 0;
+						else if (strncmp(e, "big", 3) != 0) {
+							errprintf("Service %s: framing length endianness is 'big' or "
+								  "'little', not '%s'\n", first->rec->svcname, e);
+							first->rec->flags |= TCP_DIALOGUE_BROKEN;
+						}
+					}
+					if ((width < 1) || (width > 4)) {
+						errprintf("Service %s: framing length width is 1..4 bytes, not %d\n",
+							  first->rec->svcname, width);
+						first->rec->flags |= TCP_DIALOGUE_BROKEN;
+					}
+					else {
+						for (w = first; (w); w = w->next) {
+							w->rec->framing    = FRAMING_LENGTH;
+							w->rec->framewidth = width;
+							w->rec->framebig   = big;
+						}
+					}
+				}
+				else {
+					errprintf("Service %s: unknown framing '%s' - it is 'line', "
+						  "'length(WIDTH, big|little)' or 'terminator \"SEQ\"'\n",
+						  first->rec->svcname, nm);
+					first->rec->flags |= TCP_DIALOGUE_BROKEN;
+				}
+			}
+		}
 		else if (strncmp(l, "transport ", 10) == 0) {
 			/*
 			 * Which probe runs this entry. Only tcp is implemented; anything
@@ -1264,6 +1518,17 @@ char *init_tcp_services(void)
 		}
 		else if (strncmp(l, "options ", 8) == 0) {
 			if (first) {
+				/*
+				 * options REPLACES rather than adds, so a second line
+				 * silently discards the first. Complete check, so refuse.
+				 */
+				if (first->rec->sawoptions) {
+					errprintf("Service %s: a second 'options' line - options replaces "
+						  "rather than adds, so the first would be discarded. Write "
+						  "one line with every option on it\n", first->rec->svcname);
+					first->rec->flags |= TCP_DIALOGUE_BROKEN;
+				}
+				first->rec->sawoptions = 1;
 				char *opt;
 
 				/*
@@ -1329,6 +1594,11 @@ char *init_tcp_services(void)
 		svcinfo[i].flags   = walk->rec->flags;
 		svcinfo[i].port    = walk->rec->port;
 		svcinfo[i].alpns   = walk->rec->alpns;
+		svcinfo[i].framing    = walk->rec->framing;
+		svcinfo[i].framewidth = walk->rec->framewidth;
+		svcinfo[i].framebig   = walk->rec->framebig;
+		svcinfo[i].frameterm    = walk->rec->frameterm;
+		svcinfo[i].frametermlen = walk->rec->frametermlen;
 		svcinfo[i].steps   = walk->rec->steps;
 		svcinfo[i].startlabel = walk->rec->startlabel;
 		/*
@@ -1356,6 +1626,14 @@ char *init_tcp_services(void)
 				else if (st->type == STEP_EXPECT) {
 					nexp++;
 					if (st->action != ACT_NEXT) nother++;	/* a branch edge */
+					/*
+					 * A frame is the driver's business whatever else the
+					 * entry looks like: the single-shot probe compares the
+					 * start of one read and knows nothing about waiting for
+					 * N bytes, so a lone "expect bytes(N)" left on that path
+					 * would silently be a banner match.
+					 */
+					if (st->wantbytes) nother++;
 				}
 				else nother++;					/* when/capture/label/... */
 			}
@@ -1366,11 +1644,65 @@ char *init_tcp_services(void)
 			 * something is sent AFTER, which is the ordering the
 			 * single-shot probe cannot express.
 			 */
-			if ((first_is_expect && (nsend > 0)) || (nsend > 1) || (nexp > 1) || nother)
+			if ((first_is_expect && (nsend > 0)) || (nsend > 1) || (nexp > 1) || nother ||
+			    (svcinfo[i].framing != FRAMING_LINE))
 				svcinfo[i].flags |= TCP_DIALOGUE;
+
+			/*
+			 * Under length framing the peer says where every message ends,
+			 * so a clause that says it again is either redundant or a
+			 * contradiction -- and there is no way to tell which from the
+			 * file. Refuse both rather than pick one.
+			 */
+			if (svcinfo[i].framing != FRAMING_LINE) {
+				svcstep_t *fst;
+
+				for (fst = svcinfo[i].steps; (fst); fst = fst->next) {
+					if (fst->type != STEP_EXPECT) continue;
+					if (fst->until)
+						errprintf("Service %s: 'until' under framing %s - the framing "
+							  "already says where the message ends\n",
+							  svcinfo[i].svcname,
+							  (svcinfo[i].framing == FRAMING_LENGTH) ? "length" : "terminator");
+					else if (fst->wantbytes)
+						errprintf("Service %s: 'expect bytes(%d)' under framing %s - the "
+							  "framing already says how long the message is\n",
+							  svcinfo[i].svcname, fst->wantbytes,
+							  (svcinfo[i].framing == FRAMING_LENGTH) ? "length" : "terminator");
+					else continue;
+					svcinfo[i].flags |= TCP_DIALOGUE_BROKEN;
+				}
+			}
 
 			check_undefined_vars(&svcinfo[i]);
 			refuse_overlapping_groups(&svcinfo[i]);
+			refuse_misshapen_states(&svcinfo[i]);
+
+			/*
+			 * A clause that only the driver implements, on an entry that
+			 * stays on the classic single-shot probe, does nothing at all:
+			 * "until" is ignored and the first line decides the test. That
+			 * is decidable here -- the shape of the entry is known -- so it
+			 * is refused rather than left to surprise somebody.
+			 */
+			if ((svcinfo[i].flags & TCP_DIALOGUE) == 0) {
+				svcstep_t *cst;
+
+				for (cst = svcinfo[i].steps; (cst); cst = cst->next) {
+					if (cst->type != STEP_EXPECT) continue;
+					if (cst->until)
+						errprintf("Service %s: 'until' on an entry the dialogue driver does "
+							  "not run - a lone expect is the classic probe, which "
+							  "matches one line and knows no terminator. Add the step "
+							  "that follows it\n", svcinfo[i].svcname);
+					else if (cst->varname)
+						errprintf("Service %s: 'as %s' on an entry the dialogue driver does "
+							  "not run - nothing later can read the value\n",
+							  svcinfo[i].svcname, cst->varname);
+					else continue;
+					svcinfo[i].flags |= TCP_DIALOGUE_BROKEN;
+				}
+			}
 
 			/*
 			 * "options ssl" is TLS from the first byte; "starttls" upgrades

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -68,6 +68,27 @@
    pattern matches wins and its action fires, so a state has as many
    outgoing edges as it has alternatives, plus the implicit failure edge
    taken when every alternative has been ruled out. */
+/*
+ * How a message ends on this connection. TCP is a byte stream: the boundary
+ * is always something the protocol says, never something the socket knows.
+ *
+ *   FRAMING_LINE    a line ends at "\n" -- the greeting protocols
+ *   FRAMING_LENGTH  the peer sends a count first -- DNS-over-TCP, MySQL,
+ *                   LDAP, AMQP: binary, and no newline to look for
+ *   FRAMING_TERM    a byte sequence ends every message, wherever it falls --
+ *                   a NUL, a blank line, a sentinel a custom protocol picked.
+ *                   Unlike "until" it does not look at lines at all
+ */
+#define FRAMING_LINE   0
+#define FRAMING_LENGTH 1
+#define FRAMING_TERM   2
+
+/* How much a single expect may accumulate before giving up. A server that
+   never sends the terminator must not be able to grow this without limit.
+   The parser needs it too: "expect bytes(N)" may not ask for more than a
+   conversation is allowed to hold. */
+#define MAX_DIALOGUE_BYTES (32 * 1024)
+
 typedef struct svcstep_t {
 	int type;
 	unsigned char *text;		/* send/expect literal, or extraction regex */
@@ -82,6 +103,7 @@ typedef struct svcstep_t {
 	char *user, *pass;		/* STEP_CREDS: resolved at config load */
 	unsigned char *until;		/* expect ... until "X": end-of-reply marker */
 	int untillen;
+	int wantbytes;			/* expect bytes(N): frame is N bytes, not a line */
 	int seconds;			/* STEP_TIMEOUT: budget for the following wait */
 	int oneof;			/* this alternative fires on EOF, not on bytes */
 	struct svcstep_t *next;
@@ -98,6 +120,12 @@ typedef struct svcinfo_t {
 	unsigned int flags;
 	int port;
 	char *alpns;
+	int sawoptions;		/* an 'options' line was seen: a second one replaces it */
+	int framing;		/* FRAMING_* -- how a message ends on this connection */
+	int framewidth;		/* FRAMING_LENGTH: bytes of length prefix */
+	int framebig;		/* FRAMING_LENGTH: 1 big-endian, 0 little-endian */
+	unsigned char *frameterm;	/* FRAMING_TERM: the sequence that ends a message */
+	int frametermlen;
 	svcstep_t *steps;	/* NULL unless TCP_DIALOGUE */
 	char *startlabel;	/* 'start NAME': where the dialogue begins */
 	svcstep_t *startstep;	/* ... resolved after parsing */

--- a/tests/buildsystem/dialogue-conventions.sh
+++ b/tests/buildsystem/dialogue-conventions.sh
@@ -14,7 +14,7 @@
 # This checks every entry we publish or test against the rules the manual
 # lists under CONVENTIONS:
 #
-#   R1  entry attributes (options, port, transport, start) come before the
+#   R1  entry attributes (options, port, transport, start, framing) come before the
 #       first state, since they describe the definition and not a step
 #   R2  a state's lines are indented under it
 #   R3  a state holds at most one action (send, starttls, credentials)
@@ -61,7 +61,7 @@ extract_fenced() {	# markdown: inside ``` fences
 	' "$1" >> "$stream"
 }
 extract_heredoc() {	# tests: inside the protocols.cfg heredoc
-	awk -v F="$1" '/protocols\.cfg" <<CFG/ { inb=1; next } inb && /^CFG$/ { inb=0; next }
+	awk -v F="$1" '/protocols\.cfg" <<'"'"'?CFG/ { inb=1; next } inb && /^CFG$/ { inb=0; next }
 		       inb { print F "\t" NR "\t" $0 }' "$1" >> "$stream"
 }
 extract_plain() { awk -v F="$1" '{ print F "\t" NR "\t" $0 }' "$1" >> "$stream"; }
@@ -125,7 +125,7 @@ function flush_state(   i) {
 		next
 	}
 
-	if (text ~ /^(options|port|transport|start)[[:space:]]/) {
+	if (text ~ /^(options|port|transport|start|framing)[[:space:]]/) {
 		if (seen_state && !permissive)
 			bad[++n] = sprintf("%s:%d  R1  %s writes \"%s\" after a state; attributes describe the definition and come first",
 					   file, lineno, entry, text)

--- a/tests/lib/dialogue-peer.c
+++ b/tests/lib/dialogue-peer.c
@@ -18,6 +18,9 @@
  *   recv PREFIX      read one line; record it, and record MISMATCH if it
  *                    does not begin with PREFIX
  *   recvany          read one line and record it
+ *   recvbytes N      read exactly N bytes and record them as hex, "gotbytes HEX".
+ *                    A payload that carries a NUL is neither a line nor a C
+ *                    string, so this is the only way to assert on one.
  *   hold N           stay connected and silent for N seconds
  *   dribble TEXT     send TEXT one byte per second
  *   replyall TEXT    answer TEXT to every further line, until EOF. Models a
@@ -99,11 +102,18 @@ static int unescape(const char *in, char *out, int max)
 		  case 'n': out[n++] = '\n'; in++; break;
 		  case 't': out[n++] = '\t'; in++; break;
 		  case 'x': {
-			int v = 0;
+			/*
+			 * Exactly two digits. Consuming every hex digit that follows
+			 * makes "\x05A" one byte rather than two, so a binary payload
+			 * beginning with A-F silently loses its first character -- and
+			 * a length prefix written that way announces the wrong size.
+			 */
+			int v = 0, d = 0;
+
 			in++;
-			while (isxdigit((int)*in)) {
+			while ((d < 2) && isxdigit((int)*in)) {
 				v = v * 16 + (isdigit((int)*in) ? *in - '0' : (tolower(*in) - 'a' + 10));
-				in++;
+				in++; d++;
 			}
 			out[n++] = (char)v;
 			break;
@@ -205,6 +215,31 @@ int main(int argc, char *argv[])
 			fprintf(obs, "got %s\n", got);
 			if (*arg && strncmp(got, arg, strlen(arg)) != 0)
 				fprintf(obs, "MISMATCH want=%s got=%s\n", arg, got);
+		}
+		else if (strcmp(cmd, "recvbytes") == 0) {
+			int want = atoi(arg), have = 0;
+			char hex[2*512 + 1];
+
+			if (want < 1) want = 1;
+			if (want > 512) want = 512;
+			while (have < want) {
+				int r = io_read(buf + have, want - have);
+
+				if (r <= 0) break;
+				have += r;
+			}
+			if (have < want) {
+				/*
+				 * Record what DID arrive. A probe that truncated its
+				 * payload at a NUL sends fewer bytes than it was told
+				 * to, and the short count is the evidence.
+				 */
+				tohex((unsigned char *)buf, have, hex);
+				fprintf(obs, "shortbytes %d %s\n", have, hex);
+				break;
+			}
+			tohex((unsigned char *)buf, have, hex);
+			fprintf(obs, "gotbytes %s\n", hex);
 		}
 		else if (strcmp(cmd, "replyall") == 0) {
 			n = unescape(arg, buf, sizeof(buf));

--- a/tests/network/dialogue-bytes.sh
+++ b/tests/network/dialogue-bytes.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# A reply framed by a length, not by a line.
+#
+# LDAP, MySQL, DNS-over-TCP and AMQP put a count in front of a message
+# instead of ending it with CRLF or a lone dot. "expect" is prefix-anchored
+# on text and "until" names a terminator, so neither can say where such a
+# reply stops: before "expect bytes(N)" those services could be probed no
+# further than the banner.
+#
+# The peer here sends a 12-byte frame with NO newline anywhere in it, then
+# waits. A test that passes on it has waited for the twelfth byte and for
+# nothing else.
+#
+# THE CONTROL is [short]: the same entry against a peer that sends 6 bytes
+# and stops. It must NOT go green -- otherwise "bytes(12)" would be
+# satisfied by whatever happened to arrive, which is the bug this exists to
+# prevent, and the suite would pass with the length ignored.
+#
+# The third peer checks that the frame does not eat the stream: it sends the
+# 12 bytes and then a line, and the entry reads the frame and then matches
+# that line, so what follows a frame must survive it.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+"$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile"; }
+
+# 12 bytes, no newline: only a length can say where this ends.
+printf 'send ABCDEFGHIJKL\nhold 20\n'                      > "$work/frame.script"
+printf 'send ABCDEF\nhold 20\n'                            > "$work/short.script"
+printf 'send ABCDEFGHIJKL\nsend +OK done\\r\\n\nhold 20\n' > "$work/tail.script"
+
+: > "$work/pids"
+start() {	# script portfile obsfile
+	"$work/peer" "$1" "$3" > "$2" &
+	echo $! >> "$work/pids"
+	local i=0
+	while [ "$i" -lt 50 ]; do [ -s "$2" ] && break; sleep 0.1; i=$((i + 1)); done
+	cat "$2"
+}
+pframe=$(start "$work/frame.script" "$work/pf" "$work/of")
+pshort=$(start "$work/short.script" "$work/ps" "$work/os")
+ptail=$(start  "$work/tail.script"  "$work/pt" "$work/ot")
+register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
+[ -n "$pframe" ] && [ -n "$pshort" ] && [ -n "$ptail" ] || fail "a peer never named its port"
+
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[framed]
+   options banner
+   port $pframe
+
+   state read
+      timeout(10)        -> fail
+      expect bytes(12)   -> success
+
+[short]
+   options banner
+   port $pshort
+
+   state read
+      timeout(5)         -> fail
+      expect bytes(12)   -> success
+
+[framedtail]
+   options banner
+   port $ptail
+
+   state read
+      timeout(10)        -> fail
+      expect bytes(12)   -> line
+
+   state line
+      timeout(10)        -> fail
+      expect "+OK"       -> success
+CFG
+printf '127.0.0.1\tfr\t# framed\n127.0.0.1\tsh\t# short\n127.0.0.1\ttl\t# framedtail\n' \
+	> "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse=red \
+	--dns=ip --timeout=30 >"$work/out.txt" 2>&1 || :
+
+colour_of() { grep -oE "status\+[0-9]+ $1 (green|yellow|red|clear)" "$work/out.txt" | awk '{print $3}' | head -1; }
+
+[ "$(colour_of fr.framed)" = green ] || fail \
+	"a 12-byte frame with no newline in it was not accepted by 'expect bytes(12)',
+so a length-framed reply still cannot be read:
+$(head -30 "$work/out.txt")"
+
+# THE CONTROL
+[ "$(colour_of sh.short)" = green ] && fail \
+	"a peer that sent 6 bytes satisfied 'expect bytes(12)'. The length is not
+being waited for, so the frame would accept whatever a read happened to
+return:
+$(grep -i short "$work/out.txt" | head -4)"
+
+[ "$(colour_of tl.framedtail)" = green ] || fail \
+	"the line sent after the 12-byte frame was not matched by the next state, so
+a frame consumes more than its own bytes:
+$(grep -i framedtail "$work/out.txt" | head -4)"
+
+pass "a reply framed by a length is read by 'expect bytes(N)', which waits for exactly that many"

--- a/tests/network/dialogue-framing.sh
+++ b/tests/network/dialogue-framing.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# A connection whose messages are framed by a length, not by a line.
+#
+# TCP says nothing about where a message ends; the protocol does, and it does
+# it in one of three ways -- a terminator, a count, or the close. The
+# greeting protocols use a terminator and every expect consumes a line.
+# DNS-over-TCP, MySQL, LDAP and AMQP send a count first, and their payloads
+# are binary: a 0x0A inside one is data, not the end of anything.
+#
+# "framing length(W, big|little)" says so once for the connection. The driver
+# then assembles a whole message before any expect looks at it, a literal
+# matches the start of the MESSAGE, and a match consumes the message and its
+# count together.
+#
+# Four things have to hold, and each has a control:
+#
+#   1  a message whose payload CONTAINS newlines is read whole -- the control
+#      is that the same bytes under line framing must NOT report the same
+#      thing, or the framing attribute is doing nothing
+#   2  a count that promises more than the peer sends must not report OK:
+#      an incomplete message is unfinished, never "close enough"
+#   3  little-endian widths decode the other way round -- the same 5-byte
+#      payload written as 05 00 rather than 00 05
+#   4  two messages in one write are two messages: the second must still be
+#      there for the state after
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+"$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile"; }
+
+# The peer decodes \xNN and \n itself, so the script must reach it with the
+# escapes intact. printf would expand them here -- and "\x00" would end the
+# line as a NUL, sending a frame one byte short of what it announced -- so
+# every script line is written with %s.
+#
+# 00 05 | "A\nB\nC" -- five payload bytes, two of them newlines.
+printf '%s\n' 'send \x00\x05A\nB\nC' 'hold 20'        > "$work/be.script"
+# 05 00 | the same payload, little-endian width
+printf '%s\n' 'send \x05\x00A\nB\nC' 'hold 20'        > "$work/le.script"
+# 00 09 promised, three delivered
+printf '%s\n' 'send \x00\x09ABC' 'hold 20'             > "$work/trunc.script"
+# two complete messages in one write
+printf '%s\n' 'send \x00\x03ABC\x00\x03DEF' 'hold 20' > "$work/two.script"
+# NUL-terminated, with a newline inside the message and no line structure
+printf '%s\n' 'send hello\nworld\x00rest' 'hold 20'    > "$work/term.script"
+
+: > "$work/pids"
+start() {	# script portfile obsfile
+	"$work/peer" "$1" "$3" > "$2" &
+	echo $! >> "$work/pids"
+	local i=0
+	while [ "$i" -lt 50 ]; do [ -s "$2" ] && break; sleep 0.1; i=$((i + 1)); done
+	cat "$2"
+}
+# Each peer serves ONE connection, so the control needs a peer of its own
+# running the same script rather than a second service on the same port.
+pbe=$(start    "$work/be.script"    "$work/p1" "$work/o1")
+pbeln=$(start  "$work/be.script"    "$work/p5" "$work/o5")
+ple=$(start    "$work/le.script"    "$work/p2" "$work/o2")
+ptrunc=$(start "$work/trunc.script" "$work/p3" "$work/o3")
+ptwo=$(start   "$work/two.script"   "$work/p4" "$work/o4")
+pterm=$(start  "$work/term.script"  "$work/p6" "$work/o6")
+register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
+[ -n "$pbe" ] && [ -n "$pbeln" ] && [ -n "$ple" ] && [ -n "$ptrunc" ] && [ -n "$ptwo" ] && [ -n "$pterm" ] \
+	|| fail "a peer never named its port"
+
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[framebe]
+   options banner
+   framing length(2, big)
+   port $pbe
+
+   state msg
+      timeout(10)     -> fail
+      expect "A"      -> success
+
+[frameline]
+   options banner
+   framing line
+   port $pbeln
+
+   state msg
+      timeout(5)      -> fail
+      expect "A"      -> success
+
+[framele]
+   options banner
+   framing length(2, little)
+   port $ple
+
+   state msg
+      timeout(10)     -> fail
+      expect "A"      -> success
+
+[frametrunc]
+   options banner
+   framing length(2, big)
+   port $ptrunc
+
+   state msg
+      timeout(5)      -> fail
+      expect "A"      -> success
+
+[frametwo]
+   options banner
+   framing length(2, big)
+   port $ptwo
+
+   state first
+      timeout(10)     -> fail
+      expect "A"      -> second
+
+   state second
+      timeout(10)     -> fail
+      expect "D"      -> success
+[frameterm]
+   options banner
+   framing terminator "\x00"
+   port $pterm
+
+   state msg
+      timeout(10)     -> fail
+      expect "hello"  -> success
+CFG
+{ printf '127.0.0.1\tbe\t# framebe\n127.0.0.1\tln\t# frameline\n'
+  printf '127.0.0.1\tle\t# framele\n127.0.0.1\ttr\t# frametrunc\n'
+  printf '127.0.0.1\ttw\t# frametwo\n127.0.0.1\ttm\t# frameterm\n'; } > "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse=red \
+	--dns=ip --timeout=30 >"$work/out.txt" 2>&1 || :
+
+colour_of() { grep -oE "status\+[0-9]+ $1 (green|yellow|red|clear)" "$work/out.txt" | awk '{print $3}' | head -1; }
+
+# 1 -- a binary message with newlines in it, read whole
+[ "$(colour_of be.framebe)" = green ] || fail \
+	"a 5-byte message announced by a 2-byte big-endian count was not read:
+$(head -20 "$work/out.txt")"
+
+# 1's CONTROL: the same bytes with line framing must behave differently. If
+# both spellings pass, 'framing' is being ignored and this suite proves
+# nothing.
+[ "$(colour_of ln.frameline)" = green ] && fail \
+	"the same peer passed under 'framing line' too, so the length prefix is
+not being consumed and the framing attribute changes nothing:
+$(grep -i frameline "$work/out.txt" | head -4)"
+
+# 3 -- the width read the other way round
+[ "$(colour_of le.framele)" = green ] || fail \
+	"a little-endian count (05 00) was not decoded as 5:
+$(grep -i framele "$work/out.txt" | head -4)"
+
+# 2 -- a message that never completes
+[ "$(colour_of tr.frametrunc)" = green ] && fail \
+	"a peer that promised 9 bytes and sent 3 reported OK. An incomplete
+message is unfinished, and must never be matched as if it had arrived:
+$(grep -i frametrunc "$work/out.txt" | head -4)"
+
+# 4 -- two messages in one write stay two messages
+[ "$(colour_of tw.frametwo)" = green ] || fail \
+	"the second of two messages sent in one write was lost, so a match
+consumes more than its own message:
+$(grep -i frametwo "$work/out.txt" | head -4)"
+
+# --- what the file may not say -----------------------------------------------
+# These four are refused when the file is read, so they never open a socket:
+# port 1 is deliberate, and a connection attempt to it would mean the refusal
+# did not happen.
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[badclause]
+   framing length(2, big)
+   port 1
+
+   state msg
+      timeout(5)                 -> fail
+      expect "A" until "\r\n"    -> success
+
+[badbytes]
+   framing length(2, big)
+   port 1
+
+   state msg
+      timeout(5)      -> fail
+      expect bytes(4) -> success
+
+[badwidth]
+   framing length(9, big)
+   port 1
+
+   state msg
+      timeout(5)      -> fail
+      expect "A"      -> success
+
+[badend]
+   framing length(2, sideways)
+   port 1
+
+   state msg
+      timeout(5)      -> fail
+      expect "A"      -> success
+CFG
+printf '127.0.0.1\tbad\t# badclause\n127.0.0.1\tbad2\t# badbytes\n' > "$work/home/etc/hosts.cfg"
+printf '127.0.0.1\tbad3\t# badwidth\n127.0.0.1\tbad4\t# badend\n'  >> "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse=red \
+	--dns=ip --timeout=10 >"$work/bad.txt" 2>&1 || :
+
+grep -qi "until.*framing length" "$work/bad.txt" || fail \
+	"'until' under length framing was accepted. The count already says where
+the message ends, so the two can only disagree:
+$(head -10 "$work/bad.txt")"
+grep -qi "bytes(4).*framing length" "$work/bad.txt" || fail \
+	"'expect bytes(N)' under length framing was accepted, though the peer's
+own count says how long the message is:
+$(head -10 "$work/bad.txt")"
+grep -qi "width is 1..4" "$work/bad.txt" || fail \
+	"a 9-byte length prefix was accepted:
+$(head -10 "$work/bad.txt")"
+grep -qi "endianness is 'big' or 'little'" "$work/bad.txt" || fail \
+	"an unknown endianness was accepted rather than refused:
+$(head -10 "$work/bad.txt")"
+
+# 5 -- a sequence, not a line, ends the message. The payload has a newline in
+# it and the terminator is a NUL, so nothing about this is line-shaped.
+[ "$(colour_of tm.frameterm)" = green ] || fail \
+	"a NUL-terminated message containing a newline was not read. 'until'
+compares the start of a LINE, so a terminator that does not fall on a line
+boundary needs framing of its own:
+$(grep -i frameterm "$work/out.txt" | head -4)"
+
+pass "length and terminator framing read whole messages, refuses what it cannot mean, and leaves the next message alone"

--- a/tests/network/dialogue-idle.sh
+++ b/tests/network/dialogue-idle.sh
@@ -64,10 +64,13 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
 [stopped]
    options banner
    port $pstop
-   expect "220"
-   send "ehlo xymonnet\r\n"
 
-   state waiting
+   state greeting
+      timeout(30)                 -> fail
+      expect "220"                -> ehlo
+
+   state ehlo
+      send "ehlo xymonnet\r\n"
       idle(3)                     -> warning
       timeout(30)                 -> fail
       expect "250"                -> success
@@ -75,10 +78,13 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
 [slow]
    options banner
    port $pslow
-   expect "220"
-   send "ehlo xymonnet\r\n"
 
-   state waiting
+   state greeting
+      timeout(30)                 -> fail
+      expect "220"                -> ehlo
+
+   state ehlo
+      send "ehlo xymonnet\r\n"
       idle(3)                     -> warning
       timeout(30)                 -> fail
       expect "250" until "250 "   -> success

--- a/tests/network/dialogue-nul.sh
+++ b/tests/network/dialogue-nul.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# A value bound by "as NAME" is bytes, not a string.
+#
+# "expect bytes(N)" and length framing exist for the services whose replies
+# are binary -- DNS-over-TCP, LDAP, MySQL, AMQP -- and those put NULs in the
+# first few bytes of a message. A bound value stored with strdup() is cut at
+# the first one, so ${name} expands to the stump, and a regex tested against
+# the name sees only what precedes the NUL. Nothing reports an error: the
+# probe compares almost nothing and goes green, or takes an else-arm and goes
+# red, for a reason no message names.
+#
+# Every peer here sends the SAME twelve bytes, "AB\0CDEFGHIJK", and the NUL
+# is the third of them. The three green entries each use the bound value in a
+# different place, so a value that survives storage but not one of its uses
+# still fails here:
+#
+#   [nulecho]     sends ${reply} back, and the peer counts the bytes it got
+#   [nulwhen]     tests the value with a regex that only matches past the NUL
+#   [nulcapture]  extracts a group that lies past the NUL, and tests THAT
+#
+# THE CONTROL is [nulmiss]: the same value, and a pattern that is genuinely
+# not in it. It must NOT go green -- otherwise the three above would prove
+# only that a "~" edge is always taken, and the suite would pass with the
+# value never read at all.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+"$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile"; }
+
+# AB\0CDEFGHIJK -- twelve bytes, a NUL third, and no newline anywhere.
+payload='\x41\x42\x00\x43\x44\x45\x46\x47\x48\x49\x4a\x4b'
+wire='414200434445464748494a4b'
+
+printf 'send %s\nrecvbytes 12\nsend "+OK\\r\\n"\nhold 5\n' "$payload" > "$work/echo.script"
+printf 'send %s\nhold 5\n' "$payload"                                 > "$work/when.script"
+printf 'send %s\nhold 5\n' "$payload"                                 > "$work/capture.script"
+printf 'send %s\nhold 5\n' "$payload"                                 > "$work/miss.script"
+
+: > "$work/pids"
+start() {	# script portfile obsfile
+	"$work/peer" "$1" "$3" > "$2" &
+	echo $! >> "$work/pids"
+	local i=0
+	while [ "$i" -lt 50 ]; do [ -s "$2" ] && break; sleep 0.1; i=$((i + 1)); done
+	cat "$2"
+}
+pe=$(start "$work/echo.script"    "$work/pe" "$work/oe")
+pw=$(start "$work/when.script"    "$work/pw" "$work/ow")
+pc=$(start "$work/capture.script" "$work/pc" "$work/oc")
+pz=$(start "$work/miss.script"    "$work/pz" "$work/oz")
+register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
+[ -n "$pe" ] && [ -n "$pw" ] && [ -n "$pc" ] && [ -n "$pz" ] || fail "a peer never named its port"
+
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[nulecho]
+   options banner
+   port $pe
+
+   state read
+      timeout(10)                 -> fail
+      expect bytes(12) as reply   -> echo
+
+   state echo
+      send "\${reply}"
+      timeout(10)                 -> fail
+      expect "+OK"                -> success
+
+[nulwhen]
+   options banner
+   port $pw
+
+   state read
+      timeout(10)                 -> fail
+      expect bytes(12) as reply   -> choose
+
+   state choose
+      reply ~ "HIJK"              -> success
+      else                        -> fail
+
+[nulcapture]
+   options banner
+   port $pc
+
+   state read
+      timeout(10)                 -> fail
+      expect bytes(12) as reply   -> choose
+
+   state choose
+      reply ~ "(HIJK)" as tail
+      tail ~ "HIJK"               -> success
+      else                        -> fail
+
+[nulmiss]
+   options banner
+   port $pz
+
+   state read
+      timeout(10)                 -> fail
+      expect bytes(12) as reply   -> choose
+
+   state choose
+      reply ~ "ZZZZ"              -> success
+      else                        -> fail
+CFG
+printf '127.0.0.1\tec\t# nulecho\n127.0.0.1\twh\t# nulwhen\n127.0.0.1\tcp\t# nulcapture\n127.0.0.1\tms\t# nulmiss\n' \
+	> "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse=red \
+	--dns=ip --timeout=30 >"$work/out.txt" 2>&1 || :
+sleep 1
+
+colour_of() { grep -oE "status\+[0-9]+ $1 (green|yellow|red|clear)" "$work/out.txt" | awk '{print $3}' | head -1; }
+
+# What went over the wire, which is the only account of it that a truncating
+# ${reply} cannot flatter: the peer counted the bytes and wrote them as hex.
+grep -q "^gotbytes $wire\$" "$work/oe" || fail \
+	"\${reply} did not send back the twelve bytes that were bound to it. A value
+holding a NUL is being stored or expanded as a C string, so everything past
+the third byte is gone. The peer saw:
+$(cat "$work/oe")"
+
+[ "$(colour_of ec.nulecho)" = green ] || fail \
+	"the round trip through \${reply} did not complete:
+$(grep -i nulecho "$work/out.txt" | head -4)"
+
+[ "$(colour_of wh.nulwhen)" = green ] || fail \
+	"'reply ~ \"HIJK\"' did not match, so the edge was tested against the bytes
+before the NUL rather than against the value:
+$(grep -i nulwhen "$work/out.txt" | head -4)"
+
+[ "$(colour_of cp.nulcapture)" = green ] || fail \
+	"'reply ~ \"(HIJK)\" as tail' extracted nothing: the capture is matching over
+strlen(value), which stops at the NUL:
+$(grep -i nulcapture "$work/out.txt" | head -4)"
+
+# THE CONTROL
+[ "$(colour_of ms.nulmiss)" = green ] && fail \
+	"a pattern that is not in the value took its edge anyway. The '~' edges above
+are not deciding anything, so this suite would pass on a value never read:
+$(grep -i nulmiss "$work/out.txt" | head -4)"
+
+pass "a value bound by 'as NAME' keeps every byte, and is sent, tested and extracted whole"

--- a/tests/network/dialogue-shape.sh
+++ b/tests/network/dialogue-shape.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# The shape rules, refused when the file is read.
+#
+# protocols.cfg(5) says a state does one thing and waits for one answer, that
+# every expect names where it goes, and that a clock bounds the wait that
+# follows it. Those were conventions the parser accepted any violation of, so
+# a file could read as one machine and run as another: a clock below the
+# expects bounds nothing, a second wait in a state has no name to fail under,
+# and an expect with no target leaves the file silent about where the
+# dialogue went.
+#
+# Every one of them is decidable while reading the file, which is the
+# standard this grammar set for itself when it refused regex on expect. This
+# checks that each is refused, by its own message, and that the service says
+# so rather than running a test whose meaning nobody can state.
+#
+# THE CONTROL is [good]: the same conversation written the documented way. If
+# it were refused too, these rules would be rejecting valid files and the
+# messages below would prove nothing.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+cat > "$work/home/etc/protocols.cfg" <<'CFG'
+[good]
+   options banner
+   port 1
+
+   state greeting
+      timeout(5)        -> fail
+      expect "220"      -> ehlo
+
+   state ehlo
+      send "ehlo x\r\n"
+      timeout(5)        -> fail
+      expect "250"      -> success
+
+[twoactions]
+   # conventions: permissive -- broken on purpose, this suite is what refuses it
+   port 1
+
+   state one
+      send "a\r\n"
+      starttls
+      timeout(5)        -> fail
+      expect "220"      -> success
+
+[actsagain]
+   # conventions: permissive -- broken on purpose, this suite is what refuses it
+   port 1
+
+   state one
+      timeout(5)        -> fail
+      expect "220"      -> success
+      send "b\r\n"
+
+[clockbelow]
+   # conventions: permissive -- broken on purpose, this suite is what refuses it
+   port 1
+
+   state one
+      expect "220"      -> success
+      timeout(5)        -> fail
+
+[notarget]
+   # conventions: permissive -- broken on purpose, this suite is what refuses it
+   port 1
+
+   state one
+      timeout(5)        -> fail
+      expect "220"
+
+[reserved]
+   # conventions: permissive -- broken on purpose, this suite is what refuses it
+   port 1
+
+   state success
+      timeout(5)        -> fail
+      expect "220"      -> success
+
+[twooptions]
+   # conventions: permissive -- broken on purpose, this suite is what refuses it
+   options banner
+   options ssl
+   port 1
+
+   state one
+      timeout(5)        -> fail
+      expect "220"      -> success
+
+[lonelyuntil]
+   # conventions: permissive -- broken on purpose, this suite is what refuses it
+   port 1
+   expect "250" until "250 "
+CFG
+{ for s in good twoactions actsagain clockbelow notarget reserved twooptions lonelyuntil; do
+	printf '127.0.0.1\th-%s\t# %s\n' "$s" "$s"
+  done; } > "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse=red \
+	--dns=ip --timeout=5 >"$work/out.txt" 2>&1 || :
+
+want() {	# pattern description
+	grep -qi -- "$1" "$work/out.txt" || fail \
+		"$2 was accepted. It is decidable while reading the file, so it has to be
+refused there rather than left to behave differently from how it reads:
+$(head -25 "$work/out.txt")"
+}
+
+want "more than one action"                "a state with two actions"
+want "acts again after it has waited"      "a state that sends after it has waited"
+want "clock below its expects"             "a clock written below the expects it should bound"
+want "expect with no "                     "an expect that names no state"
+want "reserved for a verdict"              "a state named 'success'"
+want "second 'options' line"               "a second options line replacing the first"
+want "does not run"                        "'until' on an entry the driver never runs"
+
+# THE CONTROL: the documented shape must not be caught by any of this.
+grep -qi "Service good" "$work/out.txt" || fail \
+	"the control entry produced no result at all, so this run proves nothing"
+grep -Ei "state '(greeting|ehlo)'" "$work/out.txt" | grep -Eqi "more than one action|no '\-> TARGET'|clock below" && fail \
+	"the entry written exactly as protocols.cfg(5) documents was refused:
+$(grep -i good "$work/out.txt" | head -5)"
+
+pass "a misshapen state is refused when the file is read, and the documented shape is not"

--- a/tests/network/dialogue-starttls-negotiation.sh
+++ b/tests/network/dialogue-starttls-negotiation.sh
@@ -144,75 +144,100 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
       expect "221"                       -> success
 
 [tlsnone]
-   # conventions: permissive -- the fall-through spelling, kept covered on purpose
    options banner
    port $pno
 
    state greeting
-      timeout(10)         -> fail
-      expect "220"
+      timeout(10)                        -> fail
+      expect "220"                       -> ehlo
+
+   state ehlo
       send "ehlo xymonnet\r\n"
-      expect "250" until "250 " as caps
-      caps ~ "STARTTLS"   -> upgrade
-      else                -> warning
+      timeout(10)                        -> fail
+      expect "250" until "250 " as caps  -> offers
+
+   state offers
+      caps ~ "STARTTLS"                  -> upgrade
+      else                               -> warning
 
    state upgrade
-      timeout(10)         -> fail
       send "starttls\r\n"
-      expect "220"        -> secure
-      expect "454"        -> warning
+      timeout(10)                        -> fail
+      expect "220"                       -> secure
+      expect "454"                       -> warning
 
    state secure
-      timeout(10)         -> fail
       starttls
+      always                             -> farewell
+
+   state farewell
       send "quit\r\n"
-      expect "221"        -> success
+      timeout(10)                        -> fail
+      expect "221"                       -> success
 
 [tls454a]
-   # conventions: permissive -- alternatives in both orders, the point of this pair
    options banner
    port $pra
 
    state greeting
-      timeout(10)         -> fail
-      expect "220"
+      timeout(10)                        -> fail
+      expect "220"                       -> ehlo
+
+   state ehlo
       send "ehlo xymonnet\r\n"
-      expect "250" until "250 "
+      timeout(10)                        -> fail
+      expect "250" until "250 " as caps  -> offers
+
+   state offers
+      caps ~ "STARTTLS"                  -> upgrade
+      else                               -> warning
 
    state upgrade
-      timeout(10)         -> fail
       send "starttls\r\n"
-      expect "220"        -> secure
-      expect "454"        -> warning
+      timeout(10)                        -> fail
+      expect "220"                       -> secure
+      expect "454"                       -> warning
 
    state secure
-      timeout(10)         -> fail
       starttls
+      always                             -> farewell
+
+   state farewell
       send "quit\r\n"
-      expect "221"        -> success
+      timeout(10)                        -> fail
+      expect "221"                       -> success
 
 [tls454b]
-   # conventions: permissive -- alternatives in both orders, the point of this pair
    options banner
    port $prb
 
    state greeting
-      timeout(10)         -> fail
-      expect "220"
+      timeout(10)                        -> fail
+      expect "220"                       -> ehlo
+
+   state ehlo
       send "ehlo xymonnet\r\n"
-      expect "250" until "250 "
+      timeout(10)                        -> fail
+      expect "250" until "250 " as caps  -> offers
+
+   state offers
+      caps ~ "STARTTLS"                  -> upgrade
+      else                               -> warning
 
    state upgrade
-      timeout(10)         -> fail
       send "starttls\r\n"
-      expect "454"        -> warning
-      expect "220"        -> secure
+      timeout(10)                        -> fail
+      expect "454"                       -> warning
+      expect "220"                       -> secure
 
    state secure
-      timeout(10)         -> fail
       starttls
+      always                             -> farewell
+
+   state farewell
       send "quit\r\n"
-      expect "221"        -> success
+      timeout(10)                        -> fail
+      expect "221"                       -> success
 
 CFG
 

--- a/tests/network/dialogue-terminals.sh
+++ b/tests/network/dialogue-terminals.sh
@@ -70,8 +70,10 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
 [termbusy]
    options banner
    port $pbusy
-   expect "220"                -> proceed
-   expect "421"                -> warning
+
+   state greeting
+      expect "220"                -> proceed
+      expect "421"                -> warning
 
    state proceed
       send "quit\r\n"
@@ -80,10 +82,14 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
 [termbad]
    options banner
    port $pbad
-   expect "220"
-   send "ehlo xymonnet\r\n"
-   expect "250"                -> done
-   expect "5"                  -> fail
+
+   state greeting
+      expect "220"                -> ehlo
+
+   state ehlo
+      send "ehlo xymonnet\r\n"
+      expect "250"                -> done
+      expect "5"                  -> fail
 
    state done
       send "quit\r\n"

--- a/tests/network/dialogue-timeout.sh
+++ b/tests/network/dialogue-timeout.sh
@@ -65,34 +65,41 @@ register_cleanup "kill $(cat "$work/silent.port.pid") $(cat "$work/quick.port.pi
 printf '127.0.0.1\tsilent\t# budgeted healthy routed\n' > "$work/home/etc/hosts.cfg"
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [budgeted]
-   # conventions: permissive -- the clock, not the shape, is what this measures
    options banner
    port $psilent
-   expect "220"
-   send "ehlo xymonnet\r\n"
+
+   state greeting
+      timeout(30)                 -> fail
+      expect "220"                -> waiting
 
    state waiting
+      send "ehlo xymonnet\r\n"
       timeout(2)                  -> fail
-      expect "250"
+      expect "250"                -> success
 
 [healthy]
-   # conventions: permissive -- the clock, not the shape, is what this measures
    options banner
    port $pquick
-   expect "220"
-   send "ehlo xymonnet\r\n"
+
+   state greeting
+      timeout(30)                 -> fail
+      expect "220"                -> waiting
 
    state waiting
+      send "ehlo xymonnet\r\n"
       timeout(2)                  -> fail
-      expect "250"
+      expect "250"                -> success
 
 [routed]
    options banner
    port $prouted
-   expect "220"
-   send "ehlo xymonnet\r\n"
+
+   state greeting
+      timeout(30)                 -> fail
+      expect "220"                -> waiting
 
    state waiting
+      send "ehlo xymonnet\r\n"
       timeout(2)                  -> warning
       expect "250"                -> success
 
@@ -140,16 +147,17 @@ ceiling, so the budget is not what ended it -- the global cutoff is."
 printf '127.0.0.1\tsilent\t# ceiling\n' > "$work/home/etc/hosts.cfg"
 cat > "$work/home/etc/protocols.cfg" <<CFG
 [ceiling]
-   # conventions: permissive -- the clock, not the shape, is what this measures
    options banner
    port $pceil
-   expect "220"
-   send "ehlo xymonnet\r\n"
+
+   state greeting
+      timeout(30)                 -> fail
+      expect "220"                -> waiting
 
    state waiting
+      send "ehlo xymonnet\r\n"
       timeout(60)                 -> fail
-      expect "250"
-
+      expect "250"                -> success
 CFG
 
 start=$(date +%s)

--- a/tests/network/dialogue-validation.sh
+++ b/tests/network/dialogue-validation.sh
@@ -36,6 +36,7 @@ run_xymonnet() {
 printf 'mypop\tuser\tsecret\n' > "$work/home/etc/credentials.cfg"
 cat > "$work/home/etc/protocols.cfg" <<'CFG'
 [bad]
+   # conventions: permissive -- malformed on purpose; this suite is the refusal
    exepct "220"
    expect "220"
    nosuch ~ "(x)"              as tooearly
@@ -46,6 +47,7 @@ cat > "$work/home/etc/protocols.cfg" <<'CFG'
    port 9
 
 [typo]
+   # conventions: permissive -- malformed on purpose; this suite is the refusal
    port 9
    port 9
    expect "+OK" as greeting
@@ -63,6 +65,7 @@ cat > "$work/home/etc/protocols.cfg" <<'CFG'
       expect "+OK"
 
 [graph]
+   # conventions: permissive -- malformed on purpose; this suite is the refusal
    port 9
    start entry
 

--- a/tests/network/dialogue-values.sh
+++ b/tests/network/dialogue-values.sh
@@ -70,26 +70,41 @@ register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
 authblock() {
 cat <<CFG
 [$1]
-   expect "+OK" as greeting
-   greeting ~ "\\+OK POP3 (\\S+) (<[^>]+>)" as server;challenge
-   credentials mypop
-   challenge ~ "<"             -> apop
-   else                        -> plain
-
-   state apop
-   send "APOP \${username} \${md5:\${challenge}\${password}}\r\n"
-   expect "+OK"                -> farewell
-
-   state plain
-   send "USER \${username}\r\n"
-   expect "+OK"
-   send "PASS \${password}\r\n"
-   expect "+OK"                -> farewell
-
-   state farewell
-   send "quit \${server}\r\n"
    options banner
    port $2
+   start greeting
+
+   state greeting
+      credentials mypop
+      timeout(10)                 -> fail
+      expect "+OK" as greeting    -> choose
+
+   state choose
+      greeting ~ "\\+OK POP3 (\\S+) (<[^>]+>)" as server;challenge
+      greeting ~ "(\\+OK)" as greeting
+      challenge ~ "<"             -> apop
+      else                        -> plain
+
+   state apop
+      send "APOP \${username} \${md5:\${challenge}\${password}}\r\n"
+      timeout(10)                 -> fail
+      expect "+OK"                -> farewell
+
+   state plain
+      send "USER \${username}\r\n"
+      timeout(10)                 -> fail
+      expect "+OK"                -> sendpass
+
+   state sendpass
+      send "PASS \${password}\r\n"
+      timeout(10)                 -> fail
+      expect "+OK"                -> farewell
+
+   state farewell
+      send "quit \${server}\r\n"
+      timeout(10)                 -> fail
+      eof                         -> success
+      expect "+OK"                -> success
 CFG
 }
 {
@@ -98,13 +113,24 @@ CFG
 	cat <<CFG
 
 [popb64]
-   expect "+OK"
-   credentials mypop
-   send "AUTH_\${base64:\${username}}\r\n"
-   expect "+OK"
-   send "quit\r\n"
    options banner
    port $pb
+
+   state greeting
+      credentials mypop
+      timeout(10)                 -> fail
+      expect "+OK"                -> auth
+
+   state auth
+      send "AUTH_\${base64:\${username}}\r\n"
+      timeout(10)                 -> fail
+      expect "+OK"                -> farewell
+
+   state farewell
+      send "quit\r\n"
+      timeout(10)                 -> fail
+      eof                         -> success
+      expect "+OK"                -> success
 CFG
 } > "$work/home/etc/protocols.cfg"
 printf '127.0.0.1\tapop\t# popapop\n127.0.0.1\tplain\t# popplain\n127.0.0.1\tb64\t# popb64\n' \

--- a/tests/network/dialogue-verdict.sh
+++ b/tests/network/dialogue-verdict.sh
@@ -76,17 +76,19 @@ cat > "$work/home/etc/protocols.cfg" <<CFG
    port $pok
 
 [dlgbad]
-   # conventions: permissive -- a dialogue that stops mid-way, written the old way
    options banner
    port $pbad
 
    state greeting
-      expect "220"
-      send "ehlo xymonnet\r\n"
+      expect "220"                -> capabilities
 
    state capabilities
-      expect "250"
+      send "ehlo xymonnet\r\n"
+      expect "250"                -> farewell
+
+   state farewell
       send "quit\r\n"
+      expect "221"                -> success
 
 [legacy]
    send "probe\r\n"

--- a/tests/network/protocol-dialogue.sh
+++ b/tests/network/protocol-dialogue.sh
@@ -57,10 +57,11 @@ printf '%s\n' "$n" | grep -qE '\+\+guard *>' ||
 	fail "dlg_run_instant has no runaway guard -- a backward jump that does no
 I/O would hang xymonnet rather than failing the test"
 
-# md5hash() returns a static buffer; freeing it corrupts the allocator.
+# md5hash_len() returns a static buffer; freeing it corrupts the allocator.
 # Asserted positively -- the negative form passed for free when the grep
-# matched nothing at all.
-md5line=$(printf '%s\n' "$n" | grep 'md5hash(' | head -1)
+# matched nothing at all. Either spelling counts: the length-taking one is
+# what a dialogue calls, and md5hash() is the wrapper over it.
+md5line=$(printf '%s\n' "$n" | grep -E 'md5hash(_len)?\(' | head -1)
 [ -n "$md5line" ] ||
 	fail "no md5hash() call found -- either the md5 expansion is gone, or the
 comment stripper ate it and this assertion is passing for free"

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -1035,11 +1035,11 @@ static void tcptest_setnext(void *a, void *newval)
  * memset on memory that is about to be freed is exactly what a compiler is
  * entitled to delete, so the write goes through a volatile pointer.
  */
-static void dlg_wipe(char *s)
+static void dlg_wipe(char *s, int len)
 {
 	volatile char *p = (volatile char *)s;
 
-	while (p && *p) *p++ = '\0';
+	while (p && (len-- > 0)) *p++ = '\0';
 }
 
 
@@ -1050,7 +1050,7 @@ static void dlg_free(tcptest_t *item)
 	while (v) {
 		dlgvar_t *next = v->next;
 
-		if (v->value) { dlg_wipe(v->value); xfree(v->value); }
+		if (v->value) { dlg_wipe(v->value, v->vallen); xfree(v->value); }
 		if (v->name) xfree(v->name);
 		xfree(v);
 		v = next;
@@ -1060,6 +1060,7 @@ static void dlg_free(tcptest_t *item)
 	if (item->stepbuf) { xfree(item->stepbuf); item->stepbuf = NULL; }
 	item->stepbuflen = 0;
 	if (item->lastreply) { xfree(item->lastreply); item->lastreply = NULL; }
+	item->lastreplylen = 0;
 	/*
 	 * Only the arming is cleared here. stepsecs and steptimedout are part
 	 * of the verdict -- dlg_free() runs after the poll loop and before the
@@ -1089,32 +1090,78 @@ static int dlg_name_listed(const char *list, const char *name)
 }
 
 
-static char *dlg_get(tcptest_t *item, const char *name)
+static char *dlg_get(tcptest_t *item, const char *name, int *lenp)
 {
 	dlgvar_t *v;
 
 	for (v = (dlgvar_t *)item->dlgvars; (v); v = v->next)
-		if (strcmp(v->name, name) == 0) return v->value;
+		if (strcmp(v->name, name) == 0) {
+			if (lenp) *lenp = v->vallen;
+			return v->value;
+		}
 
+	if (lenp) *lenp = 0;
 	return NULL;
 }
 
-static void dlg_set(tcptest_t *item, const char *name, const char *value)
+/*
+ * A value is BYTES, not a string. "expect bytes(N)" and length framing exist
+ * for the services whose messages are binary -- DNS-over-TCP, LDAP, MySQL,
+ * AMQP -- and those carry NULs in the first few bytes, so storing a bound
+ * value with strdup() would cut it to nothing and every use of it would
+ * silently compare or send the stump. The copy is still NUL-terminated, so a
+ * value that IS text can be read as a C string; everything else uses vallen.
+ */
+static void dlg_set(tcptest_t *item, const char *name, const char *value, int vallen)
 {
 	dlgvar_t *v;
+	char *copy;
+
+	if (!value || (vallen < 0)) { value = ""; vallen = 0; }
+	copy = (char *)malloc(vallen + 1);
+	memcpy(copy, value, vallen);
+	copy[vallen] = '\0';
 
 	for (v = (dlgvar_t *)item->dlgvars; (v); v = v->next) {
 		if (strcmp(v->name, name) != 0) continue;
-		if (v->value) xfree(v->value);
-		v->value = strdup(value ? value : "");
+		if (v->value) { dlg_wipe(v->value, v->vallen); xfree(v->value); }
+		v->value  = copy;
+		v->vallen = vallen;
 		return;
 	}
 
 	v = (dlgvar_t *)calloc(1, sizeof(dlgvar_t));
-	v->name  = strdup(name);
-	v->value = strdup(value ? value : "");
-	v->next  = (dlgvar_t *)item->dlgvars;
+	v->name   = strdup(name);
+	v->value  = copy;
+	v->vallen = vallen;
+	v->next   = (dlgvar_t *)item->dlgvars;
 	item->dlgvars = (void *)v;
+}
+
+/* For the values that are known to be text: credentials, and an empty bind. */
+static void dlg_setstr(tcptest_t *item, const char *name, const char *value)
+{
+	dlg_set(item, name, value, (value ? strlen(value) : 0));
+}
+
+/*
+ * matchregex() measures its subject with strlen(). A value bound from a
+ * framed reply may hold a NUL, and the pattern is then tested against the
+ * bytes before it rather than against the value -- so match over the length
+ * that was stored.
+ */
+static int dlg_match(const char *subject, int len, pcre2_code *re)
+{
+	pcre2_match_data *md;
+	int res;
+
+	if (!subject || !re) return 0;
+
+	md = pcre2_match_data_create(4, NULL);
+	res = pcre2_match(re, (PCRE2_SPTR)subject, len, 0, 0, md, NULL);
+	pcre2_match_data_free(md);
+
+	return (res >= 0);
 }
 
 /*
@@ -1136,7 +1183,7 @@ static char *dlg_expand(tcptest_t *item, const char *text, int len, int *outlen)
 	for (i = 0; (i < len); i++) {
 		int depth, j, blen;
 		char *body, *inner, *val = NULL, *freeval = NULL;
-		int innerlen;
+		int innerlen, vallen = 0;
 
 		if (!((text[i] == '$') && ((i+1) < len) && (text[i+1] == '{'))) {
 			if (n >= outsz) { outsz *= 2; out = (char *)realloc(out, outsz + 1); }
@@ -1161,33 +1208,37 @@ static char *dlg_expand(tcptest_t *item, const char *text, int len, int *outlen)
 		memcpy(body, text + i + 2, blen);
 		body[blen] = '\0';
 
+		/*
+		 * The argument is passed by length: ${md5:${salt}} over a binary
+		 * salt is the whole point of these on a framed protocol, and
+		 * measuring the expansion with strlen() would hash or encode the
+		 * bytes up to the first NUL instead of the value.
+		 */
 		if (strncmp(body, "md5:", 4) == 0) {
 			inner = dlg_expand(item, body + 4, blen - 4, &innerlen);
-			/* md5hash() hands back a static buffer -- copy, never free. */
-			val = md5hash(inner);
+			/* md5hash_len() hands back a static buffer -- copy, never free. */
+			val = md5hash_len(inner, innerlen);
+			vallen = strlen(val);
 			xfree(inner);
 		}
 		else if (strncmp(body, "base64:", 7) == 0) {
 			inner = dlg_expand(item, body + 7, blen - 7, &innerlen);
-			val = freeval = base64encode((unsigned char *)inner);
+			val = freeval = base64encode_len((unsigned char *)inner, innerlen);
+			vallen = strlen(val);
 			xfree(inner);
 		}
 		else {
 			/* Mistyped functions are reported when the file is read. */
-			val = dlg_get(item, body);
+			val = dlg_get(item, body, &vallen);
 			if (val == NULL) {
 				dbgprintf("dialogue: ${%s} is not set, expanding empty\n", body);
-				val = "";
+				val = ""; vallen = 0;
 			}
 		}
 
-		{
-			int vlen = strlen(val);
-
-			while ((n + vlen) >= outsz) { outsz *= 2; out = (char *)realloc(out, outsz + 1); }
-			memcpy(out + n, val, vlen);
-			n += vlen;
-		}
+		while ((n + vallen) >= outsz) { outsz *= 2; out = (char *)realloc(out, outsz + 1); }
+		memcpy(out + n, val, vallen);
+		n += vallen;
 
 		if (freeval) xfree(freeval);
 		xfree(body);
@@ -1202,9 +1253,9 @@ static char *dlg_expand(tcptest_t *item, const char *text, int len, int *outlen)
 /* Group 1 of the pattern, against the reply the last expect accepted. */
 static void dlg_capture(tcptest_t *item, svcstep_t *st)
 {
-	char *subject = dlg_get(item, st->srcname);
+	char *subject, *src;
 	pcre2_match_data *md;
-	int res, n;
+	int res, n, subjectlen = 0;
 	char names[256], *name, *rest;
 
 	/*
@@ -1213,11 +1264,21 @@ static void dlg_capture(tcptest_t *item, svcstep_t *st)
 	 * An unbound name binds empty, which check_undefined_vars() has
 	 * already complained about when the file was read.
 	 */
-	if (subject == NULL) subject = "";
+	/*
+	 * Work on a COPY. dlg_set() releases the old value of a name once it
+	 * has stored the new one, so binding a name that is also the source --
+	 * "banner ~ ... as banner", or any list that reuses it -- would free
+	 * the very bytes this match is reading, and the ovector offsets of
+	 * every name after it would then index freed memory.
+	 */
+	src = dlg_get(item, st->srcname, &subjectlen);
+	subject = (char *)malloc(subjectlen + 1);
+	if (src) memcpy(subject, src, subjectlen);
+	subject[subjectlen] = '\0';
 
 	md = pcre2_match_data_create(32, NULL);
 	res = pcre2_match((pcre2_code *)st->re, (PCRE2_SPTR)subject,
-			  strlen(subject), 0, 0, md, NULL);
+			  subjectlen, 0, 0, md, NULL);
 
 	/*
 	 * One name per capture group, in order: "as server;challenge" binds
@@ -1240,17 +1301,18 @@ static void dlg_capture(tcptest_t *item, svcstep_t *st)
 
 			memcpy(v, subject + b, e - b);
 			v[e-b] = '\0';
-			dlg_set(item, name, v);
+			dlg_set(item, name, v, e - b);
 			xfree(v);
 		}
 		else {
 			dbgprintf("dialogue: an extraction did not match, ${%s} left empty\n", name);
-			dlg_set(item, name, "");
+			dlg_setstr(item, name, "");
 		}
 		n++;
 	}
 
 	pcre2_match_data_free(md);
+	xfree(subject);
 }
 
 
@@ -1345,21 +1407,22 @@ static svcstep_t *dlg_run_instant(tcptest_t *item, svcstep_t *st)
 				char *u = NULL, *p = NULL;
 
 				if (lookup_credentials(item->credname, &u, &p)) {
-					dlg_set(item, "username", u);
-					dlg_set(item, "password", p);
-					if (u) { dlg_wipe(u); xfree(u); }
-					if (p) { dlg_wipe(p); xfree(p); }
+					dlg_setstr(item, "username", u);
+					dlg_setstr(item, "password", p);
+					if (u) { dlg_wipe(u, strlen(u)); xfree(u); }
+					if (p) { dlg_wipe(p, strlen(p)); xfree(p); }
 					st = st->next;
 					break;
 				}
 			}
-			dlg_set(item, "username", st->user);
-			dlg_set(item, "password", st->pass);
+			dlg_setstr(item, "username", st->user);
+			dlg_setstr(item, "password", st->pass);
 			st = st->next;
 			break;
 
 		  case STEP_WHEN: {
-			char *v = dlg_get(item, st->varname);
+			int vlen = 0;
+			char *v = dlg_get(item, st->varname, &vlen);
 
 			/*
 			 * An edge: taken when the test matches, fallen through when
@@ -1367,7 +1430,7 @@ static svcstep_t *dlg_run_instant(tcptest_t *item, svcstep_t *st)
 			 * -- gets its turn. The regex tests a value already bound,
 			 * never the socket, so nothing here races a partial read.
 			 */
-			if (!(v && st->re && matchregex(v, (pcre2_code *)st->re))) {
+			if (!(v && st->re && dlg_match(v, vlen, (pcre2_code *)st->re))) {
 				st = st->next;
 				break;
 			}
@@ -2233,14 +2296,97 @@ restartselect:
 								while (progress) {
 									svcstep_t *alt, *hit = NULL;
 									int undecided = 0;
+									int mbase = 0, mlen = item->stepbuflen;
 
 									progress = 0;
 									st = (svcstep_t *)item->curstep;
 									if (!st || (st->type != STEP_EXPECT)) break;
 
+									/*
+									 * Length framing: the peer sends a count and
+									 * then that many bytes, so a message boundary
+									 * exists where no newline does. Assemble the
+									 * whole message before anything looks at it --
+									 * an expect then matches the START of a
+									 * message rather than of whatever has arrived,
+									 * and a match consumes the message entire.
+									 */
+									if (item->svcinfo->framing == FRAMING_TERM) {
+										/*
+										 * A sequence ends the message wherever it
+										 * falls, so scan for it and take everything
+										 * through it. Nothing is consumed until it
+										 * arrives: half a message is unfinished, the
+										 * same as half a line or half a frame.
+										 */
+										int t = item->svcinfo->frametermlen, i2, found = -1;
+
+										for (i2 = 0; i2 + t <= item->stepbuflen; i2++) {
+											if (memcmp(item->stepbuf + i2,
+												   item->svcinfo->frameterm, t) == 0) {
+												found = i2 + t;
+												break;
+											}
+										}
+										if (found < 0) break;		/* still arriving */
+										mbase = 0;
+										mlen  = found;
+									}
+									else if (item->svcinfo->framing == FRAMING_LENGTH) {
+										int w = item->svcinfo->framewidth, k;
+										unsigned int n = 0;
+
+										if (item->stepbuflen < w) break;   /* not even the count yet */
+										for (k = 0; k < w; k++) {
+											int b = item->stepbuf[item->svcinfo->framebig ? k : (w - 1 - k)];
+
+											n = (n << 8) | (unsigned int)b;
+										}
+										if (n > (unsigned int)MAX_DIALOGUE_BYTES) {
+											errprintf("%s: framed message of %u bytes is over the %d "
+												  "a conversation may hold\n",
+												  item->svcinfo->svcname, n, MAX_DIALOGUE_BYTES);
+											item->dialogfail = 1;
+											if (!item->failstep) item->failstep = (void *)st;
+											item->curstep = NULL;
+											st = NULL;
+											break;
+										}
+										if ((unsigned int)(item->stepbuflen - w) < n) break;  /* still arriving */
+										mbase = w;
+										mlen  = (int)n;
+									}
+
 									/* Consecutive expects are alternatives of ONE state. */
 									for (alt = st; (alt && (alt->type == STEP_EXPECT)); alt = alt->next) {
 										if (alt->oneof) continue;	/* only fires on EOF */
+										if (item->svcinfo->framing != FRAMING_LINE) {
+											/*
+											 * The literal matches the start of the
+											 * MESSAGE. By here the message is whole,
+											 * so one shorter than the pattern is
+											 * decidably ruled out rather than still
+											 * arriving -- no "undecided", or a peer
+											 * that framed a short message would hang
+											 * until the clock.
+											 */
+											if (mlen < alt->len) continue;
+											if (memcmp(item->stepbuf + mbase, alt->text, alt->len) == 0) {
+												hit = alt; break;
+											}
+											continue;
+										}
+										if (alt->wantbytes) {
+											/*
+											 * A frame, not a line: it is decided by
+											 * how much has arrived and by nothing
+											 * else, so it cannot be "ruled out" the
+											 * way a literal can -- it is either
+											 * complete or still short.
+											 */
+											if (item->stepbuflen < alt->wantbytes) { undecided++; continue; }
+											hit = alt; break;
+										}
 										if (item->stepbuflen < alt->len) { undecided++; continue; }
 										if (memcmp(item->stepbuf, alt->text, alt->len) == 0) { hit = alt; break; }
 									}
@@ -2258,7 +2404,15 @@ restartselect:
 									if (hit) {
 										int cut = hit->len;
 
-										if (hit->until) {
+										if (item->svcinfo->framing != FRAMING_LINE) {
+											/* the message and its framing, and nothing else */
+											cut = mbase + mlen;
+										}
+										else if (hit->wantbytes) {
+											/* Exactly the frame, and not a byte more. */
+											cut = hit->wantbytes;
+										}
+										else if (hit->until) {
 											/*
 											 * A multi-line reply: consume complete
 											 * lines until one starts with the
@@ -2298,10 +2452,23 @@ restartselect:
 											if (cut < item->stepbuflen) cut++;
 										}
 
-										if (item->lastreply) xfree(item->lastreply);
-										item->lastreply = (char *)malloc(cut + 1);
-										memcpy(item->lastreply, item->stepbuf, cut);
-										item->lastreply[cut] = '\0';
+										/*
+										 * The reply is the message, not the framing
+										 * around it: under length framing the count
+										 * belongs to the transport and would only
+										 * ever be noise in a report or in a value
+										 * an "as" binds.
+										 */
+										{
+											int rbase = (item->svcinfo->framing != FRAMING_LINE) ? mbase : 0;
+											int rlen  = (item->svcinfo->framing != FRAMING_LINE) ? mlen : cut;
+
+											if (item->lastreply) xfree(item->lastreply);
+											item->lastreply = (char *)malloc(rlen + 1);
+											memcpy(item->lastreply, item->stepbuf + rbase, rlen);
+											item->lastreply[rlen] = '\0';
+											item->lastreplylen = rlen;
+										}
 
 										/*
 										 * "expect ... as NAME" binds the reply THIS
@@ -2310,7 +2477,8 @@ restartselect:
 										 * of some earlier state.
 										 */
 										if (hit->varname)
-											dlg_set(item, hit->varname, item->lastreply);
+											dlg_set(item, hit->varname, item->lastreply,
+												item->lastreplylen);
 
 										memmove(item->stepbuf, item->stepbuf + cut, item->stepbuflen - cut);
 										item->stepbuflen -= cut;

--- a/xymonnet/contest.h
+++ b/xymonnet/contest.h
@@ -86,12 +86,9 @@ typedef void (*f_callback_final)(void *privdata);
 typedef struct dlgvar_t {
 	char *name;
 	char *value;
+	int vallen;			/* value bytes: a reply is not always a string */
 	struct dlgvar_t *next;
 } dlgvar_t;
-
-/* How much a single expect may accumulate before giving up. A server that
-   never sends the terminator must not be able to grow this without limit. */
-#define MAX_DIALOGUE_BYTES (32 * 1024)
 
 typedef struct tcptest_t {
 	struct sockaddr_in addr;        /* Address (IP+port) to test */
@@ -147,6 +144,7 @@ typedef struct tcptest_t {
 	unsigned char *stepbuf;		/* replies for the CURRENT expect step */
 	int stepbuflen;
 	char *lastreply;		/* the reply that satisfied the last expect */
+	int lastreplylen;		/* ... and its length: it may hold NULs */
 	void *dlgvars;			/* captured values, a dlgvar_t list */
 	int stepsecs;			/* 'timeout(N)': budget for this state, 0 = none */
 	time_t stepdeadline;		/* ... armed against the poll clock, 0 = unarmed */

--- a/xymonnet/protocols.cfg.5
+++ b/xymonnet/protocols.cfg.5
@@ -113,6 +113,21 @@ covers them without special-casing any:
 \&   expect "*"   until "A01 "     (IMAP: the command tag ends it)
 .fi
 
+.IP "\fBexpect\fR \fBbytes(\fR\fIN\fR\fB)\fR"
+Wait for a frame of \fIN\fR bytes and consume exactly that many. LDAP,
+MySQL, DNS over TCP and AMQP put a length in front of a message instead
+of ending it with a line, so neither a literal nor \fBuntil\fR can say
+where such a reply stops. Anything beyond the frame is kept for the next
+step, as with any other \fBexpect\fR.
+.sp
+A frame is decided by length and a literal by content, so the two cannot
+share a state: which of them took the reply would be unsayable. A state
+whose \fBexpect\fR is a frame holds that one alternative, and the
+clocks. \fBuntil\fR is refused on it, and \fIN\fR must be between 1 and
+32768 -- the same ceiling a conversation may buffer.
+.sp
+\fBas\fR works as it does elsewhere, binding the frame that was consumed.
+
 .IP "\fBexpect\fR \fISTRING\fR \fBas\fR \fINAME\fR"
 Bind the reply this \fBexpect\fR accepted to \fINAME\fR, for a later
 \fB~\fR line to read. It is written on the expect itself because that is
@@ -162,7 +177,7 @@ does not.
 .sp
 \fBLayout.\fR An entry that uses states is written the same way
 throughout this page: the entry attributes -- \fBoptions\fR,
-\fBport\fR, \fBtransport\fR, \fBstart\fR -- first, in any order
+\fBport\fR, \fBtransport\fR, \fBframing\fR, \fBstart\fR -- first, in any order
 among themselves, because they describe the definition rather than any
 step; then the states, each with its lines indented under it.
 .sp
@@ -326,6 +341,46 @@ Expansion is recursive, so a digest may be taken of other values -- APOP
 is \fB${md5:${challenge}${password}}\fR. An unset name expands to
 nothing.
 
+.IP "\fBframing\fR \fBline\fR"
+.IP "\fBframing\fR \fBlength(\fR\fIWIDTH\fR\fB,\fR \fBbig\fR|\fBlittle\fR\fB)\fR"
+.IP "\fBframing\fR \fBterminator\fR \fISEQUENCE\fR"
+How a message ends on this connection. TCP says nothing about it: a
+message boundary is always something the protocol states, and it states
+it in one of three ways -- a terminator, a count, or the close.
+.sp
+\fBline\fR is the default and is what the greeting protocols do: an
+\fBexpect\fR consumes one line, and \fBuntil\fR says where a reply of
+several lines ends. \fBlength\fR is what the binary protocols do --
+DNS over TCP, MySQL, LDAP, AMQP -- where each message is preceded by a
+count of \fIWIDTH\fR bytes, 1 to 4, most significant first with
+\fBbig\fR and last with \fBlittle\fR.
+.sp
+Under \fBlength\fR the driver assembles a whole message before anything
+looks at it: an \fBexpect\fR matches the start of the MESSAGE rather
+than of whatever has arrived so far, a match consumes the message and
+its count together, and a payload containing a newline is data like any
+other byte. A message longer than 32 KB fails by name rather than being
+buffered.
+.sp
+\fBterminator\fR is for everything else, and for protocols of your own:
+a message ends at \fISEQUENCE\fR wherever that falls -- a NUL, a blank
+line, a sentinel you chose. It is not \fBuntil\fR: \fBuntil\fR
+compares the start of a LINE, so a terminator that does not fall on a
+line boundary is invisible to it, and a payload with newlines inside is
+not line-shaped at all.
+.br
+.sp
+.nf
+\&   framing terminator "\ex00"        NUL\-terminated records
+\&   framing terminator "\er\en\er\en"    a blank line ends the message
+\&   framing terminator "<END>"       a sentinel of your own
+.fi
+.sp
+It describes the connection, not one reply, so it is written once as an
+entry attribute. \fBuntil\fR and \fBexpect bytes(\fR\fIN\fR\fB)\fR are
+refused under it: the count has already said where the message ends, and
+a second answer could only agree or contradict.
+
 .IP "\fBtransport\fR \fBtcp\fR"
 Which probe runs this entry. Only \fBtcp\fR is implemented; naming
 anything else refuses the entry rather than silently running it as tcp.
@@ -379,40 +434,40 @@ not against any host's depth. Under \fBok=greeting\fR everything
 downstream is legitimately unreachable, and the checks do not know that.
 
 .SH CONVENTIONS
-The parser accepts an attribute anywhere in a block, ignores indentation,
-takes several actions and several waits in one state, and accepts an
-\fBexpect\fR that names no target. None of what follows is enforced by
-it; it is how every entry in this page and in the shipped protocols.cfg
-is written, and what a reader is entitled to assume:
+An entry that uses states is written one way, and most of it is now
+refused when the file is read rather than left to surprise somebody:
 .br
 .sp
 .nf
-\&   1  entry attributes -- options, port, transport, start -- come
-\&      before the first state, in any order among themselves
+\&   1  entry attributes -- options, port, transport, framing, start --
+\&      come before the first state, in any order among themselves
 \&   2  a state's lines are indented under it
 \&   3  a state holds at most one action: send, starttls, credentials
 \&   4  every expect names where it goes: "\-> TARGET"
 \&   5  a clock -- timeout or idle -- is written above the expects it
 \&      bounds, because it arms the wait that FOLLOWS it
+\&   6  a message boundary is stated, never guessed: a terminator with
+\&      "until", a count with "framing length", or the close with "eof"
 .fi
 .sp
-Rule 5 is the one that bites: a clock written below a state's
-\fBexpect\fR lines bounds nothing, and nothing says so. The others are
-legibility -- an entry written this way reads as the machine it
-describes, and one that is not still runs.
+Rules 3, 4 and 5 are refusals, and so is a state that acts again after it
+has waited -- that is a second wait in one state, and nothing could name
+the state it failed in. So is a state named \fBsuccess\fR, \fBwarning\fR
+or \fBfail\fR: an edge naming one of those declares a verdict rather than
+jumping, so such a state could never be reached. So is a second
+\fBoptions\fR line, which replaces the first rather than adding to it,
+and \fBuntil\fR or \fBas\fR on an entry the driver does not run, where
+they would do nothing at all.
 .sp
-A definition that means to break a rule says so, with a comment the
-parser ignores and a reader does not:
-.br
+Rules 1 and 2 are not enforced: the parser takes an attribute anywhere in
+the block and ignores indentation entirely. They are how every entry in
+this page and in the shipped protocols.cfg is written, and the regression
+suite checks them, so the page and the files cannot drift apart
+unnoticed.
 .sp
-.nf
-\&   [legacy]
-\&      # conventions: permissive -- one expect, no state to move to
-.fi
-.sp
-The regression suite checks every entry in this page, in the shipped
-protocols.cfg and in the test fixtures against these five rules, so the
-page and the files cannot drift apart unnoticed.
+None of this applies to the classic shapes -- a lone \fBsend\fR, a lone
+\fBexpect\fR, or a \fBsend\fR followed by an \fBexpect\fR -- which have
+no states and keep the probe they have always used.
 
 .SH EXAMPLES
 An SMTP service that upgrades to TLS when the server offers it, reports
@@ -474,7 +529,7 @@ it, so a clock written below the \fBexpect\fR lines bounds nothing.
 Keep it above them, as every example here does.
 .sp
 The entry attributes -- \fBoptions\fR, \fBport\fR, \fBtransport\fR,
-\fBstart\fR -- describe the definition rather than any step, so they
+\fBframing\fR, \fBstart\fR -- describe the definition rather than any step, so they
 are written together at the top, in any order among themselves.
 .sp
 This is deliberately a service of its own rather than a deeper
@@ -500,6 +555,22 @@ names the service. The ones worth knowing:
 \&   state 'NAME' has no way to finish   no path from it to a terminal
 \&   state 'NAME' waits for a reply with no timeout
 \&   'expect "A"' and 'expect "B"' overlap - both match the same reply
+\&   'expect bytes(N)' shares a state with another expect
+\&   'expect bytes(N) until ...' - a frame already ends the reply
+\&   'expect bytes(N)' is outside 1..32768
+\&   'until' under framing length/terminator
+\&   'expect bytes(N)' under framing length/terminator
+\&   'framing terminator' needs a quoted sequence
+\&   framing length width is 1..4 bytes
+\&   framing length endianness is 'big' or 'little'
+\&   framed message of N bytes is over the 32768 a conversation may hold
+\&   state 'NAME' has more than one action
+\&   state 'NAME' acts again after it has waited
+\&   state 'NAME' sets a clock below its expects, where it bounds nothing
+\&   state 'NAME' has an expect with no '-> TARGET'
+\&   state 'NAME' takes a name reserved for a verdict
+\&   a second 'options' line - options replaces rather than adds
+\&   'until'/'as' on an entry the dialogue driver does not run
 \&   ${NAME} is never captured or bound before it is used
 \&   'NAME ~ ...' tests a value that is never bound before it
 \&   'NAME ~ "..." as X' has no capture group

--- a/xymonnet/xymonnet.c
+++ b/xymonnet/xymonnet.c
@@ -720,6 +720,19 @@ void load_tests(void)
 					if (option) *(option-1) = ':';
 				}
 
+				/*
+				 * ok= and cred= are strdup'd while the options are read,
+				 * and handed to the test below. A testspec naming a
+				 * service we do not have never reaches that, so free them
+				 * here rather than losing them once per unknown test per
+				 * host, on every reload.
+				 */
+				if (!s) {
+					if (okstates) xfree(okstates);
+					if (credname) xfree(credname);
+					okstates = credname = NULL;
+				}
+
 				if (s) {
 					testitem_t *newtest;
 


### PR DESCRIPTION
TCP says nothing about where a message ends; a protocol states it in one of three ways, and until now only one of them was expressible.

- `expect bytes(N)` — a frame decided by length, waiting for exactly N bytes
- `framing length(W, big|little)` — the peer sends a count, then that many bytes: DNS-over-TCP, MySQL, LDAP, AMQP
- `framing terminator "SEQ"` — a sequence ends the message wherever it falls, for a protocol of your own
- and the seven misshapen state layouts the manual only *asked* for are refused when the file is read

**And the two fixes that make those work on the data they exist for.** A bound value was stored with `strdup()`, so a reply carrying a NUL — which is every message these protocols send — was cut at the first one: `${name}` expanded to the stump, a regex saw only what preceded it, and nothing said so. The probe compared almost nothing and reported **green**. The length is now carried with the value through storage, expansion, matching, capture and the wipe that clears a password.

That fix rewrites the subject copy in `dlg_capture()`, which is the copy the use-after-free fix introduced, so the two travel together rather than the fix trailing the feature it repairs.

`dialogue-nul.sh` drives four peers with the same twelve bytes `AB\0CDEFGHIJK`. Reverted, the peer records `shortbytes 2 4142` and all three green entries go red.

---
### Stack

**12 of 15** in the dialogue stack: base #480, next #482. The full chain is listed in #457; read bottom-up.

