### PR TITLE
trimhistory: refuse to drop on a hosts.cfg that lost an include (#512)

### DIFF
--- a/lib/stackio.c
+++ b/lib/stackio.c
@@ -51,6 +51,17 @@ static char *stackfd_mode = NULL;
 static htnames_t *fnlist = NULL;
 
 /*
+ * Non-optional "include" and "directory" lines whose target could not be
+ * opened during the current stack. A configuration file says which of its
+ * includes may be missing -- that is what the "optional" prefix is for -- and
+ * without this the two spellings are indistinguishable to a caller: both leave
+ * it holding a file that parsed cleanly and is short by whatever the include
+ * carried. Harmless for a reader, not for one that deletes on the answer
+ * (trimhistory --drop, #512).
+ */
+static int stackfd_lostincludes = 0;
+
+/*
  * initfgets() and unlimfgets() implements a fgets() style
  * input routine that can handle arbitrarily long input lines.
  * Buffer space for the input is dynamically allocated and
@@ -199,6 +210,7 @@ FILE *stackfopen(char *filename, char *mode, void **v_listhead)
 	if (fdhead == NULL) {
 		char *p;
 
+		stackfd_lostincludes = 0;
 		stackfd_base = strdup(filename);
 		p = strrchr(stackfd_base, '/'); if (p) *(p+1) = '\0';
 
@@ -275,6 +287,17 @@ int stackfclose(FILE *fd)
 	return result;
 }
 
+int stackfmissing(void)
+{
+	/*
+	 * How many non-optional includes the last stack could not open. A caller
+	 * that only renders can ignore this and show what did load; one that
+	 * deletes on the answer cannot (#512).
+	 */
+	return stackfd_lostincludes;
+}
+
+
 int stackfmodified(void *v_listhead)
 {
 	/* Walk the list of filenames, and see if any have changed */
@@ -341,7 +364,7 @@ static void addtofnlist(char *dirname, int is_optional, void **v_listhead)
 		snprintf(dirfn, sizeof(dirfn), "%s/%s", stackfd_base, dirname);
 
 	if ((dirfd = opendir(dirfn)) == NULL) {
-		if (!is_optional) errprintf("WARNING: Cannot open directory %s\n", dirfn);
+		if (!is_optional) { stackfd_lostincludes++; errprintf("WARNING: Cannot open directory %s\n", dirfn); }
 		else dbgprintf("addtofnlist(): Cannot open directory %s\n", dirfn);
 		return;
 	}
@@ -454,7 +477,7 @@ char *stackfgets(strbuffer_t *buffer, char *extraincl)
 			if (*newfn && (stackfopen(newfn, "r", (void **)fdhead->listhead) != NULL))
 				return stackfgets(buffer, extraincl);
 			else {
-				if (!optional) errprintf("WARNING: Cannot open include file '%s', line was: %s\n", newfn, STRBUF(buffer));
+				if (!optional) { stackfd_lostincludes++; errprintf("WARNING: Cannot open include file '%s', line was: %s\n", newfn, STRBUF(buffer)); }
 				else dbgprintf("stackfgets(): Cannot open include file '%s', line was: %s\n", newfn, STRBUF(buffer));
 
 				if (eol) *eol = eolchar;
@@ -480,7 +503,7 @@ char *stackfgets(strbuffer_t *buffer, char *extraincl)
 			else if (fnlist) {
 				htnames_t *tmp = fnlist;
 
-				if (!optional) errprintf("WARNING: Cannot open include file '%s', line was: %s\n", fnlist->name, buffer);
+				if (!optional) { stackfd_lostincludes++; errprintf("WARNING: Cannot open include file '%s', line was: %s\n", fnlist->name, buffer); }
 				else dbgprintf("stackfgets(): Cannot open include file '%s', line was: %s\n", fnlist->name, buffer);
 
 				fnlist = fnlist->next;
@@ -510,7 +533,7 @@ char *stackfgets(strbuffer_t *buffer, char *extraincl)
 			else {
 				htnames_t *tmp = fnlist;
 
-				if (!optional) errprintf("WARNING: Cannot open include file '%s', line was: %s\n", fnlist->name, buffer);
+				if (!optional) { stackfd_lostincludes++; errprintf("WARNING: Cannot open include file '%s', line was: %s\n", fnlist->name, buffer); }
 				else dbgprintf("stackfgets(): Cannot open include file '%s', line was: %s\n", fnlist->name, buffer);
 
 				fnlist = fnlist->next;

--- a/lib/stackio.h
+++ b/lib/stackio.h
@@ -18,6 +18,7 @@ extern char *unlimfgets(strbuffer_t *buffer, FILE *fd);
 extern FILE *stackfopen(char *filename, char *mode, void **v_filelist);
 extern int stackfclose(FILE *fd);
 extern char *stackfgets(strbuffer_t *buffer, char *extraincl);
+extern int stackfmissing(void);
 extern int stackfmodified(void *v_listhead);
 extern void stackfclist(void **v_listhead);
 

--- a/tests/xymond/trimhistory-drop-lost-include.sh
+++ b/tests/xymond/trimhistory-drop-lost-include.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# tests/xymond/trimhistory-drop-lost-include.sh
+#
+# A hosts.cfg says which of its includes are allowed to be missing: "optional
+# include ..." may be absent, a plain "include ..." is expected to be there.
+# Both were treated the same when the file would not open -- a warning, and on
+# with a host list short by everything that include carried (#512).
+#
+# For a renderer that is a degraded page. For "trimhistory --drop" it is data
+# loss: those hosts are absent from the list, so their history files look like
+# orphans, and they are deleted. Nothing in the run says the configuration was
+# incomplete -- the warning names a file, not the hosts it was carrying, and the
+# exit status is 0.
+#
+# The second half is the control, and it is why the fix reads the keyword rather
+# than counting includes: "optional include" must still proceed and drop what
+# really is orphaned. A fix that refused to run whenever a hosts.cfg mentioned
+# an include would pass the first half and be useless.
+#
+# HOSTSCFG carries a "!" prefix on purpose. load_hostnames() asks xymond for the
+# configuration whenever the filename it is handed equals $HOSTSCFG
+# (lib/loadhosts_file.c) -- which is what trimhistory passes it. With no xymond
+# listening the host list would then load empty, every file would look orphaned,
+# and a --drop test would "pass" by deleting the whole fixture. The "!" forces
+# the file load this test is about.
+
+set -euo pipefail
+# shellcheck source=tests/lib/assert.sh
+. "$(dirname "$0")/../lib/assert.sh"
+# shellcheck source=tests/lib/build-worker.sh
+. "$(dirname "$0")/../lib/build-worker.sh"
+
+work=$(mktempdir)
+build_xymond_worker "$work" trimhistory xymond/trimhistory.c
+mkdir -p "$work/etc" "$work/var/hist" "$work/var/logs"
+
+now=$(date +%s)
+cutoff=$((now - 86400))
+ancient=$((now - 8640000))   # before the cutoff: must be trimmed away
+old=$((now - 864000))        # before it too, but the last such record is kept
+recent=$((now - 3600))       # after the cutoff: must survive
+
+# A host-history file as xymond_history writes it: "testname tstamp lastchg
+# duration newcol oldcol trend", and the trimmer reads the timestamp from column
+# two. Three records, because trim_history() keeps the last pre-cutoff line on
+# purpose -- with a single old line a file looks untrimmed however well the
+# trimming works.
+seed_history() {
+	{
+		printf 'conn %d %d 3600 purple red 0\n' "$ancient" "$((ancient - 3600))"
+		printf 'conn %d %d 3600 red green 0\n'  "$old"     "$((old - 3600))"
+		printf 'conn %d %d 3600 green red 0\n'  "$recent"  "$((recent - 3600))"
+	} >"$work/var/hist/$1"
+}
+
+# XYMONSERVERLOGS is redirected with the rest: trimhistory reads
+# $XYMONSERVERLOGS/xymond_history.pid and signals that process, and left unset
+# it falls back to the compiled-in XYMONLOGDIR -- a real Xymon's.
+run_trim() {
+	set +e
+	XYMONHOME="$work" \
+	HOSTSCFG="!$work/etc/hosts.cfg" \
+	XYMONHISTDIR="$work/var/hist" \
+	XYMONHISTLOGS="$work/var/histlogs" \
+	XYMONSERVERLOGS="$work/var/logs" \
+	XYMONTMP="$work" \
+		"$work/trimhistory" --cutoff="$cutoff" "$@" >"$work/trim.log" 2>&1
+	trim_rc=$?
+	set -e
+}
+
+# ---- a plain include that will not open -------------------------------------
+# more.cfg is the file listing fromtheinclude.example.com. It has moved, been
+# renamed, or was never there.
+{
+	printf '127.0.0.1 active.example.com # conn\n'
+	printf 'include %s/etc/more.cfg\n' "$work"
+} >"$work/etc/hosts.cfg"
+seed_history active.example.com
+seed_history fromtheinclude.example.com
+
+run_trim --drop
+log=$(cat "$work/trim.log")
+
+assert_file_exists "$work/var/hist/fromtheinclude.example.com" \
+	"--drop deleted the history of a host hosts.cfg does list, in an include that could not be read (#512)"
+assert_file_exists "$work/var/hist/active.example.com" \
+	"--drop deleted the history of a host listed in hosts.cfg itself"
+[ "$trim_rc" -ne 0 ] \
+	|| { echo "$log" >&2; fail "trimhistory reported success after reading a hosts.cfg it could not read in full"; }
+assert_contains "include" "$log" \
+	"the run refused without saying that an include was the reason"
+
+# ---- the same include, declared optional ------------------------------------
+# Now the configuration says the file may be absent, so the list is complete as
+# written and fromtheinclude.example.com really is a host that no longer exists.
+# It has to be dropped, exactly as it was before this fix.
+rm -f "${work:?}/var/hist/"*
+{
+	printf '127.0.0.1 active.example.com # conn\n'
+	printf 'optional include %s/etc/more.cfg\n' "$work"
+} >"$work/etc/hosts.cfg"
+seed_history active.example.com
+seed_history fromtheinclude.example.com
+
+run_trim --drop
+log=$(cat "$work/trim.log")
+
+[ "$trim_rc" -eq 0 ] \
+	|| { echo "$log" >&2; fail "--drop refused on a hosts.cfg whose include is declared optional, which is the case the keyword exists for"; }
+[ ! -e "$work/var/hist/fromtheinclude.example.com" ] \
+	|| { echo "$log" >&2; fail "--drop kept the history of a host nothing lists: an absent optional include still leaves a complete configuration"; }
+assert_file_exists "$work/var/hist/active.example.com" \
+	"--drop deleted a listed host's history on a configuration that loaded completely"
+
+# ...and the run did its ordinary work rather than stopping early.
+events=$(cat "$work/var/hist/active.example.com")
+assert_contains "$recent" "$events" "the kept history lost its post-cutoff record"
+assert_not_contains "$ancient" "$events" \
+	"nothing was trimmed, so the run never got past the configuration load"
+
+echo "OK $(basename "$0")"

--- a/xymond/trimhistory.c
+++ b/xymond/trimhistory.c
@@ -428,6 +428,22 @@ int main(int argc, char *argv[])
 
 	load_hostnames(xgetenv("HOSTSCFG"), NULL, get_fqdn());
 
+	/*
+	 * A host list that is short is worse here than one that is missing: it
+	 * looks entirely normal. "include" says the file is expected to be there
+	 * and "optional include" says it need not be, so a non-optional include
+	 * that would not open leaves us holding a configuration the admin did not
+	 * write - and every host it carried now looks like a host that was
+	 * removed. Deleting on that answer is the loss #512 is about; rendering
+	 * on it is merely incomplete, which is why only this caller asks.
+	 */
+	if ((dropfiles || droplogs) && stackfmissing()) {
+		errprintf("%s is incomplete - %d include(s) could not be read, "
+			  "so hosts are missing from the list. Not dropping anything.\n",
+			  xgetenv("HOSTSCFG"), stackfmissing());
+		return 1;
+	}
+
 	/* First scan the directory for all files, and pick up the ones we want to process */
 	while ((hent = readdir(histdir)) != NULL) {
 		char *hostname = NULL;


### PR DESCRIPTION
`hosts.cfg` already says which of its includes may be missing: `optional include
...` may be absent, a plain `include ...` is expected to be there. That
distinction was discarded exactly where it mattered.

When the file would not open, `stackfgets()` printed a warning either way and
carried on (`lib/stackio.c:457`, and `:483`/`:513` for the directory list),
`load_hostnames()` returned 0, and the caller was left holding a host list that
parsed cleanly and was **short by every host the include carried**.

For `xymongen`, `xymonnet` and the CGIs that is an incomplete page — right, for
something that only renders. For `trimhistory --drop` it is data loss:

```
$ trimhistory --cutoff=<now-1d> --drop
WARNING: Cannot open include file '/etc/xymon/more.cfg', line was: include /etc/xymon/more.cfg
Orphaned service-history file fromtheinclude.example.com - no host
$ echo $?
0
```

**Distinct from the two cases #508 closes**, which are the ends of the same
family: there the load failed outright, or succeeded with nothing in it. Here it
succeeds and looks entirely normal, which is why it needs its own answer rather
than a stronger version of theirs.

`stackio` counts the non-optional include and directory opens that failed during
the current stack and offers the count as `stackfmissing()`; `stackfopen()`
already recognises where a stack begins, which is where it resets. `trimhistory`
refuses `--drop` and `--droplogs` when the list it just loaded lost one. No other
caller changes, because no other caller deletes on the answer.

| | on main | with this |
| --- | --- | --- |
| an `include` that will not open | the include's hosts deleted, one warning naming a file, exit 0 | run refused, exit 1, the message names the include |
| the same include, `optional` | its hosts dropped, trimming proceeds | unchanged |

The second row is the control, and it is the point of reading the keyword rather
than counting includes: a fix that refused whenever a `hosts.cfg` mentioned an
include would satisfy the first row and be useless.

`tests/xymond/trimhistory-drop-lost-include.sh` carries both rows. It builds its
own fixture rather than using the shared trimhistory helper, which exists only on
the #508 and #509 branches — worth converting once one of those lands, so the
duplication does not become permanent. Verified red on this base without the
change — *"--drop deleted the history of a host hosts.cfg does list"* — and green
with it. Suite: **96 passed, 0 skipped, 0 failed**.

Merges cleanly with both siblings, checked rather than assumed: test-merged
against #508 and #509 from a clean tree, no unmerged paths, and in the #508 case
both refusals survive in the right order — its failed-or-empty check first, this
one after it.

One thing for whoever takes #29 item `18` (`xymon.nullfollowsincl.patch`): #29's
own note says it touches the same condition region of `stackio.c` as #223 did,
which is the region the counter sits in. Not a conflict today, since that patch
is not open as a pull request.

Fixes #512.
