### PR TITLE
xymond: a connection that broke is not a message that ended

### DIFF
--- a/tests/lib/message-sender.c
+++ b/tests/lib/message-sender.c
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later                                  */
+/*
+ * tests/lib/message-sender.c
+ *
+ * Send a message to a TCP port and end the connection in one of two ways:
+ *
+ *   clean   shutdown(SHUT_WR) -- the peer's read returns end of file, which is
+ *           how a Xymon client says its message is complete.
+ *   reset   SO_LINGER with a zero timeout, so close() sends RST instead of FIN
+ *           and the peer's read FAILS. That is a sender dying mid-message.
+ *
+ * The difference is the whole point: a protocol delimited by the sender
+ * stopping cannot tell the two apart from the bytes alone, only from what the
+ * read returned.
+ *
+ * usage: message-sender HOST PORT clean|reset [TEXT]
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int main(int argc, char **argv)
+{
+	struct sockaddr_in addr;
+	struct linger lg;
+	const char *text;
+	int sock, reset;
+	size_t len;
+
+	if (argc < 4) {
+		fprintf(stderr, "usage: %s HOST PORT clean|reset [TEXT]\n", argv[0]);
+		return 2;
+	}
+	reset = (strcmp(argv[3], "reset") == 0);
+	text  = (argc > 4) ? argv[4] : "";
+	len   = strlen(text);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_port   = htons((unsigned short)atoi(argv[2]));
+	if (inet_pton(AF_INET, argv[1], &addr.sin_addr) != 1) {
+		fprintf(stderr, "bad address: %s\n", argv[1]);
+		return 2;
+	}
+
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) { perror("socket"); return 1; }
+	if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+		perror("connect");
+		return 1;
+	}
+
+	if ((len > 0) && (write(sock, text, len) != (ssize_t)len)) {
+		perror("write");
+		return 1;
+	}
+
+	if (reset) {
+		lg.l_onoff = 1; lg.l_linger = 0;
+		if (setsockopt(sock, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg)) != 0) {
+			perror("SO_LINGER");
+			return 1;
+		}
+	}
+	else if (shutdown(sock, SHUT_WR) != 0) {
+		perror("shutdown");
+		return 1;
+	}
+
+	close(sock);
+	return 0;
+}

--- a/tests/server/xymond-truncated-request.sh
+++ b/tests/server/xymond-truncated-request.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/xymond-truncated-request.sh
+#
+# Half a status message is not a status message.
+#
+# A request to xymond has no terminator -- lib/sendmsg.c writes the message text
+# and nothing else -- so the daemon takes the message to be finished when the
+# read stops. That test used to be "n <= 0", which is a clean end of file AND a
+# connection that broke, so a sender that died mid-message had its fragment
+# handled as though it were whole: a colour set from a line cut in the middle,
+# with nothing recording that anything was lost.
+#
+# The two cases are told apart now. This drives both against a real xymond,
+# because it is the daemon's own framing rule that is under test.
+#
+#   complete   written, then a clean half-close -- must land
+#   truncated  written, then RST mid-message    -- must NOT land
+#
+# THE FIRST ROW IS THE CONTROL. Discarding a fragment is easy to get right by
+# discarding everything, and a suite that only checked the fragment would not
+# notice. A sender closing with SO_LINGER 0 has its partial message accepted
+# today, so this is exactly the behaviour that changes and the row that proves
+# nothing else changed with it.
+#
+# LAYER: the daemon's receive loop, over a real socket.
+
+set -eu
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/xymond-daemon.sh
+. "$(dirname "$0")/../lib/xymond-daemon.sh"
+
+root=$(find_root)
+require_bin XYMOND xymond/xymond
+require_bin XYMONCLIENT common/xymon
+require_shm_segments "$(grep -c 'setup_channel(C_[A-Z_]*, CHAN_MASTER)' "$root/xymond/xymond.c")"
+require_cfg XYMONSERVER_CFG xymond/etcfiles/xymonserver.cfg
+require_c_buildenv "$root"
+
+work=$(mktempdir); register_cleanup "rm -rf '$work'"
+mkdir -p "$work/home/etc" "$work/home/tmp" "$work/home/www"
+printf 'page test Test\n127.0.0.1 testhost.example.com # conn\n' > "$work/hosts.cfg"
+
+sed -e 's|^XYMONHOME=.*|XYMONHOME="'"$work"'/home"|' \
+    -e 's|^XYMONTMP=.*|XYMONTMP="'"$work"'/home/tmp"|' \
+	"$XYMONSERVER_CFG" > "$work/xymonserver.cfg"
+
+xymond_launch() {
+	local port=$1; shift
+	"$XYMOND" --no-daemon --listen="127.0.0.1:$port" \
+		--hosts="$work/hosts.cfg" --env="$work/xymonserver.cfg" \
+		--pidfile="$work/xymond.pid" "$@" \
+		> "$work/xymond.log" 2>&1 &
+	XYMOND_PID=$!
+}
+
+start_xymond
+register_cleanup "kill '$XYMOND_PID' 2>/dev/null || :"
+
+# One sender, two ways of ending the connection: a clean half-close, or RST
+# from SO_LINGER 0. The bytes are identical; only the read result differs.
+"$CC" -o "$work/sender" "$root/tests/lib/message-sender.c" 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "the message sender does not compile"; }
+send_msg() { "$work/sender" 127.0.0.1 "$PORT" "$1" "$2"; }
+
+board() {	# testname -> the colour xymond holds for it, or nothing
+	"$XYMONCLIENT" "127.0.0.1:$PORT" "xymondboard fields=testname,color" 2>/dev/null \
+		| awk -F'|' -v t="$1" '$1 == t { print $2 }'
+}
+
+# --- the control: a complete message, ended cleanly ---------------------------
+send_msg clean 'status testhost,example,com.whole green everything arrived'
+sleep 0.5
+
+[ "$(board whole)" = green ] || fail \
+"a complete status message, ended with a clean half-close, did not reach the
+daemon (board says '$(board whole)'). Discarding fragments must not mean
+discarding messages:
+$(tail -5 "$work/xymond.log")"
+
+# --- the fragment: cut off mid-message ---------------------------------------
+send_msg reset 'status testhost,example,com.frag green the sender died right he'
+sleep 0.5
+
+[ -z "$(board frag)" ] || fail \
+"a status message whose connection was reset mid-send was accepted as complete
+-- the board reports '$(board frag)' for it. Nothing in the bytes says the
+message was cut: the sender stopping IS the terminator, so a broken connection
+and a finished message look identical unless the read result is checked:
+$(tail -5 "$work/xymond.log")"
+
+# It must be dropped LOUDLY. A fragment thrown away in silence is a status that
+# vanishes with no way to find out why.
+grep -q 'Truncated message' "$work/xymond.log" || fail \
+"the fragment was dropped without a word in the log. Someone chasing a status
+that never appeared has nothing to find:
+$(tail -10 "$work/xymond.log")"
+
+# --- and a connection that says nothing at all -------------------------------
+send_msg clean ''
+sleep 0.3
+kill -0 "$XYMOND_PID" 2>/dev/null || fail \
+"xymond did not survive a connection that opened and closed without sending
+anything -- which is what every port scan does:
+$(tail -5 "$work/xymond.log")"
+
+# The daemon is still serving after all three.
+[ "$(board whole)" = green ] || fail \
+"the daemon stopped answering after the fragment and the empty connection; the
+status it had accepted is gone:
+$(tail -5 "$work/xymond.log")"
+
+pass "a reset mid-message is dropped and logged, a clean half-close still lands, and an empty connection is neither"

--- a/xymond/xymond.c
+++ b/xymond/xymond.c
@@ -6425,15 +6425,58 @@ int main(int argc, char *argv[])
 			switch (cwalk->doingwhat) {
 			  case RECEIVING:
 				if (FD_ISSET(cwalk->sock, &fdread)) {
-					if ((n == -1) && (errno == EAGAIN)) break; /* Do nothing */
-
 					n = read(cwalk->sock, cwalk->bufp, (cwalk->bufsz - cwalk->buflen - 1));
