### PR TITLE
xymonnet: send the tested hostname as the TLS server name

### DIFF
--- a/docs/manpages/man5/protocols.cfg.5.html
+++ b/docs/manpages/man5/protocols.cfg.5.html
@@ -102,7 +102,16 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     <pre>   banner - include received data in the status message
    ssl - service uses SSL so perform an SSL handshake
    telnet - service is telnet, so exchange telnet options
-   alpn=protocol1,protocol2 - specify ALPN protocols to negotiate during SSL handshake</pre>
+   alpn=protocol1,protocol2 - specify ALPN protocols to negotiate during SSL handshake
+   sni - send the tested hostname as the TLS server name</pre>
+    <p class="Pp"><b>sni</b> matters wherever one address serves several names.
+        A TLS server that is asked for no server name answers with its DEFAULT
+        certificate, so the expiry Xymon reports in the <b>sslcert</b> column is
+        that of whichever certificate the address happens to answer with, and
+        not the one the test is named for -- wrong, and indistinguishable from
+        right. The name tested is sent, never the address: RFC 6066 does not
+        allow an address literal in the server_name extension, so a host entered
+        in hosts.cfg by IP sends nothing even with the option set.</p>
     <p class="Pp"></p>
     <p class="Pp"></p>
   </dd>

--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -247,6 +247,7 @@ char *init_tcp_services(void)
 					else if (strncmp(opt, "alpn=", 5) == 0) {
 						first->rec->alpns = strdup(opt+5);
 					}
+					else if (strcmp(opt, "sni") == 0)    first->rec->flags |= TCP_SNI;
 					else errprintf("Unknown option: %s\n", opt);
 
 					opt = strtok(NULL, ",");

--- a/lib/netservices.h
+++ b/lib/netservices.h
@@ -19,6 +19,7 @@
 #define TCP_SSL        0x0004
 #define TCP_HTTP       0x0008
 #define TCP_ALPN       0x0010
+#define TCP_SNI        0x0020	/* send the tested hostname as the SNI server name */
 
 typedef struct svcinfo_t {
 	char *svcname;

--- a/tests/network/sni-support.sh
+++ b/tests/network/sni-support.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/network/sni-support.sh
+#
+# Guard for the xymonnet SNI support: `options sni` on a protocols.cfg entry
+# sends the tested hostname as the TLS server name.
+#
+# Without it, a host serving several names on one address answers a handshake
+# that carries no server name with its DEFAULT certificate -- so the expiry
+# reported in the sslcert column belongs to whichever certificate that address
+# answers with, not to the name the test is for. It is wrong quietly, which is
+# the worst way for a monitoring system to be wrong.
+#
+# The wiring spans three layers:
+#   - lib/netservices.h : the TCP_SNI flag,
+#   - lib/netservices.c : parsing the `sni` option into the service flags,
+#   - xymonnet/xymonnet.c: handing the tested hostname to the test, which
+#     setup_ssl() then passes to SSL_set_tlsext_host_name().
+#
+# Exercising it for real needs a TLS server holding two certificates and
+# selecting on the server name; the build CI already compiles these files, so
+# this is a static guard that the wiring across the layers (and the manpage)
+# survives future edits -- the same tradeoff tests/network/alpn-support.sh
+# makes for ALPN. Skips only when the source files are absent (e.g. an
+# autopkgtest run against an installed package with no source tree); a present
+# tree that has lost the wiring is a regression and fails rather than skipping.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+HDR="$ROOT/lib/netservices.h"
+SRC="$ROOT/lib/netservices.c"
+NET="$ROOT/xymonnet/xymonnet.c"
+SSL="$ROOT/xymonnet/contest.c"
+MAN="$ROOT/xymonnet/protocols.cfg.5"
+
+for f in "$HDR" "$SRC" "$NET" "$SSL" "$MAN"; do
+	[ -f "$f" ] || skip "$(basename "$f") absent"
+done
+
+# header: the flag the option sets
+assert_contains "TCP_SNI" "$(cat "$HDR")" "netservices.h lost the TCP_SNI flag"
+
+# parser: the bare `sni` option must set that flag. Pin the assignment rather
+# than grepping for the word: "sni" appears in comments and in the manpage
+# reference, so a bare match stays green after the parsing is deleted.
+grep -Eq '"sni"\)[[:space:]]*==[[:space:]]*0\)[[:space:]]*first->rec->flags[[:space:]]*\|=[[:space:]]*TCP_SNI' "$SRC" \
+	|| fail "netservices.c no longer parses the 'sni' option into TCP_SNI"
+
+# xymonnet: the flag must actually put the tested hostname on the test.
+# Assigning anything else -- or assigning unconditionally -- is the bug this
+# guards, so pin both the flag test and the hostname being the value stored.
+grep -Eq 'flags[[:space:]]*&[[:space:]]*TCP_SNI' "$NET" \
+	|| fail "xymonnet.c no longer checks TCP_SNI before setting the server name"
+grep -Eq 'tt->sni[[:space:]]*=[[:space:]]*t->host->hostname' "$NET" \
+	|| fail "xymonnet.c no longer hands the tested hostname to the handshake"
+
+# RFC 6066: an address literal is not a legal server_name, and a server that
+# enforces it aborts the handshake. Sending one would turn a cosmetic gap into
+# an outage, so the guard against it is part of the contract, not a nicety.
+grep -Eq 'sni_name_is_address' "$NET" \
+	|| fail "xymonnet.c no longer refuses to send an address literal as the server name"
+
+# contest.c: the stored name must still reach OpenSSL.
+grep -Eq 'SSL_set_tlsext_host_name\(item->ssldata, item->sni\)' "$SSL" \
+	|| fail "contest.c no longer passes the server name to OpenSSL"
+
+# the manpage documents the option
+assert_contains "sni - send the tested hostname" "$(cat "$MAN")" \
+	"protocols.cfg.5 does not document the sni option"
+
+pass "options sni sends the tested hostname as the TLS server name, and never an address literal"

--- a/xymonnet/protocols.cfg.5
+++ b/xymonnet/protocols.cfg.5
@@ -80,7 +80,17 @@ Defines test options. The possible options are
 \&   ssl - service uses SSL so perform an SSL handshake
 \&   telnet - service is telnet, so exchange telnet options
 \&   alpn=protocol1,protocol2 - specify ALPN protocols to negotiate during SSL handshake
+\&   sni - send the tested hostname as the TLS server name
 .fi
+.sp
+\fBsni\fR matters wherever one address serves several names. A TLS server
+that is asked for no server name answers with its DEFAULT certificate, so
+the expiry Xymon reports in the \fBsslcert\fR column is that of whichever
+certificate the address happens to answer with, and not the one the test is
+named for -- wrong, and indistinguishable from right. The name tested is
+sent, never the address: RFC 6066 does not allow an address literal in the
+server_name extension, so a host entered in hosts.cfg by IP sends nothing
+even with the option set.
 
 
 .SH FILES

--- a/xymonnet/xymonnet.c
+++ b/xymonnet/xymonnet.c
@@ -2046,6 +2046,25 @@ void send_sslcert_status(testedhost_t *host)
 
 	freestrbuffer(sslmsg);
 }
