### PR TITLE
docs: do not delete a branch no pull request holds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,17 @@ forbids it.
   roughly a hundred untracked paths waiting to be committed by accident. Stage
   the paths you changed.
 
+- **Do not delete a branch whose commits no pull request holds.** GitHub keeps
+  `refs/pull/N/head` for ever, so a branch that had a pull request can be
+  deleted freely -- its commits stay reachable. A branch that never had one has
+  no such ref, and deleting it leaves the work reachable by raw SHA until that
+  is collected. Check before deleting:
+
+      git for-each-ref --contains <branch-tip> refs/pull/
+
+  Nothing listed means the commits go with the branch. Open a pull request
+  first -- closing it immediately is enough, the ref is what matters.
+
 ## What the test suite will not accept
 
 `tests/buildsystem/test-suite-portability.sh` fails the run on the constructs


### PR DESCRIPTION
Draft — the rule is proposed, not settled.

GitHub keeps `refs/pull/N/head` **for ever**, so deleting a branch that had a pull request costs nothing: its commits stay reachable by that ref. A branch that never had one has no such ref, and deleting it leaves the work reachable by raw SHA until that is collected.

## Why this is not hypothetical

The ten `dialogue-*` branches were deleted upstream. Five of the six tips worth keeping were also pull request heads — `refs/pull/477` and `481`–`484` still hold them, and nothing was lost.

`dialogue-10-startfeature` **never had a pull request**. Its tip `ff25e086f` — the `start FEATURE` rename and the `${tls}` outcome binding, the one feature of that stack with no equivalent anywhere — survived only in a single working clone, and was found by accident because #494 happened to cite it by SHA. It is now archived on the fork at `archive/dialogue-10-startfeature`.

## Why a rule and not a job

GitHub does not expose unreachable objects, so a scheduled scan cannot enumerate what is already orphaned — it can only ever be best-effort. A check before deletion is exact, and deletion is the action that causes the loss. One command:

```
git for-each-ref --contains <branch-tip> refs/pull/
```

Nothing listed means the commits go with the branch. Opening a pull request first — closed immediately is fine — creates the ref.

## Three branches are in that state now

`devel` (272 commits), `feature/self-describing-metrics` (27), `fix-custom-graphs` (1). None has ever had a pull request, so none can be deleted without losing what is on it. That is a separate decision from this text; the rule just makes it visible before somebody tidies up.
