### PR TITLE
tests/rrd: pin that the external processor stream is buffered by default

### DIFF
--- a/tests/buildsystem/test-suite-portability.sh
+++ b/tests/buildsystem/test-suite-portability.sh
@@ -64,6 +64,21 @@ report() {
 report "bash4" '(^|[^[:alnum:]_])(mapfile|readarray)([^[:alnum:]_]|$)|declare +-A|\$\{[A-Za-z_]+\^\^|\$\{[A-Za-z_]+,,' \
 	"bash 4 only; macOS ships bash 3.2"
 
+# Automatic file-descriptor allocation -- "exec {fd}>file", then ">&$fd" -- is
+# bash 4.1, so on bash 3.2 it is a syntax error rather than a graceful failure:
+# the whole file dies at parse time and the suite reports a failure with no
+# obvious cause. Kept apart from the bash4 rule above rather than folded into
+# it, because the probe proves a pattern non-vacuous and not each alternative
+# inside one -- widening a rule while its probe exercised only the old form is
+# how the root-lane gap survived. Use an explicit descriptor ("exec 9>file").
+#
+# The leading [^$] keeps ordinary expansion out of it: "${x}>out" is a variable
+# followed by a redirection, not an allocation. A comment naming the construct
+# is skipped like every other comment, so a test may still explain why it
+# avoids it.
+report "bash41-fd" '(^|[^$])\{[A-Za-z_][A-Za-z0-9_]*\}[<>]' \
+	"automatic fd allocation is bash 4.1; use an explicit descriptor (exec 9>...)"
+
 # Tool flags that exist on GNU and not on the BSDs, or mean different things.
 report "gnu-only" 'sed +-i|grep +[^|]*--include|grep +-[a-zA-Z]*P|stat +-c|readlink +-f|date +-d ' \
 	"GNU-only or differently-spelled on BSD/macOS; use a portable form"
@@ -200,10 +215,11 @@ probe="$work/probe.sh"
 	printf 'chmod 555 d\n'
 	printf 'cc -I"$ROOT/lib" x.c\n'
 	printf 'sed s#/proc/mounts#f# x\n'
+	printf 'exec {fd}>/dev/null\n'
 } >"$probe"
 probe_pattern=$(IFS='|'; printf '%s' "${__rule_patterns[*]}")
 hits=$(grep -cE "$probe_pattern" "$probe")
-assert_equal "8" "$hits" "the rule patterns no longer match the constructs they are meant to catch"
+assert_equal "9" "$hits" "the rule patterns no longer match the constructs they are meant to catch"
 
 # The link-flags rule the same way, including the bypass it used to allow: the
 # helpers named in a comment and nowhere else.

--- a/tests/rrd/extproc-doflush.sh
+++ b/tests/rrd/extproc-doflush.sh
@@ -18,10 +18,18 @@
 # too (tests/rrd/extproc-teardown-flush.sh covers that path), so a run that
 # waits for exit cannot tell the two modes apart.
 #
-# Deliberately only the positive direction. Asserting that the *default*
-# has not delivered yet means asserting the absence of an event, which on a
-# loaded runner is a wall-clock race, and a flaky test is worse than none
-# (tests/README.md).
+# Both directions are checked, and the negative one needs a word, because an
+# earlier version of this file left it out on the grounds that asserting the
+# absence of an event is a wall-clock race. It is not one here. do_rrd.c makes
+# the stream fully buffered in setup_extprocessor() and flushes it in exactly
+# one place, guarded by that boolean -- so with DOFLUSH unset, one small update
+# against RRD_EXTPROC_BUFSIZ=65536 *cannot* reach the processor before the
+# stream closes. Load does not flush a stdio buffer; it can only delay the
+# write. So the error this test can make is leniency, not flakiness: on a
+# machine slow enough that the write has not happened yet, the absence check
+# passes for the wrong reason. That is why the default case also asserts the
+# data arrives after teardown -- an update that never appeared at all fails the
+# test rather than quietly satisfying it.
 
 set -euo pipefail
 # shellcheck source=tests/lib/assert.sh
@@ -36,63 +44,116 @@ mkdir -p "$work/home/etc" "$work/tmp" "$work/rrd"
 
 cat > "$work/processor" <<EOF
 #!/bin/sh
-while IFS= read -r line; do printf '%s\n' "\$line" >> "$work/received.txt"; done
+while IFS= read -r line; do printf '%s\n' "\$line" >> "\$RECEIVED"; done
 EOF
 chmod +x "$work/processor"
 
-mkfifo "$work/feed"
-
 ts=$(date +%s)
 
