### PR TITLE
xymonnet: check what allocations return, and copy escaped text by length

### DIFF
--- a/lib/netservices.c
+++ b/lib/netservices.c
@@ -218,7 +218,16 @@ char *init_tcp_services(void)
 			if (first) {
 				getescapestring(skipwhitespace(l+4), &first->rec->sendtxt, &first->rec->sendlen);
 				for (walk = first->next; (walk); walk = walk->next) {
-					walk->rec->sendtxt = strdup(first->rec->sendtxt);
+					/*
+					 * By length, not strdup(): getescapestring()
+					 * resolves \xNN, so the text may contain a NUL.
+					 * strdup() stops there while sendlen still says how
+					 * long it was, and contest.c writes sendlen bytes
+					 * out of the shorter copy.
+					 */
+					walk->rec->sendtxt = (unsigned char *)malloc(first->rec->sendlen + 1);
+					memcpy(walk->rec->sendtxt, first->rec->sendtxt, first->rec->sendlen);
+					walk->rec->sendtxt[first->rec->sendlen] = '\0';
 					walk->rec->sendlen = first->rec->sendlen;
 				}
 			}
@@ -227,7 +236,10 @@ char *init_tcp_services(void)
 			if (first) {
 				getescapestring(skipwhitespace(l+6), &first->rec->exptext, &first->rec->explen);
 				for (walk = first->next; (walk); walk = walk->next) {
-					walk->rec->exptext = strdup(first->rec->exptext);
+					/* As above: binary-safe, by length. */
+					walk->rec->exptext = (unsigned char *)malloc(first->rec->explen + 1);
+					memcpy(walk->rec->exptext, first->rec->exptext, first->rec->explen);
+					walk->rec->exptext[first->rec->explen] = '\0';
 					walk->rec->explen = first->rec->explen;
 					walk->rec->expofs = 0; /* HACK - not used right now */
 				}

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -288,6 +288,11 @@ static int do_telnet_options(tcptest_t *item)
 	}
 
 	obuf = (unsigned char *)malloc(item->telnetbuflen);
+	if (!obuf) {
+		errprintf("Out of memory negotiating telnet options\n");
+		item->telnetbuflen = 0;
+		return 0;
+	}
 	y = 0;
 	inp = item->telnetbuf;
 	remain = item->telnetbuflen;
@@ -300,8 +305,28 @@ static int do_telnet_options(tcptest_t *item)
 			 * We probably have the banner in the remainder of the
 			 * buffer, so copy it over, and return it.
 			 */
-			item->banner = strdup(inp);
-			item->bannerbytes = strlen(inp);
+			/*
+			 * Copy BEFORE freeing the old banner: item->telnetbuf IS
+			 * item->banner (the read arm aliases them), so inp points
+			 * into the buffer being replaced. Freeing first would leave
+			 * inp dangling and this copy would read freed memory.
+			 *
+			 * Replacing without freeing leaked the old buffer, which is
+			 * what stood here.
+			 */
+			{
+				unsigned char *newbanner = (unsigned char *)strdup((char *)inp);
+
+				if (!newbanner) {
+					errprintf("Out of memory keeping the telnet banner\n");
+				}
+				else {
+					if (item->banner) xfree(item->banner);
+					item->banner = newbanner;
+					item->bannerbytes = strlen((char *)newbanner);
+				}
+			}
+			item->telnetbuf = NULL;
 			item->telnetbuflen = 0;
 			xfree(obuf);
 			return 0;

--- a/xymonnet/contest.c
+++ b/xymonnet/contest.c
@@ -129,11 +129,23 @@ static int tcp_callback(unsigned char *buf, unsigned int len, void *priv)
 
 	tcptest_t *item = (tcptest_t *) priv;
 
-	if (item->banner == NULL) {
-		item->banner = (unsigned char *)malloc(len+1);
-	}
-	else {
-		item->banner = (unsigned char *)realloc(item->banner, item->bannerbytes+len+1);
+	{
+		/*
+		 * Through a temporary, and checked: len comes from a remote peer,
+		 * and assigning realloc() straight back loses the old pointer when
+		 * it returns NULL -- which the memcpy() below then writes through.
+		 * Dropping the addition keeps whatever was collected so far.
+		 */
+		unsigned char *grown = (item->banner == NULL)
+			? (unsigned char *)malloc(len+1)
+			: (unsigned char *)realloc(item->banner, item->bannerbytes+len+1);
+
+		if (!grown) {
+			errprintf("Out of memory collecting the banner for %s\n",
+				  (item->svcinfo ? item->svcinfo->svcname : "?"));
+			return 1;
+		}
+		item->banner = grown;
 	}
 
 	memcpy(item->banner+item->bannerbytes, buf, len);


### PR DESCRIPTION
Three independent bugs in code that is on `main` today. One commit each; none depends on the others.

## 1. An alias's `send`/`expect` is copied with `strdup()`, its length carried separately

`[a|b]` gives every service after the first its own copy:

```c
walk->rec->sendtxt = strdup(first->rec->sendtxt);
walk->rec->sendlen = first->rec->sendlen;
```

`getescapestring()` resolves `\xNN`, so that text may contain a NUL. `strdup()` stops there; `sendlen` does not. `contest.c` then writes `sendlen` bytes out of the shorter allocation, or matches `explen` bytes against it — a heap over-read past the end of the object.

Needs a `protocols.cfg` using `\x00` in a `send` or `expect` on an aliased entry, so nothing shipped triggers it. The file is operator-editable.

## 2. The banner buffer is grown through an unchecked `realloc()`

```c
item->banner = (unsigned char *)realloc(item->banner, item->bannerbytes+len+1);
...
memcpy(item->banner+item->bannerbytes, buf, len);
```

Assigning `realloc()` straight back loses the old pointer on failure, and the `memcpy()` on the next line writes through NULL. `len` comes from the peer. Reachable only under memory pressure; the recovery is to keep what was collected and stop adding.

## 3. Telnet: the option buffer is unchecked, and the banner leaks

`do_telnet_options()` uses `malloc()` for the option buffer without checking it, on a length the peer controls.

It also replaces the banner by `strdup()`ing over it, leaking whatever was there. The obvious repair — free the old one first — is **wrong**: the read arm sets `item->telnetbuf = item->banner`, so `inp` walks the very buffer being replaced, and freeing first leaves it dangling for the copy to read. Copy first, free after, and clear `telnetbuf`, which otherwise still points at the freed buffer.

## Provenance

Found while working on #488, which is stacked three deep behind #453 and #454. These fix `main` and have nothing to do with that feature, so they are here instead of waiting behind it.

## Checks

- each commit builds on `main` and produces a binary
- `tests/network/` and `tests/buildsystem/` clean, except `rrd-api-compat.sh`, which fails identically on unmodified `main`
- the dialogue stack (#461–#486) does **not** fix any of these: it rewrites the parser and reproduces 1 verbatim (`strdup((char *)txt)` with the length set separately), and leaves 2 and 3 untouched