### PR TITLE
tests: say what the noflap prefix guard licenses, not only what it forbids

### DIFF
--- a/tests/server/xymond-noflap-prefix.sh
+++ b/tests/server/xymond-noflap-prefix.sh
@@ -3,11 +3,16 @@
 #
 # tests/server/xymond-noflap-prefix.sh
 #
-# Regression guard for issue #293: the hosts.cfg "noflap=test1,test2,..." list
-# matched test names by prefix rather than by name, so a listed entry silently
-# covered every test whose name is a prefix of it. Among the 44 services in
-# xymonnet/protocols.cfg, 18 pairs collide this way -- "noflap=imaps" also
-# silenced imap, "noflap=ssh2" also silenced ssh, and so on.
+# Regression guard for issue #293, fixed in a18a3f5f5: the hosts.cfg
+# "noflap=test1,test2,..." list matches whole test names. Before that it used
+# strncmp() over the listed name's length, so an entry silently covered every
+# test whose name it is a prefix of -- "noflap=imaps" also silenced imap,
+# "noflap=ssh2" also silenced ssh.
+#
+# The prefix pairs themselves are permanent and commonplace -- imap/imaps,
+# ssh/ssh2, pop/pop3, ftp/ftps -- and harmless while this test passes. That is
+# what it licenses: a new service or alias may be a prefix of another name, and
+# does not need renaming to avoid one.
 #
 # isset_noflap() is static in xymond/xymond.c and xymond has no library form,
 # so the function is extracted from the real source at run time and compiled


### PR DESCRIPTION
Comment-only change to `tests/server/xymond-noflap-prefix.sh`. No code, no assertions touched.

## Why

The header opened with the bug in the present tense:

> the hosts.cfg "noflap=test1,test2,..." list **matched** test names by prefix rather than by name

so a reader met the broken behaviour before learning it was fixed (a18a3f5f5, #293). It then reported a count of service-name pairs that "collide this way" inside that same description, where it reads as a live hazard rather than as an ordinary property of names like `imap`/`imaps` and `ssh`/`ssh2`.

The practical cost: the guard answers a question it never stated. **May a new service or alias be a prefix of an existing name?** Yes — that is exactly what this test licenses. Reasoning from the bug description instead leads to the opposite conclusion, and to renaming things that need no renaming.

## What changed

- leads with the fix and the commit, so the state of the code comes before the history;
- puts the old behaviour unambiguously in the past ("Before that it used `strncmp()` …");
- gives the prefix pairs their own paragraph, stated as permanent and harmless while the test passes;
- ends with what the guard permits.

The counts are gone. The number of colliding pairs changes whenever `protocols.cfg` gains a service, so a figure in a comment goes stale silently and corrects nobody; naming a few of the pairs says the same thing and stays true.