### PR TITLE
trimhistory: stop --drop deleting the history of hosts that are still listed (#281)

### DIFF
--- a/docs/manpages/man8/trimhistory.8.html
+++ b/docs/manpages/man8/trimhistory.8.html
@@ -64,7 +64,14 @@ Section: Maintenance Commands (8)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a
   </dd>
   <dt id="drop"><a class="permalink" href="#drop"><b>--drop</b></a></dt>
   <dd>Causes trimhistory to delete files from hosts that are not listed in the
-      <i><a href="../man5/hosts.cfg.5.html">hosts.cfg</a>(5)</i> file.
+      <i><a href="../man5/hosts.cfg.5.html">hosts.cfg</a>(5)</i> file. A host that is listed but currently outside a
+      <b>NOTBEFORE:</b> or <b>NOTAFTER:</b> window counts as listed, and keeps
+      its history.
+    <p class="Pp">If the host list cannot be loaded, or loads with no hosts in
+        it, trimhistory drops nothing and exits with an error: every file would
+        otherwise look like it belonged to a host that no longer exists. Runs
+        without <b>--drop</b> or <b>--droplogs</b> are unaffected, since they
+        delete nothing either way.</p>
     <p class="Pp"></p>
   </dd>
   <dt id="dropsvcs"><a class="permalink" href="#dropsvcs"><b>--dropsvcs</b></a></dt>

--- a/lib/loadhosts.c
+++ b/lib/loadhosts.c
@@ -347,18 +347,32 @@ static void build_hosttree(void)
 #include "loadhosts_file.c"
 #include "loadhosts_net.c"
 
-char *knownhost(char *hostname, char *hostip, enum ghosthandling_t ghosthandling)
+char *knownhost_ex(char *hostname, char *hostip, enum ghosthandling_t ghosthandling, int *inperiod)
 {
 	/*
 	 * ghosthandling = GH_ALLOW  : Default BB method (case-sensitive, no logging, keep ghosts)
 	 * ghosthandling = GH_IGNORE : Case-insensitive, no logging, drop ghosts
 	 * ghosthandling = GH_LOG    : Case-insensitive, log ghosts, drop ghosts
 	 * ghosthandling = GH_MATCH  : Like GH_LOG, but try to match unknown names against known hosts
+	 *
+	 * Answers whether hosts.cfg holds a record for this name, and reports
+	 * through *inperiod whether that record's NOTBEFORE:/NOTAFTER: window
+	 * covers now. The two questions are separate: a host that is listed but
+	 * outside its window still exists, and a caller that deletes data has to
+	 * be able to tell that from a host that was removed from the
+	 * configuration (#281). knownhost() below keeps the original contract,
+	 * where an out-of-period host answers "not known". A NULL inperiod
+	 * means the caller does not care about the window at all.
 	 */
 	xtreePos_t hosthandle;
 	namelist_t *walk = NULL;
 	static char *result = NULL;
 	time_t now = getcurrenttime(NULL);
+
+	/* Every early return below is a path with no window to check: the
+	 * hival single-host mode, GH_ALLOW, and "summary". They leave this as
+	 * it stands, so those callers keep answering exactly as before. */
+	if (inperiod) *inperiod = 1;
 
 	if (result) xfree(result);
 	result = NULL;
@@ -410,8 +424,19 @@ char *knownhost(char *hostname, char *hostip, enum ghosthandling_t ghosthandling
 	/* Allow all summaries */
 	if (strcmp(hostname, "summary") == 0) return result;
 
-	if (walk && ( ((walk->notbefore > now) || (walk->notafter < now)) )) walk = NULL;
-	return (walk ? result : NULL);
+	if (!walk) return NULL;
+
+	if (inperiod && ((walk->notbefore > now) || (walk->notafter < now))) *inperiod = 0;
+	return result;
+}
+
+char *knownhost(char *hostname, char *hostip, enum ghosthandling_t ghosthandling)
+{
+	int inperiod = 1;
+	char *result;
+
+	result = knownhost_ex(hostname, hostip, ghosthandling, &inperiod);
+	return (inperiod ? result : NULL);
 }
 
 int knownloghost(char *logdir)

--- a/lib/loadhosts.h
+++ b/lib/loadhosts.h
@@ -92,6 +92,7 @@ extern int load_hostnames(char *hostsfn, char *extrainclude, int fqdn);
 extern int load_hostinfo(char *hostname);
 extern char *hostscfg_content(void);
 extern char *knownhost(char *hostname, char *hostip, enum ghosthandling_t ghosthandling);
+extern char *knownhost_ex(char *hostname, char *hostip, enum ghosthandling_t ghosthandling, int *inperiod);
 extern int knownloghost(char *logdir);
 extern void *hostinfo(char *hostname);
 extern void *localhostinfo(char *hostname);

--- a/tests/lib/trimhistory.sh
+++ b/tests/lib/trimhistory.sh
@@ -53,7 +53,7 @@ TRIM_LOGSTAMP='Mon_Jan__1_00:00:00_2001'
 setup_trimhistory() {
 	local work=$1
 	build_xymond_worker "$work" trimhistory xymond/trimhistory.c
-	mkdir -p "$work/etc" "$work/var/hist" "$work/var/histlogs"
+	mkdir -p "$work/etc" "$work/var/hist" "$work/var/histlogs" "$work/var/logs"
 	: >"$work/etc/hosts.cfg"
 }
 
@@ -97,11 +97,22 @@ seed_histlogs() {
 		>"$work/var/histlogs/$logname/$svc/$TRIM_LOGSTAMP"
 }
 
-# run_trimhistory WORK ARGS... -- run against the fixture, appending stderr to
+# run_trimhistory WORK ARGS... -- run against the fixture, capturing stderr in
 # <work>/trim.log and printing it, so a caller can grep the run's messages.
+#
+# The file is replaced on every run, not added to: a test that runs twice
+# against the same fixture would otherwise grep the first run's messages and
+# see them as the second's.
 #
 # A caller that is testing the configuration load itself sets TRIM_HOSTSCFG to
 # the spelling it wants (a bare path takes the xymond-first route).
+#
+# XYMONSERVERLOGS is redirected for the same reason as the rest, and it is the
+# one that reaches outside the fixture if it is not: after trimming
+# "allevents", trimhistory reads $XYMONSERVERLOGS/xymond_history.pid and sends
+# that process a SIGHUP (xymond/trimhistory.c). Left unset it falls back to the
+# compiled-in XYMONLOGDIR, so a test that seeds an allevents file would signal
+# the xymond_history of a real Xymon running on the machine -- and pass.
 run_trimhistory() {
 	local work=$1 rc
 	shift
@@ -110,8 +121,9 @@ run_trimhistory() {
 	HOSTSCFG="${TRIM_HOSTSCFG:-!$work/etc/hosts.cfg}" \
 	XYMONHISTDIR="$work/var/hist" \
 	XYMONHISTLOGS="$work/var/histlogs" \
+	XYMONSERVERLOGS="$work/var/logs" \
 	XYMONTMP="$work" \
-		"$work/trimhistory" --cutoff="$TRIM_CUTOFF" "$@" >>"$work/trim.log" 2>&1
+		"$work/trimhistory" --cutoff="$TRIM_CUTOFF" "$@" >"$work/trim.log" 2>&1
 	rc=$?
 	set -e
 	cat "$work/trim.log"

--- a/tests/lib/trimhistory.sh
+++ b/tests/lib/trimhistory.sh
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# shellcheck shell=bash
+#
+# tests/lib/trimhistory.sh -- shared build/fixture recipe for the trimhistory
+# tests. Source after assert.sh, then:
+#
+#     setup_trimhistory "$work"
+#     hosts_cfg "$work" '127.0.0.1 active.example.com # conn'
+#     seed_hosthistory "$work" active.example.com
+#     seed_svchistory  "$work" active,example,com.conn
+#     seed_histlogs    "$work" active_example_com conn
+#     run_trimhistory  "$work" --drop
+#
+# HOSTSCFG carries a "!" prefix on purpose. load_hostnames() asks xymond for
+# the configuration whenever the filename it is handed equals $HOSTSCFG
+# (lib/loadhosts_file.c) -- which is exactly what trimhistory passes it. With
+# no xymond listening the host list then loads empty, every history file looks
+# orphaned, and a --drop test would "pass" by deleting the entire fixture.
+# The "!" forces the file load these tests are about.
+
+[ -n "${__XYMON_TESTS_TRIMHISTORY_SOURCED:-}" ] && return 0
+__XYMON_TESTS_TRIMHISTORY_SOURCED=1
+
+# shellcheck source=tests/lib/build-worker.sh
+. "$(dirname "${BASH_SOURCE[0]}")/build-worker.sh"
+
+# Each fixture file carries three records: two before the cutoff and one after
+# it. Two, because trim_history() keeps the last pre-cutoff line on purpose --
+# it is the state the host was in when the cutoff passed -- so a file seeded
+# with a single old line looks untrimmed however well the trimming works.
+# TRIM_ANCIENT is therefore the line that must disappear, TRIM_OLD the one
+# that must survive, TRIM_RECENT the line after the cutoff. Having both a kept
+# and a dropped line also means a deleted file can never be mistaken for a
+# trimmed one.
+TRIM_NOW=$(date +%s)
+TRIM_CUTOFF=$((TRIM_NOW - 86400))
+TRIM_ANCIENT=$((TRIM_NOW - 8640000))
+TRIM_OLD=$((TRIM_NOW - 864000))
+TRIM_RECENT=$((TRIM_NOW - 3600))
+
+# A service-history record carries the change time twice: as text and as the
+# epoch the trimmer actually reads (column 7). The text is never parsed there,
+# so the fixtures use one fixed, obviously-old spelling rather than formatting
+# an epoch -- converting one portably means date -d on GNU and date -r on the
+# BSDs, and the suite runs on both.
+TRIM_TEXTDATE='Mon Jan  1 00:00:00 2001'
+
+# A histlog file name, by contrast, *is* parsed: logtime() wants exactly
+# WWW_MMM_DD_hh:mm:ss_YYYY, 24 characters. This one is the same instant, and
+# comfortably before any cutoff a test can pick.
+TRIM_LOGSTAMP='Mon_Jan__1_00:00:00_2001'
+
+setup_trimhistory() {
+	local work=$1
+	build_xymond_worker "$work" trimhistory xymond/trimhistory.c
+	mkdir -p "$work/etc" "$work/var/hist" "$work/var/histlogs"
+	: >"$work/etc/hosts.cfg"
+}
+
+# hosts_cfg WORK LINE... -- append raw lines to the fixture hosts.cfg.
+hosts_cfg() {
+	local work=$1
+	shift
+	printf '%s\n' "$@" >>"$work/etc/hosts.cfg"
+}
+
+# seed_hosthistory WORK NAME -- a host-history file, as xymond_history writes
+# it: "testname tstamp lastchg duration newcol oldcol trend" (the trimmer
+# reads the timestamp from column 2).
+seed_hosthistory() {
+	local work=$1 name=$2
+	{
+		printf 'conn %d %d 3600 purple red 0\n' "$TRIM_ANCIENT" "$((TRIM_ANCIENT - 3600))"
+		printf 'conn %d %d 3600 red green 0\n' "$TRIM_OLD" "$((TRIM_OLD - 3600))"
+		printf 'conn %d %d 3600 green red 0\n' "$TRIM_RECENT" "$((TRIM_RECENT - 3600))"
+	} >"$work/var/hist/$name"
+}
+
+# seed_svchistory WORK NAME -- a service-history file: "color <ctime> tstamp
+# duration nextcolor" (the trimmer reads the timestamp from column 7).
+seed_svchistory() {
+	local work=$1 name=$2
+	{
+		printf 'purple %s %d 3600 red\n' "$TRIM_TEXTDATE" "$TRIM_ANCIENT"
+		printf 'red %s %d 3600 green\n' "$TRIM_TEXTDATE" "$TRIM_OLD"
+		printf 'green %s %d 3600 red\n' "$TRIM_TEXTDATE" "$TRIM_RECENT"
+	} >"$work/var/hist/$name"
+}
+
+# seed_histlogs WORK LOGNAME SVC -- one status log older than the cutoff.
+# LOGNAME is the hostname with dots and commas as underscores; the file name
+# is the 24-character stamp logtime() parses (WWW_MMM_DD_hh:mm:ss_YYYY).
+seed_histlogs() {
+	local work=$1 logname=$2 svc=$3
+	mkdir -p "$work/var/histlogs/$logname/$svc"
+	printf 'green %s stale\n' "$TRIM_TEXTDATE" \
+		>"$work/var/histlogs/$logname/$svc/$TRIM_LOGSTAMP"
+}
+
+# run_trimhistory WORK ARGS... -- run against the fixture, appending stderr to
+# <work>/trim.log and printing it, so a caller can grep the run's messages.
+#
+# A caller that is testing the configuration load itself sets TRIM_HOSTSCFG to
+# the spelling it wants (a bare path takes the xymond-first route).
+run_trimhistory() {
+	local work=$1 rc
+	shift
+	set +e
+	XYMONHOME="$work" \
+	HOSTSCFG="${TRIM_HOSTSCFG:-!$work/etc/hosts.cfg}" \
+	XYMONHISTDIR="$work/var/hist" \
+	XYMONHISTLOGS="$work/var/histlogs" \
+	XYMONTMP="$work" \
+		"$work/trimhistory" --cutoff="$TRIM_CUTOFF" "$@" >>"$work/trim.log" 2>&1
+	rc=$?
+	set -e
+	cat "$work/trim.log"
+	return $rc
+}

--- a/tests/xymond/trimhistory-drop-classification.sh
+++ b/tests/xymond/trimhistory-drop-classification.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/trimhistory-drop-classification.sh
+#
+# The contract around "trimhistory --drop": which history files it considers
+# to belong to a known host, and which it removes. Written alongside the #281
+# fix, which changes how trimhistory resolves a file's host, so the rest of
+# that resolution is pinned rather than left to be discovered later:
+#
+#   - a host that is absent from hosts.cfg loses its files (that is the
+#     feature), whether or not its name carries a dot;
+#   - a host that is present keeps them, including when the file name differs
+#     in case, when the name is a CLIENT: alias, and when it has no dots;
+#   - "summary" is never dropped -- knownhost() exempts it by name;
+#   - "allevents" is trimmed, never classified as a host at all;
+#   - without --drop, nothing is deleted: an orphan is only reported.
+#
+# The case, alias and summary rows in particular exist because a fix that
+# replaced knownhost() with a plain hostname lookup would silently lose them.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/trimhistory.sh
+. "$(dirname "$0")/../lib/trimhistory.sh"
+
+work=$(mktempdir)
+setup_trimhistory "$work"
+
+hosts_cfg "$work" \
+	'127.0.0.1 Active.Example.com # conn' \
+	'127.0.0.1 aliased.example.com # conn CLIENT:clientalias' \
+	'127.0.0.1 plainname # conn'
+
+seed_hosthistory "$work" active.example.com          # differs in case from hosts.cfg
+seed_hosthistory "$work" ACTIVE.EXAMPLE.COM
+seed_svchistory  "$work" active,example,com.conn
+seed_hosthistory "$work" clientalias                 # CLIENT: alias, not the hostname
+seed_svchistory  "$work" clientalias.conn
+seed_hosthistory "$work" plainname                   # listed, no dots
+seed_hosthistory "$work" summary                     # exempt by name
+seed_hosthistory "$work" nosuchhost                  # absent, no dots
+seed_hosthistory "$work" gone.example.com            # absent, dotted
+seed_svchistory  "$work" gone,example,com.conn
+seed_histlogs    "$work" active_example_com conn
+seed_histlogs    "$work" gone_example_com conn
+
+# Entries the scan skips before it ever asks whose host they are: a dotfile,
+# and a directory (someone's backup copy of a host's logs, say). Neither is a
+# history file, and neither may be deleted or reported.
+: >"$work/var/hist/.hidden"
+mkdir -p "$work/var/hist/adirectory"
+
+# A status log whose name is not the 24-character stamp logtime() parses is
+# left alone, and its service directory therefore stays.
+: >"$work/var/histlogs/active_example_com/conn/not-a-24-char-name"
+
+# allevents is the all-hosts event log: a file, not a host.
+{
+	printf 'ancient.example.com conn %d %d 3600 purple red 0\n' "$TRIM_ANCIENT" "$TRIM_ANCIENT"
+	printf 'gone.example.com conn %d %d 3600 red green 0\n' "$TRIM_OLD" "$TRIM_OLD"
+	printf 'active.example.com conn %d %d 3600 green red 0\n' "$TRIM_RECENT" "$TRIM_RECENT"
+} >"$work/var/hist/allevents"
+
+before=$(ls "$work/var/hist" | sort)
+
+# ---- a dry run deletes nothing ---------------------------------------------
+run_trimhistory "$work" >"$work/dry.log" 2>&1 || true
+assert_equal "$before" "$(ls "$work/var/hist" | sort)" \
+	"a run without --drop deleted files"
+assert_contains "Orphaned" "$(cat "$work/dry.log")" \
+	"a run without --drop did not even report the orphan"
+
+# ---- the real run -----------------------------------------------------------
+run_trimhistory "$work" --drop --droplogs >"$work/out.log" 2>&1 || true
+log=$(cat "$work/out.log")
+
+# Kept: every name that hosts.cfg accounts for, however it is spelled.
+for f in active.example.com ACTIVE.EXAMPLE.COM active,example,com.conn \
+	 clientalias clientalias.conn plainname summary allevents; do
+	assert_file_exists "$work/var/hist/$f" "--drop deleted $f, which belongs to a listed host"
+done
+
+# Dropped: the names hosts.cfg does not account for, dotted or not.
+for f in nosuchhost gone.example.com gone,example,com.conn; do
+	[ ! -e "$work/var/hist/$f" ] \
+		|| { echo "$log" >&2; fail "--drop kept $f, which is not in hosts.cfg"; }
+done
+
+# Each deletion is announced, and a dot-free name is named as a host file.
+assert_contains "Orphaned host-history file nosuchhost" "$log" \
+	"a dot-free orphan was not reported as a host-history file"
+assert_contains "gone.example.com" "$log" \
+	"a dotted orphan was deleted without being reported"
+
+# The scan's skips.
+assert_file_exists "$work/var/hist/.hidden" "--drop deleted a dotfile in the history directory"
+[ -d "$work/var/hist/adirectory" ] || fail "--drop removed a directory sitting in the history directory"
+assert_not_contains "adirectory" "$log" "a directory in the history directory was reported as an orphan"
+assert_not_contains ".hidden" "$log" "a dotfile in the history directory was reported as an orphan"
+
+# histlogs follow the same verdict as the history files.
+[ -d "$work/var/histlogs/active_example_com" ] \
+	|| fail "--droplogs removed the histlogs directory of a listed host"
+[ ! -d "$work/var/histlogs/gone_example_com" ] \
+	|| fail "--droplogs kept the histlogs of a host that is not in hosts.cfg"
+assert_file_exists "$work/var/histlogs/active_example_com/conn/not-a-24-char-name" \
+	"--droplogs deleted a status log whose name it cannot read as a timestamp"
+[ ! -e "$work/var/histlogs/active_example_com/conn/$TRIM_LOGSTAMP" ] \
+	|| fail "--droplogs left a pre-cutoff status log in place"
+
+# Trimming still happens on the files that survive.
+kept=$(cat "$work/var/hist/active.example.com")
+assert_contains "$TRIM_RECENT" "$kept" "the post-cutoff line was trimmed out of a kept file"
+assert_contains "$TRIM_OLD" "$kept" "the record spanning the cutoff was dropped from a kept file"
+assert_not_contains "$TRIM_ANCIENT" "$kept" "a pre-cutoff line survived in a kept file"
+assert_not_contains "ancient.example.com" "$(cat "$work/var/hist/allevents")" \
+	"a pre-cutoff event survived in allevents"
+
+# A service-history file has to be trimmed as one: its timestamp is column 7,
+# where a host-history file carries it in column 2. Misclassifying a kept file
+# leaves it in place but reads a weekday name as the timestamp, so everything
+# but the last line goes -- existence alone would not notice.
+svc=$(cat "$work/var/hist/active,example,com.conn")
+assert_contains "$TRIM_RECENT" "$svc" "a kept service file lost its post-cutoff record"
+assert_contains "$TRIM_OLD" "$svc" "a kept service file lost the record spanning the cutoff"
+assert_not_contains "$TRIM_ANCIENT" "$svc" "a kept service file was not trimmed"
+
+echo "OK $(basename "$0")"

--- a/tests/xymond/trimhistory-drop-classification.sh
+++ b/tests/xymond/trimhistory-drop-classification.sh
@@ -18,6 +18,12 @@
 #
 # The case, alias and summary rows in particular exist because a fix that
 # replaced knownhost() with a plain hostname lookup would silently lose them.
+#
+# control: passes with and without the #281 fix, and that is the point. Every
+# row above is behaviour the fix must leave alone, so this file stays green with
+# the fix reverted -- which for any other test would mean it proves nothing.
+# Said here because a test that cannot fail is otherwise indistinguishable from
+# a test that has stopped guarding its fix.
 
 set -euo pipefail
 # shellcheck source=tests/lib/assert.sh

--- a/tests/xymond/trimhistory-drop-dotted-column.sh
+++ b/tests/xymond/trimhistory-drop-dotted-column.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/trimhistory-drop-dotted-column.sh
+#
+# A service-history file is named "<hostname with dots as commas>.<column>",
+# and trimhistory recovers the two halves by splitting on the *last* dot
+# (xymond/trimhistory.c:458). A column name may itself contain a dot -- the
+# web side treats that as ordinary and tests/web/svcstatus-histlog-serving.sh
+# serves a "web.grp" histlog -- and for those files the split lands inside the
+# column name instead of before it:
+#
+#     dotted,example,com.web.grp  ->  host "dotted.example.com.web", test "grp"
+#
+# No such host exists, so --drop deletes the file as an orphan even though its
+# real host is listed in hosts.cfg. Same symptom as #281 (a listed host loses
+# its history) reached by a different mechanism, and independent of any
+# NOTBEFORE:/NOTAFTER: window.
+#
+# A comma inside a hostname is deliberately not tested: hosts.cfg(5) states a
+# canonical name cannot contain one, because the web URLs use a comma to
+# encode a period (#309/#314), so the loss in that case follows policy.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/trimhistory.sh
+. "$(dirname "$0")/../lib/trimhistory.sh"
+
+work=$(mktempdir)
+setup_trimhistory "$work"
+hosts_cfg "$work" \
+	'127.0.0.1 dotted.example.com # conn' \
+	'127.0.0.1 plainname # conn' \
+	'127.0.0.1 gone # conn' \
+	'127.0.0.1 sched.example.com # conn NOTAFTER:202001010000'
+
+seed_svchistory "$work" dotted,example,com.conn      # single-word column
+seed_svchistory "$work" dotted,example,com.web.grp   # column name with a dot
+seed_svchistory "$work" dotted,example,com.a.b.c     # ... and with several
+seed_svchistory "$work" plainname.web.grp            # same, host without dots
+seed_svchistory "$work" sched,example,com.web.grp    # dotted column AND out of period
+seed_svchistory "$work" gone,example,com.web.grp     # absent host, still an orphan
+seed_hosthistory "$work" dotted.example.com
+
+# The ambiguous shape: "gone.example.com" can be read as a host-history file
+# for a host of that name, or as service "example.com" of the listed host
+# "gone". The host it belongs to has been removed from hosts.cfg, so it is an
+# orphan -- and only its contents say so: a host-history record carries the
+# timestamp in column 2, a service record a weekday name there.
+seed_hosthistory "$work" gone.example.com
+
+run_trimhistory "$work" --drop >"$work/out.log" 2>&1 || true
+log=$(cat "$work/out.log")
+
+# Sanity: the ordinary case works, so a failure below is about the dot in the
+# column name and nothing else.
+assert_file_exists "$work/var/hist/dotted,example,com.conn" \
+	"--drop deleted a service-history file with a single-word column name"
+
+assert_file_exists "$work/var/hist/dotted,example,com.web.grp" \
+	"--drop deleted the history of column web.grp on a listed host: the name was split at the last dot, not the column boundary"
+assert_file_exists "$work/var/hist/plainname.web.grp" \
+	"--drop deleted the history of column web.grp on a listed host whose name has no dots"
+assert_file_exists "$work/var/hist/dotted,example,com.a.b.c" \
+	"--drop deleted the history of a column whose name holds several dots"
+
+# Both mechanisms at once: a dotted column on a host that is listed but
+# outside its window has to survive each of them.
+assert_file_exists "$work/var/hist/sched,example,com.web.grp" \
+	"--drop deleted a dotted column of a scheduled-out host (#281 plus the split)"
+
+# A stale host-history file whose first label happens to be a listed host is
+# still an orphan. Read as a service file it would also be trimmed on the wrong
+# column -- column 7 of a host-history line is the trend, so everything but the
+# last line goes.
+[ ! -e "$work/var/hist/gone.example.com" ] \
+	|| { echo "$log" >&2; fail "--drop kept gone.example.com, whose host was removed from hosts.cfg -- it was read as service 'example.com' of the listed host 'gone'"; }
+
+# The feature still has to work: an absent host is an orphan whatever its
+# column is called.
+[ ! -e "$work/var/hist/gone,example,com.web.grp" ] \
+	|| { echo "$log" >&2; fail "--drop kept a dotted-column file whose host is not in hosts.cfg"; }
+
+# ---- and without --drop, an orphan is reported, never rewritten ------------
+# Misreading the same name as a service file trims it on the service column,
+# which silently truncates a file that this mode must not touch at all.
+work2=$(mktempdir)
+setup_trimhistory "$work2"
+hosts_cfg "$work2" '127.0.0.1 gone # conn'
+seed_hosthistory "$work2" gone.example.com
+before=$(cat "$work2/var/hist/gone.example.com")
+
+run_trimhistory "$work2" >"$work2/nodrop.log" 2>&1 || true
+
+assert_equal "$before" "$(cat "$work2/var/hist/gone.example.com")" \
+	"a run without --drop rewrote an orphaned host-history file"
+
+echo "OK $(basename "$0")"

--- a/tests/xymond/trimhistory-drop-scheduled-out.sh
+++ b/tests/xymond/trimhistory-drop-scheduled-out.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/trimhistory-drop-scheduled-out.sh
+#
+# Regression guard for #281. "trimhistory --drop" is documented as deleting
+# files "from hosts that are not listed in the hosts.cfg(5) file"
+# (xymond/trimhistory.8). A host carrying NOTBEFORE: or NOTAFTER: *is* listed
+# -- it is only outside its active period -- yet --drop deletes its history,
+# so the tags that exist to schedule a host in and out of monitoring destroy
+# the history of exactly the hosts that are coming back.
+#
+# trimhistory resolves each file's host with knownhost(..., GH_IGNORE), and
+# knownhost() applies the period check to every caller except GH_ALLOW
+# (lib/loadhosts.c). To trimhistory an out-of-period host is therefore
+# indistinguishable from one deleted from hosts.cfg: F_DROPIT, then unlink.
+#
+# Three consequences, each checked below:
+#   1. the history of a scheduled-out host is deleted;
+#   2. its host-history file is reported as a *service*-history file -- the
+#      full-name lookup fails, so the code splits on the last dot and reads
+#      ".com" as a service name, which is what the operator later finds in
+#      the log when looking for the deletion;
+#   3. --droplogs disagrees with --drop about the same host: knownloghost()
+#      carries no period check, so the histlogs directory survives while the
+#      history file it belongs to is gone.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/trimhistory.sh
+. "$(dirname "$0")/../lib/trimhistory.sh"
+
+work=$(mktempdir)
+setup_trimhistory "$work"
+
+hosts_cfg "$work" \
+	'127.0.0.1 active.example.com        # conn' \
+	'127.0.0.1 scheduledout.example.com  # conn NOTAFTER:202001010000' \
+	'127.0.0.1 notyetin.example.com      # conn NOTBEFORE:209901010000' \
+	'127.0.0.1 inwindow.example.com      # conn NOTBEFORE:202001010000 NOTAFTER:209901010000' \
+	'127.0.0.1 badtime.example.com       # conn NOTAFTER:notatimestamp'
+
+# gone.example.com is deliberately absent from hosts.cfg: it is the file
+# --drop is supposed to remove, and without it every "kept" assertion below
+# would also hold for a run that dropped nothing at all.
+for h in active scheduledout notyetin inwindow badtime gone; do
+	seed_hosthistory "$work" "$h.example.com"
+	seed_svchistory  "$work" "$h,example,com.conn"
+	seed_histlogs    "$work" "${h}_example_com" conn
+done
+
+run_trimhistory "$work" --drop --droplogs >"$work/out.log" 2>&1 || true
+log=$(cat "$work/out.log")
+
+# Sanity first: --drop has to drop the real orphan, or "kept" proves nothing.
+[ ! -e "$work/var/hist/gone.example.com" ] \
+	|| { echo "$log" >&2; fail "--drop kept gone.example.com, which is not in hosts.cfg -- the test cannot tell keeping from doing nothing"; }
+[ ! -e "$work/var/hist/gone,example,com.conn" ] \
+	|| fail "--drop kept the service history of gone.example.com, which is not in hosts.cfg"
+
+# And it must not touch a plainly active host.
+assert_file_exists "$work/var/hist/active.example.com" \
+	"--drop deleted the history of an active host"
+assert_file_exists "$work/var/hist/active,example,com.conn" \
+	"--drop deleted the service history of an active host"
+
+# 1. The defect: a host that is listed but outside its window keeps its files.
+for h in scheduledout notyetin; do
+	[ -e "$work/var/hist/$h.example.com" ] \
+		|| { echo "$log" >&2; fail "--drop deleted the host history of $h.example.com, which IS listed in hosts.cfg (#281)"; }
+	[ -e "$work/var/hist/$h,example,com.conn" ] \
+		|| fail "--drop deleted the service history of $h.example.com, which IS listed in hosts.cfg (#281)"
+done
+
+# A host whose window spans now is the control: it must be kept whatever
+# happens to the two above.
+assert_file_exists "$work/var/hist/inwindow.example.com" \
+	"--drop deleted the history of a host inside its NOTBEFORE/NOTAFTER window"
+
+# An unparsable tag value leaves the host with no window at all
+# (lib/loadhosts.c turns a bad NOTAFTER: into INT_MAX and logs "Invalid
+# timestring"), so it must be treated as always active, never as absent.
+assert_file_exists "$work/var/hist/badtime.example.com" \
+	"--drop deleted the history of a host whose NOTAFTER: value does not parse"
+
+# The service side of those two, which the host-file assertions above do not
+# reach: they travel a different path through the scan.
+assert_file_exists "$work/var/hist/inwindow,example,com.conn" \
+	"--drop deleted the service history of a host inside its window"
+assert_file_exists "$work/var/hist/badtime,example,com.conn" \
+	"--drop deleted the service history of a host whose NOTAFTER: value does not parse"
+
+# 2. No file belonging to a listed host may be reported as orphaned at all,
+#    and a host-history file must never be announced as a service file.
+assert_not_contains "scheduledout" "$log" \
+	"a scheduled-out host was reported as orphaned (#281)"
+assert_not_contains "notyetin" "$log" \
+	"a not-yet-active host was reported as orphaned (#281)"
+
+# 3. The two scans must agree about the same host: history and histlogs are
+#    kept together, or dropped together.
+[ -d "$work/var/histlogs/scheduledout_example_com" ] \
+	|| fail "--droplogs removed the histlogs of a listed host"
+[ -e "$work/var/hist/scheduledout.example.com" ] \
+	|| fail "--drop deleted the history of scheduledout.example.com while --droplogs kept its histlogs -- the two scans disagree (#281)"
+[ ! -d "$work/var/histlogs/gone_example_com" ] \
+	|| fail "--droplogs kept the histlogs of a host that is not in hosts.cfg"
+
+# A kept file is trimmed, not merely left alone: the pre-cutoff line goes,
+# the post-cutoff line stays.
+kept=$(cat "$work/var/hist/scheduledout.example.com")
+assert_contains "$TRIM_RECENT" "$kept" "the post-cutoff line was trimmed out of a kept history file"
+assert_contains "$TRIM_OLD" "$kept" "the record spanning the cutoff was dropped from a kept history file"
+assert_not_contains "$TRIM_ANCIENT" "$kept" "a pre-cutoff line survived in a kept history file"
+
+echo "OK $(basename "$0")"

--- a/tests/xymond/trimhistory-drop-unloadable-hostscfg.sh
+++ b/tests/xymond/trimhistory-drop-unloadable-hostscfg.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/trimhistory-drop-unloadable-hostscfg.sh
+#
+# trimhistory judges a history file an orphan by looking its host up in the
+# configuration it just loaded. When that load fails there is nothing to look
+# anything up in -- so every host is "absent" and --drop deletes the whole
+# XYMONHISTDIR.
+#
+# load_hostnames() says so plainly: it returns -1 and logs "Cannot load host
+# data". trimhistory is the only caller that discards that return value
+# (xymond/trimhistory.c:429); xymongen (loadlayout.c:434), xymonnet
+# (xymonnet.c:404) and web/svcstatus.c:234 all check it and bail out -- and
+# none of them deletes files on the answer.
+#
+# Two ways an admin gets there, and they fail differently:
+#
+#   - HOSTSCFG names a file that is not there (a typo, a path that moved): the
+#     load returns -1 and says "Cannot load host data";
+#   - HOSTSCFG names a directory: fopen() succeeds on Linux, the read yields
+#     nothing, and the load reports *success* with an empty host list -- no
+#     message at all.
+#
+# So "the load failed" is not a sufficient guard on its own: an empty host list
+# must not authorise deletion either. A site that really has no hosts loses
+# nothing by being refused, since there is nothing to keep or trim.
+#
+# Distinct from #507, which is about the *network* load reporting success when
+# nobody was asked. Here the load correctly reports failure and trimhistory
+# proceeds regardless, so this stands whatever happens to the lib.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/trimhistory.sh
+. "$(dirname "$0")/../lib/trimhistory.sh"
+
+work=$(mktempdir)
+setup_trimhistory "$work"
+hosts_cfg "$work" '127.0.0.1 active.example.com # conn'
+
+seed_files() {
+	seed_hosthistory "$work" active.example.com
+	seed_svchistory  "$work" active,example,com.conn
+}
+
+# ---- HOSTSCFG names a file that does not exist ------------------------------
+seed_files
+export TRIM_HOSTSCFG="!$work/etc/nosuchfile.cfg"
+rc=0
+run_trimhistory "$work" --drop >"$work/missing.log" 2>&1 || rc=$?
+log=$(cat "$work/missing.log")
+
+assert_contains "Cannot load host data" "$log" \
+	"a failed configuration load was not reported"
+assert_file_exists "$work/var/hist/active.example.com" \
+	"--drop deleted a listed host's history after the configuration failed to load"
+assert_file_exists "$work/var/hist/active,example,com.conn" \
+	"--drop deleted a listed host's service history after the configuration failed to load"
+[ "$rc" -ne 0 ] \
+	|| fail "trimhistory reported success after failing to load the configuration it needs to decide what to delete"
+
+# ---- without --drop, a failed load still has work it can do safely ----------
+# "allevents" is the all-hosts event log: it is recognised by name before any
+# host lookup, so trimming it needs no host list. Refusing to run at all would
+# take that away for no gain -- nothing is deleted in this mode.
+rm -f "${work:?}/var/hist/"*
+seed_files
+{
+	printf 'ancient.example.com conn %d %d 3600 purple red 0\n' "$TRIM_ANCIENT" "$TRIM_ANCIENT"
+	printf 'old.example.com conn %d %d 3600 red green 0\n' "$TRIM_OLD" "$TRIM_OLD"
+	printf 'active.example.com conn %d %d 3600 green red 0\n' "$TRIM_RECENT" "$TRIM_RECENT"
+} >"$work/var/hist/allevents"
+export TRIM_HOSTSCFG="!$work/etc/nosuchfile.cfg"
+run_trimhistory "$work" >"$work/nodrop.log" 2>&1 || true
+
+assert_file_exists "$work/var/hist/active.example.com" \
+	"a run without --drop deleted a history file after a failed load"
+events=$(cat "$work/var/hist/allevents")
+assert_contains "$TRIM_RECENT" "$events" "allevents lost its post-cutoff event"
+assert_not_contains "$TRIM_ANCIENT" "$events" \
+	"allevents was not trimmed after a failed load, though trimming it needs no host list"
+
+# ---- HOSTSCFG names a directory: the load "succeeds" with nothing in it ------
+rm -f "${work:?}/var/hist/"*
+seed_files
+export TRIM_HOSTSCFG="!$work/etc"
+rc=0
+run_trimhistory "$work" --drop >"$work/emptyload.log" 2>&1 || rc=$?
+
+assert_file_exists "$work/var/hist/active.example.com" \
+	"--drop emptied the history directory on a host list that loaded with no hosts in it"
+assert_file_exists "$work/var/hist/active,example,com.conn" \
+	"--drop deleted a service history on a host list that loaded with no hosts in it"
+[ "$rc" -ne 0 ] \
+	|| fail "trimhistory reported success after loading a host list with no hosts in it"
+
+echo "OK $(basename "$0")"

--- a/tests/xymond/trimhistory-drop-unloadable-hostscfg.sh
+++ b/tests/xymond/trimhistory-drop-unloadable-hostscfg.sh
@@ -20,7 +20,10 @@
 #     load returns -1 and says "Cannot load host data";
 #   - HOSTSCFG names a directory: fopen() succeeds on Linux, the read yields
 #     nothing, and the load reports *success* with an empty host list -- no
-#     message at all.
+#     message at all. An empty regular file arrives at the same empty list on
+#     every platform, and is checked as well: where fopen() refuses a
+#     directory the run takes the failed-load branch instead, and the
+#     empty-list refusal would go untested.
 #
 # So "the load failed" is not a sufficient guard on its own: an empty host list
 # must not authorise deletion either. A site that really has no hosts loses
@@ -73,7 +76,11 @@ seed_files
 	printf 'active.example.com conn %d %d 3600 green red 0\n' "$TRIM_RECENT" "$TRIM_RECENT"
 } >"$work/var/hist/allevents"
 export TRIM_HOSTSCFG="!$work/etc/nosuchfile.cfg"
-run_trimhistory "$work" >"$work/nodrop.log" 2>&1 || true
+rc=0
+run_trimhistory "$work" >"$work/nodrop.log" 2>&1 || rc=$?
+
+[ "$rc" -eq 0 ] \
+	|| fail "a run without --drop failed after a failed load, though trimming allevents needs no host list"
 
 assert_file_exists "$work/var/hist/active.example.com" \
 	"a run without --drop deleted a history file after a failed load"
@@ -95,5 +102,26 @@ assert_file_exists "$work/var/hist/active,example,com.conn" \
 	"--drop deleted a service history on a host list that loaded with no hosts in it"
 [ "$rc" -ne 0 ] \
 	|| fail "trimhistory reported success after loading a host list with no hosts in it"
+
+# ---- HOSTSCFG names an empty file: the same empty list, on every platform ----
+# The directory above rests on fopen() accepting a directory. Where it does not,
+# that run is a *failed* load and takes the branch above, leaving the empty-list
+# refusal unexercised. An empty regular file loads successfully with no hosts
+# anywhere, so the message check below is what says which branch stopped the run.
+rm -f "${work:?}/var/hist/"*
+seed_files
+: >"$work/etc/empty.cfg"
+export TRIM_HOSTSCFG="!$work/etc/empty.cfg"
+rc=0
+run_trimhistory "$work" --drop >"$work/emptyfile.log" 2>&1 || rc=$?
+
+assert_not_contains "Cannot load host data" "$(cat "$work/emptyfile.log")" \
+	"an empty hosts.cfg was reported as a failed load -- the empty-list refusal is not what stopped the run"
+assert_file_exists "$work/var/hist/active.example.com" \
+	"--drop emptied the history directory on an empty hosts.cfg"
+assert_file_exists "$work/var/hist/active,example,com.conn" \
+	"--drop deleted a service history on an empty hosts.cfg"
+[ "$rc" -ne 0 ] \
+	|| fail "trimhistory reported success after loading an empty hosts.cfg"
 
 echo "OK $(basename "$0")"

--- a/tests/xymond/trimhistory-dropsvcs-board.sh
+++ b/tests/xymond/trimhistory-dropsvcs-board.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/trimhistory-dropsvcs-board.sh
+#
+# "trimhistory --dropsvcs" deletes the service-history files of tests that
+# xymond is no longer tracking. It asks the running xymond for the current
+# board (validstatus() -> "xymondboard fields=hostname,testname") and drops
+# any host+test pair the board does not carry.
+#
+# That board lists what is being monitored *now*, which is why this test
+# belongs with #281: once trimhistory stops treating a NOTBEFORE:/NOTAFTER:
+# host as absent, its service files stop being dropped as "no host" and start
+# reaching this second gate instead -- where the board cannot list them
+# either, precisely because the host is outside its window. Fixing the host
+# lookup alone would move the deletion rather than prevent it, so the rule the
+# fix has to honour is pinned here: a host that hosts.cfg lists but that is
+# outside its period is not a host --dropsvcs may judge.
+#
+# A fake xymond stands in for the real one; validstatus() exits(1) without a
+# board, so this cannot be tested by mocking nothing.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/trimhistory.sh
+. "$(dirname "$0")/../lib/trimhistory.sh"
+
+work=$(mktempdir)
+setup_trimhistory "$work"
+require_cc
+
+hosts_cfg "$work" \
+	'127.0.0.1 active.example.com       # conn http://example.com/' \
+	'127.0.0.1 scheduledout.example.com # conn NOTAFTER:202001010000'
+
+# The board a live xymond would return: the active host's conn test only.
+# "http" was removed from that host, and the scheduled-out host is not being
+# monitored at all, so neither appears.
+printf 'active.example.com|conn\nactive.example.com|web.grp\n' >"$work/board.reply"
+
+"$CC" -o "$work/fake-xymond" "$(find_root)/tests/lib/fake-xymond.c" 2>"$work/cc-fake.log" \
+	|| { cat "$work/cc-fake.log" >&2; fail "fake-xymond responder does not compile"; }
+"$work/fake-xymond" "$work/board.reply" >"$work/fake-xymond.port" &
+fakepid=$!
+register_cleanup "kill $fakepid 2>/dev/null || true"
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+	[ -s "$work/fake-xymond.port" ] && break
+	sleep 0.2
+done
+[ -s "$work/fake-xymond.port" ] || fail "fake-xymond did not report its port"
+export XYMSRV=127.0.0.1 XYMONDPORT="$(cat "$work/fake-xymond.port")"
+
+seed_svchistory "$work" active,example,com.conn         # on the board
+seed_svchistory "$work" active,example,com.web.grp      # on the board, dotted column
+seed_svchistory "$work" active,example,com.old.grp      # dotted column, retired
+seed_svchistory "$work" active,example,com.http         # listed host, test retired
+seed_svchistory "$work" scheduledout,example,com.conn   # listed host, outside its window
+seed_svchistory "$work" scheduledout,example,com.web.grp # ... and with a dotted column
+seed_hosthistory "$work" active.example.com
+seed_hosthistory "$work" scheduledout.example.com
+
+run_trimhistory "$work" --drop --dropsvcs >"$work/out.log" 2>&1 || true
+log=$(cat "$work/out.log")
+
+# The feature itself: a test the board no longer carries goes.
+[ ! -e "$work/var/hist/active,example,com.http" ] \
+	|| { echo "$log" >&2; fail "--dropsvcs kept a service-history file for a test the board does not list"; }
+assert_contains "no service" "$log" \
+	"--dropsvcs deleted a retired service file without reporting it"
+
+# What it must not touch: a test that is on the board.
+assert_file_exists "$work/var/hist/active,example,com.conn" \
+	"--dropsvcs deleted the history of a service the board lists"
+
+# The board is asked about the whole column name. Splitting the file name at
+# its last dot asks about "grp", which the board does not carry, so a live
+# dotted column looks retired.
+assert_file_exists "$work/var/hist/active,example,com.web.grp" \
+	"--dropsvcs deleted a dotted column that IS on the board -- it was asked about under a truncated name"
+
+# And a dotted column that really is retired must be reported as a missing
+# service, not as a missing host.
+[ ! -e "$work/var/hist/active,example,com.old.grp" ] \
+	|| fail "--dropsvcs kept a dotted column the board does not list"
+assert_contains "old.grp - no service" "$log" \
+	"a retired dotted column was reported as a missing host rather than a missing service"
+
+# And a host that is listed but outside its NOTBEFORE/NOTAFTER window is not
+# a host --dropsvcs gets to judge: the board omits it because it is scheduled
+# out, not because the service was retired.
+[ -e "$work/var/hist/scheduledout,example,com.conn" ] \
+	|| { echo "$log" >&2; fail "--dropsvcs deleted the service history of a scheduled-out host, which hosts.cfg still lists (#281)"; }
+assert_file_exists "$work/var/hist/scheduledout.example.com" \
+	"--drop deleted the host history of a scheduled-out host (#281)"
+assert_file_exists "$work/var/hist/scheduledout,example,com.web.grp" \
+	"--dropsvcs deleted a dotted column of a scheduled-out host -- both gates have to hold at once"
+
+echo "OK $(basename "$0")"

--- a/tests/xymond/trimhistory-dropsvcs-board.sh
+++ b/tests/xymond/trimhistory-dropsvcs-board.sh
@@ -66,7 +66,7 @@ log=$(cat "$work/out.log")
 # The feature itself: a test the board no longer carries goes.
 [ ! -e "$work/var/hist/active,example,com.http" ] \
 	|| { echo "$log" >&2; fail "--dropsvcs kept a service-history file for a test the board does not list"; }
-assert_contains "no service" "$log" \
+assert_contains "active,example,com.http - no service" "$log" \
 	"--dropsvcs deleted a retired service file without reporting it"
 
 # What it must not touch: a test that is on the board.

--- a/xymond/trimhistory.8
+++ b/xymond/trimhistory.8
@@ -50,6 +50,14 @@ file. A host that is listed but currently outside a
 or
 .B NOTAFTER:
 window counts as listed, and keeps its history.
+.sp
+If the host list cannot be loaded, or loads with no hosts in it, trimhistory
+drops nothing and exits with an error: every file would otherwise look like it
+belonged to a host that no longer exists. Runs without
+.B \-\-drop
+or
+.B \-\-droplogs
+are unaffected, since they delete nothing either way.
 
 .IP "\fB\-\-dropsvcs\fR"
 Causes trimhistory to delete files from services that are not currently

--- a/xymond/trimhistory.8
+++ b/xymond/trimhistory.8
@@ -45,7 +45,11 @@ must exist.
 .IP "\fB\-\-drop\fR"
 Causes trimhistory to delete files from hosts that are not listed in the
 .I hosts.cfg(5)
-file.
+file. A host that is listed but currently outside a
+.B NOTBEFORE:
+or
+.B NOTAFTER:
+window counts as listed, and keeps its history.
 
 .IP "\fB\-\-dropsvcs\fR"
 Causes trimhistory to delete files from services that are not currently

--- a/xymond/trimhistory.c
+++ b/xymond/trimhistory.c
@@ -398,6 +398,7 @@ int main(int argc, char *argv[])
 	int dropsvcs = 0;
 	int dropfiles = 0;
 	int droplogs = 0;
+	int loadres;
 	char *envarea = NULL;
 
 	for (argi = 1; (argi < argc); argi++) {
@@ -458,7 +459,35 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	load_hostnames(xgetenv("HOSTSCFG"), NULL, get_fqdn());
+	/*
+	 * --drop and --droplogs delete every file whose host is not in this
+	 * list, so a list that did not load is not "no hosts configured", it is
+	 * "nothing to compare against" - and acting on it empties XYMONHISTDIR.
+	 * xymongen, xymonnet and svcstatus.cgi all check this return and bail;
+	 * trimhistory was the only caller that ignored it, and the only one that
+	 * deletes on the answer.
+	 *
+	 * The return value alone is not enough. A HOSTSCFG naming a directory
+	 * (or an empty file) loads successfully with no hosts in it and says
+	 * nothing, so an empty list is refused too. A site that really has no
+	 * hosts loses nothing: there is no history to keep or trim either.
+	 *
+	 * Only the deleting modes are refused. Without them nothing is at risk,
+	 * and there is still work that needs no host list: "allevents" is
+	 * recognised by name before any lookup, so it goes on being trimmed.
+	 */
+	loadres = load_hostnames(xgetenv("HOSTSCFG"), NULL, get_fqdn());
+	if (dropfiles || droplogs) {
+		if (loadres == -1) {
+			errprintf("Cannot load %s - not dropping anything\n", xgetenv("HOSTSCFG"));
+			return 1;
+		}
+		if (first_host() == NULL) {
+			errprintf("No hosts loaded from %s - refusing to drop, every file would look orphaned\n",
+				  xgetenv("HOSTSCFG"));
+			return 1;
+		}
+	}
 
 	/* First scan the directory for all files, and pick up the ones we want to process */
 	while ((hent = readdir(histdir)) != NULL) {

--- a/xymond/trimhistory.c
+++ b/xymond/trimhistory.c
@@ -101,6 +101,38 @@ void add_to_filelist(char *fn, enum ftype_t ftype)
 }
 
 
+/*
+ * "gone.example.com" can be read two ways: a host-history file for a host of
+ * that name, or service "example.com" of a listed host "gone". The name alone
+ * cannot say which, so the record does: a host-history line is
+ * "<testname> <epoch> ...", a service-history line
+ * "<color> <Www Mmm dd hh:mm:ss yyyy> <epoch> ...", and the second field is a
+ * number in the first and a weekday name in the second.
+ *
+ * Only consulted for names that are genuinely ambiguous, which is rare: the
+ * host half of a service file normally carries the commas its dots were
+ * encoded as, and a column name normally holds no dot.
+ */
+static int looks_like_hosthistory(char *fn)
+{
+	FILE *fd;
+	char l[1024];
+	char *second;
+	int result = 0;
+
+	fd = fopen(fn, "r");
+	if (!fd) return 0;
+
+	if (fgets(l, sizeof(l), fd)) {
+		second = strchr(l, ' ');
+		while (second && (*second == ' ')) second++;
+		if (second && (*second >= '0') && (*second <= '9')) result = 1;
+	}
+
+	fclose(fd);
+	return result;
+}
+
 void trim_history(FILE *infd, FILE *outfd, enum ftype_t ftype, time_t cutoff)
 {
 	/* Does the grunt work of going through a file and copying the wanted records */
@@ -433,6 +465,7 @@ int main(int argc, char *argv[])
 		char *hostname = NULL;
 		char hostip[IP_ADDR_STRLEN];
 		enum ghosthandling_t ghosthandling = GH_IGNORE;
+		int inperiod = 1;
 
 		if (stat(hent->d_name, &st) == -1) {
 			errprintf("Odd entry %s - cannot stat: %s\n", hent->d_name, strerror(errno));
@@ -447,15 +480,33 @@ int main(int argc, char *argv[])
 			continue;
 		}
 
-		hostname = knownhost(hent->d_name, hostip, ghosthandling);
+		/*
+		 * knownhost_ex() rather than knownhost(): a host carrying
+		 * NOTBEFORE:/NOTAFTER: is listed in hosts.cfg, and only its
+		 * window is closed. knownhost() answers NULL for it, which made
+		 * --drop delete the history of exactly the hosts that are
+		 * coming back (#281).
+		 */
+		hostname = knownhost_ex(hent->d_name, hostip, ghosthandling, &inperiod);
 		if (hostname) {
 			/* Host history file. */
 			add_to_filelist(hent->d_name, F_HOSTHISTORY);
 		}
 		else {
 			char *delim, *p, *hname, *tname;
+			int ambiguous;
 
-			delim = strrchr(hent->d_name, '.');
+			/*
+			 * xymond_history writes a service-history file as
+			 * "<hostname with dots as commas>.<column>", so the host
+			 * half never holds a dot and the FIRST one is the
+			 * boundary. Splitting at the last dot instead put the
+			 * boundary inside a column name that carries one - the
+			 * web side treats "web.grp" as ordinary - so the host
+			 * came out as "host.web", resolved to nothing, and the
+			 * file was deleted as an orphan.
+			 */
+			delim = strchr(hent->d_name, '.');
 			if (!delim) {
 				/* It's a host history file (no dot in filename), but the host does not exist */
 				errprintf("Orphaned host-history file %s - no host\n", hent->d_name);
@@ -464,13 +515,30 @@ int main(int argc, char *argv[])
 			}
 
 			*delim = '\0'; hname = strdup(hent->d_name); tname = delim+1; *delim = '.';
+
+			/* Ambiguous only when the host half carries no encoded dot
+			 * and the column half does: then the same name could be a
+			 * host-history file for a host that has since been removed. */
+			ambiguous = ((strchr(hname, ',') == NULL) && (strchr(tname, '.') != NULL));
+
 			p = strchr(hname, ','); while (p) { *p = '.'; p = strchr(p, ','); }
-			hostname = knownhost(hname, hostip, ghosthandling);
+			hostname = knownhost_ex(hname, hostip, ghosthandling, &inperiod);
+			if (hostname && ambiguous && looks_like_hosthistory(hent->d_name)) {
+				/* It is a host-history file, and its own host is gone. */
+				hostname = NULL;
+			}
 			if (!hostname) {
 				errprintf("Orphaned service-history file %s - no host\n", hent->d_name);
 				if (dropfiles) add_to_filelist(hent->d_name, F_DROPIT);
 			}
-			else if (dropsvcs && !validstatus(hostname, tname)) {
+			/*
+			 * validstatus() asks the running xymond what it is
+			 * tracking now. A host outside its window is not on that
+			 * board precisely because it is scheduled out, so its
+			 * services would all look retired - the deletion #281 is
+			 * about, reached one gate later.
+			 */
+			else if (dropsvcs && inperiod && !validstatus(hostname, tname)) {
 				errprintf("Orphaned service-history file %s - no service\n", hent->d_name);
 				if (dropfiles) add_to_filelist(hent->d_name, F_DROPIT);
 			}


### PR DESCRIPTION
`--drop` is documented as deleting files "from hosts that are **not listed** in
the `hosts.cfg(5)` file". Three kinds of listed host were deleted anyway, and a
fourth case deleted everything.

**Scheduled out (#281).** A host carrying `NOTBEFORE:`/`NOTAFTER:` is listed;
only its window is closed. `knownhost()` answers NULL for it, so `--drop`
destroyed the history of exactly the hosts that are coming back.
`knownhost_ex()` now answers existence and reports the window separately;
`knownhost()` is a wrapper keeping the old contract, so no other caller moves.

**Judged by the board.** `--dropsvcs` asks the running xymond what it is
tracking, and a scheduled-out host is absent from that board *because* it is
scheduled out — so every one of its services looked retired. The board no
longer judges a host outside its window.

**A column name with a dot.** A service-history file is
`<hostname with dots as commas>.<column>`, so the host half never holds a dot
and the first one is the boundary. Splitting at the last dot put it inside the
column name: `web.grp` resolved as host `dotted.example.com.web` and the file
was dropped — while the web side serves that same column
(`tests/web/svcstatus-histlog-serving.sh`).

**No host list at all.** A list that did not load is not "no hosts configured",
it is nothing to compare against. A `HOSTSCFG` that has moved emptied
`XYMONHISTDIR`: `load_hostnames()` returned -1 and logged "Cannot load host
data", and trimhistory — the only caller that discarded that return, and the
only one that deletes on the answer — carried on. Checking the return is not
enough, since a `HOSTSCFG` naming a directory loads "successfully" with no
hosts and no message, so an empty list is refused too.

| test | on main | with this |
| --- | --- | --- |
| `trimhistory-drop-scheduled-out.sh` | scheduled-out and not-yet-active hosts deleted, host files reported as service files, histlogs kept while history went | kept and trimmed, scans agree, nothing reported |
| `trimhistory-dropsvcs-board.sh` | same deletion at the `--dropsvcs` gate; a live dotted column asked about as `grp` | kept; asked about as `web.grp`; a retired one still drops as "no service" |
| `trimhistory-drop-dotted-column.sh` | `web.grp` and `a.b.c` deleted on listed hosts | kept; an absent host's dotted column still drops |
| `trimhistory-drop-unloadable-hostscfg.sh` | history directory emptied, exit 0 | run refused, exit 1 |
| `trimhistory-drop-classification.sh` | green | green — case, `CLIENT:` aliases, dot-free names, `summary`, `allevents`, dotfile/directory skips, unparsable histlog names, trimming, dry run |

Suite on a clean build: **100 passed, 0 skipped, 0 failed**.

`trimhistory.8` documents both new rules.

Deliberate limits: a genuinely retired service on a scheduled-out host is kept
until the host returns; the "service-history file" wording for a dotted absent
host is unchanged (pre-existing, unrelated to the window). A comma inside a
hostname is not a case at all: `xymond` runs every incoming status hostname
through `uncommafy()` (`xymond/xymond.c:1300`), so a host configured as
`foo,bar` is looked up as `foo.bar`, never matches its own entry, and gets no
status and no history file to judge (#309, #314).

Fixes #281.