-# The buffer is forced far above one update, so nothing can reach the
-# processor by filling it: only a flush can, which is the point.
-env \
-	XYMONHOME="$work/home" \
-	XYMONVAR="$work" \
-	XYMONTMP="$work/tmp" \
-	XYMONRRDS="$work/rrd" \
-	HOSTSCFG="$work/hosts.cfg" \
-	TEST2RRD="inode" \
-	GRAPHS="inode" \
-	RRD_EXTPROC_BUFSIZ=65536 \
-	RRD_EXTPROC_DOFLUSH=1 \
-	"$XYMOND_RRD" --no-cache --no-rrd --rrddir="$work/rrd" \
-	--processor="$work/processor" \
-	<"$work/feed" >"$work/xymond_rrd.log" 2>&1 &
-worker=$!
-register_cleanup "kill $worker 2>/dev/null || true"
+# feed_one CASE DOFLUSH -- run a fresh xymond_rrd, send one update, and leave
+# it running with the fifo's write end still open. Sets:
+#   received  the file the processor appends to
+#   worker    its pid
+# Explicit descriptor 9 rather than "exec {fd}>": automatic allocation is bash
+# 4.1, and the suite's floor is the 3.2 macOS ships (tests/README.md).
+feed_one() {
+	fo_case=$1 fo_doflush=$2
+	received="$work/received-$fo_case.txt"
+	: > "$received"
+	mkfifo "$work/feed-$fo_case"
 
-# Hold the write end open so the worker keeps reading after the message.
-exec {feed}>"$work/feed"
-register_cleanup "exec {feed}>&- 2>/dev/null || true"
+	# The buffer is forced far above one update, so nothing can reach the
+	# processor by filling it: only a flush can, which is the point.
+	env \
+		XYMONHOME="$work/home" \
+		XYMONVAR="$work" \
+		XYMONTMP="$work/tmp" \
+		XYMONRRDS="$work/rrd" \
+		HOSTSCFG="$work/hosts.cfg" \
+		TEST2RRD="inode" \
+		GRAPHS="inode" \
+		RECEIVED="$received" \
+		RRD_EXTPROC_BUFSIZ=65536 \
+		${fo_doflush:+RRD_EXTPROC_DOFLUSH=$fo_doflush} \
+		"$XYMOND_RRD" --no-cache --no-rrd --rrddir="$work/rrd" \
+		--processor="$work/processor" \
+		<"$work/feed-$fo_case" >"$work/xymond_rrd-$fo_case.log" 2>&1 &
+	worker=$!
+	register_cleanup "kill $worker 2>/dev/null || true"
 
-printf '@@status|%s|127.0.0.1||unix.test|inode|%s|green||||||||||unix|\n' "$ts" "$((ts + 1800))" >&$feed
-printf 'status unix.test.inode green %s - Filesystems ok\n' "$ts" >&$feed
-printf 'Filesystem itotal iused ifree %%%%iused Mounted on\n' >&$feed
-printf '/dev/ld0a 259070 41020 218050 15%%%% /\n@@\n' >&$feed
+	# Hold the write end open so the worker keeps reading after the message.
+	exec 9>"$work/feed-$fo_case"
+	register_cleanup "exec 9>&- 2>/dev/null || true"
+
+	printf '@@status|%s|127.0.0.1||unix.test|inode|%s|green||||||||||unix|\n' "$ts" "$((ts + 1800))" >&9
+	printf 'status unix.test.inode green %s - Filesystems ok\n' "$ts" >&9
+	printf 'Filesystem itotal iused ifree %%%%iused Mounted on\n' >&9
+	printf '/dev/ld0a 259070 41020 218050 15%%%% /\n@@\n' >&9
+}
+
+teardown_one() {
+	exec 9>&-
+	wait "$worker" 2>/dev/null || true
+}
+
+# ---- DOFLUSH=1: the update arrives while the daemon is still running --------
+feed_one flush 1
 
 # Wait for the condition, not for a duration: poll until the processor has
 # recorded something, with a ceiling so a broken build fails instead of
 # hanging the suite.
 delivered=no
+polls=0
 for _ in $(seq 1 100); do
-	if [ -s "$work/received.txt" ]; then delivered=yes; break; fi
+	if [ -s "$received" ]; then delivered=yes; break; fi
+	polls=$((polls + 1))
 	sleep 0.1
 done
 
 if [ "$delivered" != yes ]; then
-	exec {feed}>&-
-	wait "$worker" 2>/dev/null || true
-	cat "$work/xymond_rrd.log" >&2
+	teardown_one
+	cat "$work/xymond_rrd-flush.log" >&2
 	fail "RRD_EXTPROC_DOFLUSH did not deliver the update while xymond_rrd was still running"
 fi
 
-received=$(cat "$work/received.txt")
+flushed=$(cat "$received")
+teardown_one
 
-exec {feed}>&-
-wait "$worker" 2>/dev/null || true
-
-assert_contains "unix.test inode" "$received" \
+assert_contains "unix.test inode" "$flushed" \
 	"the flushed update names the host and test"
 
