### PR TITLE
docs: say plainly that a comma in a hostname does not work

### DIFF
--- a/common/hosts.cfg.5
+++ b/common/hosts.cfg.5
@@ -35,16 +35,28 @@ interface only when built from the characters
 and
 .BR : . _ -
 (letters, digits, colon, period, underscore and hyphen). A host whose name
-contains any other character - other punctuation, a literal comma (which the
-web URLs use to encode a period, so it cannot appear in a name), or a
-non-ASCII byte - is still monitored, but
+contains other punctuation or a non-ASCII byte is still monitored - it is
+tested, its status is stored and its history is kept - but
 .I xymond(8)
-writes a warning to the Xymon log when it loads the configuration and its
+writes a warning to the Xymon log when it loads the configuration, and its
 status pages are not reachable through the web interface. To show a non-ASCII
 or otherwise decorated name in the web interface, give the host an ASCII
 canonical name and carry the display spelling in the
 .B NAME:
 tag (see below).
+.sp
+A literal comma is the exception: a name that holds one does not work at all.
+A comma stands for a period wherever a name travels - the web URLs encode it
+that way, and
+.I xymond(8)
+converts it back on the hostname of every status message it receives. A host
+configured as
+.B foo,bar
+is therefore tested like any other, but its results arrive under the name
+.B foo.bar
+and never match the entry in this file: the configured host gets no status, no
+history and no web page. It draws the same warning, for that reason. Do not
+use a comma in a canonical name.
 
 The optional tags are then used to define which tests are
 relevant for the host, and also to set e.g. the time-interval used

--- a/docs/manpages/man5/hosts.cfg.5.html
+++ b/docs/manpages/man5/hosts.cfg.5.html
@@ -56,14 +56,21 @@ Section: File Formats (5)<br/>Updated: Version 4.3.30: 4 Sep 2019<br/><a href="#
     database and appears in web-page URLs and RRD file paths. It is reachable
     through the web interface only when built from the characters <b>A-Z a-z
     0-9</b> and <b>:</b>.<b>_</b>- (letters, digits, colon, period, underscore
-    and hyphen). A host whose name contains any other character - other
-    punctuation, a literal comma (which the web URLs use to encode a period, so
-    it cannot appear in a name), or a non-ASCII byte - is still monitored, but
-    <i><a href="../man8/xymond.8.html">xymond</a>(8)</i> writes a warning to the Xymon log when it loads the
-    configuration and its status pages are not reachable through the web
-    interface. To show a non-ASCII or otherwise decorated name in the web
+    and hyphen). A host whose name contains other punctuation or a non-ASCII
+    byte is still monitored - it is tested, its status is stored and its history
+    is kept - but <i><a href="../man8/xymond.8.html">xymond</a>(8)</i> writes a warning to the Xymon log when it
+    loads the configuration, and its status pages are not reachable through the
+    web interface. To show a non-ASCII or otherwise decorated name in the web
     interface, give the host an ASCII canonical name and carry the display
     spelling in the <b>NAME:</b> tag (see below).</p>
+<p class="Pp">A literal comma is the exception: a name that holds one does not
+    work at all. A comma stands for a period wherever a name travels - the web
+    URLs encode it that way, and <i><a href="../man8/xymond.8.html">xymond</a>(8)</i> converts it back on the
+    hostname of every status message it receives. A host configured as
+    <b>foo,bar</b> is therefore tested like any other, but its results arrive
+    under the name <b>foo.bar</b> and never match the entry in this file: the
+    configured host gets no status, no history and no web page. It draws the
+    same warning, for that reason. Do not use a comma in a canonical name.</p>
 <p class="Pp">The optional tags are then used to define which tests are relevant
     for the host, and also to set e.g. the time-interval used for availability
     reporting by <i><a href="../man1/xymongen.1.html">xymongen</a>(1)</i></p>


### PR DESCRIPTION
`hosts.cfg(5)` put a literal comma in a list with other punctuation and
non-ASCII bytes, in a sentence ending "is still monitored", and left the reason
it does not work in a parenthesis. Read straight through, it says such a host
is monitored like any other and only its web pages are missing.

It is not monitored. `xymond` runs the hostname of every incoming status
message through `uncommafy()` (`xymond/xymond.c:1300`) and the lookup is exact
(`lib/loadhosts.c:397`), so a host configured as `foo,bar` is tested, its
results arrive under the name `foo.bar`, and that never matches its entry: no
status, no history, no web page. `warn_unreachable_hostnames()` already warns
about the name; the page did not say what the warning means.

The comma now has its own paragraph saying what happens and why, and the first
paragraph is left to the cases where "is still monitored" is true.

Verified: `mandoc -Tlint` reports nothing in the edited range, `mandoc -Tascii`
renders both paragraphs as intended, and the HTML is `build/makehtml.sh`
output, not hand-edited.
