### PR TITLE
lib/sendmsg: sending to nobody is not a successful send (#507)

### DIFF
--- a/lib/sendmsg.c
+++ b/lib/sendmsg.c
@@ -491,6 +491,28 @@ static int sendtomany(char *onercpt, char *morercpts, char *msg, int timeout, se
 		xymondlist = strdup(morercpts);
 
 	rcpt = strtok(xymondlist, " \t");
+	if (!rcpt) {
+		/*
+		 * Nobody to send to: an empty or whitespace-only recipient.
+		 * The loop below never runs, and this function would return
+		 * the XYMONSEND_OK it was initialised with -- a successful
+		 * send to no one, with an empty response.
+		 *
+		 * Callers cannot tell that from a real answer. prepare_fromnet()
+		 * takes the OK, caches the empty response as the configuration
+		 * and reports success, so load_hostnames() never falls back to
+		 * the file and its caller ends up with a valid-looking, empty
+		 * host list (#507). XYMSRV defaults to $XYMONSERVERIP, which
+		 * defaults to the XYMONHOSTIP the tree was built with, so an
+		 * empty value is not exotic.
+		 */
+		snprintf(errordetails+strlen(errordetails), (sizeof(errordetails) - strlen(errordetails)),
+			 "No recipient to send to! XYMSRV was '%s', XYMSERVERS '%s'",
+			 onercpt, textornull(morercpts));
+		xfree(xymondlist);
+		return XYMONSEND_EBADIP;
+	}
+
 	while (rcpt) {
 		int oneres;
 

--- a/tests/lib/trimhistory.sh
+++ b/tests/lib/trimhistory.sh
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# shellcheck shell=bash
+#
+# tests/lib/trimhistory.sh -- shared build/fixture recipe for the trimhistory
+# tests. Source after assert.sh, then:
+#
+#     setup_trimhistory "$work"
+#     hosts_cfg "$work" '127.0.0.1 active.example.com # conn'
+#     seed_hosthistory "$work" active.example.com
+#     seed_svchistory  "$work" active,example,com.conn
+#     seed_histlogs    "$work" active_example_com conn
+#     run_trimhistory  "$work" --drop
+#
+# HOSTSCFG carries a "!" prefix on purpose. load_hostnames() asks xymond for
+# the configuration whenever the filename it is handed equals $HOSTSCFG
+# (lib/loadhosts_file.c) -- which is exactly what trimhistory passes it. With
+# no xymond listening the host list then loads empty, every history file looks
+# orphaned, and a --drop test would "pass" by deleting the entire fixture.
+# The "!" forces the file load these tests are about.
+
+[ -n "${__XYMON_TESTS_TRIMHISTORY_SOURCED:-}" ] && return 0
+__XYMON_TESTS_TRIMHISTORY_SOURCED=1
+
+# shellcheck source=tests/lib/build-worker.sh
+. "$(dirname "${BASH_SOURCE[0]}")/build-worker.sh"
+
+# Each fixture file carries three records: two before the cutoff and one after
+# it. Two, because trim_history() keeps the last pre-cutoff line on purpose --
+# it is the state the host was in when the cutoff passed -- so a file seeded
+# with a single old line looks untrimmed however well the trimming works.
+# TRIM_ANCIENT is therefore the line that must disappear, TRIM_OLD the one
+# that must survive, TRIM_RECENT the line after the cutoff. Having both a kept
+# and a dropped line also means a deleted file can never be mistaken for a
+# trimmed one.
+TRIM_NOW=$(date +%s)
+TRIM_CUTOFF=$((TRIM_NOW - 86400))
+TRIM_ANCIENT=$((TRIM_NOW - 8640000))
+TRIM_OLD=$((TRIM_NOW - 864000))
+TRIM_RECENT=$((TRIM_NOW - 3600))
+
+# A service-history record carries the change time twice: as text and as the
+# epoch the trimmer actually reads (column 7). The text is never parsed there,
+# so the fixtures use one fixed, obviously-old spelling rather than formatting
+# an epoch -- converting one portably means date -d on GNU and date -r on the
+# BSDs, and the suite runs on both.
+TRIM_TEXTDATE='Mon Jan  1 00:00:00 2001'
+
+# A histlog file name, by contrast, *is* parsed: logtime() wants exactly
+# WWW_MMM_DD_hh:mm:ss_YYYY, 24 characters. This one is the same instant, and
+# comfortably before any cutoff a test can pick.
+TRIM_LOGSTAMP='Mon_Jan__1_00:00:00_2001'
+
+setup_trimhistory() {
+	local work=$1
+	build_xymond_worker "$work" trimhistory xymond/trimhistory.c
+	mkdir -p "$work/etc" "$work/var/hist" "$work/var/histlogs" "$work/var/logs"
+	: >"$work/etc/hosts.cfg"
+}
+
+# hosts_cfg WORK LINE... -- append raw lines to the fixture hosts.cfg.
+hosts_cfg() {
+	local work=$1
+	shift
+	printf '%s\n' "$@" >>"$work/etc/hosts.cfg"
+}
+
+# seed_hosthistory WORK NAME -- a host-history file, as xymond_history writes
+# it: "testname tstamp lastchg duration newcol oldcol trend" (the trimmer
+# reads the timestamp from column 2).
+seed_hosthistory() {
+	local work=$1 name=$2
+	{
+		printf 'conn %d %d 3600 purple red 0\n' "$TRIM_ANCIENT" "$((TRIM_ANCIENT - 3600))"
+		printf 'conn %d %d 3600 red green 0\n' "$TRIM_OLD" "$((TRIM_OLD - 3600))"
+		printf 'conn %d %d 3600 green red 0\n' "$TRIM_RECENT" "$((TRIM_RECENT - 3600))"
+	} >"$work/var/hist/$name"
+}
+
+# seed_svchistory WORK NAME -- a service-history file: "color <ctime> tstamp
+# duration nextcolor" (the trimmer reads the timestamp from column 7).
+seed_svchistory() {
+	local work=$1 name=$2
+	{
+		printf 'purple %s %d 3600 red\n' "$TRIM_TEXTDATE" "$TRIM_ANCIENT"
+		printf 'red %s %d 3600 green\n' "$TRIM_TEXTDATE" "$TRIM_OLD"
+		printf 'green %s %d 3600 red\n' "$TRIM_TEXTDATE" "$TRIM_RECENT"
+	} >"$work/var/hist/$name"
+}
+
+# seed_histlogs WORK LOGNAME SVC -- one status log older than the cutoff.
+# LOGNAME is the hostname with dots and commas as underscores; the file name
+# is the 24-character stamp logtime() parses (WWW_MMM_DD_hh:mm:ss_YYYY).
+seed_histlogs() {
+	local work=$1 logname=$2 svc=$3
+	mkdir -p "$work/var/histlogs/$logname/$svc"
+	printf 'green %s stale\n' "$TRIM_TEXTDATE" \
+		>"$work/var/histlogs/$logname/$svc/$TRIM_LOGSTAMP"
+}
+
+# run_trimhistory WORK ARGS... -- run against the fixture, capturing stderr in
+# <work>/trim.log and printing it, so a caller can grep the run's messages.
+#
+# The file is replaced on every run, not added to: a test that runs twice
+# against the same fixture would otherwise grep the first run's messages and
+# see them as the second's.
+#
+# A caller that is testing the configuration load itself sets TRIM_HOSTSCFG to
+# the spelling it wants (a bare path takes the xymond-first route).
+#
+# XYMONSERVERLOGS is redirected for the same reason as the rest, and it is the
+# one that reaches outside the fixture if it is not: after trimming
+# "allevents", trimhistory reads $XYMONSERVERLOGS/xymond_history.pid and sends
+# that process a SIGHUP (xymond/trimhistory.c). Left unset it falls back to the
+# compiled-in XYMONLOGDIR, so a test that seeds an allevents file would signal
+# the xymond_history of a real Xymon running on the machine -- and pass.
+run_trimhistory() {
+	local work=$1 rc
+	shift
+	set +e
+	XYMONHOME="$work" \
+	HOSTSCFG="${TRIM_HOSTSCFG:-!$work/etc/hosts.cfg}" \
+	XYMONHISTDIR="$work/var/hist" \
+	XYMONHISTLOGS="$work/var/histlogs" \
+	XYMONSERVERLOGS="$work/var/logs" \
+	XYMONTMP="$work" \
+		"$work/trimhistory" --cutoff="$TRIM_CUTOFF" "$@" >"$work/trim.log" 2>&1
+	rc=$?
+	set -e
+	cat "$work/trim.log"
+	return $rc
+}

--- a/tests/server/sendmsg-empty-recipient-harness.c
+++ b/tests/server/sendmsg-empty-recipient-harness.c
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * tests/server/sendmsg-empty-recipient-harness.c
+ *
+ * One call into sendmessage(), with the recipient left to $XYMSRV, printing the
+ * sendresult_t it came back with. The caller supplies the environment and
+ * judges the answer: sendmessage() caches $XYMSRV in a static on its first
+ * call, so each case has to be its own process.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "libxymon.h"
+
+static const char *resultname(sendresult_t r)
+{
+	switch (r) {
+	  case XYMONSEND_OK:               return "XYMONSEND_OK";
+	  case XYMONSEND_EBADIP:           return "XYMONSEND_EBADIP";
+	  case XYMONSEND_EIPUNKNOWN:       return "XYMONSEND_EIPUNKNOWN";
+	  case XYMONSEND_ENOSOCKET:        return "XYMONSEND_ENOSOCKET";
+	  case XYMONSEND_ECANNOTDONONBLOCK: return "XYMONSEND_ECANNOTDONONBLOCK";
+	  case XYMONSEND_ECONNFAILED:      return "XYMONSEND_ECONNFAILED";
+	  case XYMONSEND_ESELFAILED:       return "XYMONSEND_ESELFAILED";
+	  case XYMONSEND_ETIMEOUT:         return "XYMONSEND_ETIMEOUT";
+	  case XYMONSEND_EWRITEERROR:      return "XYMONSEND_EWRITEERROR";
+	  case XYMONSEND_EREADERROR:       return "XYMONSEND_EREADERROR";
+	  case XYMONSEND_EBADURL:          return "XYMONSEND_EBADURL";
+	}
+
+	return "XYMONSEND_UNRECOGNISED";
+}
+
+int main(int argc, char **argv)
+{
+	sendreturn_t *response;
+	sendresult_t res;
+	int timeout = (argc > 1) ? atoi(argv[1]) : 2;
+
+	response = newsendreturnbuf(1, NULL);
+	res = sendmessage("ping", NULL, timeout, response);
+	printf("result=%s\n", resultname(res));
+	freesendreturnbuf(response);
+
+	return 0;
+}

--- a/tests/server/sendmsg-empty-recipient.sh
+++ b/tests/server/sendmsg-empty-recipient.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/server/sendmsg-empty-recipient.sh
+#
+# sendtomany() initialises its result to XYMONSEND_OK and only ever changes it
+# inside the loop over recipients. An empty or whitespace-only recipient yields
+# no token from strtok(), the loop body never runs, and the function reports a
+# successful send -- with an empty response (#507). Callers cannot tell that
+# from a real answer: prepare_fromnet() caches the empty response as the
+# configuration, load_hostnames() never falls back to the file, and the caller
+# ends up with a valid-looking, empty host list.
+#
+# This checks the defect where it lives: one call into lib, no daemon, no
+# fixture. Its companion, tests/xymond/trimhistory-drop-needs-hostlist.sh,
+# follows the same bug out to its consequence -- an emptied XYMONHISTDIR.
+#
+# Both on purpose. The end-to-end one states what an admin cares about and
+# fails if any link from sendtomany() through load_hostnames() to trimhistory
+# breaks, including links nobody has touched yet. This one cannot be blinded by
+# a change anywhere outside lib/sendmsg.c, which is what an end-to-end test
+# cannot promise: a guard added downstream can stop the damage, and then the
+# damage is no longer evidence about the cause.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+
+ROOT=$(find_root)
+here=$(dirname "$0")
+
+require_cc
+[ -f "$ROOT/include/config.h" ] && [ -f "$ROOT/lib/libxymoncomm.a" ] \
+	|| skip "tree not built (run make first; the post-build CI suite covers this)"
+
+work=$(mktempdir)
+
+# The configured flags rather than a hand-rolled list: libxymon.h pulls in
+# pcre2.h, which lives under /usr/local/include or /usr/pkg/include on the
+# BSDs, and the link flags carry the library search path and the runtime path.
+harness_cflags=$(xymon_cflags "$ROOT")
+harness_ldflags=$(xymon_ldflags "$ROOT")
+pcre_libs=${PCRELIBS:-$(sed -n 's/^PCRELIBS *= *//p' "$ROOT/Makefile")}
+[ -n "$pcre_libs" ] || pcre_libs="-lpcre2-8"
+
+# Archives listed twice rather than --start-group, which is GNU ld only.
+# shellcheck disable=SC2086
+"$CC" $harness_cflags -iquote "$ROOT/lib" -o "$work/harness" \
+	"$here/sendmsg-empty-recipient-harness.c" \
+	"$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" "$ROOT/lib/libxymontime.a" \
+	"$ROOT/lib/libxymoncomm.a" "$ROOT/lib/libxymon.a" \
+	$pcre_libs $harness_ldflags 2>"$work/cc.log" \
+	|| { cat "$work/cc.log" >&2; fail "harness does not compile"; }
+
+# send RECIPIENT -- one process per case, because sendmessage() caches $XYMSRV.
+send() {
+	env XYMSRV="$1" XYMSERVERS="" XYMONDPORT="${2:-1984}" \
+		"$work/harness" 2 2>"$work/err.log"
+}
+
+# ---- an empty recipient is nobody, not everybody ---------------------------
+# XYMSRV defaults to $XYMONSERVERIP, which defaults to the XYMONHOSTIP the tree
+# was built with (lib/Makefile, -DXYMONHOSTIP). A build that passed none, or an
+# environment where it is empty, arrives here.
+got=$(send "")
+assert_not_contains "XYMONSEND_OK" "$got" \
+	"an empty XYMSRV was reported as a successful send, so a caller cannot tell it from a real answer ($got)"
+
+# ---- and neither is a recipient made only of separators --------------------
+# The same hole spelled differently: strtok() on " \t" yields no token either,
+# so a guard that only compares against "" would leave this one open.
+got=$(send "   ")
+assert_not_contains "XYMONSEND_OK" "$got" \
+	"a whitespace-only XYMSRV was reported as a successful send ($got)"
+
+# ---- control: a real recipient is still attempted --------------------------
+# Without this the test is satisfied by a sendmessage() that refuses everything.
+# Port 1 has nothing listening, so the send must fail -- but as a connection
+# failure, having got as far as the socket, not as the bad-address refusal the
+# two cases above produce.
+got=$(send "127.0.0.1" 1)
+assert_not_contains "XYMONSEND_OK" "$got" \
+	"a refused connection was reported as a successful send ($got)"
+assert_not_contains "XYMONSEND_EBADIP" "$got" \
+	"a usable recipient was refused as a bad address -- the empty-recipient guard is swallowing the normal path ($got)"
+
+pass "sending to an empty recipient is refused, and a usable one is still attempted"

--- a/tests/xymond/trimhistory-drop-needs-hostlist.sh
+++ b/tests/xymond/trimhistory-drop-needs-hostlist.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/trimhistory-drop-needs-hostlist.sh
+#
+# "trimhistory --drop" decides what to delete by asking whether each history
+# file's host is in hosts.cfg. If the host list did not load, every host is
+# absent and every file is an orphan -- so a load that quietly produces
+# nothing must never be allowed to authorise a deletion.
+#
+# It currently is. load_hostnames() asks xymond for the configuration whenever
+# the filename it is handed equals $HOSTSCFG (lib/loadhosts_file.c), which is
+# exactly what trimhistory passes it. When XYMSRV resolves to an empty string
+# there is no recipient to ask: sendmessage() hands sendtomany() an empty
+# list, whose loop body never runs, and it returns XYMONSEND_OK with an empty
+# response. prepare_fromnet() therefore does not return -1, the file-load
+# fallback never runs, the host list stays empty, and --drop deletes the whole
+# history directory without printing one error.
+#
+# XYMSRV defaults to $XYMONSERVERIP, which defaults to the XYMONHOSTIP the
+# tree was built with, so whether an unset environment lands here depends on
+# the build. The test sets XYMSRV empty itself rather than inheriting that:
+# the trigger under test is the empty recipient, and it should be stated.
+#
+# The same run with XYMSRV pointing at a refused port behaves correctly:
+# sendmessage fails, prepare_fromnet() returns -1, the file is read, and the
+# host is recognised. That contrast is asserted here too, so a fix cannot be
+# mistaken for the environment simply never reaching the network path.
+#
+# This test follows the bug to its consequence, three layers from where it
+# lives; tests/server/sendmsg-empty-recipient.sh checks sendtomany() itself.
+# Both, because each covers what the other cannot: an end-to-end test fails
+# when any link in the chain breaks, including links nobody has touched yet,
+# while a test at the defect cannot be blinded by a change somewhere else.
+#
+# That is not hypothetical here. Asserting that the history files survive -- the
+# obvious way to write this -- stops being evidence as soon as trimhistory
+# refuses to drop on an empty host list (#281), because then they survive
+# either way. So the assertions below are about the work the run did, not about
+# the damage it avoided: a fixture record old enough for any run to trim is
+# gone only if the host list really loaded.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/trimhistory.sh
+. "$(dirname "$0")/../lib/trimhistory.sh"
+
+work=$(mktempdir)
+setup_trimhistory "$work"
+hosts_cfg "$work" '127.0.0.1 active.example.com # conn'
+
+# The bug is an empty recipient, not an absent daemon: no connection is
+# attempted at all, so the result does not depend on whether this machine
+# happens to run a xymond.
+export XYMSRV=""
+unset XYMONSERVERIP XYMSERVERS
+
+# A bare path is what a real install has in xymonserver.cfg, and it is the
+# spelling that takes the xymond-first route.
+export TRIM_HOSTSCFG="$work/etc/hosts.cfg"
+
+seed_hosthistory "$work" active.example.com
+seed_svchistory  "$work" active,example,com.conn
+
+rc=0
+run_trimhistory "$work" --drop >"$work/out.log" 2>&1 || rc=$?
+log=$(cat "$work/out.log")
+
+assert_file_exists "$work/var/hist/active.example.com" \
+	"--drop deleted the history of a host that IS in hosts.cfg, because the host list loaded empty and nothing said so"
+assert_file_exists "$work/var/hist/active,example,com.conn" \
+	"--drop deleted the service history of a host that IS in hosts.cfg, because the host list loaded empty"
+
+# The files surviving is not evidence on its own. #281's fix refuses to drop at
+# all on an empty host list, so once that is in the tree they survive whether or
+# not the send was refused -- and a test that only asks whether anything was
+# deleted stops saying anything about this bug.
+#
+# What only a working file fallback produces is a run that went ahead and did
+# its work. The fixture carries a record old enough for any run to trim, so the
+# trimming is the evidence: present means the host list loaded and the host was
+# found, absent means trimhistory never got that far.
+events=$(cat "$work/var/hist/active.example.com")
+assert_contains "$TRIM_RECENT" "$events" \
+	"the host history lost its post-cutoff record"
+assert_not_contains "$TRIM_ANCIENT" "$events" \
+	"nothing was trimmed -- the host list never loaded, so there was no host to work on"
+assert_not_contains "refusing to drop" "$log" \
+	"the run was stopped by the empty-host-list guard, so the file fallback never happened"
+[ "$rc" -eq 0 ] \
+	|| fail "a run whose hosts.cfg is readable did not complete: $log"
+
+# Control: the same path with a reachable-but-refused server already falls
+# back to the file correctly, so the fixture is not simply avoiding the net.
+work2=$(mktempdir)
+setup_trimhistory "$work2"
+hosts_cfg "$work2" '127.0.0.1 active.example.com # conn'
+seed_hosthistory "$work2" active.example.com
+export XYMSRV=127.0.0.1 XYMONDPORT=1
+run_trimhistory "$work2" --drop >"$work2/out.log" 2>&1 || true
+assert_file_exists "$work2/var/hist/active.example.com" \
+	"a refused xymond connection did not fall back to the hosts.cfg file"
+assert_contains "Cannot load hosts.cfg from xymond" "$(cat "$work2/out.log")" \
+	"a refused xymond connection was not reported"
+
+echo "OK $(basename "$0")"


### PR DESCRIPTION
`sendtomany()` initialises its result to `XYMONSEND_OK` and only changes it
inside the loop over recipients. An empty or whitespace-only recipient list
yields no token from `strtok()`, the loop body never runs, and the function
reports a **successful send with an empty response**.

Callers cannot tell that from a real answer. `prepare_fromnet()` takes the OK,
caches the empty response as the configuration and returns 0 rather than -1, so
`load_hostnames()` never falls back to the file and its caller ends up with a
valid-looking, empty host list. `XYMSRV` defaults to `$XYMONSERVERIP`, which
defaults to the `XYMONHOSTIP` the tree was built with, so an empty value is not
exotic.

Where it costs data is `trimhistory --drop`, which deletes every file whose host
is not in that list:

| run | before | after |
| --- | --- | --- |
| `XYMSRV=""`, `--drop`, one listed host | `Orphaned service-history file active.example.com - no host`, `XYMONHISTDIR` emptied, no error | send refused, file read, host found, history kept |
| `XYMSRV=127.0.0.1`, port refused | already correct: `Cannot load hosts.cfg from xymond, code 5`, falls back to the file | unchanged |

The fix refuses the send, naming both recipient values the way the neighbouring
`No recipients listed!` branch does.

The other candidate site — making `prepare_fromnet()` reject an empty response —
is not included: with the root refused it has no case left to catch here, and
one guard is easier to reason about than two.

Two tests, at different layers.
`tests/server/sendmsg-empty-recipient.sh` calls `sendmessage()` with an empty
recipient, and then with a whitespace-only one, which `strtok()` treats the same
way; a refused connection to a real address is its control, so a `sendmessage()`
that rejected everything could not pass it.
`tests/xymond/trimhistory-drop-needs-hostlist.sh` drives the same bug through
trimhistory, where the consequence is visible, and carries the
refused-connection case for the same reason.

The end-to-end test asserts the work the run did, not the damage it avoided.
Asserting that the history files survive is the obvious way to write it, and it
stops being evidence as soon as trimhistory refuses to drop on an empty host
list (#281): then they survive either way. Measured on a tree carrying both
changes with `sendtomany()` put back as it was — the file assertions and the
message match all held, and the test passed while the defect was present. A
fixture record old enough for any run to trim is gone only if the host list
really loaded, so that is what it asks now.

| world | this test | the lib test |
| --- | --- | --- |
| #509 alone, fix present | pass | pass |
| #509 alone, fix removed | fail | fail |
| #508 + #509, fix removed | fail | fail |

Suite on a clean build: **97 passed, 0 skipped, 0 failed**.

`tests/lib/trimhistory.sh` is the same helper as in #508, byte for byte, so
whichever merges first satisfies the other.

Fixes #507.

