### PR TITLE
tests: keep a test's temp path inside a unix socket path

### DIFF
--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -120,7 +120,7 @@ register_cleanup() {
 # path. Callers almost always use TMP=$(mktempdir), and command substitution
 # runs in a subshell: anything mktempdir appended to the cleanup array there
 # would die with the subshell, leaking the dir (this is exactly what used to
-# happen -- /tmp filled with xymon-test.* dirs). So rather than register a
+# happen -- /tmp filled with xt.* dirs). So rather than register a
 # per-dir cleanup from inside the subshell, every dir is stamped with this
 # process's PID and a single glob removal is registered once, below, in the
 # parent shell at source time. `$$` is the script's PID even inside $(...),
@@ -133,11 +133,19 @@ __XYMON_TESTS_TMPROOT=${__XYMON_TESTS_TMPROOT%/}
 # real dir (or worse). Shell-escape the fixed prefix with printf %q and
 # append the literal glob unquoted, so the path survives eval intact while
 # the trailing * still expands.
-__xymon_tests_tmpglob=$(printf '%q' "${__XYMON_TESTS_TMPROOT}/xymon-test.$$.")
+__xymon_tests_tmpglob=$(printf '%q' "${__XYMON_TESTS_TMPROOT}/xt.$$.")
 register_cleanup "rm -rf -- ${__xymon_tests_tmpglob}*"
 mktempdir() {
 	local d
-	d=$(mktemp -d "${__XYMON_TESTS_TMPROOT}/xymon-test.$$.XXXXXX") || fail "mktemp -d failed"
+	# "xt", not "xymon-test". This path becomes $XYMONTMP, and a test that
+	# starts xymond_rrd puts its cache-control socket under it -- which has to
+	# fit in sizeof(sun_path), 104 bytes on macOS. The runner nests this
+	# directory inside a per-run root, so on macOS, where TMPDIR is already a
+	# 49-character /var/folders path, the longer name put XYMONTMP at 93 bytes
+	# against a limit of 90 and the socket could not be bound. Six tests failed
+	# on it, and only in a full run: run one alone and the per-run level is not
+	# there. CI never saw it -- Linux allows 108 bytes and TMPDIR is /tmp.
+	d=$(mktemp -d "${__XYMON_TESTS_TMPROOT}/xt.$$.XXXXXX") || fail "mktemp -d failed"
 	printf '%s' "$d"
 }
 


### PR DESCRIPTION
Fixes #489.

## The problem

A test that starts `xymond_rrd` puts its cache-control socket under `$XYMONTMP`, and a unix socket path is capped by `sizeof(sun_path)` -- 104 bytes on macOS, 108 on Linux.

The runner nests each test's directory inside a per-run root. On macOS, where `$TMPDIR` is already a 49-character `/var/folders/...` path, that put `XYMONTMP` at 93 bytes against a limit of 90, and `xymond_rrd` said so:

```
Cannot set up cache-control socket: XYMONTMP is too long for a socket path
(94 characters; max 90 with this process ID)
```

Six tests failed on it, and only in a full run -- run one alone and the per-run level is not there:

- `tests/rrd/disk-unavailable-no-sample.sh`
- `tests/rrd/extproc-teardown-flush.sh`
- `tests/rrd/inode-unix-columns.sh`
- `tests/server/xymond-rrd-ctlsocket-path.sh`
- `tests/server/xymond-rrd-drophost.sh`
- `tests/web/showgraph-stale-filter.sh` (from #349)

CI cannot see it: Linux allows 108 bytes and its `TMPDIR` is `/tmp`, so it is nowhere near. The list grows on its own -- #349 added the sixth with nothing to indicate why it fails off-CI.

## The change

One name: `xymon-test.` -> `xt.` in `mktempdir()`. That is 9 bytes back, taking `XYMONTMP` from 93 to 85 against the 90-byte limit.

That is the whole fix. The per-run root keeps its name, so nothing else changes -- `tests/testsuite` and the disposal check that globs `xymon-run.*` are untouched.

## Why not more

An earlier version of this PR also shortened the run root and fell back to `/tmp` when `$TMPDIR` was over 60 characters. Both are dropped:

- **The extra headroom buys nothing measurable.** The 5 remaining bytes are only consumed by PID length, and it costs double (the name carries the PID, and the daemon's limit is reduced by the PID in the socket name). On macOS PIDs wrap at 99999, so 5 digits is the maximum -- exactly what is measured here. Linux has 7-digit PIDs but roughly 49 bytes of slack, so the platform with big PIDs is the one with room.
- **The `/tmp` fallback was actively wrong.** It would silently override a `TMPDIR` that someone set deliberately -- which is exactly the complaint in #445 about build files being left in `/tmp`, where setting `TMPDIR` is the stated workaround.

## Verified

With the run root name left as it is, so the nesting is what a full run really produces:

```
$ root=$(mktemp -d "$TMPDIR/xymon-run.XXXXXX")
$ TMPDIR=$root sh tests/rrd/disk-unavailable-no-sample.sh      PASS
$ TMPDIR=$root sh tests/rrd/extproc-teardown-flush.sh          PASS
$ TMPDIR=$root sh tests/rrd/inode-unix-columns.sh              PASS
$ TMPDIR=$root sh tests/server/xymond-rrd-ctlsocket-path.sh    PASS
$ TMPDIR=$root sh tests/server/xymond-rrd-drophost.sh          PASS
```

All five failed the same way before the change.

## Left alone

Two things noted in #489 are not fixed here, both about legibility rather than this bug: the failure is silent (`xymond-rrd-drophost.sh` exits 1 with no output when the socket cannot bind), and a test that cannot bind for path-length reasons should probably `skip` with a message rather than fail.