+/*
+ * A server_name extension must carry a name, never an address: RFC 6066 says
+ * so, and a server that enforces it aborts the handshake rather than ignoring
+ * the field. Tested by shape rather than with inet_pton(), so that no new
+ * header is needed on the platforms this builds for -- a legal hostname
+ * cannot be all digits and dots, because the last label cannot be numeric,
+ * and a colon appears only in an IPv6 literal.
+ */
+static int sni_name_is_address(const char *name)
+{
+	const char *p;
+
+	if (strchr(name, ':')) return 1;
+	for (p = name; (*p); p++) {
+		if (!isdigit((int)*p) && (*p != '.')) return 0;
+	}
+	return 1;
+}
+
 
 int main(int argc, char *argv[])
 {
@@ -2413,6 +2432,24 @@ int main(int argc, char *argv[])
 									   t->srcip,
 									   NULL, t->silenttest, NULL, 
 									   NULL, NULL, NULL);
+
+					/*
+					 * "options sni" sends the name being tested in the
+					 * handshake. Without it, a host serving several names
+					 * on one address answers with its DEFAULT certificate,
+					 * so the expiry reported in the sslcert column is that
+					 * of whichever certificate the address answers with --
+					 * not the one this test is named for. Wrong quietly,
+					 * and it reads as authoritative.
+					 */
+					{
+						tcptest_t *tt = (tcptest_t *)t->privdata;
+
+						if (tt && tt->svcinfo && (tt->svcinfo->flags & TCP_SNI) &&
+						    t->host->hostname && !sni_name_is_address(t->host->hostname)) {
+							tt->sni = t->host->hostname;
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## The problem

A TLS server asked for no server name answers with its **default** certificate.

`xymonnet` reads the certificate from the session to fill the `sslcert` column, so wherever one address serves several names, the expiry Xymon reports belongs to whichever certificate that address answers with — not to the name the test is for. The column looks authoritative and is wrong, which is the failure mode a monitoring system can least afford.

Nothing in `protocols.cfg` ever parsed an SNI name: `item->sni` was set only by the HTTP tests (`httptest.c`), so **no protocol probe has ever sent one** — neither `options ssl` nor a STARTTLS upgrade.

## The change

`options sni` hands the tested hostname to the test:

```
[imaps]
   options ssl,banner,sni
   port 993
```

| layer | change |
|---|---|
| `lib/netservices.h` | `TCP_SNI` flag |
| `lib/netservices.c` | parse the bare `sni` option, beside `alpn=` |
| `xymonnet/xymonnet.c` | set `tt->sni` from the tested hostname when the flag is set |

`setup_ssl()` is **untouched** — it already passes `item->sni` to `SSL_set_tlsext_host_name()`, so this only supplies the value the TLS code was already looking for.

## The address guard

The name is sent, never the address. RFC 6066 does not allow an address literal in a `server_name` extension, and a server that enforces it **aborts the handshake** rather than ignoring the field — so an unguarded version would turn a quiet reporting gap into a red test for anyone whose `hosts.cfg` entry is an IP. A host entered by address sends no server name even with the option set.

Tested by shape rather than `inet_pton()` so no new header is needed on the platforms this builds for: a legal hostname cannot be all digits and dots, because the last label cannot be numeric, and a colon appears only in an IPv6 literal.

## Blast radius

**No shipped entry enables it.** `smtps`, `imaps` and `pop3s` keep todays


**Overlaps with #488, and duplicates #458.** Two different problems:

- **#458 #459** in `xymonnet/xymonnet.c` — the same feature by a different design, opened three days before this one. That is a decision about which to keep, not a rebase: merging either makes the other's approach redundant.
- **#488** in `lib/netservices.c`, `lib/netservices.h`, `xymonnet/protocols.cfg.5` and the generated page. No line is claimed by both — the edits abut. This adds a single option-parsing line to `netservices.c`; #488 rewrites that file (+465/-44 on 371 lines), so the cheap resolution is to carry the one line into #488 rather than rebase this around it.
