### PR TITLE
xymonnet: ignore PREFIX, for servers that speak unprompted

### DIFF
--- a/docs/design/protocol-dialogues.md
+++ b/docs/design/protocol-dialogues.md
@@ -17,10 +17,11 @@ entry rather than deleting it.
 
 ```
 [service|alias]
-   transport tcp          entry attributes: transport, port, options, framing and start
+   transport tcp          entry attributes: transport, port, options, framing, ignore and start
    port N                 set properties of the definition, in any order
    options ssl,banner     among themselves
    framing line           how a message ends on this connection
+   ignore "* "            a message the server sends unprompted
    start NAME
 
    state NAME             names the state that follows, and is what an
@@ -40,7 +41,7 @@ condition ::= expect "…" [ until "…" ] [ as NAME ] | expect bytes(N) | NAME 
 
 **Targets** are a state, or one of `success`, `warning`, `fail` -- green, yellow, red. `warning` is the point: a server answering correctly but refusing an optional capability is not down, and calling it down teaches operators to ignore the column. An edge saying `fail` is red whatever `--checkresponse` is set to; a reply matching no alternative takes that option's colour, yellow by default.
 
-**Layout.** Entry attributes -- `transport`, `port`, `options`, `framing`, `start` -- are written first, in any order among themselves, because they describe the definition rather than any step; then each `state` with its lines indented under it.
+**Layout.** Entry attributes -- `transport`, `port`, `options`, `framing`, `ignore`, `start` -- are written first, in any order among themselves, because they describe the definition rather than any step; then each `state` with its lines indented under it.
 
 **One action, one wait.** A state does one thing -- a `send`, a `starttls`, a `credentials` -- and waits for one answer: the clock that bounds the wait, and the `expect` lines that end the state, each naming where its answer leads. A state that acts without waiting leaves on `always`; a state that decides on a value already bound needs no action at all. Because a state holds one action and one wait, the order of its lines carries no meaning of its own: the entry is declarative down to the state, and sequence lives in the edges between states rather than in the lines within one.
 
@@ -230,6 +231,8 @@ The behaviour itself is documented in `protocols.cfg(5)`, which ships with the c
 **Why the graph checks are worth having, and how they mislead.** Three mistakes are properties of the graph rather than of any line: a state with no path to a terminal, an unreachable state, and a waiting state with no timer. All three are easy to implement too permissively, so they report nothing and look like they work -- reachability cannot simply follow the step list, and on the branch a `timeout(N) -> fail` edge briefly counted as ending the flow, which called every state after it unreachable. They are topology checks and should not be oversold: the bugs that cost time here are framing, partial reads and TLS transitions, and no topology check sees those.
 
 **What is not built.** Graph export (`--graph`) is deferred. A named state improves a failure from "step 7" to `state send-pass expected "235"`, and that is not enough: the faults that cost time are *why* it did not match -- bytes retained from the previous state, a reply matched before it was complete, a name that bound empty. A transcript mode is part of the feature and is **not implemented**. Nor is the marking it would require: `${password}` is expanded into a `send`, so the sent bytes, the buffer and anything an `as` binds may contain it. A value from `credentials.cfg` would have to be marked at binding time, stay marked through `${base64:}` and `${md5:}` -- an encoded secret is still the secret, and an APOP digest only looks opaque -- and be replaced by a placeholder in every output. The code wipes secrets from memory after use and no more, which is why it has no transcript to leak them into.
+
+**Not every message is an answer.** A protocol may speak unprompted -- IMAP's untagged lines, NNTP notices -- and a state waiting for a tagged reply would read one, fail to match it, and report a healthy server as broken. Fail-fast makes this worse rather than better: the faster the probe rules an answer out, the sooner it is wrong. `ignore PREFIX` says such a message is not an answer, so it is consumed and the wait continues. It could already be written as a self-loop on an action-less state, at the cost of an extra state per wait and a copy of every alternative in it; noise is a property of the protocol, so it belongs on the entry beside `framing`. An ignored prefix that also starts an `expect` is refused -- the same ambiguity as two overlapping alternatives, decidable by the same argument. What it deliberately does not do is stop the clock: `idle` counts bytes and is satisfied by noise, `timeout` counts the wait and is not, so a server that says nothing but noise still fails.
 
 **Three framings, because there are three ways a message ends.** `line` is the greeting protocols and `until` says where a multi-line *reply* stops within them. `length(W, endian)` is the protocols that count. `terminator "SEQ"` is everything else, and the one that makes a protocol of your own expressible: a message ends at a byte sequence wherever it falls, which `until` cannot say because it compares the start of a line. A custom protocol that ends records with a NUL, or with a blank line, or with a sentinel, needs no code -- it needs one attribute. What is deliberately absent is a read-granularity switch: how much the driver reads in one go changes no verdict, because matching is prefix-anchored and re-evaluated at every arrival, and consuming only the matched bytes is in the rejected list for breaking the ambiguity check.
 

--- a/docs/manpages/man5/protocols.cfg.5.html
+++ b/docs/manpages/man5/protocols.cfg.5.html
@@ -189,11 +189,10 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
         expected 334&quot; tells an operator what &quot;step 7&quot; does
       not.</p>
     <p class="Pp"><b>Layout.</b> An entry that uses states is written the same
-        way throughout this page: the entry attributes -- <b>options</b>,
-        <b>port</b>, <b>transport</b>, <b>framing</b>, <b>start</b> -- first, in
-        any order among themselves, because they describe the definition rather
-        than any step; then the states, each with its lines indented under
-      it.</p>
+        way throughout this page: the entry attributes -- ?Boptions?R, ?Bport?R,
+        ?Btransport?R, ?Bframing?R, ?Bignore?R, ?Bstart?R -- first, in any order
+        among themselves, because they describe the definition rather than any
+        step; then the states, each with its lines indented under it.</p>
     <p class="Pp">A state does one thing and waits for one answer: at most one
         action -- a <b>send</b>, a <b>starttls</b>, a <b>credentials</b> -- the
         clock that bounds the wait, and the <b>expect</b> lines that end the
@@ -354,6 +353,32 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
         expands to nothing.</p>
     <p class="Pp"></p>
   </dd>
+  <dt id="ignore"><a class="permalink" href="#ignore"><b>ignore</b>
+    <i>PREFIX</i></a></dt>
+  <dd>A message the server sends unprompted. IMAP emits untagged &quot;*&quot;
+      lines whenever it likes -- an EXISTS, an EXPUNGE, a BYE warning -- and
+      NNTP and XMPP have their own. A probe waiting for a tagged reply would
+      read one of those, fail to match it, and report a server that is behaving
+      exactly as its RFC says.
+    <p class="Pp">A message whose start matches <i>PREFIX</i> is consumed and
+        the wait continues. It is not an answer: it decides nothing, ends no
+        state and binds nothing. It did arrive, so <b>idle</b> is satisfied by
+        it, while <b>timeout</b> keeps running -- a server that says nothing but
+        noise still runs out of time.</p>
+    <p class="Pp">Up to eight may be given, one per line. Like <b>framing</b> it
+        describes the connection rather than one reply, so it is written on the
+        entry.</p>
+    <p class="Pp"></p>
+    <pre>   [imap]
+      ignore &quot;* &quot;
+      port 143</pre>
+    <p class="Pp">A prefix that also starts an <b>expect</b> is refused when the
+        file is read: the reply would be swallowed as noise or taken as the
+        answer, and nothing in the file would say which. That is the same
+        ambiguity, and the same completeness argument, as two overlapping
+        alternatives.</p>
+    <p class="Pp"></p>
+  </dd>
   <dt id="framing"><a class="permalink" href="#framing"><b>framing</b>
     <b>line</b></a></dt>
   <dd></dd>
@@ -455,7 +480,7 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
 <p class="Pp">An entry that uses states is written one way, and most of it is
     now refused when the file is read rather than left to surprise somebody:</p>
 <p class="Pp"></p>
-<pre>   1  entry attributes -- options, port, transport, framing, start --
+<pre>   1  entry attributes -- options, port, transport, framing, ignore, start --
       come before the first state, in any order among themselves
    2  a state's lines are indented under it
    3  a state holds at most one action: send, starttls, credentials
@@ -530,10 +555,10 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     been taught: a <b>timeout</b> or <b>idle</b> arms the wait that follows it,
     so a clock written below the <b>expect</b> lines bounds nothing. Keep it
     above them, as every example here does.</p>
-<p class="Pp">The entry attributes -- <b>options</b>, <b>port</b>,
-    <b>transport</b>, <b>framing</b>, <b>start</b> -- describe the definition
-    rather than any step, so they are written together at the top, in any order
-    among themselves.</p>
+<p class="Pp">The entry attributes -- ?Boptions?R, ?Bport?R, ?Btransport?R,
+    ?Bframing?R, ?Bignore?R, ?Bstart?R -- describe the definition rather than
+    any step, so they are written together at the top, in any order among
+    themselves.</p>
 <p class="Pp">This is deliberately a service of its own rather than a deeper
     <b>[smtp]</b>. protocols.cfg is one file for the whole installation, so
     teaching <b>[smtp]</b> to expect STARTTLS would change what every existing
@@ -564,6 +589,9 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
    'until' under framing length/terminator
    'expect bytes(N)' under framing length/terminator
    'framing terminator' needs a quoted sequence
+   'ignore' needs a quoted prefix
+   more than 8 'ignore' prefixes
+   'ignore
    framing length width is 1..4 bytes
    framing length endianness is 'big' or 'little'
    framed message of N bytes is over the 32768 a conversation may hold

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -1346,6 +1346,49 @@ char *init_tcp_services(void)
 				walk->rec->startlabel = strdup(nm);
 			}
 		}
+		else if (strncmp(l, "ignore ", 7) == 0) {
+			/*
+			 * Some protocols speak unprompted. IMAP sends untagged "* ..."
+			 * lines whenever it likes, NNTP and XMPP have their own. A
+			 * probe waiting for a tagged reply would read one of those as
+			 * the answer, not match it, and fail fast on a server that is
+			 * behaving correctly.
+			 *
+			 * It is a property of the protocol rather than of one state,
+			 * so it is written once on the entry, like framing.
+			 */
+			if (first) {
+				unsigned char *t = NULL;
+				int tlen = 0;
+				svclist_t *w;
+
+				getescapestring(skipwhitespace(l + 6), &t, &tlen);
+				if (!t || (tlen < 1)) {
+					errprintf("Service %s: 'ignore' needs a quoted prefix\n",
+						  first->rec->svcname);
+					first->rec->flags |= TCP_DIALOGUE_BROKEN;
+					if (t) xfree(t);
+				}
+				else if (first->rec->ignorecount >= 8) {
+					errprintf("Service %s: more than 8 'ignore' prefixes\n",
+						  first->rec->svcname);
+					first->rec->flags |= TCP_DIALOGUE_BROKEN;
+					xfree(t);
+				}
+				else {
+					for (w = first; (w); w = w->next) {
+						int k = w->rec->ignorecount;
+
+						w->rec->ignoretext[k] = (unsigned char *)malloc(tlen + 1);
+						memcpy(w->rec->ignoretext[k], t, tlen);
+						w->rec->ignoretext[k][tlen] = '\0';
+						w->rec->ignorelen[k] = tlen;
+						w->rec->ignorecount = k + 1;
+					}
+					xfree(t);
+				}
+			}
+		}
 		else if (strncmp(l, "framing ", 8) == 0) {
 			/*
 			 * How a message ends on this connection, which the socket
@@ -1585,6 +1628,8 @@ char *init_tcp_services(void)
 	/* Copy from the svclist to svcinfo table */
 	svcinfo = (svcinfo_t *) malloc((svccount+1) * sizeof(svcinfo_t));
 	for (walk=head, i=0; (walk && (i < svccount)); walk = walk->next, i++) {
+		int j;
+
 		svcinfo[i].svcname = walk->rec->svcname;
 		svcinfo[i].sendtxt = walk->rec->sendtxt;
 		svcinfo[i].sendlen = walk->rec->sendlen;
@@ -1599,6 +1644,11 @@ char *init_tcp_services(void)
 		svcinfo[i].framebig   = walk->rec->framebig;
 		svcinfo[i].frameterm    = walk->rec->frameterm;
 		svcinfo[i].frametermlen = walk->rec->frametermlen;
+		for (j = 0; j < 8; j++) {
+			svcinfo[i].ignoretext[j] = walk->rec->ignoretext[j];
+			svcinfo[i].ignorelen[j]  = walk->rec->ignorelen[j];
+		}
+		svcinfo[i].ignorecount = walk->rec->ignorecount;
 		svcinfo[i].steps   = walk->rec->steps;
 		svcinfo[i].startlabel = walk->rec->startlabel;
 		/*
@@ -1645,7 +1695,7 @@ char *init_tcp_services(void)
 			 * single-shot probe cannot express.
 			 */
 			if ((first_is_expect && (nsend > 0)) || (nsend > 1) || (nexp > 1) || nother ||
-			    (svcinfo[i].framing != FRAMING_LINE))
+			    (svcinfo[i].framing != FRAMING_LINE) || (svcinfo[i].ignorecount > 0))
 				svcinfo[i].flags |= TCP_DIALOGUE;
 
 			/*
@@ -1677,6 +1727,35 @@ char *init_tcp_services(void)
 			check_undefined_vars(&svcinfo[i]);
 			refuse_overlapping_groups(&svcinfo[i]);
 			refuse_misshapen_states(&svcinfo[i]);
+
+			/*
+			 * An ignored prefix and an expect that share a start are the
+			 * same ambiguity the overlap check refuses between two
+			 * expects: the reply would be swallowed as noise or taken as
+			 * the answer, and nothing in the file says which. Prefix
+			 * matching makes that decidable here.
+			 */
+			if (svcinfo[i].ignorecount > 0) {
+				svcstep_t *est;
+				int g;
+
+				for (est = svcinfo[i].steps; (est); est = est->next) {
+					if ((est->type != STEP_EXPECT) || est->oneof || est->wantbytes) continue;
+					for (g = 0; g < svcinfo[i].ignorecount; g++) {
+						int n = (est->len < svcinfo[i].ignorelen[g]) ?
+							est->len : svcinfo[i].ignorelen[g];
+
+						if ((n > 0) && (memcmp(est->text, svcinfo[i].ignoretext[g], n) == 0)) {
+							errprintf("Service %s: 'ignore \"%.20s\"' and 'expect \"%.20s\"' "
+								  "share a start - a reply would be swallowed as noise "
+								  "or taken as the answer, and the file does not say "
+								  "which\n", svcinfo[i].svcname,
+								  svcinfo[i].ignoretext[g], est->text);
+							svcinfo[i].flags |= TCP_DIALOGUE_BROKEN;
+						}
+					}
+				}
+			}
 
 			/*
 			 * A clause that only the driver implements, on an entry that

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -126,6 +126,15 @@ typedef struct svcinfo_t {
 	int framebig;		/* FRAMING_LENGTH: 1 big-endian, 0 little-endian */
 	unsigned char *frameterm;	/* FRAMING_TERM: the sequence that ends a message */
 	int frametermlen;
+	/*
+	 * "ignore TEXT": a message the server sends unprompted. IMAP's untagged
+	 * lines, NNTP notices, anything a protocol may say while the client is
+	 * waiting for something else. Such a message is consumed and the wait
+	 * continues, rather than being read as the answer that never came.
+	 */
+	unsigned char *ignoretext[8];
+	int ignorelen[8];
+	int ignorecount;
 	svcstep_t *steps;	/* NULL unless TCP_DIALOGUE */
 	char *startlabel;	/* 'start NAME': where the dialogue begins */
 	svcstep_t *startstep;	/* ... resolved after parsing */

--- a/tests/network/dialogue-async.sh
+++ b/tests/network/dialogue-async.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# A server that speaks when it was not spoken to.
+#
+# IMAP sends untagged "* ..." lines whenever it likes -- an EXISTS, an
+# EXPUNGE, a BYE warning -- and NNTP and XMPP have their own. A probe
+# waiting for a tagged reply reads one of those, does not match it, and
+# fails at once: correct by the rules of the grammar, wrong about the
+# server, which was behaving exactly as its RFC says.
+#
+# "ignore PREFIX" says such a message is not an answer. It is consumed and
+# the wait continues.
+#
+# THE CONTROL is [noisyplain]: the same peer, the same conversation, without
+# the ignore line. It must go red -- if both pass, the ignore is doing
+# nothing and this suite would pass with the feature removed.
+#
+# The second control is [quiet]: a peer that sends no untagged lines at all,
+# against an entry that ignores them. Ignoring must not swallow the answer
+# when there is no noise to skip.
+
+set -eu
+. "$(dirname "$0")/../lib/assert.sh"
+root=$(find_root)
+
+require_bin XYMONNET xymonnet/xymonnet
+require_cc
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc"
+
+"$CC" -o "$work/peer" "$root/tests/lib/dialogue-peer.c" -lssl -lcrypto 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; skip "dialogue-peer does not compile"; }
+
+# Untagged chatter before the greeting, and again before the tagged reply.
+printf '%s\n' 'send * OK [CAPABILITY IMAP4rev1] ready\r\n' \
+	      'send A01 OK ready\r\n' \
+	      'recvany' \
+	      'send * 3 EXISTS\r\n' \
+	      'send * 1 RECENT\r\n' \
+	      'send A02 OK CAPABILITY completed\r\n' \
+	      'hold 20'                                    > "$work/noisy.script"
+printf '%s\n' 'send A01 OK ready\r\n' \
+	      'recvany' \
+	      'send A02 OK CAPABILITY completed\r\n' \
+	      'hold 20'                                    > "$work/quiet.script"
+
+: > "$work/pids"
+start() {	# script portfile obsfile
+	"$work/peer" "$1" "$3" > "$2" &
+	echo $! >> "$work/pids"
+	local i=0
+	while [ "$i" -lt 50 ]; do [ -s "$2" ] && break; sleep 0.1; i=$((i + 1)); done
+	cat "$2"
+}
+pnoisy=$(start "$work/noisy.script" "$work/p1" "$work/o1")
+pplain=$(start "$work/noisy.script" "$work/p2" "$work/o2")
+pquiet=$(start "$work/quiet.script" "$work/p3" "$work/o3")
+register_cleanup "kill $(tr '\n' ' ' < "$work/pids") 2>/dev/null || :"
+[ -n "$pnoisy" ] && [ -n "$pplain" ] && [ -n "$pquiet" ] || fail "a peer never named its port"
+
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[noisyok]
+   options banner
+   ignore "* "
+   port $pnoisy
+
+   state greeting
+      timeout(10)                 -> fail
+      expect "A01 OK"             -> ask
+
+   state ask
+      send "A02 CAPABILITY\r\n"
+      timeout(10)                 -> fail
+      expect "A02 OK"             -> success
+
+[noisyplain]
+   options banner
+   port $pplain
+
+   state greeting
+      timeout(5)                  -> fail
+      expect "A01 OK"             -> ask
+
+   state ask
+      send "A02 CAPABILITY\r\n"
+      timeout(5)                  -> fail
+      expect "A02 OK"             -> success
+
+[quiet]
+   options banner
+   ignore "* "
+   port $pquiet
+
+   state greeting
+      timeout(10)                 -> fail
+      expect "A01 OK"             -> ask
+
+   state ask
+      send "A02 CAPABILITY\r\n"
+      timeout(10)                 -> fail
+      expect "A02 OK"             -> success
+CFG
+{ printf '127.0.0.1\tn\t# noisyok\n127.0.0.1\tp\t# noisyplain\n127.0.0.1\tq\t# quiet\n'; } \
+	> "$work/home/etc/hosts.cfg"
+
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse=red \
+	--dns=ip --timeout=30 >"$work/out.txt" 2>&1 || :
+
+colour_of() { grep -oE "status\+[0-9]+ $1 (green|yellow|red|clear)" "$work/out.txt" | awk '{print $3}' | head -1; }
+
+[ "$(colour_of n.noisyok)" = green ] || fail \
+	"a server sending untagged lines before and during the exchange was not
+followed. Those lines are not answers, and a probe that reads one as the
+answer reports a working server as broken:
+$(head -25 "$work/out.txt")"
+
+# THE CONTROL: without 'ignore' the same peer must fail, or the line is inert
+[ "$(colour_of p.noisyplain)" = green ] && fail \
+	"the same peer passed without an 'ignore' line, so untagged messages are
+being skipped by something else and this suite proves nothing:
+$(grep -i noisyplain "$work/out.txt" | head -4)"
+
+# THE SECOND CONTROL: ignoring must not eat the answer when nothing is noisy
+[ "$(colour_of q.quiet)" = green ] || fail \
+	"a peer that sent no untagged lines failed against an entry that ignores
+them, so 'ignore' is consuming replies it was never meant to touch:
+$(grep -i quiet "$work/out.txt" | head -4)"
+
+# --- what the file may not say -----------------------------------------------
+cat > "$work/home/etc/protocols.cfg" <<CFG
+[collide]
+   ignore "A0"
+   port 1
+
+   state greeting
+      timeout(5)                  -> fail
+      expect "A01 OK"             -> success
+CFG
+printf '127.0.0.1\tc\t# collide\n' > "$work/home/etc/hosts.cfg"
+XYMONHOME="$work/home" "$XYMONNET" --no-update --noping --checkresponse=red \
+	--dns=ip --timeout=5 >"$work/bad.txt" 2>&1 || :
+
+grep -qi "share a start" "$work/bad.txt" || fail \
+	"an ignored prefix that also starts an expect was accepted. The reply
+would be swallowed as noise or taken as the answer, and nothing in the file
+says which:
+$(head -10 "$work/bad.txt")"
+
+pass "an unprompted message is skipped and the wait continues, and an ambiguous ignore is refused"

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -2357,6 +2357,44 @@ restartselect:
 										mlen  = (int)n;
 									}
 
+									/*
+									 * A message the server sends unprompted is
+									 * consumed here and the wait continues. It is
+									 * not an answer, so it decides nothing and binds
+									 * nothing -- but it did arrive, so the idle clock
+									 * has already been restarted by the read that
+									 * brought it, exactly as a wanted reply would.
+									 */
+									if (item->svcinfo->ignorecount > 0) {
+										int g, skipped = 0;
+
+										for (g = 0; g < item->svcinfo->ignorecount; g++) {
+											int n = item->svcinfo->ignorelen[g];
+
+											if (mlen < n) continue;
+											if (memcmp(item->stepbuf + mbase,
+												   item->svcinfo->ignoretext[g], n) != 0) continue;
+
+											{
+												int cut = mbase + mlen;
+
+												if (item->svcinfo->framing == FRAMING_LINE) {
+													cut = mbase;
+													while ((cut < item->stepbuflen) &&
+													       (item->stepbuf[cut] != '\n')) cut++;
+													if (cut < item->stepbuflen) cut++;
+													else break;	/* a partial line is not a message yet */
+												}
+												memmove(item->stepbuf, item->stepbuf + cut,
+													item->stepbuflen - cut);
+												item->stepbuflen -= cut;
+												skipped = 1;
+											}
+											break;
+										}
+										if (skipped) { progress = 1; continue; }
+									}
+
 									/* Consecutive expects are alternatives of ONE state. */
 									for (alt = st; (alt && (alt->type == STEP_EXPECT)); alt = alt->next) {
 										if (alt->oneof) continue;	/* only fires on EOF */

--- a/xymonnet/protocols.cfg.5
+++ b/xymonnet/protocols.cfg.5
@@ -176,8 +176,7 @@ the state it failed in, and
 does not.
 .sp
 \fBLayout.\fR An entry that uses states is written the same way
-throughout this page: the entry attributes -- \fBoptions\fR,
-\fBport\fR, \fBtransport\fR, \fBframing\fR, \fBstart\fR -- first, in any order
+throughout this page: the entry attributes -- BoptionsR, BportR, BtransportR, BframingR, BignoreR, BstartR -- first, in any order
 among themselves, because they describe the definition rather than any
 step; then the states, each with its lines indented under it.
 .sp
@@ -341,6 +340,34 @@ Expansion is recursive, so a digest may be taken of other values -- APOP
 is \fB${md5:${challenge}${password}}\fR. An unset name expands to
 nothing.
 
+.IP "\fBignore\fR \fIPREFIX\fR"
+A message the server sends unprompted. IMAP emits untagged "*" lines
+whenever it likes -- an EXISTS, an EXPUNGE, a BYE warning -- and NNTP and
+XMPP have their own. A probe waiting for a tagged reply would read one of
+those, fail to match it, and report a server that is behaving exactly as
+its RFC says.
+.sp
+A message whose start matches \fIPREFIX\fR is consumed and the wait
+continues. It is not an answer: it decides nothing, ends no state and
+binds nothing. It did arrive, so \fBidle\fR is satisfied by it, while
+\fBtimeout\fR keeps running -- a server that says nothing but noise
+still runs out of time.
+.sp
+Up to eight may be given, one per line. Like \fBframing\fR it describes
+the connection rather than one reply, so it is written on the entry.
+.br
+.sp
+.nf
+\&   [imap]
+\&      ignore "* "
+\&      port 143
+.fi
+.sp
+A prefix that also starts an \fBexpect\fR is refused when the file is
+read: the reply would be swallowed as noise or taken as the answer, and
+nothing in the file would say which. That is the same ambiguity, and the
+same completeness argument, as two overlapping alternatives.
+
 .IP "\fBframing\fR \fBline\fR"
 .IP "\fBframing\fR \fBlength(\fR\fIWIDTH\fR\fB,\fR \fBbig\fR|\fBlittle\fR\fB)\fR"
 .IP "\fBframing\fR \fBterminator\fR \fISEQUENCE\fR"
@@ -439,7 +466,7 @@ refused when the file is read rather than left to surprise somebody:
 .br
 .sp
 .nf
-\&   1  entry attributes -- options, port, transport, framing, start --
+\&   1  entry attributes -- options, port, transport, framing, ignore, start --
 \&      come before the first state, in any order among themselves
 \&   2  a state's lines are indented under it
 \&   3  a state holds at most one action: send, starttls, credentials
@@ -528,8 +555,7 @@ been taught: a \fBtimeout\fR or \fBidle\fR arms the wait that follows
 it, so a clock written below the \fBexpect\fR lines bounds nothing.
 Keep it above them, as every example here does.
 .sp
-The entry attributes -- \fBoptions\fR, \fBport\fR, \fBtransport\fR,
-\fBframing\fR, \fBstart\fR -- describe the definition rather than any step, so they
+The entry attributes -- BoptionsR, BportR, BtransportR, BframingR, BignoreR, BstartR -- describe the definition rather than any step, so they
 are written together at the top, in any order among themselves.
 .sp
 This is deliberately a service of its own rather than a deeper
@@ -561,6 +587,9 @@ names the service. The ones worth knowing:
 \&   'until' under framing length/terminator
 \&   'expect bytes(N)' under framing length/terminator
 \&   'framing terminator' needs a quoted sequence
+\&   'ignore' needs a quoted prefix
+\&   more than 8 'ignore' prefixes
+\&   'ignore \"X\"' and 'expect \"Y\"' share a start
 \&   framing length width is 1..4 bytes
 \&   framing length endianness is 'big' or 'little'
 \&   framed message of N bytes is over the 32768 a conversation may hold


### PR DESCRIPTION
IMAP sends untagged `*` lines whenever it likes — an EXISTS, an EXPUNGE, a BYE warning — and NNTP and XMPP have their own. A state waiting for a tagged reply read one, failed to match it, and reported a server behaving exactly as its RFC says as down. Fail-fast made it worse: the faster an answer is ruled out, the sooner the probe is wrong about it.

`ignore PREFIX` says such a message is not an answer — consumed, deciding nothing, ending no state, binding nothing. `idle` is satisfied by it, `timeout` is not, so a server that says nothing but noise still runs out of time.

Up to eight prefixes, written on the entry beside `framing`, because noise is a property of the protocol rather than of one reply.

---
### Stack

**13 of 15** in the dialogue stack: base #481, next #483. The full chain is listed in #457; read bottom-up.