-					if (n <= 0) {
-						/* End of input data on this connection */
+
+					/*
+					 * Tested AFTER the read, as the RESPONDING arm below
+					 * tests its write. "n" is reused by every connection
+					 * in this loop, so checking it beforehand asked
+					 * whether the PREVIOUS one would have blocked, and
+					 * skipped a readable connection when it had.
+					 */
+					if ((n == -1) && ((errno == EAGAIN) || (errno == EWOULDBLOCK) ||
+							  (errno == EINTR))) break; /* Do nothing */
+
+					if (n < 0) {
+						/*
+						 * The connection broke while the message was
+						 * still arriving. A request is delimited by the
+						 * sender stopping, so what is in the buffer
+						 * cannot be told apart from a whole message by
+						 * looking at it -- and acting on it means acting
+						 * on half a status: a colour taken from a line
+						 * that was cut in the middle. Drop it, and say
+						 * so, which is the part that was missing before.
+						 */
+						errprintf("Truncated message from %s - %d bytes before the connection broke: %s\n",
+							  inet_ntoa(cwalk->addr.sin_addr), cwalk->buflen,
+							  strerror(errno));
+						shutdown(cwalk->sock, SHUT_RDWR);
+						close(cwalk->sock);
+						cwalk->sock = -1;
+						cwalk->doingwhat = NOTALK;
+					}
+					else if (n == 0) {
+						/* The sender finished: the message is what arrived. */
 						*(cwalk->bufp) = '\0';
 
-						/* FIXME - need to set origin here */
-						do_message(cwalk, "");
+						if (cwalk->buflen == 0) {
+							/*
+							 * Connected and said nothing. Every port
+							 * scan does this, and so does a
+							 * connect-only check on this port, so it
+							 * is not worth a log line -- but it is not
+							 * a message either.
+							 */
+							shutdown(cwalk->sock, SHUT_RDWR);
+							close(cwalk->sock);
+							cwalk->sock = -1;
+							cwalk->doingwhat = NOTALK;
+						}
+						else {
+							/* FIXME - need to set origin here */
+							do_message(cwalk, "");
+						}
 					}
 					else {
 						/* Add data to the input buffer - within reason ... */


### PR DESCRIPTION
Closes #493.

A request to xymond has no terminator — `lib/sendmsg.c` writes the message text and nothing else — so the daemon takes it to be finished when the read stops:

```c
n = read(cwalk->sock, cwalk->bufp, ...);
if (n <= 0) {
        /* End of input data on this connection */
        do_message(cwalk, "");
}
```

`n <= 0` is a clean end of file **and** a connection that broke. A sender that died mid-message had its fragment processed as a whole message — a colour taken from a line cut in the middle, with nothing recording that the rest never arrived.

| `read()` | meaning | before | after |
|---|---|---|---|
| `n > 0` | more data | accumulate | accumulate |
| `n == 0`, `buflen > 0` | FIN — complete | process | process |
| `n == 0`, `buflen == 0` | connected, said nothing | process an empty message | close quietly |
| `n < 0` | reset — a fragment | **process as complete** | discard, log peer + bytes received |

No framing change, no client change, no wire change.

**The `EAGAIN` guard had to move.** It sat *before* the read, testing `n` — which every connection in that loop reuses, so it asked whether the **previous** connection would have blocked and skipped a readable one when it had. It now runs after the read, matching what the `RESPONDING` arm already does, and covers `EWOULDBLOCK` and `EINTR`. Without that, an ordinary `-1` would read as truncation and drop a healthy message — a worse bug than the one being fixed.

## Evidence

`xymond-truncated-request.sh` drives a real xymond and sends identical bytes twice, differing only in how the connection ends: `shutdown(SHUT_WR)` versus `SO_LINGER 0`.

| | |
|---|---|
| Against the daemon as it stands | **fails** — the fragment is accepted and the board reports it `green` |
| With this change | passes |
| Suite | **96 passed / 0 failed / 0 skipped** |

The first row of the test is the control: a complete message must still land. Discarding fragments is easy to get right by discarding everything, and `SO_LINGER 0` senders are exactly the case whose handling changes, so both rows ride on the same mechanism.

The sender is C (`tests/lib/message-sender.c`) rather than a script — the BSD lanes have no python3, and the suite's portability guard rejects a test that assumes otherwise.