-pass "RRD_EXTPROC_DOFLUSH delivers --processor data while xymond_rrd is still running"
+# ---- the default: nothing until the stream closes ---------------------------
+# Without this, the pair of assertions cannot tell "DOFLUSH works" from
+# "buffering was never added": removing the buffering feature outright would
+# also deliver live, and the test above would still pass.
+feed_one default ""
+
+# Calibrated against the flushed case rather than a fixed ceiling: the default
+# gets several times however long a live delivery actually took on this machine,
+# so a slow runner stretches both and a fast one does not pay ten seconds for one
+# assertion. A floor keeps it meaningful when the flushed case was instant.
+ceiling=$(( (polls + 1) * 5 ))
+[ "$ceiling" -ge 10 ] || ceiling=10
+for _ in $(seq 1 "$ceiling"); do
+	[ -s "$received" ] && break
+	sleep 0.1
+done
+
+if [ -s "$received" ]; then
+	early=$(cat "$received")
+	teardown_one
+	cat "$work/xymond_rrd-default.log" >&2
+	fail "the default delivered to the processor while xymond_rrd was still running, so the stream is not buffered and DOFLUSH changes nothing: $early"
+fi
+
+teardown_one
+
+# The control on the check above: the update must exist and reach the processor
+# at teardown. A run that produced nothing at all would otherwise satisfy the
+# absence assertion without proving anything about buffering.
+assert_file_exists "$received" \
+	"the default lost the update entirely instead of buffering it"
+assert_contains "unix.test inode" "$(cat "$received")" \
+	"the buffered update did not reach the processor when the stream closed"
+
+pass "RRD_EXTPROC_DOFLUSH delivers while xymond_rrd runs, and the default holds the update until the stream closes"


### PR DESCRIPTION
`extproc-doflush.sh` checked that `RRD_EXTPROC_DOFLUSH` delivers `--processor`
data while `xymond_rrd` is still running, and deliberately stopped there — its
header argued that asserting the default has *not* delivered means asserting the
absence of an event, a wall-clock race on a loaded runner.

**That reasoning does not hold for this stream.** `setup_extprocessor()` makes it
fully buffered, and `do_rrd.c` flushes it in exactly one place, guarded by the
`DOFLUSH` boolean:

```
154:  n = setvbuf(processorstream, (char *)NULL, _IOFBF, processorbufsz);
494:  if (processorflush && (n >= 0)) fflush(processorstream);
```

With `DOFLUSH` unset, one small update against `RRD_EXTPROC_BUFSIZ=65536` cannot
reach the processor before the stream closes — load does not flush a stdio
buffer, it only delays the write. So the check cannot produce a false failure; it
can only be **lenient**, which is not what the header was guarding against. The
leniency is closed from the other side: the default case also asserts the update
arrives once the stream closes, so a run that produced nothing at all fails
rather than quietly satisfying the absence.

**Why it is worth having:** without it the file cannot tell "DOFLUSH works" from
"buffering was never added" — removing the feature outright also delivers live,
and the existing assertion still passed.

| | as it stands | the `do_rrd.c` half reverted |
| --- | --- | --- |
| `extproc-doflush.sh` | pass | **fail** — "the default delivered to the processor while xymond_rrd was still running, so the stream is not buffered and DOFLUSH changes nothing" |

Two incidental fixes to the same file. The fifo's write end moves from `exec
{fd}>` to descriptor 9: automatic descriptor allocation is **bash 4.1** and the
suite's floor is the 3.2 macOS ships. This was the only test in the tree using
it, and `tests/buildsystem/test-suite-portability.sh` does not check for the
construct, so nothing had flagged it. And the default case's ceiling is
calibrated against however long the flushed case actually took rather than fixed,
with a floor, so a slow runner stretches both and the file costs 2s instead of
11s.

Suite: **95 passed, 0 skipped, 0 failed**.

**And the checker now refuses the construct** (second commit). `exec {fd}>` fails
worse than most things that cross the bash 3.2 floor: it is a syntax error, so
the file dies at parse time and the lane reports a failure with no obvious cause.
Nothing had flagged it because no rule existed.

It is a rule of its own rather than a widening of the `bash4` rule beside it,
because the probe proves a *pattern* non-vacuous and not each alternative inside
one — and widening a rule while its probe exercised only the old form is how the
`root-lane` gap survived once, as that file's own comment records. A separate rule
gets its own probe line, and the probe's expected count rises with it, 8 → 9.

```
construct put back   [bash41-fd] tests/rrd/extproc-doflush.sh:85  → FAIL: 1 violation(s)
"${x}>out", "${y}<z"  0 matches — ordinary expansion is not flagged
tree as it stands     PASS
```
